### PR TITLE
CI: Add macOS and Windows to test matrix (Refreshed)

### DIFF
--- a/.github/workflows/manual_verify_install.yml
+++ b/.github/workflows/manual_verify_install.yml
@@ -1,0 +1,35 @@
+name: Manual Verify Installation
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Specific version to install (optional, defaults to latest)'
+        required: false
+        default: ''
+
+jobs:
+  verify-pypi-install:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.13"]
+    steps:
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install PyOctaveBand
+        run: |
+          python -m pip install --upgrade pip
+          if [ -z "${{ inputs.version }}" ]; then
+            pip install pyoctaveband
+          else
+            pip install pyoctaveband==${{ inputs.version }}
+          fi
+        shell: bash
+
+      - name: Verify Import
+        run: python -c "import pyoctaveband; print('Successfully imported pyoctaveband version:', pyoctaveband.__version__)"

--- a/.github/workflows/manual_verify_install.yml
+++ b/.github/workflows/manual_verify_install.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   verify-pypi-install:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -21,15 +23,16 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install PyOctaveBand
-        run: |
-          python -m pip install --upgrade pip
-          if [ -z "${{ inputs.version }}" ]; then
-            pip install pyoctaveband
-          else
-            pip install pyoctaveband==${{ inputs.version }}
-          fi
-        shell: bash
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+
+      - name: Install latest PyOctaveBand
+        if: ${{ inputs.version == '' }}
+        run: pip install pyoctaveband
+
+      - name: Install specific PyOctaveBand version
+        if: ${{ inputs.version != '' }}
+        run: pip install pyoctaveband==${{ inputs.version }}
 
       - name: Verify Import
         run: python -c "import pyoctaveband; print('Successfully imported pyoctaveband version:', pyoctaveband.__version__)"

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.13"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -36,11 +36,13 @@ jobs:
       run: bandit -r src
 
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v4
@@ -54,18 +56,18 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
-        pip install -e .
+        pip install .
     - name: Run tests
       env:
         NUMBA_DISABLE_JIT: 1
       run: |
-        pytest --junitxml=test-results-${{ matrix.python-version }}.xml --cov=src --cov-report=xml
+        pytest --junitxml=test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml --cov=src --cov-report=xml
     - name: Upload Test Results
       uses: actions/upload-artifact@v4
       with:
-        name: test-results-${{ matrix.python-version }}
+        name: test-results-${{ matrix.os }}-${{ matrix.python-version }}
         path: |
-          test-results-${{ matrix.python-version }}.xml
+          test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml
           coverage.xml
       if: always()
 
@@ -80,7 +82,7 @@ jobs:
     - name: Download coverage report
       uses: actions/download-artifact@v4
       with:
-        name: test-results-3.13
+        name: test-results-ubuntu-latest-3.13
     - name: SonarCloud Scan
       uses: SonarSource/sonarqube-scan-action@master
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'README.md'
+      - '.github/**'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,6 @@ jobs:
   release:
     runs-on: ubuntu-latest
     if: github.repository == 'jmrplens/PyOctaveBand' && !contains(github.event.head_commit.message, 'skip ci')
-    outputs:
-      version: ${{ steps.bump.outputs.version }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -83,25 +81,3 @@ jobs:
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.TOKEN_GH }}
-
-  verify-installation:
-    needs: release
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    steps:
-      - name: Wait for PyPI propagation
-        run: sleep 10
-        shell: bash
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-
-      - name: Install and verify package
-        run: |
-          python -m pip install --upgrade pip
-          pip install pyoctaveband==${{ needs.release.outputs.version }}
-          python -c "import pyoctaveband; print('Package successfully installed and imported')"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     if: github.repository == 'jmrplens/PyOctaveBand' && !contains(github.event.head_commit.message, 'skip ci')
+    outputs:
+      version: ${{ steps.bump.outputs.version }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -81,3 +83,25 @@ jobs:
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.TOKEN_GH }}
+
+  verify-installation:
+    needs: release
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - name: Wait for PyPI propagation
+        run: sleep 10
+        shell: bash
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install and verify package
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyoctaveband==${{ needs.release.outputs.version }}
+          python -c "import pyoctaveband; print('Package successfully installed and imported')"


### PR DESCRIPTION
### **User description**
**Refresh of PR #39**

This PR updates the CI workflow to include macOS and Windows in the test matrix.
It also changes the installation method from editable (`-e .`) to standard (`.`) to verify proper package installation.
Additionally, it adds a manual workflow to verify PyPI installations on all platforms.

**Changes:**
- Python 3.13 only for tests (matrix structure preserved).
- Cross-platform tests (Linux, macOS, Windows).
- New manual verify workflow.


___

### **PR Type**
Enhancement


___

### **Description**
- Expand test matrix to macOS and Windows platforms

- Reduce Python versions tested to 3.13 only

- Change installation method from editable to standard

- Add manual workflow for PyPI installation verification


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Matrix"] -->|"Add OS"| B["ubuntu, macOS, windows"]
  A -->|"Reduce Python"| C["3.13 only"]
  D["Installation"] -->|"Change method"| E["Standard install"]
  F["New Workflow"] -->|"Manual dispatch"| G["Verify PyPI install"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>python-app.yml</strong><dd><code>Cross-platform test matrix and standard installation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/python-app.yml

<ul><li>Expand test matrix to include macOS and Windows alongside Ubuntu<br> <li> Reduce Python version matrix from 3.11, 3.12, 3.13 to 3.13 only<br> <li> Change package installation from editable mode (<code>pip install -e .</code>) to <br>standard mode (<code>pip install .</code>)<br> <li> Update artifact naming to include OS in test results filenames<br> <li> Add <code>fail-fast: false</code> to allow all matrix combinations to complete<br> <li> Update SonarCloud artifact download to use new naming convention</ul>


</details>


  </td>
  <td><a href="https://github.com/jmrplens/PyOctaveBand/pull/40/files#diff-d7b3e1cc0b909c52439e5d8d3f602f70644d0f6b62a54825968d819f7a5bee89">+9/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manual_verify_install.yml</strong><dd><code>New manual PyPI installation verification workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/manual_verify_install.yml

<ul><li>Create new manual workflow triggered via <code>workflow_dispatch</code><br> <li> Test PyPI package installation across three platforms<br> <li> Support optional version specification via workflow input<br> <li> Verify successful import and version reporting</ul>


</details>


  </td>
  <td><a href="https://github.com/jmrplens/PyOctaveBand/pull/40/files#diff-d797d10c36507793da0d15147dbdbf51babbd0ea755f0db2d9f7558a9159d1c1">+35/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a manual installation verification workflow to test installing and importing the package on Ubuntu, macOS, and Windows.
  * Updated CI tests to run a matrix across multiple operating systems with Python 3.13 and include OS/Python in test artifacts.
  * Adjusted release workflow to ignore documentation and CI config changes so they no longer trigger releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->