### PR TITLE
docs: GitHub-safe math braces

### DIFF
--- a/.playwright-mcp/page-2026-07-07T00-42-24-529Z.yml
+++ b/.playwright-mcp/page-2026-07-07T00-42-24-529Z.yml
@@ -1,0 +1,1691 @@
+- generic [active] [ref=e1]:
+  - generic [ref=e2]:
+    - generic [ref=e3]:
+      - link "Skip to content" [ref=e4] [cursor=pointer]:
+        - /url: "#start-of-content"
+      - banner [ref=e6]:
+        - heading "Navigation Menu" [level=2] [ref=e7]
+        - generic [ref=e9]:
+          - button "Toggle navigation" [ref=e11] [cursor=pointer]
+          - link "Homepage" [ref=e17] [cursor=pointer]:
+            - /url: /
+            - img [ref=e18]
+          - generic [ref=e20]:
+            - link "Sign in" [ref=e21] [cursor=pointer]:
+              - /url: /login?return_to=https%3A%2F%2Fgithub.com%2Fjmrplens%2Fphonometry%2Fblob%2Fmain%2Fdocs%2Ftheory.md
+            - button "Appearance settings" [ref=e24] [cursor=pointer]:
+              - img
+    - main [ref=e28]:
+      - generic [ref=e29]:
+        - generic [ref=e30]:
+          - generic [ref=e32]:
+            - img [ref=e33]
+            - link "jmrplens" [ref=e36] [cursor=pointer]:
+              - /url: /jmrplens
+            - generic [ref=e37]: /
+            - strong [ref=e38]:
+              - link "phonometry" [ref=e39] [cursor=pointer]:
+                - /url: /jmrplens/phonometry
+            - generic [ref=e40]: Public
+          - generic [ref=e41]:
+            - list:
+              - listitem [ref=e42]:
+                - link "Sponsor @jmrplens" [ref=e43] [cursor=pointer]:
+                  - /url: /sponsors/jmrplens
+                  - generic [ref=e45]:
+                    - img [ref=e46]
+                    - text: Sponsor
+              - listitem [ref=e48]:
+                - link "You must be signed in to change notification settings" [ref=e49] [cursor=pointer]:
+                  - /url: /login?return_to=%2Fjmrplens%2Fphonometry
+                  - img [ref=e50]
+                  - text: Notifications
+              - listitem [ref=e52]:
+                - link "Fork 21" [ref=e53] [cursor=pointer]:
+                  - /url: /login?return_to=%2Fjmrplens%2Fphonometry
+                  - img [ref=e54]
+                  - text: Fork
+                  - generic "21" [ref=e56]
+              - listitem [ref=e57]:
+                - link "You must be signed in to star a repository" [ref=e59] [cursor=pointer]:
+                  - /url: /login?return_to=%2Fjmrplens%2Fphonometry
+                  - img [ref=e60]
+                  - text: Star
+                  - generic "108 users starred this repository" [ref=e62]: "108"
+        - navigation "Repository" [ref=e63]:
+          - list [ref=e64]:
+            - listitem [ref=e65]:
+              - link "Code" [ref=e66] [cursor=pointer]:
+                - /url: /jmrplens/phonometry
+                - img [ref=e67]
+                - generic [ref=e69]: Code
+            - listitem [ref=e70]:
+              - link "Issues" [ref=e71] [cursor=pointer]:
+                - /url: /jmrplens/phonometry/issues
+                - img [ref=e72]
+                - generic [ref=e75]: Issues
+            - listitem [ref=e76]:
+              - link "Pull requests 1" [ref=e77] [cursor=pointer]:
+                - /url: /jmrplens/phonometry/pulls
+                - img [ref=e78]
+                - generic [ref=e80]: Pull requests
+                - generic "1" [ref=e81]
+            - listitem [ref=e82]:
+              - link "Actions" [ref=e83] [cursor=pointer]:
+                - /url: /jmrplens/phonometry/actions
+                - img [ref=e84]
+                - generic [ref=e86]: Actions
+            - listitem [ref=e87]:
+              - link "Projects" [ref=e88] [cursor=pointer]:
+                - /url: /jmrplens/phonometry/projects
+                - img [ref=e89]
+                - generic [ref=e91]: Projects
+            - listitem [ref=e92]
+            - listitem [ref=e93]
+          - button "Additional navigation options" [ref=e97] [cursor=pointer]:
+            - img
+      - generic [ref=e108]:
+        - generic [ref=e112]:
+          - generic [ref=e113]:
+            - heading "Expand file tree" [level=2] [ref=e115]:
+              - button "Expand file tree" [ref=e116] [cursor=pointer]:
+                - img [ref=e117]
+            - button "main branch" [ref=e121] [cursor=pointer]:
+              - generic [ref=e122]:
+                - generic [ref=e124]:
+                  - img [ref=e126]
+                  - generic [ref=e129]: main
+                - generic:
+                  - img
+            - generic [ref=e131]:
+              - navigation "Breadcrumbs" [ref=e132]:
+                - heading "Breadcrumbs" [level=2] [ref=e133]
+                - list [ref=e134]:
+                  - listitem [ref=e135]:
+                    - link "phonometry" [ref=e136] [cursor=pointer]:
+                      - /url: /jmrplens/phonometry/tree/main
+                  - listitem [ref=e137]:
+                    - text: /
+                    - link "docs" [ref=e138] [cursor=pointer]:
+                      - /url: /jmrplens/phonometry/tree/main/docs
+              - generic [ref=e139]:
+                - text: /
+                - heading "theory.md" [level=1] [ref=e140]
+              - button "Copy path" [ref=e141] [cursor=pointer]:
+                - img [ref=e142]
+          - generic [ref=e147]:
+            - generic [ref=e150]:
+              - img [ref=e152]
+              - combobox "Go to file" [ref=e154]
+            - button "More file actions" [ref=e155] [cursor=pointer]:
+              - img [ref=e156]
+        - generic [ref=e158]:
+          - generic [ref=e160]:
+            - heading "Latest commit" [level=2] [ref=e161]
+            - generic [ref=e162]:
+              - generic [ref=e164]:
+                - link "jmrplens" [ref=e165] [cursor=pointer]:
+                  - /url: /jmrplens
+                  - img "jmrplens" [ref=e166]
+                - link "commits by jmrplens" [ref=e167] [cursor=pointer]:
+                  - /url: /jmrplens/phonometry/commits?author=jmrplens
+                  - text: jmrplens
+              - generic [ref=e168]:
+                - 'link "Didactic documentation: theory everywhere, bilingual figures, setup d…" [ref=e171] [cursor=pointer]':
+                  - /url: /jmrplens/phonometry/commit/fa02c6139613580d26ae4736509bb089cf34c342
+                - button "Open commit details" [ref=e172] [cursor=pointer]:
+                  - img [ref=e173]
+                - button "success" [ref=e175] [cursor=pointer]:
+                  - img [ref=e176]
+            - generic [ref=e178]:
+              - generic [ref=e180]:
+                - link "Commit fa02c61" [ref=e181] [cursor=pointer]:
+                  - /url: /jmrplens/phonometry/commit/fa02c6139613580d26ae4736509bb089cf34c342
+                  - text: fa02c61
+                - text: ·
+                - generic "Jul 7, 2026, 1:22 AM GMT+2" [ref=e182]: Jul 7, 20261 hour ago
+              - generic [ref=e183]:
+                - heading "History" [level=2] [ref=e184]
+                - link "View commit history for this file." [ref=e186] [cursor=pointer]:
+                  - /url: /jmrplens/phonometry/commits/main/docs/theory.md
+                  - generic [ref=e187]:
+                    - generic:
+                      - img
+          - generic [ref=e189]:
+            - generic "14.8 KB" [ref=e193]: 334 lines (232 loc) · 14.8 KB
+            - generic [ref=e195]:
+              - heading "File metadata and controls" [level=2] [ref=e196]
+              - list "File view" [ref=e198]:
+                - listitem [ref=e199]:
+                  - button "Preview" [ref=e200] [cursor=pointer]:
+                    - generic [ref=e202]: Preview
+                - listitem [ref=e203]:
+                  - button "Code" [ref=e204] [cursor=pointer]:
+                    - generic [ref=e206]: Code
+                - listitem [ref=e207]:
+                  - button "Blame" [ref=e208] [cursor=pointer]:
+                    - generic [ref=e210]: Blame
+              - generic [ref=e211]:
+                - generic [ref=e213]:
+                  - link "Raw" [ref=e215] [cursor=pointer]:
+                    - /url: https://github.com/jmrplens/phonometry/raw/refs/heads/main/docs/theory.md
+                    - generic [ref=e217]: Raw
+                  - button "Copy raw file" [ref=e219] [cursor=pointer]:
+                    - img [ref=e220]
+                  - button "Download raw file" [ref=e224] [cursor=pointer]:
+                    - img [ref=e225]
+                - button "Outline" [ref=e228] [cursor=pointer]:
+                  - img [ref=e229]
+            - region [ref=e232]:
+              - article [ref=e234]:
+                - paragraph [ref=e235]:
+                  - text: ←
+                  - link "Documentation index" [ref=e236] [cursor=pointer]:
+                    - /url: /jmrplens/phonometry/blob/main/docs/README.md
+                - generic [ref=e237]:
+                  - heading "Theoretical Background" [level=1] [ref=e238]
+                  - 'link "Permalink: Theoretical Background" [ref=e239] [cursor=pointer]':
+                    - /url: "#theoretical-background"
+                    - img [ref=e240]
+                - generic [ref=e242]:
+                  - heading "Octave Band Frequencies (ANSI S1.11 / IEC 61260)" [level=2] [ref=e243]
+                  - 'link "Permalink: Octave Band Frequencies (ANSI S1.11 / IEC 61260)" [ref=e244] [cursor=pointer]':
+                    - /url: "#octave-band-frequencies-ansi-s111--iec-61260"
+                    - img [ref=e245]
+                - paragraph [ref=e247]: "The mid-band frequencies (fm) and edges (f1, f2) use a base-10 ratio:"
+                - paragraph [ref=e248]:
+                  - math [ref=e250]:
+                    - generic [ref=e251]: G
+                    - generic [ref=e252]: =
+                    - generic [ref=e253]:
+                      - generic [ref=e254]: "10"
+                      - generic [ref=e256]: "0.3"
+                - paragraph [ref=e257]:
+                  - strong [ref=e258]: "Mid-band:"
+                - paragraph [ref=e259]:
+                  - math [ref=e261]:
+                    - generic [ref=e262]:
+                      - generic [ref=e263]: f
+                      - generic [ref=e264]: m
+                    - generic [ref=e265]: =
+                    - generic [ref=e266]: "1000"
+                    - generic [ref=e267]: ⋅
+                    - generic [ref=e268]:
+                      - generic [ref=e269]: G
+                      - generic [ref=e270]:
+                        - generic [ref=e271]: x
+                        - generic [ref=e273]: /
+                        - generic [ref=e274]: b
+                - paragraph [ref=e275]: (for odd b)
+                - paragraph [ref=e276]:
+                  - strong [ref=e277]: "Band edges:"
+                - paragraph [ref=e278]:
+                  - math [ref=e280]:
+                    - generic [ref=e281]:
+                      - generic [ref=e282]: f
+                      - generic [ref=e283]: "1"
+                    - generic [ref=e284]: =
+                    - generic [ref=e285]:
+                      - generic [ref=e286]: f
+                      - generic [ref=e287]: m
+                    - generic [ref=e288]: ⋅
+                    - generic [ref=e289]:
+                      - generic [ref=e290]: G
+                      - generic [ref=e291]:
+                        - generic [ref=e292]: −
+                        - generic [ref=e293]: "1"
+                        - generic [ref=e295]: /
+                        - generic [ref=e296]: "2"
+                        - generic [ref=e297]: b
+                    - generic [ref=e298]: ","
+                    - generic [ref=e299]:
+                      - generic [ref=e300]: f
+                      - generic [ref=e301]: "2"
+                    - generic [ref=e302]: =
+                    - generic [ref=e303]:
+                      - generic [ref=e304]: f
+                      - generic [ref=e305]: m
+                    - generic [ref=e306]: ⋅
+                    - generic [ref=e307]:
+                      - generic [ref=e308]: G
+                      - generic [ref=e309]:
+                        - generic [ref=e310]: "1"
+                        - generic [ref=e312]: /
+                        - generic [ref=e313]: "2"
+                        - generic [ref=e314]: b
+                - generic [ref=e315]:
+                  - heading "Frequency Resolution vs FFT Bin Spacing" [level=2] [ref=e316]
+                  - 'link "Permalink: Frequency Resolution vs FFT Bin Spacing" [ref=e317] [cursor=pointer]':
+                    - /url: "#frequency-resolution-vs-fft-bin-spacing"
+                    - img [ref=e318]
+                - paragraph [ref=e320]:
+                  - code [ref=e321]: octavefilter
+                  - text: is a
+                  - strong [ref=e322]: time-domain fractional-octave filter bank
+                  - text: ", not an FFT or Welch spectrum estimator. Therefore, its result does not have a frequency resolution in the"
+                  - code [ref=e323]: fs / nfft
+                  - text: sense.
+                - paragraph [ref=e324]:
+                  - text: For
+                  - code [ref=e325]: fraction=3
+                  - text: ", the output contains one scalar level per third-octave band. The relevant frequency granularity is the standardized band definition: center frequency, lower edge, and upper edge. Because fractional-octave bands are logarithmically spaced, their absolute bandwidth in Hz grows with frequency while their relative bandwidth remains approximately constant."
+                - paragraph [ref=e326]:
+                  - text: For example, with
+                  - code [ref=e327]: fraction=3
+                  - text: and
+                  - code [ref=e328]: limits=[12, 20000]
+                  - text: ", the exact third-octave band around 1 kHz is approximately:"
+                - table [ref=e330]:
+                  - rowgroup [ref=e331]:
+                    - row "Nominal band Lower edge Center Upper edge Bandwidth" [ref=e332]:
+                      - columnheader "Nominal band" [ref=e333]
+                      - columnheader "Lower edge" [ref=e334]
+                      - columnheader "Center" [ref=e335]
+                      - columnheader "Upper edge" [ref=e336]
+                      - columnheader "Bandwidth" [ref=e337]
+                  - rowgroup [ref=e338]:
+                    - row "1 kHz 891.25 Hz 1000.00 Hz 1122.02 Hz 230.77 Hz" [ref=e339]:
+                      - cell "1 kHz" [ref=e340]
+                      - cell "891.25 Hz" [ref=e341]
+                      - cell "1000.00 Hz" [ref=e342]
+                      - cell "1122.02 Hz" [ref=e343]
+                      - cell "230.77 Hz" [ref=e344]
+                - paragraph [ref=e345]: "You can inspect the exact bands with:"
+                - generic [ref=e346]:
+                  - generic [ref=e347]: "from phonometry import getansifrequencies fc, fl, fu, labels = getansifrequencies(fraction=3, limits=[12, 20000]) for label, center, lower, upper in zip(labels, fc, fl, fu): print(label, center, lower, upper, upper - lower)"
+                  - button "Copy code to clipboard" [ref=e349] [cursor=pointer]:
+                    - img [ref=e350]
+                - paragraph [ref=e353]: "If you need narrowband FFT bins for tonal inspection, run Welch/FFT on the original signal and use the phonometry band edges as masks:"
+                - generic [ref=e354]:
+                  - generic [ref=e355]: "import numpy as np from scipy import signal from phonometry import octavefilter, getansifrequencies fs = 100_000 x = pressure_signal_pa # 1D pressure signal in Pa # Standardized third-octave levels from phonometry. levels, centers = octavefilter( x, fs=fs, fraction=3, limits=[12, 20_000], ) # Same standardized band definitions, including lower/upper edges. fc, fl, fu, labels = getansifrequencies(fraction=3, limits=[12, 20_000]) # Narrowband Welch estimate on the original signal. nperseg = min(2**15, len(x)) freq_bins, psd = signal.welch( x, fs=fs, window=\"hann\", nperseg=nperseg, noverlap=nperseg // 2, scaling=\"density\", ) # Example: list the Welch bins inside the third-octave band closest to 1 kHz. band_index = int(np.argmin(np.abs(np.asarray(fc) - 1000.0))) in_band = (freq_bins >= fl[band_index]) & (freq_bins <= fu[band_index]) print(\"Selected third-octave band:\", labels[band_index]) print(\"Welch bin spacing:\", freq_bins[1] - freq_bins[0], \"Hz\") for f, pxx in zip(freq_bins[in_band], psd[in_band]): print(f, pxx)"
+                  - button "Copy code to clipboard" [ref=e357] [cursor=pointer]:
+                    - img [ref=e358]
+                - paragraph [ref=e361]:
+                  - text: "This keeps the two concepts separate: phonometry gives standardized fractional-octave levels, while Welch gives narrowband FFT bins. With"
+                  - code [ref=e362]: fs=100000
+                  - text: and
+                  - code [ref=e363]: nperseg=2**15
+                  - text: ", the Welch bin spacing is about"
+                  - code [ref=e364]: 3.05 Hz
+                  - text: . Window choice and overlap affect leakage and averaging variance, but they do not change the bin spacing of each FFT segment.
+                - paragraph [ref=e365]:
+                  - text: When
+                  - code [ref=e366]: sigbands=True
+                  - text: ","
+                  - code [ref=e367]: octavefilter
+                  - text: can also return the time-domain waveform filtered by each band. Applying Welch/FFT to one selected filtered waveform can be useful as a diagnostic view of the content inside that filtered band, but it does not recover FFT bins from the scalar band levels.
+                - generic [ref=e368]:
+                  - heading "Magnitude Responses |H(jw)|" [level=2] [ref=e369]
+                  - 'link "Permalink: Magnitude Responses |H(jw)|" [ref=e370] [cursor=pointer]':
+                    - /url: "#magnitude-responses-hjw"
+                    - img [ref=e371]
+                - paragraph [ref=e373]: "The library implements standard classical filter prototypes:"
+                - paragraph [ref=e374]:
+                  - strong [ref=e375]: "1. Butterworth:"
+                  - text: Maximally flat passband.
+                - paragraph [ref=e376]:
+                  - math [ref=e378]:
+                    - generic [ref=e379]: "|"
+                    - generic [ref=e380]: H
+                    - generic [ref=e381]: (
+                    - generic [ref=e382]: j
+                    - generic [ref=e383]: ω
+                    - generic [ref=e384]: )
+                    - generic [ref=e385]: "|"
+                    - generic [ref=e386]: =
+                    - generic [ref=e387]:
+                      - generic [ref=e388]: "1"
+                      - generic [ref=e389]:
+                        - generic [ref=e390]: "1"
+                        - generic [ref=e391]: +
+                        - generic [ref=e392]: (
+                        - generic [ref=e393]: ω
+                        - generic [ref=e395]: /
+                        - generic [ref=e396]:
+                          - generic [ref=e397]: ω
+                          - generic [ref=e398]: c
+                        - generic [ref=e399]:
+                          - generic [ref=e400]: )
+                          - generic [ref=e401]:
+                            - generic [ref=e402]: "2"
+                            - generic [ref=e403]: "n"
+                - paragraph [ref=e404]:
+                  - strong [ref=e405]: "2. Chebyshev I:"
+                  - text: Equiripple in passband, steeper roll-off.
+                - paragraph [ref=e406]:
+                  - math [ref=e408]:
+                    - generic [ref=e409]: "|"
+                    - generic [ref=e410]: H
+                    - generic [ref=e411]: (
+                    - generic [ref=e412]: j
+                    - generic [ref=e413]: ω
+                    - generic [ref=e414]: )
+                    - generic [ref=e415]: "|"
+                    - generic [ref=e416]: =
+                    - generic [ref=e417]:
+                      - generic [ref=e418]: "1"
+                      - generic [ref=e419]:
+                        - generic [ref=e420]: "1"
+                        - generic [ref=e421]: +
+                        - generic [ref=e422]:
+                          - generic [ref=e423]: ϵ
+                          - generic [ref=e424]: "2"
+                        - generic [ref=e425]:
+                          - generic [ref=e426]: T
+                          - generic [ref=e427]: "n"
+                          - generic [ref=e428]: "2"
+                        - generic [ref=e429]: (
+                        - generic [ref=e430]: ω
+                        - generic [ref=e432]: /
+                        - generic [ref=e433]:
+                          - generic [ref=e434]: ω
+                          - generic [ref=e435]: c
+                        - generic [ref=e436]: )
+                - paragraph [ref=e437]:
+                  - strong [ref=e438]: "3. Chebyshev II:"
+                  - text: Inverse Chebyshev, equiripple in stopband, flat passband.
+                - paragraph [ref=e439]:
+                  - math [ref=e441]:
+                    - generic [ref=e442]: "|"
+                    - generic [ref=e443]: H
+                    - generic [ref=e444]: (
+                    - generic [ref=e445]: j
+                    - generic [ref=e446]: ω
+                    - generic [ref=e447]: )
+                    - generic [ref=e448]: "|"
+                    - generic [ref=e449]: =
+                    - generic [ref=e450]:
+                      - generic [ref=e451]: "1"
+                      - generic [ref=e452]:
+                        - generic [ref=e453]: "1"
+                        - generic [ref=e454]: +
+                        - generic [ref=e455]:
+                          - generic [ref=e456]: "1"
+                          - generic [ref=e457]:
+                            - generic [ref=e458]:
+                              - generic [ref=e459]: ϵ
+                              - generic [ref=e460]: "2"
+                            - generic [ref=e461]:
+                              - generic [ref=e462]: T
+                              - generic [ref=e463]: "n"
+                              - generic [ref=e464]: "2"
+                            - generic [ref=e465]: (
+                            - generic [ref=e466]:
+                              - generic [ref=e467]: ω
+                              - generic [ref=e468]:
+                                - generic [ref=e469]: s
+                                - generic [ref=e470]: t
+                                - generic [ref=e471]: o
+                                - generic [ref=e472]: p
+                            - generic [ref=e474]: /
+                            - generic [ref=e475]: ω
+                            - generic [ref=e476]: )
+                - paragraph [ref=e477]:
+                  - strong [ref=e478]: "4. Elliptic:"
+                  - text: Equiripple in both, maximum selectivity.
+                - paragraph [ref=e479]:
+                  - math [ref=e481]:
+                    - generic [ref=e482]: "|"
+                    - generic [ref=e483]: H
+                    - generic [ref=e484]: (
+                    - generic [ref=e485]: j
+                    - generic [ref=e486]: ω
+                    - generic [ref=e487]: )
+                    - generic [ref=e488]: "|"
+                    - generic [ref=e489]: =
+                    - generic [ref=e490]:
+                      - generic [ref=e491]: "1"
+                      - generic [ref=e492]:
+                        - generic [ref=e493]: "1"
+                        - generic [ref=e494]: +
+                        - generic [ref=e495]:
+                          - generic [ref=e496]: ϵ
+                          - generic [ref=e497]: "2"
+                        - generic [ref=e498]:
+                          - generic [ref=e499]: R
+                          - generic [ref=e500]: "n"
+                          - generic [ref=e501]: "2"
+                        - generic [ref=e502]: (
+                        - generic [ref=e503]: ω
+                        - generic [ref=e505]: /
+                        - generic [ref=e506]:
+                          - generic [ref=e507]: ω
+                          - generic [ref=e508]: c
+                        - generic [ref=e509]: ","
+                        - generic [ref=e510]: L
+                        - generic [ref=e511]: )
+                - paragraph [ref=e512]:
+                  - strong [ref=e513]: "5. Bessel:"
+                  - text: Maximally flat group delay (linear phase).
+                - paragraph [ref=e514]:
+                  - math [ref=e516]:
+                    - generic [ref=e517]: H
+                    - generic [ref=e518]: (
+                    - generic [ref=e519]: s
+                    - generic [ref=e520]: )
+                    - generic [ref=e521]: =
+                    - generic [ref=e522]:
+                      - generic [ref=e523]:
+                        - generic [ref=e524]:
+                          - generic [ref=e525]: θ
+                          - generic [ref=e526]: "n"
+                        - generic [ref=e527]: (
+                        - generic [ref=e528]: "0"
+                        - generic [ref=e529]: )
+                      - generic [ref=e530]:
+                        - generic [ref=e531]:
+                          - generic [ref=e532]: θ
+                          - generic [ref=e533]: "n"
+                        - generic [ref=e534]: (
+                        - generic [ref=e535]: s
+                        - generic [ref=e537]: /
+                        - generic [ref=e538]:
+                          - generic [ref=e539]: ω
+                          - generic [ref=e540]: "0"
+                        - generic [ref=e541]: )
+                - paragraph [ref=e542]:
+                  - text: (Where
+                  - math [ref=e544]:
+                    - generic [ref=e545]:
+                      - generic [ref=e546]: θ
+                      - generic [ref=e547]: "n"
+                  - text: is the reverse Bessel polynomial)
+                - generic [ref=e548]:
+                  - heading "Band-edge placement" [level=3] [ref=e549]
+                  - 'link "Permalink: Band-edge placement" [ref=e550] [cursor=pointer]':
+                    - /url: "#band-edge-placement"
+                    - img [ref=e551]
+                - paragraph [ref=e553]:
+                  - text: For every architecture the bank places the
+                  - strong [ref=e554]: −3 dB points on the band edges
+                  - text: ". Two cases need special handling:"
+                - list [ref=e555]:
+                  - listitem [ref=e556]:
+                    - strong [ref=e557]: Chebyshev II
+                    - text: ": scipy's"
+                    - code [ref=e558]: Wn
+                    - text: is the
+                    - emphasis [ref=e559]: stopband
+                    - text: edge. phonometry maps the desired −3 dB edges to stopband edges analytically — the prototype transition ratio is
+                    - generic [ref=e560]:
+                      - generic [ref=e561]: "The following macros are not allowed: operatorname"
+                      - generic [ref=e562]: "$\\cosh(\\operatorname{acosh}(\\sqrt{10^{A/10}-1})/N)$"
+                    - text: — applying the lowpass→bandpass transform in the pre-warped bilinear domain so the mapping stays exact for decimated bands close to Nyquist.
+                  - listitem [ref=e563]:
+                    - strong [ref=e564]: Bessel
+                    - text: ": designed with"
+                    - code [ref=e565]: norm="mag"
+                    - text: ", which defines the −3 dB point exactly at"
+                    - code [ref=e566]: Wn
+                    - text: (the
+                    - code [ref=e567]: phase
+                    - text: norm would shift the edges to roughly −10 dB).
+                - generic [ref=e568]:
+                  - heading "Filter Bank Design & Numerical Stability" [level=2] [ref=e569]
+                  - 'link "Permalink: Filter Bank Design & Numerical Stability" [ref=e570] [cursor=pointer]':
+                    - /url: "#filter-bank-design--numerical-stability"
+                    - img [ref=e571]
+                - paragraph [ref=e573]:
+                  - text: To ensure
+                  - strong [ref=e574]: 100% stability
+                  - text: "across the entire audible spectrum (even at low frequencies like 16 Hz with high sample rates), phonometry employs two critical strategies:"
+                - region "mermaid rendered output container" [ref=e575]:
+                  - generic [ref=e576]:
+                    - generic [ref=e577]:
+                      - group [ref=e578]:
+                        - button "Open dialog" [ref=e579] [cursor=pointer]:
+                          - img [ref=e580]
+                      - button "Copy mermaid code" [ref=e582] [cursor=pointer]:
+                        - img [ref=e583]
+                    - iframe [ref=e587]:
+                      - generic [active] [ref=f1e1]:
+                        - img [ref=f1e6]
+                        - generic [ref=f1e7]:
+                          - button "Zoom in" [ref=f1e8] [cursor=pointer]:
+                            - img [ref=f1e9]
+                          - button "Zoom out" [ref=f1e12] [cursor=pointer]:
+                            - img [ref=f1e13]
+                          - button "Reset view" [ref=f1e16] [cursor=pointer]:
+                            - img [ref=f1e17]
+                          - button "Pan up" [ref=f1e19] [cursor=pointer]:
+                            - img [ref=f1e20]
+                          - button "Pan down" [ref=f1e22] [cursor=pointer]:
+                            - img [ref=f1e23]
+                          - button "Pan left" [ref=f1e25] [cursor=pointer]:
+                            - img [ref=f1e26]
+                          - button "Pan right" [ref=f1e28] [cursor=pointer]:
+                            - img [ref=f1e29]
+                  - generic [ref=e588]:
+                    - img [ref=e589]
+                    - generic [ref=e592]: Loading
+                - list [ref=e593]:
+                  - listitem [ref=e594]:
+                    - strong [ref=e595]: "Second-Order Sections (SOS):"
+                    - text: All filters are implemented as a series of cascaded biquads. This avoids the catastrophic numerical precision loss associated with high-order transfer functions (coefficients a, b).
+                  - listitem [ref=e596]:
+                    - strong [ref=e597]: "Multi-rate Decimation:"
+                    - text: For low-frequency bands, the signal is automatically downsampled (decimated) before filtering and upsampled afterwards. This keeps the digital pole locations far from the unit circle boundary, preventing oscillation and noise. Chebyshev II banks reserve extra decimation headroom so their stopband edges stay below the decimated Nyquist.
+                - generic [ref=e598]:
+                  - heading "Weighting Curves (IEC 61672-1)" [level=2] [ref=e599]
+                  - 'link "Permalink: Weighting Curves (IEC 61672-1)" [ref=e600] [cursor=pointer]':
+                    - /url: "#weighting-curves-iec-61672-1"
+                    - img [ref=e601]
+                - paragraph [ref=e603]: "The A-weighting transfer function:"
+                - paragraph [ref=e604]:
+                  - math [ref=e606]:
+                    - generic [ref=e607]:
+                      - generic [ref=e608]: R
+                      - generic [ref=e609]: A
+                    - generic [ref=e610]: (
+                    - generic [ref=e611]: f
+                    - generic [ref=e612]: )
+                    - generic [ref=e613]: =
+                    - generic [ref=e614]:
+                      - generic [ref=e615]:
+                        - generic [ref=e616]:
+                          - generic [ref=e617]: "12194"
+                          - generic [ref=e618]: "2"
+                        - generic [ref=e619]: ⋅
+                        - generic [ref=e620]:
+                          - generic [ref=e621]: f
+                          - generic [ref=e622]: "4"
+                      - generic [ref=e623]:
+                        - generic [ref=e624]: (
+                        - generic [ref=e625]:
+                          - generic [ref=e626]: f
+                          - generic [ref=e627]: "2"
+                        - generic [ref=e628]: +
+                        - generic [ref=e629]:
+                          - generic [ref=e630]: "20.6"
+                          - generic [ref=e631]: "2"
+                        - generic [ref=e632]: )
+                        - generic [ref=e633]:
+                          - generic [ref=e634]: (
+                          - generic [ref=e635]:
+                            - generic [ref=e636]: f
+                            - generic [ref=e637]: "2"
+                          - generic [ref=e638]: +
+                          - generic [ref=e639]:
+                            - generic [ref=e640]: "107.7"
+                            - generic [ref=e641]: "2"
+                          - generic [ref=e642]: )
+                          - generic [ref=e643]: (
+                          - generic [ref=e644]:
+                            - generic [ref=e645]: f
+                            - generic [ref=e646]: "2"
+                          - generic [ref=e647]: +
+                          - generic [ref=e648]:
+                            - generic [ref=e649]: "737.9"
+                            - generic [ref=e650]: "2"
+                          - generic [ref=e651]: )
+                        - generic [ref=e652]: (
+                        - generic [ref=e653]:
+                          - generic [ref=e654]: f
+                          - generic [ref=e655]: "2"
+                        - generic [ref=e656]: +
+                        - generic [ref=e657]:
+                          - generic [ref=e658]: "12194"
+                          - generic [ref=e659]: "2"
+                        - generic [ref=e660]: )
+                - paragraph [ref=e661]:
+                  - math [ref=e663]:
+                    - generic [ref=e664]: A
+                    - generic [ref=e665]: (
+                    - generic [ref=e666]: f
+                    - generic [ref=e667]: )
+                    - generic [ref=e668]: =
+                    - generic [ref=e669]: "20"
+                    - generic [ref=e670]:
+                      - generic [ref=e671]: log
+                      - generic [ref=e673]: "10"
+                    - generic: ⁡
+                    - generic [ref=e674]: (
+                    - generic [ref=e675]:
+                      - generic [ref=e676]: R
+                      - generic [ref=e677]: A
+                    - generic [ref=e678]: (
+                    - generic [ref=e679]: f
+                    - generic [ref=e680]: )
+                    - generic [ref=e681]: )
+                    - generic [ref=e682]: +
+                    - generic [ref=e683]: "2.00"
+                - paragraph [ref=e684]:
+                  - text: The digital filter is obtained from the analog poles/zeros via the bilinear transform. Because the bilinear transform compresses frequencies near Nyquist, the default
+                  - code [ref=e685]: high_accuracy
+                  - text: mode designs and runs the filter at an internally oversampled rate (≥ 96 kHz) — see
+                  - link "Frequency Weighting" [ref=e686] [cursor=pointer]:
+                    - /url: /jmrplens/phonometry/blob/main/docs/weighting.md
+                  - text: .
+                - generic [ref=e687]:
+                  - heading "Time Integration" [level=2] [ref=e688]
+                  - 'link "Permalink: Time Integration" [ref=e689] [cursor=pointer]':
+                    - /url: "#time-integration"
+                    - img [ref=e690]
+                - paragraph [ref=e692]: "Implemented as a first-order IIR exponential integrator:"
+                - paragraph [ref=e693]:
+                  - math [ref=e695]:
+                    - generic [ref=e696]: "y"
+                    - generic [ref=e697]: "["
+                    - generic [ref=e698]: "n"
+                    - generic [ref=e699]: "]"
+                    - generic [ref=e700]: =
+                    - generic [ref=e701]: α
+                    - generic [ref=e702]: ⋅
+                    - generic [ref=e703]:
+                      - generic [ref=e704]: x
+                      - generic [ref=e705]: "2"
+                    - generic [ref=e706]: "["
+                    - generic [ref=e707]: "n"
+                    - generic [ref=e708]: "]"
+                    - generic [ref=e709]: +
+                    - generic [ref=e710]: (
+                    - generic [ref=e711]: "1"
+                    - generic [ref=e712]: −
+                    - generic [ref=e713]: α
+                    - generic [ref=e714]: )
+                    - generic [ref=e715]: ⋅
+                    - generic [ref=e716]: "y"
+                    - generic [ref=e717]: "["
+                    - generic [ref=e718]: "n"
+                    - generic [ref=e719]: −
+                    - generic [ref=e720]: "1"
+                    - generic [ref=e721]: "]"
+                - paragraph [ref=e722]:
+                  - math [ref=e724]:
+                    - generic [ref=e725]: α
+                    - generic [ref=e726]: =
+                    - generic [ref=e727]: "1"
+                    - generic [ref=e728]: −
+                    - generic [ref=e729]:
+                      - generic [ref=e730]: e
+                      - generic [ref=e731]:
+                        - generic [ref=e732]: −
+                        - generic [ref=e733]: "1"
+                        - generic [ref=e735]: /
+                        - generic [ref=e736]: (
+                        - generic [ref=e737]:
+                          - generic [ref=e738]: f
+                          - generic [ref=e739]: s
+                        - generic [ref=e740]: ⋅
+                        - generic [ref=e741]: τ
+                        - generic [ref=e742]: )
+                - paragraph [ref=e743]:
+                  - text: Where
+                  - code [ref=e744]: tau
+                  - text: is the time constant (e.g., 125 ms for Fast).
+                - paragraph [ref=e745]:
+                  - text: The default initial condition is
+                  - code [ref=e746]: y[-1] = 0
+                  - text: . Use
+                  - code [ref=e747]: initial_state='first'
+                  - text: to start from the first input energy, or pass a scalar/array with the previous mean-square output state. See
+                  - link "Why phonometry" [ref=e748] [cursor=pointer]:
+                    - /url: /jmrplens/phonometry/blob/main/docs/why-phonometry.md
+                  - text: for the IEC 61672-1 tone-burst verification of this implementation.
+                - generic [ref=e749]:
+                  - heading "G-weighting (ISO 7196)" [level=2] [ref=e750]
+                  - 'link "Permalink: G-weighting (ISO 7196)" [ref=e751] [cursor=pointer]':
+                    - /url: "#g-weighting-iso-7196"
+                    - img [ref=e752]
+                - paragraph [ref=e754]:
+                  - text: The G curve extends frequency weighting into the infrasound range. ISO 7196:1995 Table 1 (p. 2) defines it by four zeros at the origin and four complex-conjugate pole pairs, given as coordinates in Hz (multiplied by
+                  - math [ref=e756]:
+                    - generic [ref=e757]: "2"
+                    - generic [ref=e758]: π
+                  - text: "to obtain rad/s):"
+                - paragraph [ref=e759]:
+                  - generic [ref=e760]:
+                    - generic [ref=e761]: Missing or unrecognized delimiter for \left
+                    - generic [ref=e762]: "$$ z_{1..4} = 0, \\qquad p = 2\\pi \\left{ -0.707 \\pm j0.707,; -19.27 \\pm j5.16,; -14.11 \\pm j14.11,; -5.16 \\pm j19.27 \\right} \\ \\text{Hz} $$"
+                - paragraph [ref=e763]:
+                  - text: The gain
+                  - math [ref=e765]:
+                    - generic [ref=e766]: k
+                  - text: is chosen so that the response is exactly
+                  - strong [ref=e767]: 0 dB at 10 Hz
+                  - text: "(clause 4):"
+                - paragraph [ref=e768]:
+                  - math [ref=e770]:
+                    - generic [ref=e771]: k
+                    - generic [ref=e772]: =
+                    - generic [ref=e773]:
+                      - generic [ref=e774]: "|"
+                      - generic [ref=e775]:
+                        - generic [ref=e776]:
+                          - generic [ref=e777]:
+                            - generic [ref=e778]: ∏
+                            - generic [ref=e779]: i
+                          - generic [ref=e780]: (
+                          - generic [ref=e781]: j
+                          - generic [ref=e782]:
+                            - generic [ref=e783]: ω
+                            - generic [ref=e785]: "10"
+                          - generic [ref=e786]: −
+                          - generic [ref=e787]:
+                            - generic [ref=e788]: p
+                            - generic [ref=e789]: i
+                          - generic [ref=e790]: )
+                        - generic [ref=e791]:
+                          - generic [ref=e792]:
+                            - generic [ref=e793]: ∏
+                            - generic [ref=e794]: i
+                          - generic [ref=e795]: (
+                          - generic [ref=e796]: j
+                          - generic [ref=e797]:
+                            - generic [ref=e798]: ω
+                            - generic [ref=e800]: "10"
+                          - generic [ref=e801]: −
+                          - generic [ref=e802]:
+                            - generic [ref=e803]: z
+                            - generic [ref=e804]: i
+                          - generic [ref=e805]: )
+                      - generic [ref=e806]: "|"
+                    - generic [ref=e807]: ","
+                    - generic [ref=e808]:
+                      - generic [ref=e809]: ω
+                      - generic [ref=e811]: "10"
+                    - generic [ref=e812]: =
+                    - generic [ref=e813]: "2"
+                    - generic [ref=e814]: π
+                    - generic [ref=e815]: ⋅
+                    - generic [ref=e816]: "10"
+                    - generic [ref=e817]: rad/s
+                - paragraph [ref=e818]:
+                  - text: "The four zeros against eight poles shape the characteristic response: a rise of approximately"
+                  - strong [ref=e819]: +12 dB/octave between 1 Hz and 20 Hz
+                  - text: ", with roll-offs of approximately"
+                  - strong [ref=e820]: 24 dB/octave
+                  - text: below 1 Hz and above 20 Hz. Infrasound needs its own curve because near the hearing threshold the perceived loudness of very-low-frequency tones grows much more steeply with sound pressure level than at mid frequencies — a small dB increase above threshold produces a large loudness jump — so the A curve (anchored at 1 kHz) grossly misrepresents infrasonic annoyance.
+                - paragraph [ref=e821]: Since G acts on 0.25 Hz – 315 Hz, the plain bilinear transform is already exact there and the internal oversampling used for the A/C designs (whose action extends to 16 kHz) is not applied.
+                - paragraph [ref=e822]:
+                  - text: See the
+                  - link "Frequency Weighting guide" [ref=e823] [cursor=pointer]:
+                    - /url: /jmrplens/phonometry/blob/main/docs/weighting.md
+                  - text: for usage.
+                - generic [ref=e824]:
+                  - heading "Equal-loudness contours (ISO 226:2023)" [level=2] [ref=e825]
+                  - 'link "Permalink: Equal-loudness contours (ISO 226:2023)" [ref=e826] [cursor=pointer]':
+                    - /url: "#equal-loudness-contours-iso-2262023"
+                    - img [ref=e827]
+                - paragraph [ref=e829]:
+                  - text: A tone has a
+                  - emphasis [ref=e830]: loudness level
+                  - text: of
+                  - math [ref=e832]:
+                    - generic [ref=e833]:
+                      - generic [ref=e834]: L
+                      - generic [ref=e835]: "N"
+                  - text: phon when it is judged equally loud as a 1 kHz pure tone at
+                  - math [ref=e837]:
+                    - generic [ref=e838]:
+                      - generic [ref=e839]: L
+                      - generic [ref=e840]: "N"
+                  - text: dB SPL. ISO 226:2023 Formula (1) (clause 4.1, p. 2) gives the SPL of a pure tone at frequency
+                  - math [ref=e842]:
+                    - generic [ref=e843]: f
+                  - text: that reaches loudness level
+                  - math [ref=e845]:
+                    - generic [ref=e846]:
+                      - generic [ref=e847]: L
+                      - generic [ref=e848]: "N"
+                  - text: ":"
+                - paragraph [ref=e849]:
+                  - math [ref=e851]:
+                    - generic [ref=e852]:
+                      - generic [ref=e853]: L
+                      - generic [ref=e854]: f
+                    - generic [ref=e855]: =
+                    - generic [ref=e856]:
+                      - generic [ref=e857]: "10"
+                      - generic [ref=e858]:
+                        - generic [ref=e859]: α
+                        - generic [ref=e860]: f
+                    - generic [ref=e861]:
+                      - generic [ref=e862]: log
+                      - generic [ref=e864]: "10"
+                    - generic [ref=e865]: "!"
+                    - generic [ref=e866]:
+                      - generic [ref=e867]: "["
+                      - generic [ref=e868]:
+                        - generic [ref=e869]:
+                          - generic [ref=e870]: (
+                          - generic [ref=e871]: "4"
+                          - generic [ref=e872]: ⋅
+                          - generic [ref=e873]:
+                            - generic [ref=e874]: "10"
+                            - generic [ref=e875]:
+                              - generic [ref=e876]: −
+                              - generic [ref=e877]: "10"
+                          - generic [ref=e878]: )
+                        - generic [ref=e879]:
+                          - generic [ref=e880]: "0.3"
+                          - generic [ref=e881]: −
+                          - generic [ref=e882]:
+                            - generic [ref=e883]: α
+                            - generic [ref=e884]: f
+                      - generic [ref=e885]:
+                        - generic [ref=e886]: (
+                        - generic [ref=e887]:
+                          - generic [ref=e888]: "10"
+                          - generic [ref=e889]:
+                            - generic [ref=e890]: ","
+                            - generic [ref=e891]: "0.03"
+                            - generic [ref=e892]:
+                              - generic [ref=e893]: L
+                              - generic [ref=e894]: "N"
+                        - generic [ref=e895]: −
+                        - generic [ref=e896]:
+                          - generic [ref=e897]: "10"
+                          - generic [ref=e898]:
+                            - generic [ref=e899]: ","
+                            - generic [ref=e900]: "0.072"
+                        - generic [ref=e901]: )
+                      - generic [ref=e902]: +
+                      - generic [ref=e903]:
+                        - generic [ref=e904]: "10"
+                        - generic [ref=e905]:
+                          - generic [ref=e906]: ","
+                          - generic [ref=e907]:
+                            - generic [ref=e908]: α
+                            - generic [ref=e909]: f
+                          - generic [ref=e910]: (
+                          - generic [ref=e911]:
+                            - generic [ref=e912]: T
+                            - generic [ref=e913]: f
+                          - generic [ref=e914]: +
+                          - generic [ref=e915]:
+                            - generic [ref=e916]: L
+                            - generic [ref=e917]: U
+                          - generic [ref=e918]: )
+                          - generic [ref=e920]: /
+                          - generic [ref=e921]: "10"
+                      - generic [ref=e922]: "]"
+                    - generic [ref=e923]: −
+                    - generic [ref=e924]:
+                      - generic [ref=e925]: L
+                      - generic [ref=e926]: U
+                - paragraph [ref=e927]:
+                  - text: Formula (2) (clause 4.2) inverts it, returning the loudness level of a tone at SPL
+                  - math [ref=e929]:
+                    - generic [ref=e930]:
+                      - generic [ref=e931]: L
+                      - generic [ref=e932]: f
+                  - text: ":"
+                - paragraph [ref=e933]:
+                  - math [ref=e935]:
+                    - generic [ref=e936]:
+                      - generic [ref=e937]: L
+                      - generic [ref=e938]: "N"
+                    - generic [ref=e939]: =
+                    - generic [ref=e940]:
+                      - generic [ref=e941]: "100"
+                      - generic [ref=e942]: "3"
+                    - generic [ref=e943]:
+                      - generic [ref=e944]: log
+                      - generic [ref=e946]: "10"
+                    - generic [ref=e947]: "!"
+                    - generic [ref=e948]:
+                      - generic [ref=e949]: "["
+                      - generic [ref=e950]:
+                        - generic [ref=e951]:
+                          - generic [ref=e952]:
+                            - generic [ref=e953]: "10"
+                            - generic [ref=e954]:
+                              - generic [ref=e955]: ","
+                              - generic [ref=e956]:
+                                - generic [ref=e957]: α
+                                - generic [ref=e958]: f
+                              - generic [ref=e959]: (
+                              - generic [ref=e960]:
+                                - generic [ref=e961]: L
+                                - generic [ref=e962]: f
+                              - generic [ref=e963]: +
+                              - generic [ref=e964]:
+                                - generic [ref=e965]: L
+                                - generic [ref=e966]: U
+                              - generic [ref=e967]: )
+                              - generic [ref=e969]: /
+                              - generic [ref=e970]: "10"
+                          - generic [ref=e971]: −
+                          - generic [ref=e972]:
+                            - generic [ref=e973]: "10"
+                            - generic [ref=e974]:
+                              - generic [ref=e975]: ","
+                              - generic [ref=e976]:
+                                - generic [ref=e977]: α
+                                - generic [ref=e978]: f
+                              - generic [ref=e979]: (
+                              - generic [ref=e980]:
+                                - generic [ref=e981]: T
+                                - generic [ref=e982]: f
+                              - generic [ref=e983]: +
+                              - generic [ref=e984]:
+                                - generic [ref=e985]: L
+                                - generic [ref=e986]: U
+                              - generic [ref=e987]: )
+                              - generic [ref=e989]: /
+                              - generic [ref=e990]: "10"
+                        - generic [ref=e991]:
+                          - generic [ref=e992]:
+                            - generic [ref=e993]: (
+                            - generic [ref=e994]: "4"
+                            - generic [ref=e995]: ⋅
+                            - generic [ref=e996]:
+                              - generic [ref=e997]: "10"
+                              - generic [ref=e998]:
+                                - generic [ref=e999]: −
+                                - generic [ref=e1000]: "10"
+                            - generic [ref=e1001]: )
+                          - generic [ref=e1002]:
+                            - generic [ref=e1003]: "0.3"
+                            - generic [ref=e1004]: −
+                            - generic [ref=e1005]:
+                              - generic [ref=e1006]: α
+                              - generic [ref=e1007]: f
+                      - generic [ref=e1008]: +
+                      - generic [ref=e1009]:
+                        - generic [ref=e1010]: "10"
+                        - generic [ref=e1011]:
+                          - generic [ref=e1012]: ","
+                          - generic [ref=e1013]: "0.072"
+                      - generic [ref=e1014]: "]"
+                - paragraph [ref=e1015]: "The three parameters come from Table 1 (p. 4), tabulated at the 29 preferred third-octave frequencies of ISO 266 from 20 Hz to 12.5 kHz:"
+                - list [ref=e1016]:
+                  - listitem [ref=e1017]:
+                    - math [ref=e1019]:
+                      - generic [ref=e1020]:
+                        - generic [ref=e1021]: α
+                        - generic [ref=e1022]: f
+                    - text: — exponent for loudness perception at frequency
+                    - math [ref=e1024]:
+                      - generic [ref=e1025]: f
+                    - text: ","
+                  - listitem [ref=e1026]:
+                    - math [ref=e1028]:
+                      - generic [ref=e1029]:
+                        - generic [ref=e1030]: L
+                        - generic [ref=e1031]: U
+                    - text: — magnitude of the linear transfer function, normalized at 1 kHz (
+                    - math [ref=e1033]:
+                      - generic [ref=e1034]:
+                        - generic [ref=e1035]: L
+                        - generic [ref=e1036]: U
+                      - generic [ref=e1037]: =
+                      - generic [ref=e1038]: "0"
+                    - text: at 1 kHz),
+                  - listitem [ref=e1039]:
+                    - math [ref=e1041]:
+                      - generic [ref=e1042]:
+                        - generic [ref=e1043]: T
+                        - generic [ref=e1044]: f
+                    - text: — threshold of hearing at
+                    - math [ref=e1046]:
+                      - generic [ref=e1047]: f
+                    - text: ", in dB."
+                - paragraph [ref=e1048]:
+                  - text: The standard specifies
+                  - strong [ref=e1049]: no interpolation
+                  - text: between the tabulated frequencies. Formula (1) is specified for
+                  - strong [ref=e1050]: 20 phon to 90 phon
+                  - text: between 20 Hz and 4 kHz, and only up to
+                  - strong [ref=e1051]: 80 phon between 5 kHz and 12.5 kHz
+                  - text: — above 80 phon the contour therefore stops at 4 kHz. Values outside these limits from Formula (2) are extrapolations the standard labels as informative only.
+                - paragraph [ref=e1052]:
+                  - text: See the
+                  - link "Levels guide" [ref=e1053] [cursor=pointer]:
+                    - /url: /jmrplens/phonometry/blob/main/docs/levels.md
+                  - text: for usage.
+                - generic [ref=e1054]:
+                  - 'heading "Tone prominence: TNR and PR (ECMA-418-1)" [level=2] [ref=e1055]'
+                  - 'link "Permalink: Tone prominence: TNR and PR (ECMA-418-1)" [ref=e1056] [cursor=pointer]':
+                    - /url: "#tone-prominence-tnr-and-pr-ecma-418-1"
+                    - img [ref=e1057]
+                - paragraph [ref=e1059]:
+                  - text: Both methods operate on a Hann-windowed, RMS-averaged power spectrum (clauses 11.1 / 12.1) and use the clause 10 critical-band model. The critical bandwidth centred on a tone at
+                  - math [ref=e1061]:
+                    - generic [ref=e1062]: f
+                  - text: "is (Formula 2):"
+                - paragraph [ref=e1063]:
+                  - math [ref=e1065]:
+                    - generic [ref=e1066]: Δ
+                    - generic [ref=e1067]:
+                      - generic [ref=e1068]: f
+                      - generic [ref=e1069]: c
+                    - generic [ref=e1070]: =
+                    - generic [ref=e1071]: "25.0"
+                    - generic [ref=e1072]: +
+                    - generic [ref=e1073]: "75.0"
+                    - generic [ref=e1074]:
+                      - generic [ref=e1075]:
+                        - generic [ref=e1076]: (
+                        - generic [ref=e1077]: "1.0"
+                        - generic [ref=e1078]: +
+                        - generic [ref=e1079]: "1.4"
+                        - generic [ref=e1080]:
+                          - generic [ref=e1081]:
+                            - generic [ref=e1082]: (
+                            - generic [ref=e1084]:
+                              - generic [ref=e1085]: f
+                              - generic [ref=e1086]: "1000"
+                            - generic [ref=e1087]: )
+                          - generic [ref=e1088]: "2"
+                        - generic [ref=e1089]: )
+                      - generic [ref=e1091]: "0.69"
+                    - generic [ref=e1092]: Hz
+                - paragraph [ref=e1093]:
+                  - text: Band edges are placed
+                  - strong [ref=e1094]: arithmetically
+                  - text: for
+                  - math [ref=e1096]:
+                    - generic [ref=e1097]: f
+                    - generic [ref=e1098]: ≤
+                    - generic [ref=e1099]: "500"
+                  - text: "Hz (Formulae 4–5):"
+                  - math [ref=e1101]:
+                    - generic [ref=e1102]:
+                      - generic [ref=e1103]: f
+                      - generic [ref=e1104]:
+                        - generic [ref=e1105]: "1"
+                        - generic [ref=e1106]: ","
+                        - generic [ref=e1107]: "2"
+                    - generic [ref=e1108]: =
+                    - generic [ref=e1109]: f
+                    - generic [ref=e1110]: ∓
+                    - generic [ref=e1111]: Δ
+                    - generic [ref=e1112]:
+                      - generic [ref=e1113]: f
+                      - generic [ref=e1114]: c
+                    - generic [ref=e1116]: /
+                    - generic [ref=e1117]: "2"
+                  - text: ", and"
+                  - strong [ref=e1118]: geometrically
+                  - text: "above (Formulae 7–8):"
+                  - math [ref=e1120]:
+                    - generic [ref=e1121]:
+                      - generic [ref=e1122]: f
+                      - generic [ref=e1123]: "1"
+                    - generic [ref=e1124]: =
+                    - generic [ref=e1125]: −
+                    - generic [ref=e1126]: Δ
+                    - generic [ref=e1127]:
+                      - generic [ref=e1128]: f
+                      - generic [ref=e1129]: c
+                    - generic [ref=e1131]: /
+                    - generic [ref=e1132]: "2"
+                    - generic [ref=e1133]: +
+                    - generic [ref=e1134]:
+                      - generic [ref=e1135]: Δ
+                      - generic [ref=e1136]:
+                        - generic [ref=e1137]: f
+                        - generic [ref=e1138]: c
+                        - generic [ref=e1139]: "2"
+                      - generic [ref=e1140]: +
+                      - generic [ref=e1141]: "4"
+                      - generic [ref=e1142]:
+                        - generic [ref=e1143]: f
+                        - generic [ref=e1144]: "2"
+                    - generic [ref=e1146]: /
+                    - generic [ref=e1147]: "2"
+                  - text: ","
+                  - math [ref=e1149]:
+                    - generic [ref=e1150]:
+                      - generic [ref=e1151]: f
+                      - generic [ref=e1152]: "2"
+                    - generic [ref=e1153]: =
+                    - generic [ref=e1154]:
+                      - generic [ref=e1155]: f
+                      - generic [ref=e1156]: "1"
+                    - generic [ref=e1157]: +
+                    - generic [ref=e1158]: Δ
+                    - generic [ref=e1159]:
+                      - generic [ref=e1160]: f
+                      - generic [ref=e1161]: c
+                  - text: .
+                - paragraph [ref=e1162]:
+                  - strong [ref=e1163]: TNR
+                  - text: (clause 11). The tone band spans the spectral minima on both sides of the peak within 15 % of
+                  - math [ref=e1165]:
+                    - generic [ref=e1166]: Δ
+                    - generic [ref=e1167]:
+                      - generic [ref=e1168]: f
+                      - generic [ref=e1169]: c
+                  - text: "(clause 11.2). The tone power subtracts the straight line connecting the band-edge bins (Formula 9): over"
+                  - math [ref=e1171]:
+                    - generic [ref=e1172]: "N"
+                  - text: tone-band bins,
+                  - math [ref=e1174]:
+                    - generic [ref=e1175]:
+                      - generic [ref=e1176]: P
+                      - generic [ref=e1177]: t
+                    - generic [ref=e1178]: =
+                    - generic [ref=e1179]:
+                      - generic [ref=e1180]: ∑
+                      - generic [ref=e1181]: k
+                    - generic [ref=e1182]:
+                      - generic [ref=e1183]: P
+                      - generic [ref=e1184]: k
+                    - generic [ref=e1185]: −
+                    - generic [ref=e1186]: (
+                    - generic [ref=e1187]:
+                      - generic [ref=e1188]: P
+                      - generic [ref=e1190]: lo
+                    - generic [ref=e1191]: +
+                    - generic [ref=e1192]:
+                      - generic [ref=e1193]: P
+                      - generic [ref=e1195]: hi
+                    - generic [ref=e1196]: )
+                    - generic [ref=e1197]: ","
+                    - generic [ref=e1198]: "N"
+                    - generic [ref=e1200]: /
+                    - generic [ref=e1201]: "2"
+                  - text: ". The masking-noise power is the remaining critical-band power rescaled to the full critical bandwidth (Formula 10):"
+                  - math [ref=e1203]:
+                    - generic [ref=e1204]:
+                      - generic [ref=e1205]: P
+                      - generic [ref=e1206]: "n"
+                    - generic [ref=e1207]: =
+                    - generic [ref=e1208]: (
+                    - generic [ref=e1209]:
+                      - generic [ref=e1210]: P
+                      - generic [ref=e1212]: band
+                    - generic [ref=e1213]: −
+                    - generic [ref=e1214]:
+                      - generic [ref=e1215]: P
+                      - generic [ref=e1216]: t
+                    - generic [ref=e1217]: )
+                    - generic [ref=e1218]: ⋅
+                    - generic [ref=e1219]: Δ
+                    - generic [ref=e1220]:
+                      - generic [ref=e1221]: f
+                      - generic [ref=e1222]: c
+                    - generic [ref=e1224]: /
+                    - generic [ref=e1225]: Δ
+                    - generic [ref=e1226]:
+                      - generic [ref=e1227]: f
+                      - generic [ref=e1229]: band
+                  - text: ", and"
+                  - math [ref=e1231]:
+                    - generic [ref=e1233]: TNR
+                    - generic [ref=e1234]: =
+                    - generic [ref=e1235]: "10"
+                    - generic [ref=e1236]:
+                      - generic [ref=e1237]: log
+                      - generic [ref=e1239]: "10"
+                    - generic: ⁡
+                    - generic [ref=e1240]: (
+                    - generic [ref=e1241]:
+                      - generic [ref=e1242]: P
+                      - generic [ref=e1243]: t
+                    - generic [ref=e1245]: /
+                    - generic [ref=e1246]:
+                      - generic [ref=e1247]: P
+                      - generic [ref=e1248]: "n"
+                    - generic [ref=e1249]: )
+                  - text: (Formula 11). The prominence criterion (Formulae 12–13) is
+                - paragraph [ref=e1250]:
+                  - math [ref=e1252]:
+                    - generic [ref=e1253]:
+                      - generic [ref=e1255]: TNR
+                      - generic [ref=e1257]: crit
+                    - generic [ref=e1258]: =
+                    - generic [ref=e1259]:
+                      - generic [ref=e1260]: "{"
+                      - generic [ref=e1262]:
+                        - generic [ref=e1263]:
+                          - generic [ref=e1264]: "8.0"
+                          - generic [ref=e1265]: +
+                          - generic [ref=e1266]: "8.33"
+                          - generic [ref=e1267]:
+                            - generic [ref=e1268]: log
+                            - generic [ref=e1270]: "10"
+                          - generic: ⁡
+                          - generic [ref=e1271]: (
+                          - generic [ref=e1272]: "1000"
+                          - generic [ref=e1274]: /
+                          - generic [ref=e1275]:
+                            - generic [ref=e1276]: f
+                            - generic [ref=e1277]: t
+                          - generic [ref=e1278]: )
+                          - generic [ref=e1279]: dB
+                        - generic [ref=e1280]:
+                          - generic [ref=e1281]:
+                            - generic [ref=e1282]: f
+                            - generic [ref=e1283]: t
+                          - generic [ref=e1284]: <
+                          - generic [ref=e1285]: "1"
+                          - generic [ref=e1286]: ","
+                          - generic [ref=e1287]: kHz
+                          - generic [ref=e1288]: "8.0"
+                          - generic [ref=e1289]: dB
+                        - generic [ref=e1290]:
+                          - generic [ref=e1291]:
+                            - generic [ref=e1292]: f
+                            - generic [ref=e1293]: t
+                          - generic [ref=e1294]: ≥
+                          - generic [ref=e1295]: "1"
+                          - generic [ref=e1296]: ","
+                          - generic [ref=e1297]: kHz
+                - paragraph [ref=e1298]:
+                  - strong [ref=e1299]: PR
+                  - text: (clause 12) compares the level of the critical band centred on the tone,
+                  - math [ref=e1301]:
+                    - generic [ref=e1302]:
+                      - generic [ref=e1303]: L
+                      - generic [ref=e1304]: M
+                  - text: ", with the mean power of the two"
+                  - strong [ref=e1305]: contiguous
+                  - text: critical bands
+                  - math [ref=e1307]:
+                    - generic [ref=e1308]:
+                      - generic [ref=e1309]: L
+                      - generic [ref=e1310]: L
+                  - text: ","
+                  - math [ref=e1312]:
+                    - generic [ref=e1313]:
+                      - generic [ref=e1314]: L
+                      - generic [ref=e1315]: U
+                  - text: "(edges from the fitted Formulae 21–22 with Tables 2–3):"
+                  - math [ref=e1317]:
+                    - generic [ref=e1319]: PR
+                    - generic [ref=e1320]: =
+                    - generic [ref=e1321]: "10"
+                    - generic [ref=e1322]:
+                      - generic [ref=e1323]: log
+                      - generic [ref=e1325]: "10"
+                    - generic: ⁡
+                    - generic [ref=e1326]:
+                      - generic [ref=e1327]: P
+                      - generic [ref=e1328]: M
+                    - generic [ref=e1329]: −
+                    - generic [ref=e1330]: "10"
+                    - generic [ref=e1331]:
+                      - generic [ref=e1332]: log
+                      - generic [ref=e1334]: "10"
+                    - generic: ⁡
+                    - generic [ref=e1335]:
+                      - generic [ref=e1336]: "["
+                      - generic [ref=e1337]: (
+                      - generic [ref=e1338]:
+                        - generic [ref=e1339]: P
+                        - generic [ref=e1340]: L
+                      - generic [ref=e1341]: +
+                      - generic [ref=e1342]:
+                        - generic [ref=e1343]: P
+                        - generic [ref=e1344]: U
+                      - generic [ref=e1345]: )
+                      - generic [ref=e1347]: /
+                      - generic [ref=e1348]: "2"
+                      - generic [ref=e1349]: "]"
+                  - text: (Formula 23). For
+                  - math [ref=e1351]:
+                    - generic [ref=e1352]:
+                      - generic [ref=e1353]: f
+                      - generic [ref=e1354]: t
+                    - generic [ref=e1355]: ≤
+                    - generic [ref=e1356]: "171.4"
+                  - text: Hz the lower band is truncated at 20 Hz and its power rescaled to a
+                  - strong [ref=e1357]: 100 Hz bandwidth
+                  - text: (Formula 24). The criterion (Formulae 25–26) is 9.0 dB at
+                  - math [ref=e1359]:
+                    - generic [ref=e1360]:
+                      - generic [ref=e1361]: f
+                      - generic [ref=e1362]: t
+                    - generic [ref=e1363]: ≥
+                    - generic [ref=e1364]: "1"
+                  - text: kHz, rising as
+                  - math [ref=e1366]:
+                    - generic [ref=e1367]: "9.0"
+                    - generic [ref=e1368]: +
+                    - generic [ref=e1369]: "10.0"
+                    - generic [ref=e1370]:
+                      - generic [ref=e1371]: log
+                      - generic [ref=e1373]: "10"
+                    - generic: ⁡
+                    - generic [ref=e1374]: (
+                    - generic [ref=e1375]: "1000"
+                    - generic [ref=e1377]: /
+                    - generic [ref=e1378]:
+                      - generic [ref=e1379]: f
+                      - generic [ref=e1380]: t
+                    - generic [ref=e1381]: )
+                  - text: below. Tones are assessed within the 89.1 Hz – 11.2 kHz range of interest (clauses 11.5 / 12.6).
+                - paragraph [ref=e1382]:
+                  - text: See the
+                  - link "Levels guide" [ref=e1383] [cursor=pointer]:
+                    - /url: /jmrplens/phonometry/blob/main/docs/levels.md
+                  - text: for usage.
+                - generic [ref=e1384]:
+                  - heading "Event and dose metrics" [level=2] [ref=e1385]
+                  - 'link "Permalink: Event and dose metrics" [ref=e1386] [cursor=pointer]':
+                    - /url: "#event-and-dose-metrics"
+                    - img [ref=e1387]
+                - paragraph [ref=e1389]:
+                  - strong [ref=e1390]: Sound exposure level
+                  - text: "(SEL; LAE with A-weighting, IEC 61672-1:2013) normalizes the energy of a discrete event (aircraft flyover, train pass) to a 1 s reference duration:"
+                - paragraph [ref=e1391]:
+                  - math [ref=e1393]:
+                    - generic [ref=e1395]: SEL
+                    - generic [ref=e1396]: =
+                    - generic [ref=e1397]:
+                      - generic [ref=e1398]: L
+                      - generic [ref=e1399]:
+                        - generic [ref=e1400]: e
+                        - generic [ref=e1401]: q
+                        - generic [ref=e1402]: ","
+                        - generic [ref=e1403]: T
+                    - generic [ref=e1404]: +
+                    - generic [ref=e1405]: "10"
+                    - generic [ref=e1406]:
+                      - generic [ref=e1407]: log
+                      - generic [ref=e1409]: "10"
+                    - generic [ref=e1410]: "!"
+                    - generic [ref=e1411]:
+                      - generic [ref=e1412]: (
+                      - generic [ref=e1413]:
+                        - generic [ref=e1414]: T
+                        - generic [ref=e1415]:
+                          - generic [ref=e1416]: T
+                          - generic [ref=e1417]: "0"
+                      - generic [ref=e1418]: )
+                    - generic [ref=e1419]: ","
+                    - generic [ref=e1420]:
+                      - generic [ref=e1421]: T
+                      - generic [ref=e1422]: "0"
+                    - generic [ref=e1423]: =
+                    - generic [ref=e1424]: "1"
+                    - generic [ref=e1425]: s
+                - paragraph [ref=e1426]:
+                  - strong [ref=e1427]: Sound exposure
+                  - math [ref=e1429]:
+                    - generic [ref=e1430]: E
+                  - text: "(IEC 61252, 3.1) is the time integral of the squared A-weighted sound pressure, expressed in pascal-squared hours:"
+                - paragraph [ref=e1431]:
+                  - math [ref=e1433]:
+                    - generic [ref=e1434]: E
+                    - generic [ref=e1435]: =
+                    - generic [ref=e1436]:
+                      - generic [ref=e1437]: ∫
+                      - generic [ref=e1438]: "0"
+                      - generic [ref=e1439]: T
+                    - generic [ref=e1440]:
+                      - generic [ref=e1441]: p
+                      - generic [ref=e1442]: A
+                      - generic [ref=e1443]: "2"
+                    - generic [ref=e1444]: (
+                    - generic [ref=e1445]: t
+                    - generic [ref=e1446]: )
+                    - generic [ref=e1447]: ","
+                    - generic [ref=e1448]: d
+                    - generic [ref=e1449]: t
+                    - generic [ref=e1450]: =
+                    - generic [ref=e1451]:
+                      - generic [ref=e1452]:
+                        - generic [ref=e1453]: p
+                        - generic [ref=e1454]: A
+                        - generic [ref=e1455]: "2"
+                      - generic [ref=e1456]: ―
+                    - generic [ref=e1457]: ⋅
+                    - generic [ref=e1458]: T
+                    - generic [ref=e1459]: "["
+                    - generic [ref=e1460]:
+                      - generic [ref=e1461]: Pa
+                      - generic [ref=e1462]: "2"
+                    - generic [ref=e1463]: h
+                    - generic [ref=e1464]: "]"
+                - paragraph [ref=e1465]:
+                  - text: When the recording is a representative sample of a longer shift,
+                  - math [ref=e1467]:
+                    - generic [ref=e1468]: E
+                  - text: scales the measured mean square by the actual exposure duration. The
+                  - strong [ref=e1469]: normalized 8 h level
+                  - text: "(IEC 61252, 3.3) converts exposure to the steady level that carries the same energy over a nominal working day:"
+                - paragraph [ref=e1470]:
+                  - math [ref=e1472]:
+                    - generic [ref=e1473]:
+                      - generic [ref=e1474]: L
+                      - generic [ref=e1475]:
+                        - generic [ref=e1476]: E
+                        - generic [ref=e1477]: X
+                        - generic [ref=e1478]: ","
+                        - generic [ref=e1479]: "8"
+                        - generic [ref=e1480]: h
+                    - generic [ref=e1481]: =
+                    - generic [ref=e1482]: "10"
+                    - generic [ref=e1483]:
+                      - generic [ref=e1484]: log
+                      - generic [ref=e1486]: "10"
+                    - generic [ref=e1487]: "!"
+                    - generic [ref=e1488]:
+                      - generic [ref=e1489]: (
+                      - generic [ref=e1490]:
+                        - generic [ref=e1491]: E
+                        - generic [ref=e1492]:
+                          - generic [ref=e1493]: "8"
+                          - generic [ref=e1494]: h
+                          - generic [ref=e1495]: ⋅
+                          - generic [ref=e1496]:
+                            - generic [ref=e1497]: p
+                            - generic [ref=e1498]: "0"
+                            - generic [ref=e1499]: "2"
+                      - generic [ref=e1500]: )
+                    - generic [ref=e1501]: ","
+                    - generic [ref=e1502]:
+                      - generic [ref=e1503]: p
+                      - generic [ref=e1504]: "0"
+                    - generic [ref=e1505]: =
+                    - generic [ref=e1506]: "20"
+                    - generic [ref=e1507]: μ
+                    - generic [ref=e1508]: Pa
+                - paragraph [ref=e1509]:
+                  - text: It is identical to
+                  - math [ref=e1511]:
+                    - generic [ref=e1512]:
+                      - generic [ref=e1513]: L
+                      - generic [ref=e1514]:
+                        - generic [ref=e1515]: E
+                        - generic [ref=e1516]: P
+                        - generic [ref=e1517]: ","
+                        - generic [ref=e1518]: d
+                  - text: of Directive 86/188/EEC and
+                  - math [ref=e1520]:
+                    - generic [ref=e1521]:
+                      - generic [ref=e1522]: L
+                      - generic [ref=e1523]:
+                        - generic [ref=e1524]: E
+                        - generic [ref=e1525]: X
+                        - generic [ref=e1526]: ","
+                        - generic [ref=e1527]: "8"
+                        - generic [ref=e1528]: h
+                  - text: "of ISO 1999 (BS EN 61252:1995, 3.3 NOTES 5–6). The anchor of BS EN 61252:1995 (3.3 NOTE 4): an exposure of"
+                  - strong [ref=e1529]:
+                    - text: 3.2 Pa²h corresponds to
+                    - math [ref=e1531]:
+                      - generic [ref=e1532]:
+                        - generic [ref=e1533]: L
+                        - generic [ref=e1534]:
+                          - generic [ref=e1535]: E
+                          - generic [ref=e1536]: X
+                          - generic [ref=e1537]: ","
+                          - generic [ref=e1538]: "8"
+                          - generic [ref=e1539]: h
+                    - text: of exactly 90 dB
+                  - text: .
+                - paragraph [ref=e1540]:
+                  - strong [ref=e1541]: LCpeak
+                  - text: (IEC 61672-1:2013, subclause 5.13) is the absolute maximum of the C-weighted sound pressure expressed in dB,
+                  - math [ref=e1543]:
+                    - generic [ref=e1544]:
+                      - generic [ref=e1545]: L
+                      - generic [ref=e1546]:
+                        - generic [ref=e1547]: C
+                        - generic [ref=e1548]: p
+                        - generic [ref=e1549]: e
+                        - generic [ref=e1550]: a
+                        - generic [ref=e1551]: k
+                    - generic [ref=e1552]: =
+                    - generic [ref=e1553]: "20"
+                    - generic [ref=e1554]:
+                      - generic [ref=e1555]: log
+                      - generic [ref=e1557]: "10"
+                    - generic: ⁡
+                    - generic [ref=e1558]: (
+                    - generic [ref=e1559]: max
+                    - generic [ref=e1560]: "|"
+                    - generic [ref=e1561]:
+                      - generic [ref=e1562]: p
+                      - generic [ref=e1563]: C
+                    - generic [ref=e1564]: (
+                    - generic [ref=e1565]: t
+                    - generic [ref=e1566]: )
+                    - generic [ref=e1567]: "|"
+                    - generic [ref=e1569]: /
+                    - generic [ref=e1570]:
+                      - generic [ref=e1571]: p
+                      - generic [ref=e1572]: "0"
+                    - generic [ref=e1573]: )
+                  - text: — the quantity behind the 135/137/140 dB(C) occupational action limits. The implementation is verified against the one-cycle and half-cycle reference responses of Table 5.
+                - paragraph [ref=e1574]:
+                  - text: See the
+                  - link "Levels guide" [ref=e1575] [cursor=pointer]:
+                    - /url: /jmrplens/phonometry/blob/main/docs/levels.md
+                  - text: for usage and the
+                  - link "Calibration guide" [ref=e1576] [cursor=pointer]:
+                    - /url: /jmrplens/phonometry/blob/main/docs/calibration.md
+                  - text: for absolute-scale setup.
+                - generic [ref=e1577]:
+                  - heading "Environmental descriptors (ISO 1996-1)" [level=2] [ref=e1578]
+                  - 'link "Permalink: Environmental descriptors (ISO 1996-1)" [ref=e1579] [cursor=pointer]':
+                    - /url: "#environmental-descriptors-iso-1996-1"
+                    - img [ref=e1580]
+                - paragraph [ref=e1582]:
+                  - text: The
+                  - strong [ref=e1583]: day-evening-night level
+                  - math [ref=e1585]:
+                    - generic [ref=e1586]:
+                      - generic [ref=e1587]: L
+                      - generic [ref=e1588]:
+                        - generic [ref=e1589]: d
+                        - generic [ref=e1590]: e
+                        - generic [ref=e1591]: "n"
+                  - text: (ISO 1996-1:2016, 3.6.4) is an energy average over the 24 h day with penalty weightings of
+                  - strong [ref=e1592]: +5 dB for the evening
+                  - text: and
+                  - strong [ref=e1593]: +10 dB for the night
+                  - text: ":"
+                - paragraph [ref=e1594]:
+                  - generic [ref=e1595]:
+                    - generic [ref=e1596]: Missing or unrecognized delimiter for \left
+                    - generic [ref=e1597]: "$$ L_{den} = 10 \\log_{10}!\\left{\\frac{1}{24}\\left[ t_d, 10^{0.1 L_{day}} + t_e, 10^{0.1 (L_{evening} + 5)} + t_n, 10^{0.1 (L_{night} + 10)} \\right]\\right} $$"
+                - paragraph [ref=e1598]:
+                  - text: with default period durations
+                  - math [ref=e1600]:
+                    - generic [ref=e1601]: (
+                    - generic [ref=e1602]:
+                      - generic [ref=e1603]: t
+                      - generic [ref=e1604]: d
+                    - generic [ref=e1605]: ","
+                    - generic [ref=e1606]:
+                      - generic [ref=e1607]: t
+                      - generic [ref=e1608]: e
+                    - generic [ref=e1609]: ","
+                    - generic [ref=e1610]:
+                      - generic [ref=e1611]: t
+                      - generic [ref=e1612]: "n"
+                    - generic [ref=e1613]: )
+                    - generic [ref=e1614]: =
+                    - generic [ref=e1615]: (
+                    - generic [ref=e1616]: "12"
+                    - generic [ref=e1617]: ","
+                    - generic [ref=e1618]: "4"
+                    - generic [ref=e1619]: ","
+                    - generic [ref=e1620]: "8"
+                    - generic [ref=e1621]: )
+                  - text: h — countries may define the periods differently (3.6.4 Note 1). The
+                  - strong [ref=e1622]: day-night level
+                  - math [ref=e1624]:
+                    - generic [ref=e1625]:
+                      - generic [ref=e1626]: L
+                      - generic [ref=e1627]:
+                        - generic [ref=e1628]: d
+                        - generic [ref=e1629]: "n"
+                  - text: "(3.6.5) drops the evening period:"
+                - paragraph [ref=e1630]:
+                  - generic [ref=e1631]:
+                    - generic [ref=e1632]: Missing or unrecognized delimiter for \left
+                    - generic [ref=e1633]: "$$ L_{dn} = 10 \\log_{10}!\\left{\\frac{1}{24}\\left[ t_d, 10^{0.1 L_{day}} + t_n, 10^{0.1 (L_{night} + 10)} \\right]\\right}, \\qquad (t_d, t_n) = (15, 9)\\ \\text{h} $$"
+                - paragraph [ref=e1634]:
+                  - text: Both are special cases of the
+                  - strong [ref=e1635]: composite whole-day rating level
+                  - text: (6.5, generalizing Formulae 5–6), where each period
+                  - math [ref=e1637]:
+                    - generic [ref=e1638]: i
+                  - text: contributes its rating level
+                  - math [ref=e1640]:
+                    - generic [ref=e1641]:
+                      - generic [ref=e1642]: L
+                      - generic [ref=e1643]: i
+                  - text: plus an adjustment
+                  - math [ref=e1645]:
+                    - generic [ref=e1646]:
+                      - generic [ref=e1647]: K
+                      - generic [ref=e1648]: i
+                  - text: ", weighted by its share of the day:"
+                - paragraph [ref=e1649]:
+                  - math [ref=e1651]:
+                    - generic [ref=e1652]:
+                      - generic [ref=e1653]: L
+                      - generic [ref=e1654]: R
+                    - generic [ref=e1655]: =
+                    - generic [ref=e1656]: "10"
+                    - generic [ref=e1657]:
+                      - generic [ref=e1658]: log
+                      - generic [ref=e1660]: "10"
+                    - generic [ref=e1661]: "!"
+                    - generic [ref=e1662]:
+                      - generic [ref=e1663]: "["
+                      - generic [ref=e1664]:
+                        - generic [ref=e1665]: ∑
+                        - generic [ref=e1666]: i
+                      - generic [ref=e1667]:
+                        - generic [ref=e1668]:
+                          - generic [ref=e1669]: h
+                          - generic [ref=e1670]: i
+                        - generic [ref=e1671]: "24"
+                      - generic [ref=e1672]: ","
+                      - generic [ref=e1673]:
+                        - generic [ref=e1674]: "10"
+                        - generic [ref=e1675]:
+                          - generic [ref=e1676]: "0.1"
+                          - generic [ref=e1677]: (
+                          - generic [ref=e1678]:
+                            - generic [ref=e1679]: L
+                            - generic [ref=e1680]: i
+                          - generic [ref=e1681]: +
+                          - generic [ref=e1682]:
+                            - generic [ref=e1683]: K
+                            - generic [ref=e1684]: i
+                          - generic [ref=e1685]: )
+                      - generic [ref=e1686]: "]"
+                    - generic [ref=e1687]: ","
+                    - generic [ref=e1688]:
+                      - generic [ref=e1689]: ∑
+                      - generic [ref=e1690]: i
+                    - generic [ref=e1691]:
+                      - generic [ref=e1692]: h
+                      - generic [ref=e1693]: i
+                    - generic [ref=e1694]: =
+                    - generic [ref=e1695]: "24"
+                    - generic [ref=e1696]: h
+                - paragraph [ref=e1697]:
+                  - text: The adjustments
+                  - math [ref=e1699]:
+                    - generic [ref=e1700]:
+                      - generic [ref=e1701]: K
+                      - generic [ref=e1702]: i
+                  - text: "cover time-of-day penalties (ISO 1996-1 Table A.1: evening 5 dB, night 10 dB) as well as source-character adjustments — e.g. tonal penalties, which the ECMA-418-1 TNR/PR assessments can justify objectively."
+                - paragraph [ref=e1703]:
+                  - text: See the
+                  - link "Levels guide" [ref=e1704] [cursor=pointer]:
+                    - /url: /jmrplens/phonometry/blob/main/docs/levels.md
+                  - text: for usage.
+  - alert [ref=e1708]

--- a/docs/levels.md
+++ b/docs/levels.md
@@ -10,7 +10,7 @@ The equivalent continuous level integrates the squared pressure over the
 measurement time:
 
 $$
-L_{eq} = 10\log_{10}\!\left(\frac{1}{T}\int_0^T \frac{p^2(t)}{p_0^2}\,dt\right) \text{ dB}, \qquad p_0 = 20\ \mu\text{Pa}
+L_{eq} = 10\log_{10}\left(\frac{1}{T}\int_0^T \frac{p^2(t)}{p_0^2}\,dt\right) \text{ dB}, \qquad p_0 = 20\ \mu\text{Pa}
 $$
 
 and $L_{Aeq}$ is the same integral after A-weighting the signal. $L_N$ is the

--- a/docs/theory.md
+++ b/docs/theory.md
@@ -224,7 +224,7 @@ The G curve extends frequency weighting into the infrasound range. ISO 7196:1995
 
 $$
 z_{1..4} = 0, \qquad
-p = 2\pi \left\{ -0.707 \pm j0.707,\; -19.27 \pm j5.16,\; -14.11 \pm j14.11,\; -5.16 \pm j19.27 \right\} \ \text{Hz}
+p = 2\pi \left\lbrace -0.707 \pm j0.707,\; -19.27 \pm j5.16,\; -14.11 \pm j14.11,\; -5.16 \pm j19.27 \right\rbrace \ \text{Hz}
 $$
 
 The gain $k$ is chosen so that the response is exactly **0 dB at 10 Hz** (clause 4):
@@ -244,13 +244,13 @@ See the [Frequency Weighting guide](weighting.md) for usage.
 A tone has a *loudness level* of $L_N$ phon when it is judged equally loud as a 1 kHz pure tone at $L_N$ dB SPL. ISO 226:2023 Formula (1) (clause 4.1, p. 2) gives the SPL of a pure tone at frequency $f$ that reaches loudness level $L_N$:
 
 $$
-L_f = \frac{10}{\alpha_f} \log_{10}\!\left[ \left(4 \cdot 10^{-10}\right)^{0.3 - \alpha_f} \left( 10^{\,0.03 L_N} - 10^{\,0.072} \right) + 10^{\,\alpha_f (T_f + L_U)/10} \right] - L_U
+L_f = \frac{10}{\alpha_f} \log_{10}\left[ \left(4 \cdot 10^{-10}\right)^{0.3 - \alpha_f} \left( 10^{\,0.03 L_N} - 10^{\,0.072} \right) + 10^{\,\alpha_f (T_f + L_U)/10} \right] - L_U
 $$
 
 Formula (2) (clause 4.2) inverts it, returning the loudness level of a tone at SPL $L_f$:
 
 $$
-L_N = \frac{100}{3} \log_{10}\!\left[ \frac{10^{\,\alpha_f (L_f + L_U)/10} - 10^{\,\alpha_f (T_f + L_U)/10}}{\left(4 \cdot 10^{-10}\right)^{0.3 - \alpha_f}} + 10^{\,0.072} \right]
+L_N = \frac{100}{3} \log_{10}\left[ \frac{10^{\,\alpha_f (L_f + L_U)/10} - 10^{\,\alpha_f (T_f + L_U)/10}}{\left(4 \cdot 10^{-10}\right)^{0.3 - \alpha_f}} + 10^{\,0.072} \right]
 $$
 
 The three parameters come from Table 1 (p. 4), tabulated at the 29 preferred third-octave frequencies of ISO 266 from 20 Hz to 12.5 kHz:
@@ -288,7 +288,7 @@ See the [Levels guide](levels.md) for usage.
 **Sound exposure level** (SEL; LAE with A-weighting, IEC 61672-1:2013) normalizes the energy of a discrete event (aircraft flyover, train pass) to a 1 s reference duration:
 
 $$
-\mathrm{SEL} = L_{eq,T} + 10 \log_{10}\!\left(\frac{T}{T_0}\right), \qquad T_0 = 1\ \text{s}
+\mathrm{SEL} = L_{eq,T} + 10 \log_{10}\left(\frac{T}{T_0}\right), \qquad T_0 = 1\ \text{s}
 $$
 
 **Sound exposure** $E$ (IEC 61252, 3.1) is the time integral of the squared A-weighted sound pressure, expressed in pascal-squared hours:
@@ -300,7 +300,7 @@ $$
 When the recording is a representative sample of a longer shift, $E$ scales the measured mean square by the actual exposure duration. The **normalized 8 h level** (IEC 61252, 3.3) converts exposure to the steady level that carries the same energy over a nominal working day:
 
 $$
-L_{EX,8h} = 10 \log_{10}\!\left(\frac{E}{8\ \text{h} \cdot p_0^2}\right), \qquad p_0 = 20\ \mu\text{Pa}
+L_{EX,8h} = 10 \log_{10}\left(\frac{E}{8\ \text{h} \cdot p_0^2}\right), \qquad p_0 = 20\ \mu\text{Pa}
 $$
 
 It is identical to $L_{EP,d}$ of Directive 86/188/EEC and $L_{EX,8h}$ of ISO 1999 (BS EN 61252:1995, 3.3 NOTES 5–6). The anchor of BS EN 61252:1995 (3.3 NOTE 4): an exposure of **3.2 Pa²h corresponds to $L_{EX,8h}$ of exactly 90 dB**.
@@ -314,19 +314,19 @@ See the [Levels guide](levels.md) for usage and the [Calibration guide](calibrat
 The **day-evening-night level** $L_{den}$ (ISO 1996-1:2016, 3.6.4) is an energy average over the 24 h day with penalty weightings of **+5 dB for the evening** and **+10 dB for the night**:
 
 $$
-L_{den} = 10 \log_{10}\!\left\{\frac{1}{24}\left[ t_d\, 10^{0.1 L_{day}} + t_e\, 10^{0.1 (L_{evening} + 5)} + t_n\, 10^{0.1 (L_{night} + 10)} \right]\right\}
+L_{den} = 10 \log_{10}\left\lbrace\frac{1}{24}\left[ t_d\, 10^{0.1 L_{day}} + t_e\, 10^{0.1 (L_{evening} + 5)} + t_n\, 10^{0.1 (L_{night} + 10)} \right]\right\rbrace
 $$
 
 with default period durations $(t_d, t_e, t_n) = (12, 4, 8)$ h — countries may define the periods differently (3.6.4 Note 1). The **day-night level** $L_{dn}$ (3.6.5) drops the evening period:
 
 $$
-L_{dn} = 10 \log_{10}\!\left\{\frac{1}{24}\left[ t_d\, 10^{0.1 L_{day}} + t_n\, 10^{0.1 (L_{night} + 10)} \right]\right\}, \qquad (t_d, t_n) = (15, 9)\ \text{h}
+L_{dn} = 10 \log_{10}\left\lbrace\frac{1}{24}\left[ t_d\, 10^{0.1 L_{day}} + t_n\, 10^{0.1 (L_{night} + 10)} \right]\right\rbrace, \qquad (t_d, t_n) = (15, 9)\ \text{h}
 $$
 
 Both are special cases of the **composite whole-day rating level** (6.5, generalizing Formulae 5–6), where each period $i$ contributes its rating level $L_i$ plus an adjustment $K_i$, weighted by its share of the day:
 
 $$
-L_R = 10 \log_{10}\!\left[ \sum_i \frac{h_i}{24}\, 10^{0.1 (L_i + K_i)} \right], \qquad \sum_i h_i = 24\ \text{h}
+L_R = 10 \log_{10}\left[ \sum_i \frac{h_i}{24}\, 10^{0.1 (L_i + K_i)} \right], \qquad \sum_i h_i = 24\ \text{h}
 $$
 
 The adjustments $K_i$ cover time-of-day penalties (ISO 1996-1 Table A.1: evening 5 dB, night 10 dB) as well as source-character adjustments — e.g. tonal penalties, which the ECMA-418-1 TNR/PR assessments can justify objectively.

--- a/site/src/content/docs/es/guides/levels.md
+++ b/site/src/content/docs/es/guides/levels.md
@@ -12,7 +12,7 @@ El nivel continuo equivalente integra la presión al cuadrado durante el tiempo
 de medición:
 
 $$
-L_{eq} = 10\log_{10}\!\left(\frac{1}{T}\int_0^T \frac{p^2(t)}{p_0^2}\,dt\right) \text{ dB}, \qquad p_0 = 20\ \mu\text{Pa}
+L_{eq} = 10\log_{10}\left(\frac{1}{T}\int_0^T \frac{p^2(t)}{p_0^2}\,dt\right) \text{ dB}, \qquad p_0 = 20\ \mu\text{Pa}
 $$
 
 y $L_{Aeq}$ es la misma integral tras ponderar A la señal. $L_N$ es el nivel

--- a/site/src/content/docs/es/reference/theory.md
+++ b/site/src/content/docs/es/reference/theory.md
@@ -230,7 +230,7 @@ La curva G extiende la ponderación frecuencial al rango de los infrasonidos. La
 
 $$
 z_{1..4} = 0, \qquad
-p = 2\pi \left\{ -0.707 \pm j0.707,\; -19.27 \pm j5.16,\; -14.11 \pm j14.11,\; -5.16 \pm j19.27 \right\} \ \text{Hz}
+p = 2\pi \left\lbrace -0.707 \pm j0.707,\; -19.27 \pm j5.16,\; -14.11 \pm j14.11,\; -5.16 \pm j19.27 \right\rbrace \ \text{Hz}
 $$
 
 La ganancia $k$ se elige para que la respuesta sea exactamente **0 dB a 10 Hz** (apartado 4):
@@ -250,13 +250,13 @@ Consulta la [guía de ponderación frecuencial](/phonometry/es/guides/weighting/
 Un tono tiene un *nivel de sonoridad* de $L_N$ fonios cuando se juzga igual de sonoro que un tono puro de 1 kHz a $L_N$ dB SPL. La Fórmula (1) de ISO 226:2023 (apartado 4.1, p. 2) da el SPL de un tono puro a la frecuencia $f$ que alcanza el nivel de sonoridad $L_N$:
 
 $$
-L_f = \frac{10}{\alpha_f} \log_{10}\!\left[ \left(4 \cdot 10^{-10}\right)^{0.3 - \alpha_f} \left( 10^{\,0.03 L_N} - 10^{\,0.072} \right) + 10^{\,\alpha_f (T_f + L_U)/10} \right] - L_U
+L_f = \frac{10}{\alpha_f} \log_{10}\left[ \left(4 \cdot 10^{-10}\right)^{0.3 - \alpha_f} \left( 10^{\,0.03 L_N} - 10^{\,0.072} \right) + 10^{\,\alpha_f (T_f + L_U)/10} \right] - L_U
 $$
 
 La Fórmula (2) (apartado 4.2) la invierte, devolviendo el nivel de sonoridad de un tono a SPL $L_f$:
 
 $$
-L_N = \frac{100}{3} \log_{10}\!\left[ \frac{10^{\,\alpha_f (L_f + L_U)/10} - 10^{\,\alpha_f (T_f + L_U)/10}}{\left(4 \cdot 10^{-10}\right)^{0.3 - \alpha_f}} + 10^{\,0.072} \right]
+L_N = \frac{100}{3} \log_{10}\left[ \frac{10^{\,\alpha_f (L_f + L_U)/10} - 10^{\,\alpha_f (T_f + L_U)/10}}{\left(4 \cdot 10^{-10}\right)^{0.3 - \alpha_f}} + 10^{\,0.072} \right]
 $$
 
 Los tres parámetros provienen de la Tabla 1 (p. 4), tabulados en las 29 frecuencias preferentes de tercio de octava de ISO 266 desde 20 Hz hasta 12,5 kHz:
@@ -294,7 +294,7 @@ Consulta la [guía de niveles](/phonometry/es/guides/levels/) para su uso.
 El **nivel de exposición sonora** (SEL; LAE con ponderación A, IEC 61672-1:2013) normaliza la energía de un evento discreto (sobrevuelo de un avión, paso de un tren) a una duración de referencia de 1 s:
 
 $$
-\mathrm{SEL} = L_{eq,T} + 10 \log_{10}\!\left(\frac{T}{T_0}\right), \qquad T_0 = 1\ \text{s}
+\mathrm{SEL} = L_{eq,T} + 10 \log_{10}\left(\frac{T}{T_0}\right), \qquad T_0 = 1\ \text{s}
 $$
 
 La **exposición sonora** $E$ (IEC 61252, 3.1) es la integral temporal del cuadrado de la presión sonora ponderada A, expresada en pascales al cuadrado por hora:
@@ -306,7 +306,7 @@ $$
 Cuando la grabación es una muestra representativa de una jornada más larga, $E$ escala el cuadrático medio medido por la duración real de la exposición. El **nivel normalizado a 8 h** (IEC 61252, 3.3) convierte la exposición en el nivel estacionario que transporta la misma energía a lo largo de una jornada laboral nominal:
 
 $$
-L_{EX,8h} = 10 \log_{10}\!\left(\frac{E}{8\ \text{h} \cdot p_0^2}\right), \qquad p_0 = 20\ \mu\text{Pa}
+L_{EX,8h} = 10 \log_{10}\left(\frac{E}{8\ \text{h} \cdot p_0^2}\right), \qquad p_0 = 20\ \mu\text{Pa}
 $$
 
 Es idéntico al $L_{EP,d}$ de la Directiva 86/188/CEE y al $L_{EX,8h}$ de ISO 1999 (BS EN 61252:1995, 3.3 NOTAS 5–6). El ancla de BS EN 61252:1995 (3.3 NOTA 4): una exposición de **3,2 Pa²h corresponde a un $L_{EX,8h}$ de exactamente 90 dB**.
@@ -320,19 +320,19 @@ Consulta la [guía de niveles](/phonometry/es/guides/levels/) para su uso y la [
 El **nivel día-tarde-noche** $L_{den}$ (ISO 1996-1:2016, 3.6.4) es un promedio energético sobre las 24 h del día con penalizaciones de **+5 dB para la tarde** y **+10 dB para la noche**:
 
 $$
-L_{den} = 10 \log_{10}\!\left\{\frac{1}{24}\left[ t_d\, 10^{0.1 L_{day}} + t_e\, 10^{0.1 (L_{evening} + 5)} + t_n\, 10^{0.1 (L_{night} + 10)} \right]\right\}
+L_{den} = 10 \log_{10}\left\lbrace\frac{1}{24}\left[ t_d\, 10^{0.1 L_{day}} + t_e\, 10^{0.1 (L_{evening} + 5)} + t_n\, 10^{0.1 (L_{night} + 10)} \right]\right\rbrace
 $$
 
 con duraciones de periodo por defecto $(t_d, t_e, t_n) = (12, 4, 8)$ h — cada país puede definir los periodos de forma distinta (3.6.4 Nota 1). El **nivel día-noche** $L_{dn}$ (3.6.5) prescinde del periodo de tarde:
 
 $$
-L_{dn} = 10 \log_{10}\!\left\{\frac{1}{24}\left[ t_d\, 10^{0.1 L_{day}} + t_n\, 10^{0.1 (L_{night} + 10)} \right]\right\}, \qquad (t_d, t_n) = (15, 9)\ \text{h}
+L_{dn} = 10 \log_{10}\left\lbrace\frac{1}{24}\left[ t_d\, 10^{0.1 L_{day}} + t_n\, 10^{0.1 (L_{night} + 10)} \right]\right\rbrace, \qquad (t_d, t_n) = (15, 9)\ \text{h}
 $$
 
 Ambos son casos particulares del **nivel de evaluación compuesto de día completo** (6.5, que generaliza las Fórmulas 5–6), donde cada periodo $i$ aporta su nivel de evaluación $L_i$ más un ajuste $K_i$, ponderado por su fracción del día:
 
 $$
-L_R = 10 \log_{10}\!\left[ \sum_i \frac{h_i}{24}\, 10^{0.1 (L_i + K_i)} \right], \qquad \sum_i h_i = 24\ \text{h}
+L_R = 10 \log_{10}\left[ \sum_i \frac{h_i}{24}\, 10^{0.1 (L_i + K_i)} \right], \qquad \sum_i h_i = 24\ \text{h}
 $$
 
 Los ajustes $K_i$ cubren las penalizaciones horarias (ISO 1996-1 Tabla A.1: tarde 5 dB, noche 10 dB) así como los ajustes por carácter de la fuente — p. ej. penalizaciones tonales, que las evaluaciones TNR/PR de ECMA-418-1 permiten justificar objetivamente.

--- a/site/src/content/docs/guides/levels.md
+++ b/site/src/content/docs/guides/levels.md
@@ -11,7 +11,7 @@ The equivalent continuous level integrates the squared pressure over the
 measurement time:
 
 $$
-L_{eq} = 10\log_{10}\!\left(\frac{1}{T}\int_0^T \frac{p^2(t)}{p_0^2}\,dt\right) \text{ dB}, \qquad p_0 = 20\ \mu\text{Pa}
+L_{eq} = 10\log_{10}\left(\frac{1}{T}\int_0^T \frac{p^2(t)}{p_0^2}\,dt\right) \text{ dB}, \qquad p_0 = 20\ \mu\text{Pa}
 $$
 
 and $L_{Aeq}$ is the same integral after A-weighting the signal. $L_N$ is the

--- a/site/src/content/docs/reference/theory.md
+++ b/site/src/content/docs/reference/theory.md
@@ -225,7 +225,7 @@ The G curve extends frequency weighting into the infrasound range. ISO 7196:1995
 
 $$
 z_{1..4} = 0, \qquad
-p = 2\pi \left\{ -0.707 \pm j0.707,\; -19.27 \pm j5.16,\; -14.11 \pm j14.11,\; -5.16 \pm j19.27 \right\} \ \text{Hz}
+p = 2\pi \left\lbrace -0.707 \pm j0.707,\; -19.27 \pm j5.16,\; -14.11 \pm j14.11,\; -5.16 \pm j19.27 \right\rbrace \ \text{Hz}
 $$
 
 The gain $k$ is chosen so that the response is exactly **0 dB at 10 Hz** (clause 4):
@@ -245,13 +245,13 @@ See the [Frequency Weighting guide](/phonometry/guides/weighting/) for usage.
 A tone has a *loudness level* of $L_N$ phon when it is judged equally loud as a 1 kHz pure tone at $L_N$ dB SPL. ISO 226:2023 Formula (1) (clause 4.1, p. 2) gives the SPL of a pure tone at frequency $f$ that reaches loudness level $L_N$:
 
 $$
-L_f = \frac{10}{\alpha_f} \log_{10}\!\left[ \left(4 \cdot 10^{-10}\right)^{0.3 - \alpha_f} \left( 10^{\,0.03 L_N} - 10^{\,0.072} \right) + 10^{\,\alpha_f (T_f + L_U)/10} \right] - L_U
+L_f = \frac{10}{\alpha_f} \log_{10}\left[ \left(4 \cdot 10^{-10}\right)^{0.3 - \alpha_f} \left( 10^{\,0.03 L_N} - 10^{\,0.072} \right) + 10^{\,\alpha_f (T_f + L_U)/10} \right] - L_U
 $$
 
 Formula (2) (clause 4.2) inverts it, returning the loudness level of a tone at SPL $L_f$:
 
 $$
-L_N = \frac{100}{3} \log_{10}\!\left[ \frac{10^{\,\alpha_f (L_f + L_U)/10} - 10^{\,\alpha_f (T_f + L_U)/10}}{\left(4 \cdot 10^{-10}\right)^{0.3 - \alpha_f}} + 10^{\,0.072} \right]
+L_N = \frac{100}{3} \log_{10}\left[ \frac{10^{\,\alpha_f (L_f + L_U)/10} - 10^{\,\alpha_f (T_f + L_U)/10}}{\left(4 \cdot 10^{-10}\right)^{0.3 - \alpha_f}} + 10^{\,0.072} \right]
 $$
 
 The three parameters come from Table 1 (p. 4), tabulated at the 29 preferred third-octave frequencies of ISO 266 from 20 Hz to 12.5 kHz:
@@ -289,7 +289,7 @@ See the [Levels guide](/phonometry/guides/levels/) for usage.
 **Sound exposure level** (SEL; LAE with A-weighting, IEC 61672-1:2013) normalizes the energy of a discrete event (aircraft flyover, train pass) to a 1 s reference duration:
 
 $$
-\mathrm{SEL} = L_{eq,T} + 10 \log_{10}\!\left(\frac{T}{T_0}\right), \qquad T_0 = 1\ \text{s}
+\mathrm{SEL} = L_{eq,T} + 10 \log_{10}\left(\frac{T}{T_0}\right), \qquad T_0 = 1\ \text{s}
 $$
 
 **Sound exposure** $E$ (IEC 61252, 3.1) is the time integral of the squared A-weighted sound pressure, expressed in pascal-squared hours:
@@ -301,7 +301,7 @@ $$
 When the recording is a representative sample of a longer shift, $E$ scales the measured mean square by the actual exposure duration. The **normalized 8 h level** (IEC 61252, 3.3) converts exposure to the steady level that carries the same energy over a nominal working day:
 
 $$
-L_{EX,8h} = 10 \log_{10}\!\left(\frac{E}{8\ \text{h} \cdot p_0^2}\right), \qquad p_0 = 20\ \mu\text{Pa}
+L_{EX,8h} = 10 \log_{10}\left(\frac{E}{8\ \text{h} \cdot p_0^2}\right), \qquad p_0 = 20\ \mu\text{Pa}
 $$
 
 It is identical to $L_{EP,d}$ of Directive 86/188/EEC and $L_{EX,8h}$ of ISO 1999 (BS EN 61252:1995, 3.3 NOTES 5–6). The anchor of BS EN 61252:1995 (3.3 NOTE 4): an exposure of **3.2 Pa²h corresponds to $L_{EX,8h}$ of exactly 90 dB**.
@@ -315,19 +315,19 @@ See the [Levels guide](/phonometry/guides/levels/) for usage and the [Calibratio
 The **day-evening-night level** $L_{den}$ (ISO 1996-1:2016, 3.6.4) is an energy average over the 24 h day with penalty weightings of **+5 dB for the evening** and **+10 dB for the night**:
 
 $$
-L_{den} = 10 \log_{10}\!\left\{\frac{1}{24}\left[ t_d\, 10^{0.1 L_{day}} + t_e\, 10^{0.1 (L_{evening} + 5)} + t_n\, 10^{0.1 (L_{night} + 10)} \right]\right\}
+L_{den} = 10 \log_{10}\left\lbrace\frac{1}{24}\left[ t_d\, 10^{0.1 L_{day}} + t_e\, 10^{0.1 (L_{evening} + 5)} + t_n\, 10^{0.1 (L_{night} + 10)} \right]\right\rbrace
 $$
 
 with default period durations $(t_d, t_e, t_n) = (12, 4, 8)$ h — countries may define the periods differently (3.6.4 Note 1). The **day-night level** $L_{dn}$ (3.6.5) drops the evening period:
 
 $$
-L_{dn} = 10 \log_{10}\!\left\{\frac{1}{24}\left[ t_d\, 10^{0.1 L_{day}} + t_n\, 10^{0.1 (L_{night} + 10)} \right]\right\}, \qquad (t_d, t_n) = (15, 9)\ \text{h}
+L_{dn} = 10 \log_{10}\left\lbrace\frac{1}{24}\left[ t_d\, 10^{0.1 L_{day}} + t_n\, 10^{0.1 (L_{night} + 10)} \right]\right\rbrace, \qquad (t_d, t_n) = (15, 9)\ \text{h}
 $$
 
 Both are special cases of the **composite whole-day rating level** (6.5, generalizing Formulae 5–6), where each period $i$ contributes its rating level $L_i$ plus an adjustment $K_i$, weighted by its share of the day:
 
 $$
-L_R = 10 \log_{10}\!\left[ \sum_i \frac{h_i}{24}\, 10^{0.1 (L_i + K_i)} \right], \qquad \sum_i h_i = 24\ \text{h}
+L_R = 10 \log_{10}\left[ \sum_i \frac{h_i}{24}\, 10^{0.1 (L_i + K_i)} \right], \qquad \sum_i h_i = 24\ \text{h}
 $$
 
 The adjustments $K_i$ cover time-of-day penalties (ISO 1996-1 Table A.1: evening 5 dB, night 10 dB) as well as source-character adjustments — e.g. tonal penalties, which the ECMA-418-1 TNR/PR assessments can justify objectively.


### PR DESCRIPTION
GitHub's markdown layer eats the backslash in `\{`/`\}` before MathJax parses the block, so the display formulas using `\left\{` rendered as raw text on github.com (theory.md, levels.md and their site mirrors, EN/ES). Replaced with `\lbrace`/`\rbrace` (not markdown escapes; identical output in MathJax and KaTeX) and dropped a cosmetic `\!`. Site builds with all links valid.

https://claude.ai/code/session_013kkVt3nxi9svp1an28uHxf

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/78?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved the rendering and consistency of several math expressions across the documentation, especially in audio level and theory formulas.
  * Standardized equation formatting in both English and Spanish docs for clearer, more readable technical content.

* **Style**
  * Minor formatting updates were applied to mathematical notation without changing any underlying calculations or meaning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->