### PR TITLE
docs: drop downloads and sponsor badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 <!-- Package -->
 [![PyPI version](https://img.shields.io/pypi/v/PyOctaveBand?logo=pypi&logoColor=white)](https://pypi.org/project/PyOctaveBand/)
-[![PyPI downloads](https://img.shields.io/pypi/dm/PyOctaveBand?logo=pypi&logoColor=white)](https://pypi.org/project/PyOctaveBand/)
 [![Python versions](https://img.shields.io/pypi/pyversions/PyOctaveBand?logo=python&logoColor=white)](https://pypi.org/project/PyOctaveBand/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/jmrplens/PyOctaveBand/blob/main/LICENSE)
 
@@ -11,7 +10,6 @@
 
 <!-- Citation & support -->
 [![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.21215280-blue?logo=doi&logoColor=white)](https://doi.org/10.5281/zenodo.21215280)
-[![GitHub Sponsors](https://img.shields.io/github/sponsors/jmrplens?logo=githubsponsors&label=Sponsor&color=ea4aaa)](https://github.com/sponsors/jmrplens)
 
 # PyOctaveBand
 


### PR DESCRIPTION
The pypi/dm badge hits shields.io rate limits and renders broken; the sponsor badge goes too (the repo's Sponsor button from FUNDING.yml remains).

https://claude.ai/code/session_013kkVt3nxi9svp1an28uHxf

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/PyOctaveBand/pull/71?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

