### PR TITLE
fix(docs): valid HTML width on room-acoustics figures (unblock Deploy Docs)

### DIFF
--- a/site/src/content/docs/guides/room-acoustics.md
+++ b/site/src/content/docs/guides/room-acoustics.md
@@ -709,7 +709,7 @@ the field $R'$. EN 12354 predicts the in-situ apparent rating from the
 laboratory ratings of the elements plus the vibration transmission of their
 junctions.
 
-<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_flanking_paths_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_flanking_paths.svg" alt="The direct path Dd through the separating element and the three flanking paths Ff, Df and Fd across each junction between a flanking element and the separating element" width="92%"></picture>
+<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_flanking_paths_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_flanking_paths.svg" alt="The direct path Dd through the separating element and the three flanking paths Ff, Df and Fd across each junction between a flanking element and the separating element" style="width:92%"></picture>
 
 Each junction between a flanking element and the separating element carries
 three paths — $Ff$ (flanking→flanking), $Df$ (direct→flanking) and $Fd$
@@ -734,7 +734,7 @@ where $l_0 = 1$ m is the reference coupling length, $l_f$ the junction coupling
 length and $K_{ij}$ the junction's **vibration reduction index** (Annex E,
 empirical in the mass ratio $M = \log_{10}(m'_{\perp,i}/m'_i)$).
 
-<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/prediction_flanking_demo_dark.png"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/prediction_flanking_demo.png" alt="Per-path sound reduction indices for the EN 12354-1 Annex H.3 example and each path's share of the transmitted energy, showing the direct path dominating at R'w = 52 dB" width="80%"></picture>
+<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/prediction_flanking_demo_dark.png"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/prediction_flanking_demo.png" alt="Per-path sound reduction indices for the EN 12354-1 Annex H.3 example and each path's share of the transmitted energy, showing the direct path dominating at R'w = 52 dB" style="width:80%"></picture>
 
 ```python
 import numpy as np
@@ -866,7 +866,7 @@ of Table 8. A two-sided interval $Y = y \pm U$ (Formula 3, $k = 1.96$ at 95 %)
 *reports* a value; the **one-sided** factor ($k = 1.65$ at 95 %) *declares
 conformity* with a requirement (Formulae 4/5).
 
-<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/insulation_uncertainty_demo_dark.png"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/insulation_uncertainty_demo.png" alt="A weighted rating reported with its two-sided 95 % expanded uncertainty in situations A, B and C, the reproducibility uncertainty widest and the repeatability uncertainty narrowest" width="80%"></picture>
+<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/insulation_uncertainty_demo_dark.png"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/insulation_uncertainty_demo.png" alt="A weighted rating reported with its two-sided 95 % expanded uncertainty in situations A, B and C, the reproducibility uncertainty widest and the repeatability uncertainty narrowest" style="width:80%"></picture>
 
 ```python
 from phonometry import (band_uncertainty, single_number_uncertainty,


### PR DESCRIPTION
## Problem

The **Deploy Docs** workflow fails at the **Validate HTML** step, blocking site deployment ([failing run](https://github.com/jmrplens/phonometry/actions/runs/28982390762)):

```
site/dist/guides/room-acoustics/index.html
  880:466  error  Attribute "width" has invalid value "92%"  attribute-allowed-values
  895:481  error  Attribute "width" has invalid value "80%"  attribute-allowed-values
 1037:489  error  Attribute "width" has invalid value "80%"  attribute-allowed-values
```

Three `<img>` tags in the room-acoustics guide (introduced with the building-acoustics II work) carry a **percentage `width` attribute**. In HTML5 the `width` attribute must be a non-negative integer (pixels), so `width="92%"` / `width="80%"` are invalid and `html-validate`'s `attribute-allowed-values` rule fails the build.

## Fix

Switch those three figures to the inline **`style="width:NN%"`** form already used by **every other figure** on the site (260 occurrences) and targeted by the responsive rules in `site/src/styles/theme-images.css`. No visual change.

## Verification

Local `pnpm run build` succeeds and `pnpm run html-validate` now exits 0 (previously 3 errors). Only the 3 offending lines changed.

https://claude.ai/code/session_01JJLhQzF5hTdnEi3bfmqnqm

## Summary by Sourcery

Bug Fixes:
- Replace percentage-based HTML width attributes on three room-acoustics images with equivalent inline CSS styles to comply with HTML5 validation rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated several guide illustrations to better support dark mode.
  * Images now automatically switch to dark-themed versions when the system is in dark mode, while keeping light-mode fallbacks.
  * Removed outdated image sizing from the affected figures for cleaner rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->