### PR TITLE
docs(site): remove reference to deleted Wikidata item

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -158,7 +158,6 @@ const jsonLd = JSON.stringify({
       sameAs: [
         'https://pypi.org/project/phonometry/',
         'https://doi.org/10.5281/zenodo.21215280',
-        'https://www.wikidata.org/wiki/Q140451720',
         `${fullUrl}/`,
       ],
     },


### PR DESCRIPTION
## Summary

The project Wikidata item (Q140451720) was deleted by a Wikidata admin on 2026-07-07 ("Mass deletion of pages added by Jmrplens", notability policy). Links to nonexistent entities are a negative entity-verification signal, so this removes the sameAs entry from `site/astro.config.mjs`. PyPI, Zenodo DOI, and site sameAs entries are unaffected.

Part of a cross-repo cleanup; companion PR jmrplens/gitlab-mcp-server#221.

https://claude.ai/code/session_016KQnnNLPVouuFYJqLd6kzv

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/85?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated structured metadata by removing an outdated external reference, keeping site information cleaner and more accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->