### PR TITLE
ci: skip self-assignment

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -12,6 +12,9 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
+    if: >-
+      (github.event_name == 'issues' && github.event.issue.user.login != 'jmrplens') ||
+      (github.event_name == 'pull_request' && github.event.pull_request.user.login != 'jmrplens')
     steps:
       - name: Assign to jmrplens
         env:
@@ -19,4 +22,8 @@ jobs:
           REPO: ${{ github.repository }}
           NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
         run: |
-          gh api             --method POST             -H "Accept: application/vnd.github+json"             /repos/$REPO/issues/$NUMBER/assignees             -f assignees[]=jmrplens
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            /repos/$REPO/issues/$NUMBER/assignees \
+            -f assignees[]=jmrplens


### PR DESCRIPTION
El workflow ahora no asigna si el autor es @jmrplens.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/PyOctaveBand/pull/56?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the auto-assignment workflow so it only assigns items when the author is not already the designated assignee.
  * Kept the assignment request behavior unchanged while improving how the step is executed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->