### PR TITLE
Fix release workflow trigger and indentation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ on:
       - main
     paths-ignore:
       - '**/README.md'
-      - '.github/**'
 
 permissions:
   contents: write
@@ -16,71 +15,72 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'skip ci') && !contains(github.event.head_commit.message, 'bump version')"
     steps:
-            - uses: actions/checkout@v4
-              with:
-                fetch-depth: 0
-                token: ${{ secrets.TOKEN_GH }}
-      
-            - name: Set up Python
-              uses: actions/setup-python@v5
-              with:
-                python-version: "3.13"
-      
-            - name: Install dependencies
-              run: |
-                python -m pip install --upgrade pip
-                pip install build twine
-      
-                  - name: Bump version
-                    id: bump
-                    run: |
-                      # Read current version from pyproject.toml (only matching the one at the start of the line)
-                      CURRENT_VERSION=$(grep -m 1 -oP '^version = "\K[^"]+' pyproject.toml)
-                      echo "Current version: $CURRENT_VERSION"
-                      
-                      # Increment patch version
-                      IFS='.' read -r major minor patch <<< "$CURRENT_VERSION"
-                      NEW_PATCH=$((patch + 1))
-                      NEW_VERSION="$major.$minor.$NEW_PATCH"
-                      echo "New version: $NEW_VERSION"
-                      
-                      # Update pyproject.toml
-                      sed -i "s/^version = \"$CURRENT_VERSION\"/version = \"$NEW_VERSION\"/" pyproject.toml
-                      
-                      echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT      
-            - name: Commit and push changes
-              run: |
-                git config --global user.name "github-actions[bot]"
-                git config --global user.email "github-actions[bot]@users.noreply.github.com"
-                git add pyproject.toml
-                git commit -m "chore: bump version to ${{ steps.bump.outputs.version }} [skip ci]"
-                git push origin main
-      
-            - name: Create Git Tag
-              run: |
-                git tag v${{ steps.bump.outputs.version }}
-                git push origin v${{ steps.bump.outputs.version }}
-      
-            - name: Build package
-              run: python -m build
-      
-            - name: Publish to PyPI
-              env:
-                TWINE_USERNAME: __token__
-                TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-              run: python -m twine upload dist/*
-      
-            - name: Create GitHub Release
-              uses: softprops/action-gh-release@v2
-              with:
-                tag_name: v${{ steps.bump.outputs.version }}
-                name: Release v${{ steps.bump.outputs.version }}
-                body: |
-                  Automated release for version v${{ steps.bump.outputs.version }}
-                  
-                  Changes in this release:
-                  ${{ github.event.head_commit.message }}
-                draft: false
-                prerelease: false
-              env:
-                GITHUB_TOKEN: ${{ secrets.TOKEN_GH }}
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.TOKEN_GH }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - name: Bump version
+        id: bump
+        run: |
+          # Read current version from pyproject.toml (only matching the one at the start of the line)
+          CURRENT_VERSION=$(grep -m 1 -oP '^version = "\K[^" ]+' pyproject.toml)
+          echo "Current version: $CURRENT_VERSION"
+          
+          # Increment patch version
+          IFS='.' read -r major minor patch <<< "$CURRENT_VERSION"
+          NEW_PATCH=$((patch + 1))
+          NEW_VERSION="$major.$minor.$NEW_PATCH"
+          echo "New version: $NEW_VERSION"
+          
+          # Update pyproject.toml
+          sed -i "s/^version = \"$CURRENT_VERSION\"/version = \"$NEW_VERSION\"/" pyproject.toml
+          
+          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Commit and push changes
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml
+          git commit -m "chore: bump version to ${{ steps.bump.outputs.version }} [skip ci]"
+          git push origin main
+
+      - name: Create Git Tag
+        run: |
+          git tag v${{ steps.bump.outputs.version }}
+          git push origin v${{ steps.bump.outputs.version }}
+
+      - name: Build package
+        run: python -m build
+
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: python -m twine upload dist/*
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.bump.outputs.version }}
+          name: Release v${{ steps.bump.outputs.version }}
+          body: |
+            Automated release for version v${{ steps.bump.outputs.version }}
+            
+            Changes in this release:
+            ${{ github.event.head_commit.message }}
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.TOKEN_GH }}


### PR DESCRIPTION
This PR fixes the release workflow by:
1. Fixing YAML indentation (previously broken).
2. Removing `.github/**` from `paths-ignore` to ensure changes to workflows can also trigger the release if they are merged into main.
3. Keeping README exclusion to avoid redundant releases on documentation updates.