### PR TITLE
docs: correct impedance-tube inputs in materials reference

### DIFF
--- a/docs/materials.md
+++ b/docs/materials.md
@@ -264,7 +264,8 @@ print(np.round(tm.transmission_loss(rho_c), 6))   # [0. 0. 0.]
 ```
 
 `transfer_matrix_two_load` / `transfer_matrix_one_load` build the
-`TransferMatrix` from measured four-microphone wave amplitudes; its methods
+`TransferMatrix` from the four measured microphone transfer functions
+`(H1, H2, H3, H4)` of each load; its methods
 (`transmission_loss`, `reflection_hard_backed`, `absorption_hard_backed`,
 `characteristic_impedance_material`, `material_wavenumber`) then read off the
 ASTM E2611 quantities.


### PR DESCRIPTION
One-line accuracy fix in the GitHub-facing `docs/materials.md`, the twin of the site guide corrected in #95.

`transfer_matrix_two_load` / `transfer_matrix_one_load` document their inputs as "the tuple `(H1, H2, H3, H4)` of the four microphone transfer functions" (ASTM E2611), so "wave amplitudes" was inaccurate. Now consistent with the API docstring and the documentation site.

## Summary by Sourcery

Documentation:
- Update materials reference to describe transfer matrix construction in terms of measured microphone transfer functions (H1–H4) instead of wave amplitudes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/96?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

