### PR TITLE
docs: reorganize badges, GitHub-Sponsors-only funding, fix DOI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
-[![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.com/donate?hosted_button_id=BLP3R6VGYJB4Q)
-[![Donate](https://img.shields.io/badge/Donate-Ko--fi-brightgreen?color=ff5f5f)](https://ko-fi.com/jmrplens) 
-[![PyPI version](https://img.shields.io/pypi/v/PyOctaveBand)](https://pypi.org/project/PyOctaveBand/)
-[![PyPI downloads](https://img.shields.io/pypi/dm/PyOctaveBand)](https://pypi.org/project/PyOctaveBand/)
-[![Python versions](https://img.shields.io/pypi/pyversions/PyOctaveBand)](https://pypi.org/project/PyOctaveBand/)
-[![Python application](https://github.com/jmrplens/PyOctaveBand/actions/workflows/python-app.yml/badge.svg)](https://github.com/jmrplens/PyOctaveBand/actions/workflows/python-app.yml)
+<!-- Package -->
+[![PyPI version](https://img.shields.io/pypi/v/PyOctaveBand?logo=pypi&logoColor=white)](https://pypi.org/project/PyOctaveBand/)
+[![PyPI downloads](https://img.shields.io/pypi/dm/PyOctaveBand?logo=pypi&logoColor=white)](https://pypi.org/project/PyOctaveBand/)
+[![Python versions](https://img.shields.io/pypi/pyversions/PyOctaveBand?logo=python&logoColor=white)](https://pypi.org/project/PyOctaveBand/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/jmrplens/PyOctaveBand/blob/main/LICENSE)
+
+<!-- Quality -->
+[![CI](https://github.com/jmrplens/PyOctaveBand/actions/workflows/python-app.yml/badge.svg)](https://github.com/jmrplens/PyOctaveBand/actions/workflows/python-app.yml)
 [![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=jmrplens_PyOctaveBand&metric=alert_status)](https://sonarcloud.io/summary/overall?id=jmrplens_PyOctaveBand)
 [![codecov](https://codecov.io/gh/jmrplens/PyOctaveBand/branch/main/graph/badge.svg)](https://codecov.io/gh/jmrplens/PyOctaveBand)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21215280.svg)](https://doi.org/10.5281/zenodo.21215280)
+
+<!-- Citation & support -->
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.21215280-blue?logo=doi&logoColor=white)](https://doi.org/10.5281/zenodo.21215280)
+[![GitHub Sponsors](https://img.shields.io/github/sponsors/jmrplens?logo=githubsponsors&label=Sponsor&color=ea4aaa)](https://github.com/sponsors/jmrplens)
 
 # PyOctaveBand
 


### PR DESCRIPTION
- Removes the PayPal and Ko-fi donate badges — funding is GitHub Sponsors only (FUNDING.yml already reflected this).
- Groups the badges into three logical rows (package / quality / citation & support) with consistent shields.io styling: PyPI version, downloads, pyversions, MIT license · CI, SonarCloud quality gate, codecov · DOI, GitHub Sponsors.
- Fixes the invisible DOI badge: GitHub's camo proxy cached the 404 from before the DOI was registered; the shields.io URL forces a fresh fetch (badge and doi.org both verified 200).

https://claude.ai/code/session_013kkVt3nxi9svp1an28uHxf

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/PyOctaveBand/pull/70?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

