### PR TITLE
Audit pass 3: shared validation, energy math, types and warning base

### DIFF
--- a/src/phonometry/__init__.py
+++ b/src/phonometry/__init__.py
@@ -14,7 +14,7 @@ import numpy as np
 from .calibration import CalibrationWarning, calculate_sensitivity
 from .environmental import composite_rating_level, lden, ldn
 from .compliance import verify_filter_class
-from .core import OctaveFilterBank
+from .core import FilterBankWarning, OctaveFilterBank
 from .frequencies import getansifrequencies, normalizedfreq
 from .intensity import (
     FieldIndicators,
@@ -104,10 +104,21 @@ from .sii import (
     speech_intelligibility_index,
     standard_speech_spectrum,
 )
-from .sti import STIResult, sti_from_impulse_response, stipa, stipa_signal
+from .sti import (
+    STIResult,
+    STIWarning,
+    sti_from_impulse_response,
+    stipa,
+    stipa_signal,
+)
 from .tonality_ecma import EcmaTonality, tonality_ecma
 from .roughness_ecma import EcmaRoughness, roughness_ecma
-from .tonality import ToneAssessment, prominence_ratio, tone_to_noise_ratio
+from .tonality import (
+    TonalityWarning,
+    ToneAssessment,
+    prominence_ratio,
+    tone_to_noise_ratio,
+)
 from .parametric_filters import (
     TimeWeighting,
     WeightingFilter,
@@ -339,6 +350,7 @@ from .outdoor_propagation import (
 )
 from .room_ir import (
     ImpulseResponseResult,
+    ImpulseResponseWarning,
     impulse_response,
     inverse_filter,
     mls_impulse_response,
@@ -346,6 +358,7 @@ from .room_ir import (
     sweep_signal,
 )
 from ._plotting import plot_excitation
+from ._warnings import PhonometryWarning
 from .building_prediction import (
     AirbornePredictionResult,
     FlankingPath,
@@ -398,11 +411,13 @@ from ._version import __version__
 
 # Public methods
 __all__ = [
+    "PhonometryWarning",
     "__version__",
     "octavefilter",
     "getansifrequencies",
     "normalizedfreq",
     "OctaveFilterBank",
+    "FilterBankWarning",
     "WeightingFilter",
     "weighting_filter",
     "time_weighting",
@@ -439,6 +454,7 @@ __all__ = [
     "tone_to_noise_ratio",
     "prominence_ratio",
     "ToneAssessment",
+    "TonalityWarning",
     "sound_intensity",
     "IntensityResult",
     "field_indicators",
@@ -448,6 +464,7 @@ __all__ = [
     "stipa",
     "stipa_signal",
     "STIResult",
+    "STIWarning",
     "speech_intelligibility_index",
     "standard_speech_spectrum",
     "SIIResult",
@@ -504,6 +521,7 @@ __all__ = [
     "mls_signal",
     "mls_impulse_response",
     "ImpulseResponseResult",
+    "ImpulseResponseWarning",
     "plot_excitation",
     "room_parameters",
     "decay_curve",

--- a/src/phonometry/_levels_math.py
+++ b/src/phonometry/_levels_math.py
@@ -1,0 +1,102 @@
+#  Copyright (c) 2026. Jose M. Requena-Plens
+"""
+Shared decibel-energy arithmetic helpers (private).
+
+Seeded by the library audit: many modules restated the same
+``10 lg(sum/mean 10^(L/10))`` energy combinations inline. New code
+should combine levels through these helpers; existing modules migrate
+as they are touched.
+"""
+
+from __future__ import annotations
+
+from typing import overload
+
+import numpy as np
+from numpy.typing import ArrayLike
+
+
+@overload
+def energy_mean(levels: ArrayLike, axis: None = None) -> float: ...
+
+
+@overload
+def energy_mean(levels: ArrayLike, axis: int) -> np.ndarray: ...
+
+
+def energy_mean(levels: ArrayLike, axis: int | None = None) -> np.ndarray | float:
+    """Energy (mean-square) average of decibel levels.
+
+    Computes ``10 lg( (1/n) sum_i 10^(Li/10) )`` along *axis*.
+
+    :param levels: Levels to average, in decibels.
+    :param axis: Axis over which to average; ``None`` averages everything.
+    :return: A ``float`` when *axis* is ``None``, otherwise an array.
+    """
+    arr = np.asarray(levels, dtype=np.float64)
+    n = arr.size if axis is None else arr.shape[axis]
+    out = 10.0 * np.log10(np.sum(10.0 ** (arr / 10.0), axis=axis) / n)
+    if axis is None:
+        return float(out)
+    return np.asarray(out, dtype=np.float64)
+
+
+@overload
+def energy_sum(levels: ArrayLike, axis: None = None) -> float: ...
+
+
+@overload
+def energy_sum(levels: ArrayLike, axis: int) -> np.ndarray: ...
+
+
+def energy_sum(levels: ArrayLike, axis: int | None = None) -> np.ndarray | float:
+    """Energetic sum of decibel levels.
+
+    Computes ``10 lg( sum_i 10^(Li/10) )`` along *axis*.
+
+    :param levels: Levels to combine, in decibels.
+    :param axis: Axis over which to sum; ``None`` sums everything.
+    :return: A ``float`` when *axis* is ``None``, otherwise an array.
+    """
+    arr = np.asarray(levels, dtype=np.float64)
+    out = 10.0 * np.log10(np.sum(10.0 ** (arr / 10.0), axis=axis))
+    if axis is None:
+        return float(out)
+    return np.asarray(out, dtype=np.float64)
+
+
+@overload
+def weighted_energy_mean(
+    levels: ArrayLike, weights: ArrayLike, axis: None = None
+) -> float: ...
+
+
+@overload
+def weighted_energy_mean(
+    levels: ArrayLike, weights: ArrayLike, axis: int
+) -> np.ndarray: ...
+
+
+def weighted_energy_mean(
+    levels: ArrayLike, weights: ArrayLike, axis: int | None = None
+) -> np.ndarray | float:
+    """Weighted energy average of decibel levels.
+
+    Computes ``10 lg( sum_i wi 10^(Li/10) / sum_i wi )`` along *axis*.
+    The weights must broadcast against *levels* along the reduced axis
+    (e.g. pass ``areas[:, None]`` for per-row weights of a 2-D array).
+
+    :param levels: Levels to average, in decibels.
+    :param weights: Non-negative weights (e.g. sub-areas or durations).
+    :param axis: Axis over which to average; ``None`` averages everything.
+    :return: A ``float`` when *axis* is ``None``, otherwise an array.
+    """
+    arr = np.asarray(levels, dtype=np.float64)
+    w = np.asarray(weights, dtype=np.float64)
+    # Normalize by the weights summed over the SAME reduction, so weights
+    # that vary along a non-reduced axis stay correct.
+    denominator = np.sum(np.broadcast_to(w, arr.shape), axis=axis)
+    out = 10.0 * np.log10(np.sum(w * 10.0 ** (arr / 10.0), axis=axis) / denominator)
+    if axis is None:
+        return float(out)
+    return np.asarray(out, dtype=np.float64)

--- a/src/phonometry/_levels_math.py
+++ b/src/phonometry/_levels_math.py
@@ -34,8 +34,7 @@ def energy_mean(levels: ArrayLike, axis: int | None = None) -> np.ndarray | floa
     :return: A ``float`` when *axis* is ``None``, otherwise an array.
     """
     arr = np.asarray(levels, dtype=np.float64)
-    n = arr.size if axis is None else arr.shape[axis]
-    out = 10.0 * np.log10(np.sum(10.0 ** (arr / 10.0), axis=axis) / n)
+    out = 10.0 * np.log10(np.mean(10.0 ** (arr / 10.0), axis=axis))
     if axis is None:
         return float(out)
     return np.asarray(out, dtype=np.float64)

--- a/src/phonometry/_types.py
+++ b/src/phonometry/_types.py
@@ -17,10 +17,10 @@ from numpy.typing import NDArray
 Real = NDArray[np.float64]
 
 
-def as_float_or_array(x: np.ndarray) -> np.ndarray | float:
-    """Return a Python ``float`` for a 0-d array, the array otherwise.
+def as_float_or_array(x: np.ndarray | float) -> np.ndarray | float:
+    """Return a Python ``float`` for a 0-d array or scalar, the array otherwise.
 
-    :param x: The array produced by a vectorised computation.
+    :param x: The array (or scalar) produced by a vectorised computation.
     :return: ``float(x)`` when *x* is zero-dimensional, else *x* unchanged.
     """
-    return float(x) if x.ndim == 0 else x
+    return float(x) if np.ndim(x) == 0 else x

--- a/src/phonometry/_types.py
+++ b/src/phonometry/_types.py
@@ -1,0 +1,26 @@
+#  Copyright (c) 2026. Jose M. Requena-Plens
+"""
+Shared typing aliases and array/scalar coercion helpers (private).
+
+Seeded by the library audit: several modules re-declared the same
+``Real`` alias and hand-copied the "0-d array becomes a float" return
+idiom. New code should import from here; existing modules migrate as
+they are touched.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+#: Real-valued float64 array alias shared across the library.
+Real = NDArray[np.float64]
+
+
+def as_float_or_array(x: np.ndarray) -> np.ndarray | float:
+    """Return a Python ``float`` for a 0-d array, the array otherwise.
+
+    :param x: The array produced by a vectorised computation.
+    :return: ``float(x)`` when *x* is zero-dimensional, else *x* unchanged.
+    """
+    return float(x) if x.ndim == 0 else x

--- a/src/phonometry/_validation.py
+++ b/src/phonometry/_validation.py
@@ -9,8 +9,63 @@ through these helpers; existing modules migrate as they are touched.
 
 from __future__ import annotations
 
+import math
+
 import numpy as np
 from numpy.typing import ArrayLike
+
+
+def require_positive(value: float, name: str) -> float:
+    """Require a positive finite number (rejects NaN).
+
+    :param value: The value to validate.
+    :param name: Parameter name used in the error message.
+    :return: The validated value as a ``float``.
+    :raises ValueError: for NaN or a non-positive value.
+    """
+    if math.isnan(value) or value <= 0.0:
+        raise ValueError(f"'{name}' must be positive.")
+    return float(value)
+
+
+def require_non_negative(value: float, name: str) -> float:
+    """Require a non-negative finite number (rejects NaN).
+
+    :param value: The value to validate.
+    :param name: Parameter name used in the error message.
+    :return: The validated value as a ``float``.
+    :raises ValueError: for NaN or a negative value.
+    """
+    if math.isnan(value) or value < 0.0:
+        raise ValueError(f"'{name}' must be non-negative.")
+    return float(value)
+
+
+def require_fraction(value: float, name: str) -> float:
+    """Require a fraction in ``[0, 1)`` (rejects NaN).
+
+    :param value: The value to validate.
+    :param name: Parameter name used in the error message.
+    :return: The validated value as a ``float``.
+    :raises ValueError: for NaN or a value outside ``[0, 1)``.
+    """
+    if math.isnan(value) or value < 0.0 or value >= 1.0:
+        raise ValueError(f"'{name}' must be in the range [0, 1).")
+    return float(value)
+
+
+def require_choice(value: str, name: str, options: tuple[str, ...]) -> str:
+    """Require *value* to be one of *options*.
+
+    :param value: The value to validate.
+    :param name: Parameter name used in the error message.
+    :param options: The accepted values.
+    :return: The validated value.
+    :raises ValueError: for a value not in *options*.
+    """
+    if value not in options:
+        raise ValueError(f"'{name}' must be one of {options}; got {value!r}.")
+    return value
 
 
 def require_1d_signal(x: ArrayLike, name: str = "signal") -> np.ndarray:

--- a/src/phonometry/_validation.py
+++ b/src/phonometry/_validation.py
@@ -16,40 +16,40 @@ from numpy.typing import ArrayLike
 
 
 def require_positive(value: float, name: str) -> float:
-    """Require a positive finite number (rejects NaN).
+    """Require a positive finite number (rejects NaN and infinities).
 
     :param value: The value to validate.
     :param name: Parameter name used in the error message.
     :return: The validated value as a ``float``.
-    :raises ValueError: for NaN or a non-positive value.
+    :raises ValueError: for a non-finite or non-positive value.
     """
-    if math.isnan(value) or value <= 0.0:
+    if not math.isfinite(value) or value <= 0.0:
         raise ValueError(f"'{name}' must be positive.")
     return float(value)
 
 
 def require_non_negative(value: float, name: str) -> float:
-    """Require a non-negative finite number (rejects NaN).
+    """Require a non-negative finite number (rejects NaN and infinities).
 
     :param value: The value to validate.
     :param name: Parameter name used in the error message.
     :return: The validated value as a ``float``.
-    :raises ValueError: for NaN or a negative value.
+    :raises ValueError: for a non-finite or negative value.
     """
-    if math.isnan(value) or value < 0.0:
+    if not math.isfinite(value) or value < 0.0:
         raise ValueError(f"'{name}' must be non-negative.")
     return float(value)
 
 
 def require_fraction(value: float, name: str) -> float:
-    """Require a fraction in ``[0, 1)`` (rejects NaN).
+    """Require a finite fraction in ``[0, 1)``.
 
     :param value: The value to validate.
     :param name: Parameter name used in the error message.
     :return: The validated value as a ``float``.
-    :raises ValueError: for NaN or a value outside ``[0, 1)``.
+    :raises ValueError: for a non-finite value or one outside ``[0, 1)``.
     """
-    if math.isnan(value) or value < 0.0 or value >= 1.0:
+    if not math.isfinite(value) or value < 0.0 or value >= 1.0:
         raise ValueError(f"'{name}' must be in the range [0, 1).")
     return float(value)
 

--- a/src/phonometry/_warnings.py
+++ b/src/phonometry/_warnings.py
@@ -1,0 +1,14 @@
+#  Copyright (c) 2026. Jose M. Requena-Plens
+"""
+Warning hierarchy root (private module, public class).
+
+Every warning the library emits derives from :class:`PhonometryWarning`
+so users can filter or escalate all phonometry diagnostics with a single
+:func:`warnings.filterwarnings` rule.
+"""
+
+from __future__ import annotations
+
+
+class PhonometryWarning(UserWarning):
+    """Base class for all phonometry warnings."""

--- a/src/phonometry/air_absorption.py
+++ b/src/phonometry/air_absorption.py
@@ -55,7 +55,10 @@ from __future__ import annotations
 import warnings
 
 import numpy as np
+
 from numpy.typing import ArrayLike, NDArray
+
+from ._warnings import PhonometryWarning
 
 from .sound_absorption import attenuation_from_alpha
 
@@ -78,7 +81,7 @@ _HUMIDITY_RANGE = (10.0, 100.0)
 _PRESSURE_MAX = 200.0
 
 
-class AtmosphericAbsorptionWarning(UserWarning):
+class AtmosphericAbsorptionWarning(PhonometryWarning):
     """Advisory for ISO 9613-1 inputs outside the tabulated/validity ranges."""
 
 

--- a/src/phonometry/airflow_resistance.py
+++ b/src/phonometry/airflow_resistance.py
@@ -66,7 +66,10 @@ import warnings
 from dataclasses import dataclass
 
 import numpy as np
+
 from numpy.typing import ArrayLike, NDArray
+
+from ._warnings import PhonometryWarning
 
 __all__ = [
     "AirflowResistanceWarning",
@@ -109,7 +112,7 @@ _ALT_VALIDITY_LIMIT = 0.3
 _ALT_BACKGROUND_MARGIN = 10.0
 
 
-class AirflowResistanceWarning(UserWarning):
+class AirflowResistanceWarning(PhonometryWarning):
     """Advisory for out-of-range or non-conforming ISO 9053 airflow inputs."""
 
 

--- a/src/phonometry/calibration.py
+++ b/src/phonometry/calibration.py
@@ -10,8 +10,10 @@ from typing import List
 
 import numpy as np
 
+from ._warnings import PhonometryWarning
 
-class CalibrationWarning(UserWarning):
+
+class CalibrationWarning(PhonometryWarning):
     """The calibration reference recording looks unreliable."""
 
 

--- a/src/phonometry/core.py
+++ b/src/phonometry/core.py
@@ -11,9 +11,14 @@ from typing import List, Tuple, cast, overload, Literal
 import numpy as np
 from scipy import signal
 
+from ._warnings import PhonometryWarning
 from .filter_design import _cheby2_headroom, _design_sos_filter
 from .frequencies import _genfreqs
 from .utils import _downsamplingfactor, _resample_to_length, _typesignal
+
+
+class FilterBankWarning(PhonometryWarning):
+    """Warns about fractional-octave filter-bank processing pitfalls."""
 
 
 class OctaveFilterBank:
@@ -285,7 +290,7 @@ class OctaveFilterBank:
                 warnings.warn(
                     "Detrending is not recommended during block processing "
                     "as it can introduce discontinuities between blocks.",
-                    UserWarning,
+                    FilterBankWarning,
                     stacklevel=2,
                 )
             # Axis -1 handles both 1D and 2D arrays correctly

--- a/src/phonometry/en12354_6.py
+++ b/src/phonometry/en12354_6.py
@@ -24,7 +24,6 @@ distribution is out of scope.
 
 from __future__ import annotations
 
-import math
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -35,6 +34,9 @@ if TYPE_CHECKING:
     from matplotlib.axes import Axes
 
 from numpy.typing import ArrayLike
+
+from ._types import as_float_or_array
+from ._validation import require_fraction, require_positive
 
 # ---------------------------------------------------------------------------
 # Normative constants.
@@ -70,20 +72,6 @@ AIR_ATTENUATION: dict[str, np.ndarray] = {
 DEFAULT_AIR_CONDITION = "20C_50-70"
 
 
-def _require_positive(value: float, name: str) -> float:
-    """Validate that *value* is a positive finite number (rejects NaN)."""
-    if math.isnan(value) or value <= 0.0:
-        raise ValueError(f"{name} must be positive.")
-    return float(value)
-
-
-def _require_fraction(value: float, name: str) -> float:
-    """Validate that *value* is a fraction in ``[0, 1)`` (rejects NaN)."""
-    if math.isnan(value) or value < 0.0 or value >= 1.0:
-        raise ValueError(f"{name} must be in the range [0, 1).")
-    return float(value)
-
-
 # ---------------------------------------------------------------------------
 # Clause 4.3 - total equivalent absorption area.
 # ---------------------------------------------------------------------------
@@ -96,7 +84,7 @@ def object_fraction(object_volumes: ArrayLike, volume: float) -> float:
     :param volume: Volume of the empty enclosed space ``V``, m3.
     :return: The object fraction ``psi = sum(Vobj) / V``.
     """
-    volume = _require_positive(volume, "volume")
+    volume = require_positive(volume, "volume")
     vols = np.asarray(object_volumes, dtype=np.float64)
     if np.any(vols < 0.0):
         raise ValueError("object volumes must be non-negative.")
@@ -132,13 +120,13 @@ def air_absorption_area(
     :param object_fraction: Object fraction ``psi`` (0-1).
     :return: The air absorption area ``Aair = 4*m*V*(1 - psi)``, m2.
     """
-    volume = _require_positive(volume, "volume")
-    object_fraction = _require_fraction(object_fraction, "object_fraction")
+    volume = require_positive(volume, "volume")
+    object_fraction = require_fraction(object_fraction, "object_fraction")
     m_arr = np.asarray(m, dtype=np.float64)
     if np.any(m_arr < 0.0):
         raise ValueError("the attenuation coefficient m must be non-negative.")
     area = 4.0 * m_arr * volume * (1.0 - object_fraction)
-    return float(area) if area.ndim == 0 else area
+    return as_float_or_array(area)
 
 
 def equivalent_absorption_area(
@@ -176,7 +164,7 @@ def equivalent_absorption_area(
         if np.any(obj < 0.0):
             raise ValueError("object absorption areas must be non-negative.")
         total = total + obj.sum(axis=0)
-    return float(total) if total.ndim == 0 else total
+    return as_float_or_array(total)
 
 
 # ---------------------------------------------------------------------------
@@ -200,14 +188,14 @@ def reverberation_time(
         :data:`SPEED_OF_SOUND`, giving the factor ``0.16``).
     :return: The reverberation time ``T = 55.3/c0 * V*(1 - psi) / A``, s.
     """
-    volume = _require_positive(volume, "volume")
-    speed_of_sound = _require_positive(speed_of_sound, "speed_of_sound")
-    object_fraction = _require_fraction(object_fraction, "object_fraction")
+    volume = require_positive(volume, "volume")
+    speed_of_sound = require_positive(speed_of_sound, "speed_of_sound")
+    object_fraction = require_fraction(object_fraction, "object_fraction")
     area = np.asarray(absorption_area, dtype=np.float64)
     if np.any(area <= 0.0):
         raise ValueError("absorption_area must be positive.")
     t = _RT_CONSTANT / speed_of_sound * volume * (1.0 - object_fraction) / area
-    return float(t) if t.ndim == 0 else t
+    return as_float_or_array(t)
 
 
 @dataclass(frozen=True)

--- a/src/phonometry/frequencies.py
+++ b/src/phonometry/frequencies.py
@@ -11,6 +11,8 @@ from typing import List, Tuple
 
 import numpy as np
 
+from ._warnings import PhonometryWarning
+
 
 def getansifrequencies(
     fraction: float,
@@ -102,7 +104,11 @@ def _deleteouters(
 
     idx = np.nonzero(freq_u_arr > fs / 2)[0]
     if len(idx) > 0:
-        warnings.warn("Low sampling rate: frequencies above fs/2 removed", stacklevel=3)
+        warnings.warn(
+            "Low sampling rate: frequencies above fs/2 removed",
+            PhonometryWarning,
+            stacklevel=3,
+        )
         freq_arr = np.delete(freq_arr, idx)
         freq_d_arr = np.delete(freq_d_arr, idx)
         freq_u_arr = np.delete(freq_u_arr, idx)

--- a/src/phonometry/human_vibration.py
+++ b/src/phonometry/human_vibration.py
@@ -54,12 +54,14 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
+
+from ._types import Real
+from ._warnings import PhonometryWarning
 from scipy import signal as sig
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from matplotlib.axes import Axes
 
-Real = NDArray[np.float64]
 Complex = NDArray[np.complex128]
 
 __all__ = [
@@ -130,7 +132,7 @@ WBV_ELV_VDV = 21.0
 _Q_BUTTERWORTH = 1.0 / math.sqrt(2.0)
 
 
-class HumanVibrationWarning(UserWarning):
+class HumanVibrationWarning(PhonometryWarning):
     """Advisory for out-of-range human-vibration measurement conditions."""
 
 

--- a/src/phonometry/impedance_tube.py
+++ b/src/phonometry/impedance_tube.py
@@ -44,8 +44,10 @@ from dataclasses import dataclass
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
 
+from ._types import Real
+from ._warnings import PhonometryWarning
+
 Complex = NDArray[np.complex128]
-Real = NDArray[np.float64]
 
 #: Reference speed of sound of ISO 10534-2 Eq. (5), in m/s (343,2 exactly).
 _ISO_C_REF = 343.2
@@ -110,7 +112,7 @@ __all__ = [
 ]
 
 
-class ImpedanceTubeWarning(UserWarning):
+class ImpedanceTubeWarning(PhonometryWarning):
     """Advisory for out-of-plane-wave-range impedance-tube frequencies."""
 
 

--- a/src/phonometry/insulation.py
+++ b/src/phonometry/insulation.py
@@ -91,6 +91,9 @@ from typing import TYPE_CHECKING, Any, Sequence, Tuple
 
 import numpy as np
 
+from ._levels_math import energy_mean, energy_sum
+from ._types import as_float_or_array
+
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
 
@@ -362,13 +365,7 @@ def energy_average_level(
         raise ValueError("'levels' must not be empty.")
     if not np.all(np.isfinite(data)):
         raise ValueError("'levels' must contain only finite values.")
-    n = data.shape[axis]
-    result: np.ndarray = 10.0 * np.log10(
-        np.sum(10.0 ** (data / 10.0), axis=axis) / n
-    )
-    if result.ndim == 0:
-        return float(result)
-    return result
+    return as_float_or_array(energy_mean(data, axis=axis))
 
 
 def _as_band_levels(
@@ -534,9 +531,7 @@ def _adaptation_term(
     measured: np.ndarray, spectrum: Tuple[int, ...], rating: int
 ) -> int:
     """Spectrum adaptation term ``Xaj - rating`` (Clause 4.5, Formula (2))."""
-    x_aj = -10.0 * np.log10(
-        np.sum(10.0 ** ((np.asarray(spectrum, dtype=np.float64) - measured) / 10.0))
-    )
+    x_aj = -energy_sum(np.asarray(spectrum, dtype=np.float64) - measured)
     return int(math.floor(x_aj + 0.5)) - rating
 
 
@@ -853,7 +848,7 @@ def _impact_ci(measured: np.ndarray, rating: int, n_bands: int) -> int:
     the first 15 bands; octave 125-2000 Hz), rounded to an integer
     (round half up), Formulae (A.1) to (A.3).
     """
-    l_sum = 10.0 * np.log10(np.sum(10.0 ** (measured[:n_bands] / 10.0)))
+    l_sum = energy_sum(measured[:n_bands])
     return int(math.floor(l_sum + 0.5)) - 15 - rating
 
 

--- a/src/phonometry/intensity.py
+++ b/src/phonometry/intensity.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
     from matplotlib.axes import Axes
 from scipy import signal
 
+from ._levels_math import energy_mean
 from .frequencies import _genfreqs
 from .utils import _typesignal
 
@@ -366,7 +367,7 @@ def field_indicators(
         raise ValueError("At least two measurement positions are required.")
 
     # Equation (A.4): surface pressure level.
-    lp_surface = float(10.0 * np.log10(np.mean(10.0 ** (0.1 * lp))))
+    lp_surface = energy_mean(lp)
     # Equation (A.5): level of the mean magnitude of the normal intensity.
     li_abs = _level(float(np.mean(np.abs(i_n))), _I0)
     mean_i = float(np.mean(i_n))

--- a/src/phonometry/iso2631_5.py
+++ b/src/phonometry/iso2631_5.py
@@ -29,7 +29,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from ._validation import require_1d_signal
+from ._types import as_float_or_array
+from ._validation import require_1d_signal, require_choice, require_positive
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -88,11 +89,6 @@ RISK_THRESHOLDS_FEMALE: tuple[float, float, float] = (0.52, 0.87, 1.20)
 _SEXES = ("male", "female")
 
 
-def _check_sex(sex: str) -> None:
-    if sex not in _SEXES:
-        raise ValueError(f"sex must be one of {_SEXES}; got {sex!r}.")
-
-
 def _mz_for_sex(sex: str) -> float:
     return MZ_MALE if sex == "male" else MZ_FEMALE
 
@@ -121,12 +117,6 @@ def seat_to_spine_transfer(frequencies: ArrayLike) -> np.ndarray:
     return np.asarray(response, dtype=np.complex128)
 
 
-def _positive_fs(fs: float) -> float:
-    if not fs > 0.0:
-        raise ValueError("fs must be positive.")
-    return float(fs)
-
-
 def spinal_response(acceleration: ArrayLike, fs: float) -> np.ndarray:
     """Vertical spinal response ``Az(t)`` (clause 5.2, Formula 2).
 
@@ -138,7 +128,7 @@ def spinal_response(acceleration: ArrayLike, fs: float) -> np.ndarray:
     :param fs: Sampling frequency, in hertz.
     :return: The spinal response acceleration ``Az(t)``, m/s2, same length.
     """
-    fs = _positive_fs(fs)
+    fs = require_positive(fs, "fs")
     az = np.asarray(acceleration, dtype=np.float64)
     if az.ndim != 1:
         raise ValueError("acceleration must be a 1-D time series.")
@@ -266,7 +256,7 @@ def ultimate_strength(age: ArrayLike, *, sex: str = "male") -> np.ndarray:
     :param sex: ``"male"`` or ``"female"`` (sets the age slope ``Sage``).
     :return: The ultimate strength ``Su = 6.75 - Sage*(b+i)``, MPa.
     """
-    _check_sex(sex)
+    require_choice(sex, "sex", _SEXES)
     slope = STRENGTH_AGE_SLOPE_MALE if sex == "male" else STRENGTH_AGE_SLOPE_FEMALE
     years = np.asarray(age, dtype=np.float64)
     return ULTIMATE_STRENGTH_INTERCEPT - slope * years
@@ -297,7 +287,7 @@ def injury_risk(
     :raises ValueError: if ``years`` is not positive or the spine strength is
         exhausted (``Su - Sstat <= 0``) within the exposure period.
     """
-    _check_sex(sex)
+    require_choice(sex, "sex", _SEXES)
     if years <= 0:
         raise ValueError("years must be a positive integer.")
     if not days_per_year > 0.0:
@@ -325,11 +315,11 @@ def injury_probability(risk: ArrayLike, *, sex: str = "male") -> np.ndarray | fl
     :return: The injury probability ``P = 1 - exp(-(R/alpha)**beta)`` in 0-1;
         a float for a scalar input, otherwise an array. Negative ``R`` gives 0.
     """
-    _check_sex(sex)
+    require_choice(sex, "sex", _SEXES)
     alpha, beta = WEIBULL_MALE if sex == "male" else WEIBULL_FEMALE
     r = np.asarray(risk, dtype=np.float64)
     prob = 1.0 - np.exp(-((np.maximum(r, 0.0) / alpha) ** beta))
-    return float(prob) if prob.ndim == 0 else prob
+    return as_float_or_array(prob)
 
 
 def _risk_thresholds(sex: str) -> tuple[float, float, float]:
@@ -409,7 +399,7 @@ def multiple_shock_assessment(
         sex-specific value.
     :return: The :class:`MultipleShockResult`.
     """
-    _check_sex(sex)
+    require_choice(sex, "sex", _SEXES)
     if (exposure_time is None) != (measurement_time is None):
         raise ValueError(
             "provide both exposure_time and measurement_time to scale to a "

--- a/src/phonometry/lab_insulation.py
+++ b/src/phonometry/lab_insulation.py
@@ -52,6 +52,8 @@ import warnings
 
 import numpy as np
 
+from ._warnings import PhonometryWarning
+
 from .insulation import (
     ImpactRatingResult,
     WeightedRatingResult,
@@ -82,7 +84,7 @@ _BACKGROUND_LOW = 6.0
 _BACKGROUND_HIGH = 15.0
 
 
-class LabInsulationWarning(UserWarning):
+class LabInsulationWarning(PhonometryWarning):
     """Warning for laboratory-insulation limit-of-measurement conditions."""
 
 

--- a/src/phonometry/levels.py
+++ b/src/phonometry/levels.py
@@ -10,6 +10,7 @@ from typing import Dict, List, Sequence
 import numpy as np
 from scipy import signal
 
+from ._types import as_float_or_array
 from .parametric_filters import time_weighting, weighting_filter
 from .utils import _typesignal
 
@@ -53,7 +54,7 @@ def leq(
     _validate_level_input(x_proc, calibration_factor)
     ms = np.mean(x_proc**2, axis=-1)
     out = _level_db(np.asarray(ms), calibration_factor, dbfs)
-    return float(out) if out.ndim == 0 else out
+    return as_float_or_array(out)
 
 
 def laeq(
@@ -168,7 +169,7 @@ def lc_peak(
         weighted = signal.resample_poly(weighted, oversample, 1, axis=-1)
     peak = np.max(np.abs(weighted), axis=-1)
     out = _level_db(np.asarray(peak) ** 2, calibration_factor, dbfs)
-    return float(out) if out.ndim == 0 else out
+    return as_float_or_array(out)
 
 
 def sel(
@@ -202,7 +203,7 @@ def sel(
     duration_s = x_proc.shape[-1] / fs
     base = leq(x_proc, calibration_factor, dbfs)
     out = np.asarray(base) + 10 * np.log10(duration_s)
-    return float(out) if out.ndim == 0 else out
+    return as_float_or_array(out)
 
 
 def sound_exposure(
@@ -235,7 +236,7 @@ def sound_exposure(
     mean_square = np.mean(p_a ** 2, axis=-1)
     hours = duration_hours if duration_hours is not None else x_proc.shape[-1] / fs / 3600.0
     out = np.asarray(mean_square * hours)
-    return float(out) if out.ndim == 0 else out
+    return as_float_or_array(out)
 
 
 def lex_8h(
@@ -264,4 +265,4 @@ def lex_8h(
     )
     eps = np.finfo(float).eps
     out = 10 * np.log10(np.maximum(exposure, eps) / (8.0 * _REF_PRESSURE ** 2))
-    return float(out) if out.ndim == 0 else out
+    return as_float_or_array(out)

--- a/src/phonometry/loudness_moore_glasberg_time.py
+++ b/src/phonometry/loudness_moore_glasberg_time.py
@@ -60,6 +60,7 @@ from .loudness_moore_glasberg import (
     _cochlea_levels,
     _erb_bandwidth,
     _fc_from_cam,
+    _validate_conditions,
 )
 
 # One entry per FFT window: (segment length, Hann window, sum of window^2,
@@ -323,9 +324,6 @@ _T5_SONE = np.array(
 )
 _LOG_T5_SONE = np.log10(_T5_SONE)
 
-_FIELDS = ("free", "diffuse", "eardrum")
-_PRESENTATIONS = ("binaural", "diotic", "monaural")
-
 
 @dataclass(frozen=True)
 class MooreGlasbergTimeVaryingLoudness:
@@ -581,15 +579,6 @@ def _run_ear(
 # ---------------------------------------------------------------------------
 # Input handling and public API
 # ---------------------------------------------------------------------------
-
-
-def _validate_conditions(field: str, presentation: str) -> None:
-    if field not in _FIELDS:
-        raise ValueError(f"field must be one of {_FIELDS}, got {field!r}.")
-    if presentation not in _PRESENTATIONS:
-        raise ValueError(
-            f"presentation must be one of {_PRESENTATIONS}, got {presentation!r}."
-        )
 
 
 def _as_two_channels(

--- a/src/phonometry/occupational_exposure.py
+++ b/src/phonometry/occupational_exposure.py
@@ -48,6 +48,9 @@ from typing import Dict, Literal, Sequence, Tuple
 
 import numpy as np
 
+from ._levels_math import energy_mean
+from ._warnings import PhonometryWarning
+
 #: Reference duration T0 = 8 h (Clause 4).
 _T0: float = 8.0
 
@@ -70,7 +73,7 @@ INSTRUMENT_U2: Dict[str, float] = {
 }
 
 
-class ExposureWarning(UserWarning):
+class ExposureWarning(PhonometryWarning):
     """Advisory raised when an ISO 9612 sampling rule recommends more measurements."""
 
 
@@ -157,12 +160,6 @@ def minimum_cumulative_duration_hours(n_workers: int) -> float:
 # --------------------------------------------------------------------------- #
 # Energy helpers.
 # --------------------------------------------------------------------------- #
-def _energy_average(levels: Sequence[float]) -> float:
-    """Energy (logarithmic) average of A-weighted levels, dB (Eq 7 / Eq 11)."""
-    arr = np.asarray(levels, dtype=float)
-    return float(10.0 * log10(float(np.mean(10.0 ** (0.1 * arr)))))
-
-
 def _sampling_std(levels: Sequence[float]) -> float:
     """Sample standard deviation about the arithmetic mean (Eq C.12), dB.
 
@@ -323,7 +320,7 @@ def task_based_exposure(
             raise ValueError("Each task needs at least one sample.")
         if task.duration_hours <= 0:
             raise ValueError("Task 'duration_hours' must be positive.")
-        levels.append(_energy_average(task.samples))
+        levels.append(energy_mean(task.samples))  # Eq 7
         durations.append(task.duration_hours)
 
     # Daily level: energy sum of contributions (Eq 9 == Eq 10).
@@ -421,7 +418,7 @@ def _sampled_exposure(
     if u3 < 0:
         raise ValueError("'u3' must be non-negative.")
 
-    lp_aeqte = _energy_average(samples)  # Eq 11
+    lp_aeqte = energy_mean(samples)  # Eq 11
     lex_8h = lp_aeqte + 10.0 * log10(effective_duration_hours / _T0)  # Eq 12/13
 
     u1 = _sampling_std(samples)  # Eq C.12

--- a/src/phonometry/road_absorption.py
+++ b/src/phonometry/road_absorption.py
@@ -61,10 +61,12 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
 
+from ._types import Real
+from ._warnings import PhonometryWarning
+
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from matplotlib.axes import Axes
 
-Real = NDArray[np.float64]
 Complex = NDArray[np.complex128]
 
 #: Mandatory source-to-reference-plane distance ``ds`` (ISO 13472-1, 4.2), m.
@@ -133,7 +135,7 @@ __all__ = [
 ]
 
 
-class RoadAbsorptionWarning(UserWarning):
+class RoadAbsorptionWarning(PhonometryWarning):
     """Advisory for out-of-range in-situ road-absorption frequencies."""
 
 

--- a/src/phonometry/room_ir.py
+++ b/src/phonometry/room_ir.py
@@ -42,7 +42,13 @@ from typing import TYPE_CHECKING, Any, Dict, List, Tuple
 import numpy as np
 from scipy import signal
 
+from ._warnings import PhonometryWarning
 from .utils import _typesignal
+
+
+class ImpulseResponseWarning(PhonometryWarning):
+    """Warns about suspect recovered impulse responses (e.g. MLS aliasing)."""
+
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -472,7 +478,7 @@ def mls_impulse_response(
         consumer and adds :meth:`ImpulseResponseResult.plot`.
 
     .. note::
-        A ``UserWarning`` is emitted when the recovered IR retains significant
+        An :class:`ImpulseResponseWarning` is emitted when the recovered IR retains significant
         energy at the end of the period (a circular-aliasing symptom). The
         tail-RMS heuristic is advisory: a high ambient noise floor in the
         recording raises the tail RMS on its own and can trigger a
@@ -513,7 +519,7 @@ def mls_impulse_response(
                 f"dB re peak, above {_MLS_ALIAS_TAIL_DB:.0f} dB): the impulse "
                 "response is likely longer than one period and aliases "
                 "circularly. Use a higher MLS order.",
-                UserWarning,
+                ImpulseResponseWarning,
                 stacklevel=2,
             )
 

--- a/src/phonometry/scattering_diffusion.py
+++ b/src/phonometry/scattering_diffusion.py
@@ -42,12 +42,14 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from numpy.typing import ArrayLike, NDArray
+from numpy.typing import ArrayLike
+
+from ._types import Real
+from ._warnings import PhonometryWarning
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from matplotlib.axes import Axes
 
-Real = NDArray[np.float64]
 
 __all__ = [
     "BASE_PLATE_BANDS_HZ",
@@ -117,7 +119,7 @@ BASE_PLATE_MAX_SCATTERING: dict[int, float] = {
 TWO_DIMENSIONAL_SOURCE_WEIGHTS: tuple[int, ...] = (1, 3, 3, 3, 3)
 
 
-class ScatteringDiffusionWarning(UserWarning):
+class ScatteringDiffusionWarning(PhonometryWarning):
     """Advisory for out-of-range scattering/diffusion measurement conditions."""
 
 

--- a/src/phonometry/sound_absorption.py
+++ b/src/phonometry/sound_absorption.py
@@ -46,7 +46,10 @@ import math
 import warnings
 
 import numpy as np
+
 from numpy.typing import ArrayLike, NDArray
+
+from ._warnings import PhonometryWarning
 
 #: Sabine constant of ISO 354:2003, Eq. (5)/(7) (55,3 exactly as printed).
 _SABINE = 55.3
@@ -63,7 +66,7 @@ _SAMPLE_AREA_MAX = 12.0
 _SAMPLE_AREA_REF_VOLUME = 200.0
 
 
-class AbsorptionWarning(UserWarning):
+class AbsorptionWarning(PhonometryWarning):
     """Advisory for out-of-range or non-physical ISO 354 absorption inputs."""
 
 

--- a/src/phonometry/sound_power.py
+++ b/src/phonometry/sound_power.py
@@ -41,6 +41,10 @@ from typing import TYPE_CHECKING, Any, Dict, Literal, Tuple, cast
 
 import numpy as np
 
+from ._levels_math import energy_mean, energy_sum, weighted_energy_mean
+from ._types import as_float_or_array
+from ._warnings import PhonometryWarning
+
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
 
@@ -50,7 +54,7 @@ Grade = Literal["engineering", "survey"]
 Surface = Literal["hemisphere", "box"]
 
 
-class SoundPowerWarning(UserWarning):
+class SoundPowerWarning(PhonometryWarning):
     """Non-fatal qualification issue in any of the sound-power methods.
 
     Emitted for ISO 3744/3746 background margin below the criterion and for
@@ -175,15 +179,6 @@ class SoundPowerResult:
         return plot_sound_power(self, ax=ax, **kwargs)
 
 
-def _energy_average(levels: np.ndarray) -> np.ndarray:
-    """Energy (mean-square) average of levels over axis 0 (ISO 3744 Eq. 12)."""
-    n = levels.shape[0]
-    return np.asarray(
-        10.0 * np.log10(np.sum(10.0 ** (0.1 * levels), axis=0) / n),
-        dtype=np.float64,
-    )
-
-
 def background_noise_correction(
     source_levels: np.ndarray,
     background_levels: np.ndarray,
@@ -296,7 +291,7 @@ def environmental_correction(
     if np.any(a <= 0.0):
         raise ValueError("absorption_area must be positive.")
     k2 = 10.0 * np.log10(1.0 + 4.0 * surface_area / a)
-    return float(k2) if k2.ndim == 0 else np.asarray(k2, dtype=np.float64)
+    return as_float_or_array(k2)
 
 
 def measurement_positions(
@@ -491,7 +486,7 @@ def sound_power_pressure(
         )
 
     # --- energy average and background correction K1 ----------------------
-    mean_level = _energy_average(levels)
+    mean_level = energy_mean(levels, axis=0)
     n_bands = mean_level.shape[0]
     if background_levels is not None:
         bg = np.atleast_2d(np.asarray(background_levels, dtype=np.float64))
@@ -505,7 +500,7 @@ def sound_power_pressure(
                 "a single spectrum of shape (NB,) or (1, NB) broadcast to all "
                 "positions."
             )
-        k1 = background_noise_correction(mean_level, _energy_average(bg), grade)
+        k1 = background_noise_correction(mean_level, energy_mean(bg, axis=0), grade)
     else:
         k1 = np.zeros(n_bands, dtype=np.float64)
 
@@ -544,7 +539,7 @@ def sound_power_pressure(
         if freqs.shape[0] != n_bands:
             raise ValueError("'frequencies' length must match the number of bands.")
         ck = _a_weighting_corrections(freqs)
-        lwa = float(10.0 * np.log10(np.sum(10.0 ** (0.1 * (lw + ck)))))
+        lwa = energy_sum(lw + ck)
     else:
         freqs = None
         # A-weighting needs the band centre frequencies; with several bands and
@@ -899,7 +894,7 @@ def meteorological_corrections(
         if np.any(a0 < 0.0):
             raise ValueError("'air_absorption_coefficient' must be non-negative.")
         c3_arr = a0 * (1.0053 - 0.0012 * a0) ** 1.6
-        c3 = float(c3_arr) if c3_arr.ndim == 0 else np.asarray(c3_arr, dtype=np.float64)
+        c3 = as_float_or_array(c3_arr)
     return MeteorologicalCorrection(c1=c1, c2=c2, c3=c3)
 
 
@@ -943,7 +938,7 @@ def precision_uncertainty(
         raise ValueError("'sigma_omc' must be non-negative.")
     sigma_tot = np.hypot(np.asarray(sigma_r0, dtype=np.float64), sigma_omc)
     u = coverage_factor * sigma_tot
-    return float(u) if u.ndim == 0 else np.asarray(u, dtype=np.float64)
+    return as_float_or_array(u)
 
 
 def sound_power_anechoic(
@@ -1032,23 +1027,16 @@ def sound_power_anechoic(
     corrected = levels - k1  # Lpi = L'pi(ST) - K1i
 
     # --- surface time-averaged level Lp_bar (Eq. 12 equal / Eq. 13 area) --
-    mean_level = _energy_average(levels)
+    mean_level = energy_mean(levels, axis=0)
     if areas is None:
-        lp_bar = _energy_average(corrected)
+        lp_bar = energy_mean(corrected, axis=0)
     else:
         seg = np.asarray(areas, dtype=np.float64)
         if seg.shape != (n_positions,):
             raise ValueError("'areas' must have one value per microphone position.")
         if np.any(seg <= 0.0):
             raise ValueError("All 'areas' must be positive.")
-        s_total = float(np.sum(seg))
-        lp_bar = np.asarray(
-            10.0
-            * np.log10(
-                np.sum(seg[:, None] * 10.0 ** (0.1 * corrected), axis=0) / s_total
-            ),
-            dtype=np.float64,
-        )
+        lp_bar = weighted_energy_mean(corrected, seg[:, None], axis=0)
 
     # --- meteorological corrections C1, C2, C3 (Eq. 14) -------------------
     mc = meteorological_corrections(
@@ -1066,7 +1054,7 @@ def sound_power_anechoic(
     # --- A-weighted total LWA (Eq. C.1) -----------------------------------
     if freqs is not None:
         ck = _a_weighting_corrections(freqs)
-        lwa = float(10.0 * np.log10(np.sum(10.0 ** (0.1 * (lw + ck)))))
+        lwa = energy_sum(lw + ck)
     else:
         lwa = float(lw[0]) if n_bands == 1 else float("nan")
 
@@ -1240,7 +1228,7 @@ def precision_field_indicators(
     if n_seg < 2:
         raise ValueError("At least two segments are required for the indicators.")
 
-    lp_bar = _energy_average(lp)  # Eq. B.4
+    lp_bar = energy_mean(lp, axis=0)  # Eq. B.4
     li_unsigned = 10.0 * np.log10(np.mean(np.abs(i_n), axis=0) / _I0)  # Eq. B.5
     mean_signed = np.mean(i_n, axis=0)
     li_signed = 10.0 * np.log10(

--- a/src/phonometry/sound_power_intensity.py
+++ b/src/phonometry/sound_power_intensity.py
@@ -46,15 +46,16 @@ from __future__ import annotations
 
 import warnings
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, Literal, cast
+from typing import TYPE_CHECKING, Any, Dict, Literal
 
 import numpy as np
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
 
+from ._levels_math import weighted_energy_mean
 from .intensity import dynamic_capability_index
-from .sound_power import SoundPowerWarning, _a_weighting_corrections
+from .sound_power import SoundPowerWarning, _a_weighting_corrections, _check_grade
 
 _P0 = 1.0e-12  #: Reference sound power, in watts (ISO 9614-2, 3.6.3).
 _S0 = 1.0  #: Reference surface area, in square metres (ISO 9614-2, A.2.1).
@@ -148,12 +149,6 @@ class SoundPowerIntensityResult:
         from ._plotting import plot_sound_power
 
         return plot_sound_power(self, ax=ax, **kwargs)
-
-
-def _check_grade(grade: str) -> Grade:
-    if grade not in ("engineering", "survey"):
-        raise ValueError("'grade' must be 'engineering' or 'survey'.")
-    return cast(Grade, grade)
 
 
 def _level_magnitude(values: np.ndarray) -> np.ndarray:
@@ -293,9 +288,7 @@ def sound_power_intensity(
     if pressure_levels is not None:
         lp = _as_2d("pressure_levels", np.asarray(pressure_levels), n_seg, n_bands)
         # Eq. A.1: area-weighted surface pressure level [Lp].
-        lp_surface = 10.0 * np.log10(
-            np.sum(seg[:, None] * 10.0 ** (0.1 * lp), axis=0) / s_total
-        )
+        lp_surface = weighted_energy_mean(lp, seg[:, None], axis=0)
         fpi = np.asarray(
             lp_surface - lw_magnitude + 10.0 * np.log10(s_total / _S0),
             dtype=np.float64,

--- a/src/phonometry/sound_power_reverberation.py
+++ b/src/phonometry/sound_power_reverberation.py
@@ -47,10 +47,10 @@ import numpy as np
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
 
+from ._levels_math import energy_mean, energy_sum
 from .sound_power import (
     SoundPowerWarning,
     _a_weighting_corrections,
-    _energy_average,
 )
 
 _A0 = 1.0  #: Reference absorption area, in square metres (ISO 3741, Eq. 20).
@@ -144,7 +144,7 @@ def _mean_level(levels: np.ndarray) -> np.ndarray:
     if arr.ndim == 1:
         return arr
     if arr.ndim == 2:
-        return _energy_average(arr)
+        return energy_mean(arr, axis=0)
     raise ValueError("'levels' must be a 1D spectrum or a 2D (positions, bands) array.")
 
 
@@ -282,7 +282,7 @@ def _a_weighted_total(
             # Frequencies are not nominal band centres (e.g. exact filter
             # centres from room_parameters); the A-weighted total is undefined.
             return float("nan")
-        return float(10.0 * np.log10(np.sum(10.0 ** (0.1 * (sound_power_level + ck)))))
+        return energy_sum(sound_power_level + ck)
     return float(sound_power_level[0]) if n_bands == 1 else float("nan")
 
 

--- a/src/phonometry/sti.py
+++ b/src/phonometry/sti.py
@@ -27,9 +27,15 @@ if TYPE_CHECKING:
     from matplotlib.axes import Axes
 from scipy import signal
 
+from ._warnings import PhonometryWarning
 from .core import OctaveFilterBank
 from .frequencies import getansifrequencies
 from .utils import _typesignal
+
+
+class STIWarning(PhonometryWarning):
+    """Warns about suspect STI/STIPA measurements or inputs."""
+
 
 # Octave-band analysis range: 125 Hz - 8 kHz (Ed.4 A.5.1 = Ed.5), 7 bands.
 _BAND_LIMITS = (125.0, 8000.0)
@@ -198,7 +204,7 @@ def _sti_from_mtf(
         warnings.warn(
             "Modulation transfer values above 1.3 detected: the measurement "
             "is likely invalid (IEC 60268-16 A.5.3). Values truncated to 1.0.",
-            UserWarning,
+            STIWarning,
             stacklevel=3,
         )
     m = np.minimum(m, 1.0)
@@ -412,7 +418,7 @@ def stipa(
     ``level`` (and optionally ``ambient``) only to enable the absolute
     level-dependent corrections, which are otherwise skipped.
 
-    A :class:`UserWarning` is emitted when the recording is shorter than
+    An :class:`STIWarning` is emitted when the recording is shorter than
     the recommended 15 s (IEC 60268-16 STIPA practice, 15 s to 25 s),
     because the slow modulation components are then averaged over too few
     periods and the recovered modulation depths - and hence the STI - are
@@ -446,7 +452,7 @@ def stipa(
             f"recommended {_STIPA_MIN_SECONDS:.0f} s (IEC 60268-16 STIPA "
             "practice, 15 s to 25 s): the recovered modulation depths, and "
             "hence the STI, are biased low.",
-            UserWarning,
+            STIWarning,
             stacklevel=2,
         )
 

--- a/src/phonometry/tonality.py
+++ b/src/phonometry/tonality.py
@@ -16,7 +16,12 @@ from typing import List, Tuple
 import numpy as np
 from scipy import signal
 
+from ._warnings import PhonometryWarning
 from .utils import _typesignal
+
+
+class TonalityWarning(PhonometryWarning):
+    """Warns about biased tonality estimates (e.g. coarse FFT resolution)."""
 
 
 def _warn_coarse_resolution(dfc: float, df: float, ft: float) -> None:
@@ -32,7 +37,7 @@ def _warn_coarse_resolution(dfc: float, df: float, ft: float) -> None:
             f"Frequency resolution {df:.3g} Hz is coarse for the tone at "
             f"{ft:.0f} Hz: the tone band spans only {bins:.1f} bins (< 3), "
             "which biases TNR/PR. Use a finer resolution_hz.",
-            UserWarning,
+            TonalityWarning,
             stacklevel=3,
         )
 

--- a/tests/test_en12354_6.py
+++ b/tests/test_en12354_6.py
@@ -139,17 +139,17 @@ def test_air_condition_none_neglects_air() -> None:
 
 
 def test_invalid_inputs_raise() -> None:
-    with pytest.raises(ValueError, match="volume must be positive"):
+    with pytest.raises(ValueError, match="'volume' must be positive"):
         m.object_fraction([1.0], 0.0)
     with pytest.raises(ValueError, match="non-negative"):
         m.hard_object_absorption([-1.0])
     with pytest.raises(ValueError, match="absorption_area must be positive"):
         m.reverberation_time(0.0, 30.0)
-    with pytest.raises(ValueError, match="volume must be positive"):
+    with pytest.raises(ValueError, match="'volume' must be positive"):
         m.reverberation_time(2.0, 0.0)
-    with pytest.raises(ValueError, match="speed_of_sound must be positive"):
+    with pytest.raises(ValueError, match="'speed_of_sound' must be positive"):
         m.reverberation_time(2.0, 30.0, speed_of_sound=0.0)
-    with pytest.raises(ValueError, match="volume must be positive"):
+    with pytest.raises(ValueError, match="'volume' must be positive"):
         m.reverberation_time(2.0, float("nan"))
     with pytest.raises(ValueError, match="air_condition must be"):
         m.enclosed_space_reverberation([(20.0, 0.5)], 50.0, air_condition="hot")

--- a/tests/test_iso2631_5.py
+++ b/tests/test_iso2631_5.py
@@ -202,7 +202,7 @@ def test_multiple_shock_assessment_end_to_end() -> None:
 
 
 def test_invalid_inputs_raise() -> None:
-    with pytest.raises(ValueError, match="fs must be positive"):
+    with pytest.raises(ValueError, match="'fs' must be positive"):
         v.spinal_response([1.0, 2.0], 0.0)
     with pytest.raises(ValueError, match="empty"):
         v.spinal_response([], 256.0)
@@ -212,7 +212,7 @@ def test_invalid_inputs_raise() -> None:
         v.daily_dose_multi([1.0, 2.0], [1.0], [1.0, 2.0])
     with pytest.raises(ValueError, match="years must be"):
         v.injury_risk(1.0, start_age=20, years=0, days_per_year=120)
-    with pytest.raises(ValueError, match="sex must be"):
+    with pytest.raises(ValueError, match="'sex' must be"):
         v.injury_probability(1.0, sex="other")
     with pytest.raises(ValueError, match="both exposure_time and measurement_time"):
         v.multiple_shock_assessment(


### PR DESCRIPTION
Third execution batch from the library audit: the shared private infrastructure that ~19 per-module helpers and a dozen inline restatements kept reinventing, with **numerically identical** behavior throughout (all pinned worked-example values and the byte-stable conformance report unchanged).

## What changes

- **`_validation.py`** grows `require_positive` / `require_non_negative` / `require_fraction` / `require_choice` — all NaN-rejecting (the audit found four coexisting NaN semantics; a NaN volume passed some modules' checks) and using the dominant quoted-parameter message style. `en12354_6` and `iso2631_5` drop their local equivalents.
- **`_levels_math.py`** (new): `energy_mean` / `energy_sum` / `weighted_energy_mean` replace the two duplicated `_energy_average` helpers and the inline `10·lg(Σ10^(L/10))` restatements across `sound_power`, `sound_power_intensity`, `sound_power_reverberation`, `occupational_exposure`, `intensity` and `insulation` (15 sites). The weighted denominator sums the broadcast weights over the same reduction axis, so axis-varying weights stay correct.
- **`_types.py`** (new): the `Real` alias (defined identically in 4 modules) and `as_float_or_array` (the scalar-or-array return idiom, hand-copied 13×).
- **`_warnings.py`** (new): `PhonometryWarning` base — all 11 warning classes rebase onto it so users can filter the whole library with one `simplefilter`; bare `UserWarning` sites gain proper categories (`FilterBankWarning`, `STIWarning`, `TonalityWarning`, `ImpulseResponseWarning`) and the category-less `frequencies` warning is fixed. Class names, exports and message texts unchanged.
- The byte-identical `_check_grade` and `_validate_conditions` duplicates are merged (import direction verified acyclic).

**Deliberately not migrated** (subtly different math, documented): the SII masking composition, NT ACOU 112's reference-time-normalized rating, and the exposure-weighted sum in `occupational_exposure`.

## Verification

Adversarial review focused on numerical identity (axis semantics, mean-vs-sum, weight normalization, dtype/copy behavior, stacklevels, circular imports) found no defects; its one hardening suggestion (axis-aware weighted denominator) is applied and proven bit-identical at the existing call sites.

## Gate

`ruff` · `mypy src scripts` (60 files) · full `pytest` (**1752 passed**) · conformance byte-stable (90/90).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified `PhonometryWarning` base class and specialized warning types for filtering and handling diagnostics consistently.
  * Exposed additional warning types through the public package interface.
  * Added shared energy-based level calculations, including weighted energy averaging.

* **Bug Fixes**
  * Standardized numeric and option validation with clearer, parameter-specific error messages.
  * Improved consistent scalar and array result handling across calculations.
  * Improved channel input handling for time-based loudness analysis.

* **Refactor**
  * Consolidated repeated calculation, validation, and typing utilities while preserving existing public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->