### PR TITLE
chore: SonarCloud key renamed to jmrplens_phonometry

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <!-- Quality -->
 [![CI](https://github.com/jmrplens/phonometry/actions/workflows/python-app.yml/badge.svg)](https://github.com/jmrplens/phonometry/actions/workflows/python-app.yml)
-[![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=jmrplens_PyOctaveBand&metric=alert_status)](https://sonarcloud.io/summary/overall?id=jmrplens_PyOctaveBand)
+[![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=jmrplens_phonometry&metric=alert_status)](https://sonarcloud.io/summary/overall?id=jmrplens_phonometry)
 [![codecov](https://codecov.io/gh/jmrplens/phonometry/branch/main/graph/badge.svg)](https://codecov.io/gh/jmrplens/phonometry)
 
 <!-- Citation & support -->

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 #  Copyright (c) 2026. Jose M. Requena-Plens
 
 # Project identification
-sonar.projectKey=jmrplens_PyOctaveBand
+sonar.projectKey=jmrplens_phonometry
 sonar.organization=jmrplens
 
 # Path to sources and tests


### PR DESCRIPTION
The SonarCloud project key was renamed server-side (`api/projects/update_key`, history preserved). This PR points the scanner config and README badge at the new key. New badge already resolves (200).

https://claude.ai/code/session_013kkVt3nxi9svp1an28uHxf

## Summary by Sourcery

Update SonarCloud project references to use the renamed jmrplens_phonometry key.

Build:
- Align sonar-project.properties configuration with the new SonarCloud project key.

Documentation:
- Update README quality gate badge to point at the new SonarCloud project on SonarCloud.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/75?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

