### PR TITLE
docs: backfill Zenodo concept DOI

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,6 +9,7 @@ authors:
     orcid: "https://orcid.org/0000-0003-1250-6212"
 repository-code: "https://github.com/jmrplens/PyOctaveBand"
 url: "https://jmrplens.github.io/PyOctaveBand/"
+doi: "10.5281/zenodo.21215280"
 license: MIT
 keywords:
   - acoustics

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Python application](https://github.com/jmrplens/PyOctaveBand/actions/workflows/python-app.yml/badge.svg)](https://github.com/jmrplens/PyOctaveBand/actions/workflows/python-app.yml)
 [![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=jmrplens_PyOctaveBand&metric=alert_status)](https://sonarcloud.io/summary/overall?id=jmrplens_PyOctaveBand)
 [![codecov](https://codecov.io/gh/jmrplens/PyOctaveBand/branch/main/graph/badge.svg)](https://codecov.io/gh/jmrplens/PyOctaveBand)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21215280.svg)](https://doi.org/10.5281/zenodo.21215280)
 
 # PyOctaveBand
 

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -136,6 +136,11 @@ const jsonLd = JSON.stringify({
       screenshot: socialImage,
       license: 'https://opensource.org/licenses/MIT',
       isAccessibleForFree: true,
+      identifier: {
+        '@type': 'PropertyValue',
+        propertyID: 'DOI',
+        value: '10.5281/zenodo.21215280',
+      },
       datePublished,
       dateModified,
       softwareRequirements,

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -150,7 +150,11 @@ const jsonLd = JSON.stringify({
         priceCurrency: 'USD',
       },
       author: { '@id': authorId },
-      sameAs: ['https://pypi.org/project/PyOctaveBand/', `${fullUrl}/`],
+      sameAs: [
+        'https://pypi.org/project/PyOctaveBand/',
+        'https://doi.org/10.5281/zenodo.21215280',
+        `${fullUrl}/`,
+      ],
     },
     {
       '@type': 'SoftwareSourceCode',


### PR DESCRIPTION
First DOI registered automatically from the v2.0.0 release (record: https://zenodo.org/record/21215281). Adds the version-independent concept DOI to CITATION.cff (cffconvert-validated), a DOI badge in the README, and the DOI to the site's JSON-LD sameAs.

https://claude.ai/code/session_013kkVt3nxi9svp1an28uHxf

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/PyOctaveBand/pull/69?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Zenodo DOI badge and updated citation metadata for the latest release.
* **Website**
  * Updated structured data on the site to include the new DOI, including an added DOI reference URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->