### PR TITLE
ci: skip dependabot PRs

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -13,8 +13,8 @@ jobs:
       issues: write
       pull-requests: write
     if: >-
-      (github.event_name == 'issues' && github.event.issue.user.login != 'jmrplens') ||
-      (github.event_name == 'pull_request' && github.event.pull_request.user.login != 'jmrplens')
+      (github.event_name == 'issues' && github.event.issue.user.login != 'jmrplens' && github.event.issue.user.login != 'dependabot[bot]') ||
+      (github.event_name == 'pull_request' && github.event.pull_request.user.login != 'jmrplens' && github.event.pull_request.user.login != 'dependabot[bot]')
     steps:
       - name: Assign to jmrplens
         env:


### PR DESCRIPTION
Añade filtro para no asignar PRs abiertos por `dependabot[bot]` (además del filtro de auto-asignación).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/PyOctaveBand/pull/57?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

