### PR TITLE
Audit pass 9: the tests batch

### DIFF
--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -158,7 +158,7 @@ Only **Butterworth** (the library default) and **Chebyshev-II** are class-compli
 | ISO 11654:1997 Annex A.2 | Weighted absorption alpha_w with M indicator | 0.60(M) | 0.60(M) | 0 | &#9989; |
 | ISO 9053-2:2020 Annex A.3 | Thermal boundary-layer thickness b | 0.00183 m (+/-0.00001 m) | 0.00183 m | 0 m | &#9989; |
 | ISO 9053-2:2020 Annex A.3 | Effective ratio of specific heats kappa' | 1.37 (+/-0.001) | 1.37 | 0 | &#9989; |
-| ISO 10534-1:1996 Eqs (9)/(13)/(14) | Absorption from standing-wave ratio s=3 | 0.75 (+/-0) | 0.75 | 0 | &#9989; |
+| ISO 10534-1:1996 Eqs (9)/(13)/(14) | Absorption from standing-wave ratio s=3 | alpha 0.75 (+/-0), |r| 0.5 | alpha 0.75, |r| 0.5000 | 0 | &#9989; |
 | ISO 10534-2 Eq. (17) / Annex D | Two-microphone round trip recovers a known reflection factor | abs(r - (0.3-0.4j)) = 0 (identity, +/-1e-9) | 0 | 0 | &#9989; |
 
 </details>

--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -15,7 +15,7 @@
 
 ## Numerical conformance report
 
-&#9989; **90/90 conformance checks pass** across 21 domains and 56 standards - filters class 1 - weightings within IEC 61672-1 class 1.
+&#9989; **95/95 conformance checks pass** across 22 domains and 60 standards - filters class 1 - weightings within IEC 61672-1 class 1.
 
 ### Numerical validation - filters &amp; weightings
 
@@ -83,7 +83,7 @@ Only **Butterworth** (the library default) and **Chebyshev-II** are class-compli
 </details>
 
 <details>
-<summary>&#9989; <b>Speech intelligibility</b> — 100% (2/2)</summary>
+<summary>&#9989; <b>Speech transmission (IEC 60268-16)</b> — 100% (2/2)</summary>
 
 | Standard | Quantity | Expected (norm) | Computed | &#916; | Status |
 |:---|:---|:---|:---|:---|:---:|
@@ -110,13 +110,13 @@ Only **Butterworth** (the library default) and **Chebyshev-II** are class-compli
 | Standard | Quantity | Expected (norm) | Computed | &#916; | Status |
 |:---|:---|:---|:---|:---|:---:|
 | ISO 3382-2:2008 5.3.3 | T30 from a synthetic exponential decay (T=1.0 s) | 1 s (+/-1%) | 1 s | 0 s | &#9989; |
+| ISO 18233:2006 (swept-sine method) | Sweep deconvolution recovers a known IIR response | 0 dB in-band error (+/-0.1 dB) | 0.0006 dB | 0.001 dB | &#9989; |
 | ISO 717-1 Annex C, Table C.1 | Weighted sound reduction index Rw (C;Ctr) | Rw 30 (C -2; Ctr -3) | Rw 30 (C -2; Ctr -3) | sum 31.8 dB | &#9989; |
+| ISO 717-2 Annex C, Table C.1 | Weighted impact sound pressure level Ln,w (CI) | Ln,w 79 (CI -11; sum 28.0 dB) | Ln,w 79 (CI -11; sum 28.0 dB) | +0 dB | &#9989; |
 | ISO 354:2003 Eq. 5/8 | Sabine inversion recovers absorption area | 9.212828 m^2 (+/-0 m^2) | 9.212828 m^2 | 0 m^2 | &#9989; |
 | ISO 3382-3:2012 Clause 6.2 | Open-plan spatial decay rate D2,S (-6 dB/doubling) | 6 dB (+/-0 dB) | 6 dB | 0 dB | &#9989; |
 | ISO 16283-3:2016 Clause 3.12 | Facade R'45 isolates the -1.5 dB incidence correction (S=A) | 38.5 dB (+/-0 dB) | 38.5 dB | 0 dB | &#9989; |
 | ISO 10140-2:2010 Formula (2) | Lab airborne R on the ISO 717-1 reference shape -> Rw = 54 | Rw 54 dB | Rw 54 dB | +0 dB | &#9989; |
-| ISO 9613-1:1993 Table 1 | Air attenuation @ 10 degC, 70 %, 1 kHz | 3.66 dB/km (+/-0.01 dB/km) | 3.658 dB/km | -0.002 dB/km | &#9989; |
-| ISO 9613-1:1993 Table 1 | Air attenuation @ 0 degC, 20 %, 2 kHz | 34.6 dB/km (+/-0.1 dB/km) | 34.64 dB/km | 0.04 dB/km | &#9989; |
 
 </details>
 
@@ -133,10 +133,12 @@ Only **Butterworth** (the library default) and **Chebyshev-II** are class-compli
 </details>
 
 <details>
-<summary>&#9989; <b>Outdoor propagation &amp; occupational exposure</b> — 100% (7/7)</summary>
+<summary>&#9989; <b>Outdoor propagation &amp; occupational exposure</b> — 100% (9/9)</summary>
 
 | Standard | Quantity | Expected (norm) | Computed | &#916; | Status |
 |:---|:---|:---|:---|:---|:---:|
+| ISO 9613-1:1993 Table 1 | Air attenuation @ 10 degC, 70 %, 1 kHz | 3.66 dB/km (+/-0.01 dB/km) | 3.658 dB/km | -0.002 dB/km | &#9989; |
+| ISO 9613-1:1993 Table 1 | Air attenuation @ 0 degC, 20 %, 2 kHz | 34.6 dB/km (+/-0.1 dB/km) | 34.64 dB/km | 0.04 dB/km | &#9989; |
 | ISO 9613-2:1996 Eq. (7) | Geometrical divergence Adiv = 20 lg(d/d0) + 11 at 100 m | 51 dB (+/-0 dB) | 51 dB | 0 dB | &#9989; |
 | ISO 9613-2:1996 Table 3 | Ground b'(0) porous limit -> Agr(250 Hz) = 2(-1.5 + 10.1) | 17.2 dB (+/-0 dB) | 17.2 dB | 0 dB | &#9989; |
 | ISO 9613-2:1996 clause 7.4 | Single-edge diffraction saturates at the 20 dB cap | 20 dB (+/-0 dB) | 20 dB | 0 dB | &#9989; |
@@ -148,7 +150,7 @@ Only **Butterworth** (the library default) and **Chebyshev-II** are class-compli
 </details>
 
 <details>
-<summary>&#9989; <b>Materials: absorption, airflow &amp; impedance</b> — 100% (5/5)</summary>
+<summary>&#9989; <b>Materials: absorption, airflow &amp; impedance</b> — 100% (6/6)</summary>
 
 | Standard | Quantity | Expected (norm) | Computed | &#916; | Status |
 |:---|:---|:---|:---|:---|:---:|
@@ -157,6 +159,7 @@ Only **Butterworth** (the library default) and **Chebyshev-II** are class-compli
 | ISO 9053-2:2020 Annex A.3 | Thermal boundary-layer thickness b | 0.00183 m (+/-0.00001 m) | 0.00183 m | 0 m | &#9989; |
 | ISO 9053-2:2020 Annex A.3 | Effective ratio of specific heats kappa' | 1.37 (+/-0.001) | 1.37 | 0 | &#9989; |
 | ISO 10534-1:1996 Eqs (9)/(13)/(14) | Absorption from standing-wave ratio s=3 | 0.75 (+/-0) | 0.75 | 0 | &#9989; |
+| ISO 10534-2 Eq. (17) / Annex D | Two-microphone round trip recovers a known reflection factor | abs(r - (0.3-0.4j)) = 0 (identity, +/-1e-9) | 0 | 0 | &#9989; |
 
 </details>
 
@@ -295,6 +298,16 @@ Only **Butterworth** (the library default) and **Chebyshev-II** are class-compli
 |:---|:---|:---|:---|:---|:---:|
 | EN 12354-6:2003 Formula 1 | Equivalent absorption area, Annex E bare room | 2.26 m2 (+/-0.01 m2) | 2.26 m2 | 0.003 m2 | &#9989; |
 | EN 12354-6:2003 Formula 5 | Reverberation time, Annex E bare room | 2.1 s (+/-0.1 s) | 2.1 s | 0.003 s | &#9989; |
+
+</details>
+
+<details>
+<summary>&#9989; <b>Prominent discrete tones (ECMA-418-1)</b> — 100% (2/2)</summary>
+
+| Standard | Quantity | Expected (norm) | Computed | &#916; | Status |
+|:---|:---|:---|:---|:---|:---:|
+| ECMA-418-1:2024 Clause 10 Formula (2) | Critical band at 1 kHz (f1,c / f2,c / dfc) | dfc 162.2 Hz (+/-0.05 Hz); edges 922.2-1084.4 Hz | dfc 162.22 Hz; edges 922.2-1084.4 Hz | 0.017 Hz | &#9989; |
+| ECMA-418-1:2024 Clause 11.6 Formula (14) | Proximity spacing dfprox at 150 / 850 Hz | 23 Hz @ 150 Hz; 63.8 Hz @ 850 Hz (+/-0.5 Hz) | 23.0 Hz; 63.8 Hz | +0.004; +0.044 Hz | &#9989; |
 
 </details>
 

--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -158,7 +158,7 @@ Only **Butterworth** (the library default) and **Chebyshev-II** are class-compli
 | ISO 11654:1997 Annex A.2 | Weighted absorption alpha_w with M indicator | 0.60(M) | 0.60(M) | 0 | &#9989; |
 | ISO 9053-2:2020 Annex A.3 | Thermal boundary-layer thickness b | 0.00183 m (+/-0.00001 m) | 0.00183 m | 0 m | &#9989; |
 | ISO 9053-2:2020 Annex A.3 | Effective ratio of specific heats kappa' | 1.37 (+/-0.001) | 1.37 | 0 | &#9989; |
-| ISO 10534-1:1996 Eqs (9)/(13)/(14) | Absorption from standing-wave ratio s=3 | alpha 0.75 (+/-0), |r| 0.5 | alpha 0.75, |r| 0.5000 | 0 | &#9989; |
+| ISO 10534-1:1996 Eqs (9)/(13)/(14) | Absorption from standing-wave ratio s=3 | alpha 0.75 (+/-0), \|r\| 0.5 | alpha 0.75, \|r\| 0.5000 | 0 | &#9989; |
 | ISO 10534-2 Eq. (17) / Annex D | Two-microphone round trip recovers a known reflection factor | abs(r - (0.3-0.4j)) = 0 (identity, +/-1e-9) | 0 | 0 | &#9989; |
 
 </details>

--- a/scripts/conformance_report.py
+++ b/scripts/conformance_report.py
@@ -1218,7 +1218,10 @@ def _chk_iso10534_1_swr() -> Outcome:
     r_mag = float(standing_wave_reflection_magnitude(ref.ISO10534_1_SWR))
     out = numeric(ref.ISO10534_1_ABSORPTION, alpha, 1e-9, places=4)
     r_ok = abs(r_mag - ref.ISO10534_1_REFLECTION_MAGNITUDE) <= 1e-9
-    return Outcome(out.expected, out.computed, out.delta, out.passed and r_ok)
+    # Show both chained values so a |r| failure is visible in the report.
+    expected = f"alpha {out.expected}, |r| {ref.ISO10534_1_REFLECTION_MAGNITUDE:g}"
+    computed = f"alpha {out.computed}, |r| {r_mag:.4f}"
+    return Outcome(expected, computed, out.delta, out.passed and r_ok)
 
 
 @register(

--- a/scripts/conformance_report.py
+++ b/scripts/conformance_report.py
@@ -1219,8 +1219,10 @@ def _chk_iso10534_1_swr() -> Outcome:
     out = numeric(ref.ISO10534_1_ABSORPTION, alpha, 1e-9, places=4)
     r_ok = abs(r_mag - ref.ISO10534_1_REFLECTION_MAGNITUDE) <= 1e-9
     # Show both chained values so a |r| failure is visible in the report.
-    expected = f"alpha {out.expected}, |r| {ref.ISO10534_1_REFLECTION_MAGNITUDE:g}"
-    computed = f"alpha {out.computed}, |r| {r_mag:.4f}"
+    expected = (
+        f"alpha {out.expected}, \\|r\\| {ref.ISO10534_1_REFLECTION_MAGNITUDE:g}"
+    )
+    computed = f"alpha {out.computed}, \\|r\\| {r_mag:.4f}"
     return Outcome(expected, computed, out.delta, out.passed and r_ok)
 
 

--- a/scripts/conformance_report.py
+++ b/scripts/conformance_report.py
@@ -619,14 +619,14 @@ def _chk_mg_time_loudness() -> Outcome:
 
 
 # ===========================================================================
-# Domain 4 - Speech intelligibility
+# Domain 4 - Speech transmission (IEC 60268-16)
 # ===========================================================================
 _NUM_STI_BANDS = 7
 _NUM_MOD_FREQS = 14
 
 
 @register(
-    "Speech intelligibility",
+    "Speech transmission (IEC 60268-16)",
     "IEC 60268-16:2020 A.2.2",
     "STI weighting-factor pair (500 Hz + 1 kHz bands)",
 )
@@ -638,7 +638,7 @@ def _chk_sti_weighting_pair() -> Outcome:
 
 
 @register(
-    "Speech intelligibility",
+    "Speech transmission (IEC 60268-16)",
     "IEC 60268-16:2020 A.3.1.2",
     "Uniform MTF m=0.5 maps to STI=0.5",
 )
@@ -773,6 +773,32 @@ def _chk_room_t30() -> Outcome:
 
 @register(
     "Room & building acoustics",
+    "ISO 18233:2006 (swept-sine method)",
+    "Sweep deconvolution recovers a known IIR response",
+)
+def _chk_iso18233_sweep_deconvolution() -> Outcome:
+    # Closed-form identity: an exponential sweep through a known Butterworth
+    # band-pass, deconvolved back, must reproduce the filter's freqz response.
+    b, a = sg.butter(4, [200.0, 2000.0], btype="band", fs=_FS)
+    x = ph.sweep_signal(_FS, 20.0, 20000.0, 2.0)
+    y = sg.lfilter(b, a, x)
+    ir = np.asarray(ph.impulse_response(y, x, _FS, length=16384))
+    freqs = np.fft.rfftfreq(ir.size, d=1.0 / _FS)
+    h_est = np.fft.rfft(ir)
+    _, h_true = sg.freqz(b, a, worN=freqs, fs=_FS)
+    mask = (freqs >= 300.0) & (freqs <= 1500.0)
+    worst = float(np.max(np.abs(
+        20.0 * np.log10(np.abs(h_est[mask])) - 20.0 * np.log10(np.abs(h_true[mask]))
+    )))
+    # Linear deconvolution is exact in-band up to windowing/regularisation
+    # leakage; 0.1 dB is the demonstrated in-band bound (tests/test_room_ir.py)
+    # with the same 300-1500 Hz evaluation band, well inside the sweep edges.
+    return numeric(0.0, worst, 0.1, unit="dB", places=4,
+                   expected_label="0 dB in-band error (+/-0.1 dB)")
+
+
+@register(
+    "Room & building acoustics",
     "ISO 717-1 Annex C, Table C.1",
     "Weighted sound reduction index Rw (C;Ctr)",
 )
@@ -784,6 +810,27 @@ def _chk_iso717_rw() -> Outcome:
         expected=f"Rw {exp['rw']} (C {exp['c']}; Ctr {exp['ctr']})",
         computed=f"Rw {res.rating} (C {res.c}; Ctr {res.ctr})",
         delta=f"sum {res.unfavourable_sum:.1f} dB",
+        passed=ok,
+    )
+
+
+@register(
+    "Room & building acoustics",
+    "ISO 717-2 Annex C, Table C.1",
+    "Weighted impact sound pressure level Ln,w (CI)",
+)
+def _chk_iso717_2_lnw() -> Outcome:
+    # Worked example: Ln,w = 79 dB, CI = -11 dB, unfavourable sum 28,0 dB.
+    # Integer ratings and CI must match exactly; the unfavourable sum is a
+    # one-decimal tabulated intermediate, so 1e-9 = exact up to float noise.
+    exp = ref.ISO717_2_ANNEX_C1_EXPECTED
+    res = ph.weighted_impact_rating(ref.ISO717_2_ANNEX_C1_LN)
+    sum_ok = abs(res.unfavourable_sum - exp["unfavourable_sum"]) <= 1e-9
+    ok = res.rating == exp["ln_w"] and res.ci == exp["ci"] and sum_ok
+    return Outcome(
+        expected=f"Ln,w {exp['ln_w']} (CI {exp['ci']}; sum {exp['unfavourable_sum']:.1f} dB)",
+        computed=f"Ln,w {res.rating} (CI {res.ci}; sum {res.unfavourable_sum:.1f} dB)",
+        delta=f"{res.rating - exp['ln_w']:+d} dB",
         passed=ok,
     )
 
@@ -830,8 +877,16 @@ def _chk_facade_r45() -> Outcome:
         surface_level=np.full(n, ref.ISO16283_3_R45_SURFACE_LEVEL_DB),
     )
     assert res.r_prime is not None
+    # The expected value is rebuilt from its components, so the -1,5 dB
+    # oblique-incidence correction constant is exercised explicitly.
+    expected = (
+        ref.ISO16283_3_R45_SURFACE_LEVEL_DB
+        - ref.ISO16283_3_R45_RECEIVE_LEVEL_DB
+        - ref.ISO16283_3_R45_LOUDSPEAKER_CORRECTION_DB
+    )
+    assert expected == ref.ISO16283_3_R45_EXPECTED_DB
     computed = float(np.asarray(res.r_prime)[0])
-    return numeric(ref.ISO16283_3_R45_EXPECTED_DB, computed, 1e-9, unit="dB", places=6)
+    return numeric(expected, computed, 1e-9, unit="dB", places=6)
 
 
 @register(
@@ -941,6 +996,9 @@ def _chk_iso12999_expanded() -> Outcome:
     return numeric(expected, computed, 1e-9, unit="dB", places=6)
 
 
+# ===========================================================================
+# Domain 8 - Outdoor propagation & occupational exposure
+# ===========================================================================
 def _iso9613_table1(point: tuple[float, float, float, float]) -> Outcome:
     """Compare air_attenuation against an ISO 9613-1 Table 1 grid point (dB/km)."""
     temp, rh, freq, alpha_km = point
@@ -953,7 +1011,7 @@ def _iso9613_table1(point: tuple[float, float, float, float]) -> Outcome:
 
 
 @register(
-    "Room & building acoustics",
+    "Outdoor propagation & occupational exposure",
     "ISO 9613-1:1993 Table 1",
     "Air attenuation @ 10 degC, 70 %, 1 kHz",
 )
@@ -962,7 +1020,7 @@ def _chk_iso9613_table1_mid() -> Outcome:
 
 
 @register(
-    "Room & building acoustics",
+    "Outdoor propagation & occupational exposure",
     "ISO 9613-1:1993 Table 1",
     "Air attenuation @ 0 degC, 20 %, 2 kHz",
 )
@@ -970,9 +1028,7 @@ def _chk_iso9613_table1_corner() -> Outcome:
     return _iso9613_table1(ref.ISO9613_1_TABLE1_CORNER)
 
 
-# ===========================================================================
-# Domain 8 - Outdoor propagation & occupational exposure
-# ===========================================================================
+
 @register(
     "Outdoor propagation & occupational exposure",
     "ISO 9613-2:1996 Eq. (7)",
@@ -1155,7 +1211,43 @@ def _chk_iso9053_2_kappa() -> Outcome:
 @register(_MATERIALS, "ISO 10534-1:1996 Eqs (9)/(13)/(14)", "Absorption from standing-wave ratio s=3")
 def _chk_iso10534_1_swr() -> Outcome:
     alpha = float(ph.standing_wave_absorption(ref.ISO10534_1_SWR))
-    return numeric(ref.ISO10534_1_ABSORPTION, alpha, 1e-9, places=4)
+    # The intermediate |r| = (s-1)/(s+1) (Eq. (13)) must match its shared
+    # oracle too, so both steps of the chain are pinned.
+    from phonometry.impedance_tube import standing_wave_reflection_magnitude
+
+    r_mag = float(standing_wave_reflection_magnitude(ref.ISO10534_1_SWR))
+    out = numeric(ref.ISO10534_1_ABSORPTION, alpha, 1e-9, places=4)
+    r_ok = abs(r_mag - ref.ISO10534_1_REFLECTION_MAGNITUDE) <= 1e-9
+    return Outcome(out.expected, out.computed, out.delta, out.passed and r_ok)
+
+
+@register(
+    _MATERIALS,
+    "ISO 10534-2 Eq. (17) / Annex D",
+    "Two-microphone round trip recovers a known reflection factor",
+)
+def _chk_iso10534_2_roundtrip() -> Outcome:
+    # Synthesise the transfer function H12 of a known complex r via the
+    # Annex D field equations (Eq. (D.7)), then recover r with the library's
+    # Eq. (17) reduction. Synthesis and reduction share only the plane-wave
+    # field model, so this is an algebraic identity: the only residual is
+    # float rounding, hence the 1e-9 tolerance.
+    from phonometry.impedance_tube import reflection_factor, tube_wavenumber
+
+    f = np.array([500.0, 1000.0, 1800.0])
+    x1, spacing, c0 = 0.12, 0.03, 343.2
+    r_true = 0.3 - 0.4j
+    k0 = np.asarray(tube_wavenumber(f, c0))
+    x2 = x1 - spacing
+    h12 = (
+        (np.exp(1j * k0 * x2) + r_true * np.exp(-1j * k0 * x2))
+        / (np.exp(1j * k0 * x1) + r_true * np.exp(-1j * k0 * x1))
+    )
+    r = reflection_factor(h12, spacing=spacing, x1=x1, wavenumber=k0)
+    err = float(np.max(np.abs(np.asarray(r) - r_true)))
+    # NOTE: no pipe characters in the label (it lands in a Markdown table cell).
+    return numeric(0.0, err, 1e-9, places=9,
+                   expected_label="abs(r - (0.3-0.4j)) = 0 (identity, +/-1e-9)")
 
 
 # ---------------------------------------------------------------------------
@@ -1498,23 +1590,70 @@ def _chk_multiple_shock_probability() -> Outcome:
 
 _ABS = "Sound absorption in enclosed spaces (EN 12354-6)"
 
-_ENCLOSED_SPACE_SURFACES = [
-    (12.39, 0.05), (12.39, 0.02), (10.90, 0.04),
-    (10.90, 0.04), (6.55, 0.04), (6.55, 0.04),
-]
-
 
 @register(_ABS, "EN 12354-6:2003 Formula 1", "Equivalent absorption area, Annex E bare room")
 def _chk_enclosed_space_area() -> Outcome:
-    value = float(ph.equivalent_absorption_area(_ENCLOSED_SPACE_SURFACES))
+    value = float(ph.equivalent_absorption_area(ref.EN12354_6_ANNEX_E_BARE_SURFACES))
     return numeric(ref.EN12354_6_A_BARE, value, 0.01, unit="m2", places=2)
 
 
 @register(_ABS, "EN 12354-6:2003 Formula 5", "Reverberation time, Annex E bare room")
 def _chk_enclosed_space_rt() -> Outcome:
-    area = ph.equivalent_absorption_area(_ENCLOSED_SPACE_SURFACES)
-    value = float(ph.reverberation_time(area, 29.75))
+    area = ph.equivalent_absorption_area(ref.EN12354_6_ANNEX_E_BARE_SURFACES)
+    value = float(ph.reverberation_time(area, ref.EN12354_6_ANNEX_E_VOLUME))
     return numeric(ref.EN12354_6_T_BARE, value, 0.05, unit="s", places=1)
+
+
+_TONES = "Prominent discrete tones (ECMA-418-1)"
+
+
+@register(_TONES, "ECMA-418-1:2024 Clause 10 Formula (2)", "Critical band at 1 kHz (f1,c / f2,c / dfc)")
+def _chk_ecma418_1_critical_band() -> Outcome:
+    from phonometry.tonality import _critical_band
+
+    f1, f2, dfc = _critical_band(1000.0)
+    # 0.05 Hz = half a unit in the last printed digit (the clause EXAMPLE
+    # values are given to one decimal: 922,2 / 1084,4 / 162,2 Hz).
+    out = numeric(ref.ECMA418_1_DFC_1KHZ, float(dfc), 0.05, unit="Hz", places=2)
+    edges_ok = (
+        abs(float(f1) - ref.ECMA418_1_F1_1KHZ) <= 0.05
+        and abs(float(f2) - ref.ECMA418_1_F2_1KHZ) <= 0.05
+    )
+    return Outcome(
+        expected=(
+            f"dfc {out.expected}; edges {ref.ECMA418_1_F1_1KHZ:g}"
+            f"-{ref.ECMA418_1_F2_1KHZ:g} Hz"
+        ),
+        computed=f"dfc {out.computed}; edges {float(f1):.1f}-{float(f2):.1f} Hz",
+        delta=out.delta,
+        passed=out.passed and edges_ok,
+    )
+
+
+@register(_TONES, "ECMA-418-1:2024 Clause 11.6 Formula (14)", "Proximity spacing dfprox at 150 / 850 Hz")
+def _chk_ecma418_1_proximity_spacing() -> Outcome:
+    from phonometry.tonality import _proximity_spacing
+
+    v150 = float(_proximity_spacing(150.0))
+    v850 = float(_proximity_spacing(850.0))
+    # 0.5 Hz = half a unit in the last printed digit of the coarser EXAMPLE
+    # value (the standard prints 23 Hz with no decimals; 63,8 Hz with one).
+    ok = (
+        abs(v150 - ref.ECMA418_1_PROX_150HZ) <= 0.5
+        and abs(v850 - ref.ECMA418_1_PROX_850HZ) <= 0.5
+    )
+    return Outcome(
+        expected=(
+            f"{ref.ECMA418_1_PROX_150HZ:g} Hz @ 150 Hz; "
+            f"{ref.ECMA418_1_PROX_850HZ:g} Hz @ 850 Hz (+/-0.5 Hz)"
+        ),
+        computed=f"{v150:.1f} Hz; {v850:.1f} Hz",
+        delta=(
+            f"{v150 - ref.ECMA418_1_PROX_150HZ:+.3f}; "
+            f"{v850 - ref.ECMA418_1_PROX_850HZ:+.3f} Hz"
+        ),
+        passed=ok,
+    )
 
 
 # ===========================================================================

--- a/tests/reference_data.py
+++ b/tests/reference_data.py
@@ -4,14 +4,15 @@
 Tables transcribed verbatim from the published standards. Both the test
 suite (``tests/test_*.py``) and the CI conformance report
 (``scripts/conformance_report.py``) import these constants, so the report's
-expected values can never drift from what the tests assert. The PR-B
-building-acoustics, PR-E scattering/in-situ/precision-power and PR-F
-human-vibration oracles are the exception: their test modules re-hardcode the
-values inline rather than import them, and dedicated consistency tests
-(``test_building_reference_data_matches_published_oracles``,
-``test_scattering_insitu_precision_reference_data_matches_oracles`` and
-``test_human_vibration_reference_data_matches_oracles``) pin this shared table
-to those same published results so neither copy can drift.
+expected values can never drift from what the tests assert. Test modules
+either import a constant directly where they assert it, or - where the
+oracle lives inside a larger inline table (e.g. the ISO 1999 Annex D or
+ANSI S12.2 Table D.1 transcriptions) - pin the inline copy to the shared
+constant with an explicit consistency assertion. The PR-B building-acoustics
+and PR-F human-vibration oracles are additionally pinned to their published
+values by dedicated tests in ``tests/test_conformance_report.py``
+(``test_building_reference_data_matches_published_oracles`` and
+``test_human_vibration_reference_data_matches_oracles``).
 
 This module is deliberately dependency-free (stdlib only) so it can be
 imported in the ``pr-comment`` CI job, which installs the runtime
@@ -523,9 +524,51 @@ ISO2631_5_PI_MALE = 0.37  # probability of lumbar injury (Formula C.5)
 
 # ---------------------------------------------------------------------------
 # Sound absorption in enclosed spaces - EN 12354-6:2003, Annex E worked
-# example (29,75 m3 room, 1000 Hz octave band). Case 1 (bare) A = 2,26 m2,
-# T = 2,1 s; Case 2 (with hard objects) A = 5,03 m2.
+# example (4,54 x 2,73 x 2,40 = 29,75 m3 room, 1000 Hz octave band). Case 1
+# (bare) A = 2,26 m2, T = 2,1 s; Case 2 (with hard objects) A = 5,03 m2.
+# The six bare-room surfaces are (area_m2, alpha at 1000 Hz): floor, ceiling,
+# long wall, side wall, side wall, glass facade.
 # ---------------------------------------------------------------------------
+EN12354_6_ANNEX_E_VOLUME = 29.75  # room volume (m3)
+EN12354_6_ANNEX_E_BARE_SURFACES: list[tuple[float, float]] = [
+    (12.39, 0.05),  # floor
+    (12.39, 0.02),  # ceiling
+    (10.90, 0.04),  # long wall
+    (10.90, 0.04),  # side wall
+    (6.55, 0.04),   # side wall
+    (6.55, 0.04),   # glass facade
+]
 EN12354_6_A_BARE = 2.26  # equivalent absorption area, bare room (m2)
 EN12354_6_T_BARE = 2.1  # reverberation time, bare room (s)
 EN12354_6_A_OBJECTS = 5.03  # equivalent absorption area, with objects (m2)
+
+# ---------------------------------------------------------------------------
+# Prominent discrete tones - ECMA-418-1:2024, clause-EXAMPLE anchors
+# (transcribed from the official PDF, printed to one decimal).
+# Clause 10 Formula (2): critical band around ft = 1 kHz is
+# f1,c = 922,2 Hz .. f2,c = 1084,4 Hz, width dfc = 162,2 Hz (117,3 Hz at
+# 500 Hz). Clause 11.6 Formula (14): proximity spacing dfprox = 23 Hz at
+# 150 Hz and 63,8 Hz at 850 Hz.
+# ---------------------------------------------------------------------------
+ECMA418_1_DFC_1KHZ = 162.2  # critical bandwidth at 1 kHz (Hz)
+ECMA418_1_DFC_500HZ = 117.3  # critical bandwidth at 500 Hz (Hz)
+ECMA418_1_F1_1KHZ = 922.2  # lower critical-band edge at 1 kHz (Hz)
+ECMA418_1_F2_1KHZ = 1084.4  # upper critical-band edge at 1 kHz (Hz)
+ECMA418_1_PROX_150HZ = 23.0  # proximity spacing at 150 Hz (Hz)
+ECMA418_1_PROX_850HZ = 63.8  # proximity spacing at 850 Hz (Hz)
+
+# ---------------------------------------------------------------------------
+# ISO 717-2 Annex C, Table C.1 - measured normalized impact sound pressure
+# level Ln (100-3150 Hz, one-third-octave, laboratory). The worked example
+# gives Ln,w = 79 dB, CI = -11 dB with an unfavourable-deviation sum of
+# 28,0 dB.
+# ---------------------------------------------------------------------------
+ISO717_2_ANNEX_C1_LN: list[float] = [
+    62.1, 63.2, 63.5, 66.2, 68.5, 70.0, 71.7, 73.1,
+    73.8, 73.5, 73.8, 73.3, 73.1, 73.0, 72.4, 71.2,
+]
+ISO717_2_ANNEX_C1_EXPECTED = {
+    "ln_w": 79,
+    "ci": -11,
+    "unfavourable_sum": 28.0,
+}

--- a/tests/test_absorption_rating.py
+++ b/tests/test_absorption_rating.py
@@ -23,6 +23,15 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
+from reference_data import (
+    ISO11654_ANNEX_A1_ALPHA_P,
+    ISO11654_ANNEX_A1_ALPHA_W,
+    ISO11654_ANNEX_A1_CLASS,
+    ISO11654_ANNEX_A1_INDICATOR,
+    ISO11654_ANNEX_A2_ALPHA_P,
+    ISO11654_ANNEX_A2_ALPHA_W,
+    ISO11654_ANNEX_A2_INDICATOR,
+)
 
 from phonometry.absorption_rating import (
     OCTAVE_BANDS,
@@ -36,8 +45,9 @@ from phonometry.absorption_rating import (
 
 # ISO 11654:1997 Annex A worked examples (the "Absorber" alpha_p columns).
 # Bands 250, 500, 1000, 2000, 4000 Hz (the 125 Hz row is not rated).
-_ANNEX_A1_ALPHA_P = [0.35, 0.70, 0.65, 0.60, 0.55]
-_ANNEX_A2_ALPHA_P = [0.35, 1.00, 0.65, 0.60, 0.55]
+# Imported from tests/reference_data.py (shared with the conformance report).
+_ANNEX_A1_ALPHA_P = list(ISO11654_ANNEX_A1_ALPHA_P)
+_ANNEX_A2_ALPHA_P = list(ISO11654_ANNEX_A2_ALPHA_P)
 # The tabulated shifted reference curve (shift s = 0.40) shared by both.
 _ANNEX_A_SHIFTED_REF = [0.40, 0.60, 0.60, 0.60, 0.50]
 
@@ -70,19 +80,19 @@ def test_band_layout() -> None:
 
 def test_annex_a1_no_indicator() -> None:
     res = weighted_absorption(_ANNEX_A1_ALPHA_P)
-    assert _almost(res.alpha_w, 0.60)
-    assert res.shape_indicator == ""
+    assert _almost(res.alpha_w, ISO11654_ANNEX_A1_ALPHA_W)
+    assert res.shape_indicator == ISO11654_ANNEX_A1_INDICATOR
     assert _almost(res.shift, 0.40)
     assert _almost(res.unfavourable_sum, 0.05)
-    assert res.absorption_class == "C"
+    assert res.absorption_class == ISO11654_ANNEX_A1_CLASS
     assert res.rating_label == "0.60"
     np.testing.assert_allclose(res.shifted_reference, _ANNEX_A_SHIFTED_REF)
 
 
 def test_annex_a2_shape_indicator_m() -> None:
     res = weighted_absorption(_ANNEX_A2_ALPHA_P)
-    assert _almost(res.alpha_w, 0.60)
-    assert res.shape_indicator == "M"
+    assert _almost(res.alpha_w, ISO11654_ANNEX_A2_ALPHA_W)
+    assert res.shape_indicator == ISO11654_ANNEX_A2_INDICATOR
     assert _almost(res.shift, 0.40)
     assert _almost(res.unfavourable_sum, 0.05)
     assert res.absorption_class == "C"
@@ -102,7 +112,7 @@ def test_shift_is_the_smallest_qualifying_one() -> None:
     res = weighted_absorption(_ANNEX_A1_ALPHA_P)
     ref_units = [16, 20, 20, 20, 18]
     meas_units = [7, 14, 13, 12, 11]
-    smaller = sum(max(0, (r - 7) - m) for r, m in zip(ref_units, meas_units))
+    smaller = sum(max(0, (r - 7) - m) for r, m in zip(ref_units, meas_units, strict=True))
     assert smaller / 20.0 > 0.10
     assert _almost(res.shift, 0.40)
 
@@ -157,7 +167,7 @@ def test_practical_wrong_length() -> None:
 
 def test_practical_mapping_matches_sequence() -> None:
     seq = [0.10 + 0.05 * i for i in range(15)]
-    mapping = dict(zip(THIRD_OCTAVE_BANDS, seq))
+    mapping = dict(zip(THIRD_OCTAVE_BANDS, seq, strict=True))
     np.testing.assert_allclose(
         practical_absorption_coefficient(mapping),
         practical_absorption_coefficient(seq),
@@ -235,7 +245,7 @@ def test_result_exposes_curves_for_plotting() -> None:
 
 
 def test_weighted_mapping_matches_sequence() -> None:
-    mapping = dict(zip(OCTAVE_BANDS, _ANNEX_A2_ALPHA_P))
+    mapping = dict(zip(OCTAVE_BANDS, _ANNEX_A2_ALPHA_P, strict=True))
     res_map = weighted_absorption(mapping)
     res_seq = weighted_absorption(_ANNEX_A2_ALPHA_P)
     assert _almost(res_map.alpha_w, res_seq.alpha_w)

--- a/tests/test_airflow_resistance.py
+++ b/tests/test_airflow_resistance.py
@@ -25,6 +25,13 @@ import warnings
 
 import numpy as np
 import pytest
+from reference_data import (
+    ISO9053_2_ANNEX_A_BOUNDARY_LAYER,
+    ISO9053_2_ANNEX_A_FREQUENCY,
+    ISO9053_2_ANNEX_A_KAPPA_PRIME,
+    ISO9053_2_ANNEX_A_SURFACE,
+    ISO9053_2_ANNEX_A_VOLUME,
+)
 
 from phonometry.airflow_resistance import (
     AirflowResistanceWarning,
@@ -247,26 +254,32 @@ def test_alternating_invalid_inputs_raise(kwargs: dict[str, float]) -> None:
 # --- Annex A (normative): effective ratio of specific heats kappa' -----------
 # Worked example, ISO 9053-2:2020 Annex A.3 (page-verified oracle): closed cylinder
 # 100 mm x 100 mm -> V = 7.854e-4 m3, S = 0.0471 m2; IEC 61094-2:2009 air properties
-# at 23 C; f = 2 Hz give b = 1.83e-3 m and kappa' = kappa*0.978 = 1.370.
+# at 23 C; f = 2 Hz give b = 1.83e-3 m and kappa' = kappa*0.978 = 1.370. The inputs
+# and expected values are imported from tests/reference_data.py (shared with the
+# CI conformance report).
 
 def test_thermal_boundary_layer_thickness_annex_a_example() -> None:
-    b = thermal_boundary_layer_thickness(frequency=2.0)
-    assert b == pytest.approx(1.83e-3, abs=5e-6)
+    b = thermal_boundary_layer_thickness(frequency=ISO9053_2_ANNEX_A_FREQUENCY)
+    assert b == pytest.approx(ISO9053_2_ANNEX_A_BOUNDARY_LAYER, abs=5e-6)
 
 
 def test_effective_kappa_annex_a_example() -> None:
     kappa_prime = effective_kappa(
-        cavity_surface=0.0471, cavity_volume=7.854e-4, frequency=2.0
+        cavity_surface=ISO9053_2_ANNEX_A_SURFACE,
+        cavity_volume=ISO9053_2_ANNEX_A_VOLUME,
+        frequency=ISO9053_2_ANNEX_A_FREQUENCY,
     )
     # Standard prints kappa' = kappa*0.978 = 1.370 (kappa = 1.4008).
-    assert kappa_prime == pytest.approx(1.370, abs=5e-4)
+    assert kappa_prime == pytest.approx(ISO9053_2_ANNEX_A_KAPPA_PRIME, abs=5e-4)
     assert kappa_prime == pytest.approx(1.4008 * 0.978, abs=1e-3)
 
 
 def test_effective_kappa_below_adiabatic() -> None:
     # Heat conduction always lowers kappa below the adiabatic value.
     kappa_prime = effective_kappa(
-        cavity_surface=0.0471, cavity_volume=7.854e-4, frequency=2.0
+        cavity_surface=ISO9053_2_ANNEX_A_SURFACE,
+        cavity_volume=ISO9053_2_ANNEX_A_VOLUME,
+        frequency=ISO9053_2_ANNEX_A_FREQUENCY,
     )
     assert kappa_prime < 1.4008
 

--- a/tests/test_building_prediction.py
+++ b/tests/test_building_prediction.py
@@ -101,13 +101,15 @@ def test_kij_lightweight_facade_minimum() -> None:
 
 
 def test_kij_invalid_inputs() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'mass_ratio' must be positive"):
         junction_vibration_reduction("rigid_cross", "through", 0.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'mass_ratio' must be positive"):
         junction_vibration_reduction("rigid_cross", "through", -1.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'junction_type' must be one of"):
         junction_vibration_reduction("unknown", "through", 1.0)  # type: ignore[arg-type]
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'path' must be 'through' or 'corner'"
+    ):
         junction_vibration_reduction("rigid_cross", "diagonal", 1.0)  # type: ignore[arg-type]
 
 
@@ -116,7 +118,10 @@ def test_kij_min_formula_29() -> None:
     lf, si, sj = 4.5, 11.5, 19.6
     expected = 10.0 * math.log10(4.5 * (1.0 / 11.5 + 1.0 / 19.6))
     assert junction_min_vibration_reduction(lf, si, sj) == pytest.approx(expected)
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match="'coupling_length', 's_i' and 's_j' must be positive",
+    ):
         junction_min_vibration_reduction(0.0, 11.5, 19.6)
 
 
@@ -162,12 +167,17 @@ def test_flanking_element_triplet() -> None:
 
 
 def test_flanking_path_invalid() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'kind' must be 'Ff', 'Df' or 'Fd'"
+    ):
         flanking_path(
             label="x", kind="XX", r_source=40.0, r_receive=40.0,  # type: ignore[arg-type]
             k_ij=5.0, separating_area=11.5, coupling_length=4.5,
         )
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match="'separating_area' and 'coupling_length' must be positive",
+    ):
         flanking_path(
             label="x", kind="Ff", r_source=40.0, r_receive=40.0,
             k_ij=5.0, separating_area=-1.0, coupling_length=4.5,
@@ -331,7 +341,7 @@ def test_airborne_dominant_path_is_weakest() -> None:
 def test_equivalent_impact_level_annex_e3() -> None:
     # Concrete floor m' = 322 kg/m² -> Ln,w,eq = 164 - 35 lg(322) = 76.2 dB.
     assert equivalent_impact_level(322.0) == pytest.approx(76.2, abs=0.1)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'mass_per_area' must be positive"):
         equivalent_impact_level(0.0)
 
 
@@ -347,7 +357,10 @@ def test_impact_flanking_correction_table_cells() -> None:
     assert impact_flanking_correction(900.0, 100.0) == 6
     assert impact_flanking_correction(900.0, 500.0) == 2
     assert impact_flanking_correction(500.0, 100.0) == 4
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match="'separating_mass' and 'flanking_mass' must be positive",
+    ):
         impact_flanking_correction(-1.0, 100.0)
 
 
@@ -374,7 +387,7 @@ def test_standardized_impact_level_annex_e3() -> None:
     # L'nT,w = L'n,w - 10 lg(V/30) = 45 - 10 lg(50/30) = 42.8 -> 43 dB.
     assert standardized_impact_level(45.0, 50.0) == pytest.approx(42.8, abs=0.1)
     assert round(standardized_impact_level(45.0, 50.0)) == 43
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'volume' must be positive"):
         standardized_impact_level(45.0, 0.0)
 
 
@@ -386,5 +399,7 @@ def test_impact_covering_improves_level() -> None:
 
 
 def test_impact_non_finite_rejected() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'ln_w_eq' must be a finite number"
+    ):
         predicted_impact_insulation(ln_w_eq=float("nan"))

--- a/tests/test_building_uncertainty.py
+++ b/tests/test_building_uncertainty.py
@@ -58,7 +58,7 @@ TABLE2 = {
 def test_table2_airborne_every_band(situation, col):
     result = band_uncertainty("airborne", situation)
     assert list(result.frequencies) == FREQ_FULL
-    for f, u in zip(result.frequencies, result.uncertainties):
+    for f, u in zip(result.frequencies, result.uncertainties, strict=True):
         assert u == pytest.approx(TABLE2[int(f)][col]), f"{situation} @ {f} Hz"
 
 
@@ -79,7 +79,7 @@ def test_table4_impact_every_band(situation, col):
     result = band_uncertainty("impact", situation)
     assert list(result.frequencies) == FREQ_IMPACT
     assert 500 not in result.frequencies  # 2020 edition drops 500 Hz
-    for f, u in zip(result.frequencies, result.uncertainties):
+    for f, u in zip(result.frequencies, result.uncertainties, strict=True):
         assert u == pytest.approx(TABLE4[int(f)][col]), f"{situation} @ {f} Hz"
 
 
@@ -100,7 +100,7 @@ TABLE6_A = [
 def test_table6_reduction_every_band():
     result = band_uncertainty("impact_reduction", "A")
     assert list(result.frequencies) == FREQ_FULL
-    for u, expected in zip(result.uncertainties, TABLE6_A):
+    for u, expected in zip(result.uncertainties, TABLE6_A, strict=True):
         assert u == pytest.approx(expected)
 
 
@@ -123,7 +123,7 @@ def test_tabled1_sigma_r95_bands():
     result = band_uncertainty("airborne", "A", upper_limit=True)
     assert result.upper_limit is True
     assert list(result.frequencies) == FREQ_FULL
-    for u, expected in zip(result.uncertainties, TABLED1):
+    for u, expected in zip(result.uncertainties, TABLED1, strict=True):
         assert u == pytest.approx(expected)
 
 
@@ -142,7 +142,7 @@ def test_table1_maximum_repeatability():
         1.3, 1.3, 1.3, 1.3, 1.3, 1.3, 1.3, 1.3, 1.3, 1.3,
     ]
     assert list(result.frequencies) == FREQ_FULL
-    for u, e in zip(result.uncertainties, expected):
+    for u, e in zip(result.uncertainties, expected, strict=True):
         assert u == pytest.approx(e)
 
 
@@ -182,7 +182,7 @@ def test_airborne_aliases_share_row():
     [("ln_w", (1.5, 1.0, 0.5)), ("ln_w+ci", (1.5, 1.0, 0.6))],
 )
 def test_table5_impact_single_number(quantity, expected):
-    for situation, e in zip("ABC", expected):
+    for situation, e in zip("ABC", expected, strict=True):
         assert single_number_uncertainty(quantity, situation) == pytest.approx(e)
 
 

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -82,7 +82,7 @@ def test_stateful_bank_matches_stateless_design() -> None:
     r_stateful = verify_filter_class(stateful)
     r_stateless = verify_filter_class(stateless)
     assert r_stateful["overall_class"] == r_stateless["overall_class"]
-    for a, b in zip(r_stateful["bands"], r_stateless["bands"]):
+    for a, b in zip(r_stateful["bands"], r_stateless["bands"], strict=True):
         assert a["margin_class1_db"] == pytest.approx(b["margin_class1_db"])
 
 

--- a/tests/test_conformance_report.py
+++ b/tests/test_conformance_report.py
@@ -21,9 +21,12 @@ import conformance_report as cr  # noqa: E402
 
 
 def test_registry_is_populated() -> None:
-    assert len(cr.CHECKS) >= 32
+    # Realistic floors for the current registry size (95 checks / 22 domains
+    # as of the tests-audit batch): loose enough to allow pruning a couple of
+    # checks, tight enough that losing a whole domain fails.
+    assert len(cr.CHECKS) >= 90
     # Every domain has at least one check.
-    assert len(cr._domains()) >= 7
+    assert len(cr._domains()) >= 20
 
 
 def test_block_a_psychoacoustics_checks_registered() -> None:

--- a/tests/test_enclosed_space_absorption.py
+++ b/tests/test_enclosed_space_absorption.py
@@ -12,21 +12,17 @@ import pytest
 from reference_data import (
     EN12354_6_A_BARE,
     EN12354_6_A_OBJECTS,
+    EN12354_6_ANNEX_E_BARE_SURFACES,
+    EN12354_6_ANNEX_E_VOLUME,
     EN12354_6_T_BARE,
 )
 
 from phonometry import enclosed_space_absorption as m
 
-_VOLUME = 29.75
-# The six surfaces of the bare room (area, absorption coefficient at 1000 Hz).
-_BARE_SURFACES = [
-    (12.39, 0.05),  # floor
-    (12.39, 0.02),  # ceiling
-    (10.90, 0.04),  # long wall
-    (10.90, 0.04),  # side wall
-    (6.55, 0.04),   # side wall
-    (6.55, 0.04),   # glass facade
-]
+_VOLUME = EN12354_6_ANNEX_E_VOLUME
+# The six surfaces of the bare room (area, absorption coefficient at 1000 Hz),
+# shared with the CI conformance report via tests/reference_data.py.
+_BARE_SURFACES = EN12354_6_ANNEX_E_BARE_SURFACES
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_hearing.py
+++ b/tests/test_hearing.py
@@ -9,8 +9,11 @@ reference threshold against the ISO 389-7 Table 1 values.
 
 from __future__ import annotations
 
+from itertools import pairwise
+
 import numpy as np
 import pytest
+from reference_data import ISO389_7_REF_FREE_1KHZ, ISO7029_MEDIAN_MALE_60_4KHZ
 
 from phonometry import hearing as h
 
@@ -40,14 +43,14 @@ def test_median_matches_reference_values() -> None:
     # Reference median deviations computed from the Table 1 formula.
     male = h.age_threshold(60, "male", 0.5)
     assert male.median[4] == pytest.approx(7.8473, abs=1e-3)   # 1000 Hz
-    assert male.median[8] == pytest.approx(20.2085, abs=1e-3)  # 4000 Hz
+    assert male.median[8] == pytest.approx(ISO7029_MEDIAN_MALE_60_4KHZ, abs=1e-3)  # 4000 Hz
     female = h.age_threshold(60, "female", 0.5)
     assert female.median[8] == pytest.approx(15.3218, abs=1e-3)
 
 
 def test_median_increases_with_age() -> None:
     m = [h.age_threshold(a, "male", 0.5).median[8] for a in (18, 30, 50, 70)]
-    assert all(x < y for x, y in zip(m, m[1:]))
+    assert all(x < y for x, y in pairwise(m))
     assert m[0] == pytest.approx(0.0, abs=1e-12)
 
 
@@ -70,7 +73,7 @@ def test_reference_threshold_matches_iso389_7() -> None:
     free = h.reference_threshold("free-field")
     diffuse = h.reference_threshold("diffuse-field")
     # ISO 389-7:2006 Table 1 (audiometric frequencies).
-    assert free[4] == pytest.approx(2.4)    # 1000 Hz free-field
+    assert free[4] == pytest.approx(ISO389_7_REF_FREE_1KHZ)  # 1000 Hz free-field
     assert free[10] == pytest.approx(12.6)  # 8000 Hz free-field
     assert diffuse[4] == pytest.approx(0.8)  # 1000 Hz diffuse-field
     # Free- and diffuse-field agree at low frequencies, diverge higher up.

--- a/tests/test_human_vibration.py
+++ b/tests/test_human_vibration.py
@@ -276,7 +276,7 @@ def test_hav_daily_exposure_matches_partial_combination() -> None:
     values = [3.0, 5.0]
     durations = [2 * 3600.0, 1 * 3600.0]
     direct = hv.hav_daily_exposure(values, durations)
-    partials = [hv.partial_exposure(v, d) for v, d in zip(values, durations)]
+    partials = [hv.partial_exposure(v, d) for v, d in zip(values, durations, strict=True)]
     assert direct == pytest.approx(hv.combine_partial_exposures(partials))
 
 

--- a/tests/test_impact_insulation.py
+++ b/tests/test_impact_insulation.py
@@ -31,6 +31,7 @@ from phonometry import (
     impact_insulation,
     weighted_impact_rating,
 )
+from reference_data import ISO717_2_ANNEX_C1_LN
 
 # ISO 717-2 Table 3 reference values.
 _REF_IMPACT_THIRD = [
@@ -41,10 +42,8 @@ _INDEX_500_THIRD = 7
 _INDEX_500_OCTAVE = 2
 
 # ISO 717-2 Annex C, Table C.1 measured Ln (one-third octave, 100-3150).
-_ANNEX_C1_LN = [
-    62.1, 63.2, 63.5, 66.2, 68.5, 70.0, 71.7, 73.1,
-    73.8, 73.5, 73.8, 73.3, 73.1, 73.0, 72.4, 71.2,
-]
+# Shared oracle with the CI conformance report (tests/reference_data.py).
+_ANNEX_C1_LN = list(ISO717_2_ANNEX_C1_LN)
 # ISO 717-2 Annex C, Table C.3 measured Ln (octave, 125-2000).
 _ANNEX_C3_LN = [65.3, 64.5, 58.0, 55.8, 43.0]
 
@@ -163,14 +162,16 @@ def test_measured_data_rounded_to_one_decimal() -> None:
 
 
 def test_weighted_impact_rating_rejects_bad_length() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Expected 16 one-third-octave"):
         weighted_impact_rating([1.0, 2.0, 3.0])
 
 
 def test_weighted_impact_rating_rejects_nan() -> None:
     bad = list(_ANNEX_C1_LN)
     bad[0] = float("nan")
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'values_by_band' must contain only finite values"
+    ):
         weighted_impact_rating(bad)
 
 
@@ -256,12 +257,16 @@ def test_impact_energy_averages_positions() -> None:
 
 
 def test_impact_rejects_length_mismatch() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'li' and 't2' must share the same band count"
+    ):
         impact_insulation(np.array([60.0, 60.0]), np.array([0.5]))
 
 
 def test_impact_rejects_bad_reverberation_time() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'t2' must contain positive, finite values"
+    ):
         impact_insulation(np.array([60.0]), np.array([0.0]))
 
 

--- a/tests/test_insulation.py
+++ b/tests/test_insulation.py
@@ -168,14 +168,16 @@ def test_measured_data_rounded_to_one_decimal() -> None:
 
 
 def test_weighted_rating_rejects_bad_length() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Expected 16 one-third-octave"):
         weighted_rating([1.0, 2.0, 3.0])
 
 
 def test_weighted_rating_rejects_nan() -> None:
     bad = list(_ANNEX_C_R)
     bad[0] = float("nan")
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'values_by_band' must contain only finite values"
+    ):
         weighted_rating(bad)
 
 
@@ -282,14 +284,19 @@ def test_airborne_energy_averages_positions() -> None:
 
 
 def test_airborne_rejects_length_mismatch() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match="'l1', 'l2' and 't2' must share the same band count",
+    ):
         airborne_insulation(
             np.array([80.0, 80.0]), np.array([40.0]), np.array([0.5])
         )
 
 
 def test_airborne_requires_both_area_and_volume() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'area' and 'volume' must be given together"
+    ):
         airborne_insulation(
             np.array([80.0]), np.array([40.0]), np.array([0.5]), area=10.0
         )

--- a/tests/test_loudness_contours.py
+++ b/tests/test_loudness_contours.py
@@ -13,15 +13,18 @@ rounded to 0.1 dB / 0.1 phon.
 
 import numpy as np
 import pytest
+from reference_data import ISO226_2023_TABLE_B1_ANCHOR
 
 from phonometry import equal_loudness_contour, hearing_threshold, loudness_level
 
-# (phon, frequency Hz, expected SPL dB) - ISO 226:2023 Table B.1
+# (phon, frequency Hz, expected SPL dB) - ISO 226:2023 Table B.1. The
+# (60 phon, 100 Hz) anchor is imported from tests/reference_data.py (shared
+# with the CI conformance report) so the two copies cannot drift.
 TABLE_B1 = [
     (20, 20.0, 89.5), (20, 1000.0, 20.0), (20, 12500.0, 33.0),
     (40, 20.0, 99.7), (40, 63.0, 73.0), (40, 250.0, 50.3),
     (40, 1000.0, 40.0), (40, 4000.0, 36.7), (40, 8000.0, 51.6),
-    (60, 100.0, 78.5), (60, 500.0, 62.1), (60, 2000.0, 60.0),
+    ISO226_2023_TABLE_B1_ANCHOR, (60, 500.0, 62.1), (60, 2000.0, 60.0),
     (80, 20.0, 118.9), (80, 1000.0, 80.0), (80, 12500.0, 85.6),
     (90, 20.0, 123.6), (90, 4000.0, 88.8),
 ]
@@ -56,7 +59,7 @@ def test_identity_at_1khz() -> None:
 
 def test_roundtrip() -> None:
     freqs, spl = equal_loudness_contour(55.0)
-    back = [loudness_level(s, f) for f, s in zip(freqs, spl)]
+    back = [loudness_level(s, f) for f, s in zip(freqs, spl, strict=True)]
     np.testing.assert_allclose(back, 55.0, atol=1e-9)
 
 

--- a/tests/test_loudness_ecma.py
+++ b/tests/test_loudness_ecma.py
@@ -42,29 +42,46 @@ def test_calibration_1khz_40db_is_one_sone(ref_1k_40: EcmaLoudness) -> None:
     assert ref_1k_40.loudness == pytest.approx(1.0, abs=0.03)
 
 
+def test_calibration_constant_is_the_tabulated_c_n() -> None:
+    # Clause 5.1.8 tabulates c_N = 0.0211964; the implementation must use the
+    # standard's value verbatim (shared oracle in tests/reference_data.py).
+    from reference_data import ECMA418_2_LOUDNESS_C_N
+
+    from phonometry.loudness_ecma import _C_N
+
+    assert _C_N == ECMA418_2_LOUDNESS_C_N
+
+
 # --------------------------------------------------------------------------
 # Internal cross-checks
 # --------------------------------------------------------------------------
 
 
 def test_monotonic_in_level() -> None:
-    values = [loudness_ecma(_tone(1000.0, lvl), FS).loudness for lvl in (20, 40, 60, 80)]
-    assert values[0] < values[1] < values[2] < values[3]
+    # Monotonicity is level-driven, not duration-driven: 0.6 s segments and
+    # three levels suffice (the 0.6 s / 40 dB anchor also holds 1 sone within
+    # 3 % in the CI conformance check, which uses the same duration).
+    values = [
+        loudness_ecma(_tone(1000.0, lvl, seconds=0.6), FS).loudness
+        for lvl in (20, 40, 80)
+    ]
+    assert values[0] < values[1] < values[2]
     # 40 dB is the 1-sone anchor; higher levels are clearly louder.
     assert values[1] == pytest.approx(1.0, abs=0.03)
-    assert values[2] > 2.0
-    assert values[3] > 5.0
+    assert values[2] > 5.0
 
 
 def test_silence_is_zero() -> None:
-    result = loudness_ecma(np.zeros(int(FS * 1.2)), FS)
+    # Pure-property check: zero in, zero out at any length past the
+    # transient-discard window, so 0.6 s is enough.
+    result = loudness_ecma(np.zeros(int(FS * 0.6)), FS)
     assert result.loudness == 0.0
     assert np.all(result.specific_loudness == 0.0)
 
 
 def test_subthreshold_tone_is_inaudible() -> None:
     # A 1 kHz tone at -10 dB SPL is well below the threshold in quiet.
-    result = loudness_ecma(_tone(1000.0, -10.0), FS)
+    result = loudness_ecma(_tone(1000.0, -10.0, seconds=0.6), FS)
     assert result.loudness < 0.01
 
 
@@ -79,8 +96,11 @@ def test_specific_loudness_peaks_near_tone(ref_1k_40: EcmaLoudness) -> None:
 
 
 def test_free_and_diffuse_fields_differ() -> None:
-    free = loudness_ecma(_tone(1000.0, 60.0), FS, field="free").loudness
-    diffuse = loudness_ecma(_tone(1000.0, 60.0), FS, field="diffuse").loudness
+    # Property check (ear-filter difference), not a calibration: 0.6 s is
+    # enough for a stable value in both fields.
+    x = _tone(1000.0, 60.0, seconds=0.6)
+    free = loudness_ecma(x, FS, field="free").loudness
+    diffuse = loudness_ecma(x, FS, field="diffuse").loudness
     # Both plausible loudspeaker-range values, but the ear filter differs.
     assert free > 1.0 and diffuse > 1.0
     assert free != diffuse
@@ -88,7 +108,7 @@ def test_free_and_diffuse_fields_differ() -> None:
 
 def test_resampling_matches_native_rate() -> None:
     fs_alt = 44100
-    t = np.arange(int(fs_alt * 1.2)) / fs_alt
+    t = np.arange(int(fs_alt * 0.6)) / fs_alt
     amp = np.sqrt(2.0) * 2e-5 * 10 ** (40.0 / 20.0)
     x = amp * np.sin(2.0 * np.pi * 1000.0 * t)
     resampled = loudness_ecma(x, fs_alt).loudness

--- a/tests/test_loudness_moore_glasberg.py
+++ b/tests/test_loudness_moore_glasberg.py
@@ -76,6 +76,17 @@ def test_anchor_single_ear_is_two_thirds_of_binaural() -> None:
     assert binaural / monaural == pytest.approx(1.5, abs=0.02)
 
 
+def test_calibration_constant_is_the_tabulated_c() -> None:
+    # ISO 532-2 Formula (7) tabulates C = 0.0617 sone/Cam; the implementation
+    # must use the standard's value verbatim (shared oracle in
+    # tests/reference_data.py).
+    from reference_data import ISO532_2_C
+
+    from phonometry.loudness_moore_glasberg import _C_SONE
+
+    assert _C_SONE == ISO532_2_C
+
+
 # --------------------------------------------------------------------------
 # Annex B.1 - sinusoidal tones
 # --------------------------------------------------------------------------
@@ -335,17 +346,23 @@ def test_diotic_alias_matches_binaural() -> None:
 
 
 def test_invalid_inputs() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="field must be one of"):
         loudness_moore_glasberg_from_spectrum([(1000.0, 40.0)], field="near")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="presentation must be one of"):
         loudness_moore_glasberg_from_spectrum([(1000.0, 40.0)], presentation="mono")
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="component frequencies must be positive"
+    ):
         loudness_moore_glasberg_from_spectrum([(-10.0, 40.0)])
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="components must contain only finite values"
+    ):
         loudness_moore_glasberg_from_spectrum([(1000.0, np.inf)])
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="band_levels must contain exactly"):
         loudness_moore_glasberg_from_third_octave([60.0] * 10)  # wrong length
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Input signal 'x' cannot be empty"):
         loudness_moore_glasberg(np.array([]), FS)
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'fs' must be a positive sampling rate"
+    ):
         loudness_moore_glasberg(np.ones(100), -1.0)

--- a/tests/test_loudness_moore_glasberg_time.py
+++ b/tests/test_loudness_moore_glasberg_time.py
@@ -187,9 +187,13 @@ def test_silence_is_zero() -> None:
 
 
 def test_louder_tone_is_louder() -> None:
-    """Peak long-term loudness increases monotonically with level."""
+    """Peak long-term loudness increases monotonically with level.
+
+    0.7 s segments: monotonicity in level is duration-independent once the
+    long-term averager has settled (attack ~100 ms).
+    """
     values = [
-        loudness_moore_glasberg_time(_tone(1000.0, lvl), FS).n_max
+        loudness_moore_glasberg_time(_tone(1000.0, lvl, duration=0.7), FS).n_max
         for lvl in (30.0, 50.0, 70.0)
     ]
     assert values[0] < values[1] < values[2]
@@ -219,8 +223,12 @@ def test_result_fields_and_percentiles() -> None:
 
 
 def test_diotic_equals_binaural_and_exceeds_monaural() -> None:
-    """Binaural (diotic) loudness exceeds the single-ear monaural loudness."""
-    tone = _tone(1000.0, 60.0)
+    """Binaural (diotic) loudness exceeds the single-ear monaural loudness.
+
+    0.7 s: the binaural-vs-monaural gain is a spectral property, not a
+    duration effect.
+    """
+    tone = _tone(1000.0, 60.0, duration=0.7)
     binaural = loudness_moore_glasberg_time(tone, FS, presentation="binaural")
     monaural = loudness_moore_glasberg_time(
         tone, FS, field="eardrum", presentation="monaural"
@@ -229,8 +237,11 @@ def test_diotic_equals_binaural_and_exceeds_monaural() -> None:
 
 
 def test_stereo_input_accepted() -> None:
-    """A two-channel (n, 2) signal is accepted as the two ear signals."""
-    tone = _tone(1000.0, 60.0)
+    """A two-channel (n, 2) signal is accepted as the two ear signals.
+
+    0.7 s: the (n, 2)-input/diotic equivalence is exact at any length.
+    """
+    tone = _tone(1000.0, 60.0, duration=0.7)
     stereo = np.column_stack([tone, tone])
     res = loudness_moore_glasberg_time(stereo, FS)
     mono = loudness_moore_glasberg_time(tone, FS)
@@ -263,9 +274,12 @@ def test_dichotic_ltl_is_per_ear_then_summed() -> None:
     per-ear-then-sum long-term loudness must differ from smoothing the binaural
     sum (the old behaviour); for a diotic input the two are provably identical.
     """
-    left = np.concatenate([_tone(1000.0, 75.0, 0.3), np.zeros(int(0.7 * FS))])
+    # Halved (0.5 s) dichotic transient: the per-ear-vs-summed AGC difference
+    # is ~1.16 sone here, > 10x the 0.1 threshold, so the shorter signal keeps
+    # the same discriminating power at half the cost.
+    left = np.concatenate([_tone(1000.0, 75.0, 0.15), np.zeros(int(0.35 * FS))])
     right = np.concatenate(
-        [np.zeros(int(0.3 * FS)), _tone(1000.0, 55.0, 0.4), np.zeros(int(0.3 * FS))]
+        [np.zeros(int(0.15 * FS)), _tone(1000.0, 55.0, 0.2), np.zeros(int(0.15 * FS))]
     )
     n = min(left.size, right.size)
     res = loudness_moore_glasberg_time(np.column_stack([left[:n], right[:n]]), FS)
@@ -273,8 +287,9 @@ def test_dichotic_ltl_is_per_ear_then_summed() -> None:
     # (a) The fix changes the dichotic result substantially.
     assert np.max(np.abs(res.long_term_loudness - old)) > 0.1
 
-    # (b) A diotic input is byte-identical to the old sum-then-AGC (regression).
-    tone = _tone(1000.0, 60.0)
+    # (b) A diotic input is byte-identical to the old sum-then-AGC (regression);
+    # the identity is algebraic, so 0.7 s is as strong as any length.
+    tone = _tone(1000.0, 60.0, duration=0.7)
     diotic = loudness_moore_glasberg_time(np.column_stack([tone, tone]), FS)
     assert np.array_equal(
         diotic.long_term_loudness, _sum_then_agc(diotic.short_term_loudness)
@@ -323,15 +338,19 @@ def test_low_freq_band_not_truncated_across_sample_rates() -> None:
 def test_invalid_inputs_raise() -> None:
     """Invalid field, presentation, sampling rate and signal raise ValueError."""
     tone = _tone(1000.0, 40.0, duration=0.1)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="field must be one of"):
         loudness_moore_glasberg_time(tone, FS, field="bogus")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="presentation must be one of"):
         loudness_moore_glasberg_time(tone, FS, presentation="bogus")
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'fs' must be a positive sampling rate"
+    ):
         loudness_moore_glasberg_time(tone, -1.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Input signal cannot be empty"):
         loudness_moore_glasberg_time(np.array([]), FS)
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="Input signal must contain only finite values"
+    ):
         loudness_moore_glasberg_time(np.array([1.0, np.nan, 2.0]), FS)
 
 

--- a/tests/test_noise_induced_hearing_loss.py
+++ b/tests/test_noise_induced_hearing_loss.py
@@ -14,6 +14,11 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
+from reference_data import (
+    ISO1999_N10_3K_100_40,
+    ISO1999_N10_4K_90_20,
+    ISO1999_N50_4K_90_20,
+)
 
 from phonometry import noise_induced_hearing_loss as m
 
@@ -26,6 +31,17 @@ _ANNEX_D = {
     (100.0, 40.0): [(5, 7, 11), (8, 11, 19), (16, 24, 39), (29, 38, 60),
                     (30, 41, 56), (19, 30, 48)],
 }
+
+
+def test_annex_d_table_pins_shared_reference_data() -> None:
+    """Pin the inline Annex D transcription to ``tests/reference_data.py``.
+
+    The CI conformance report asserts the shared constants; this guard keeps
+    the (larger) inline table and the shared scalars from drifting apart.
+    """
+    assert _ANNEX_D[(90.0, 20.0)][4][1] == ISO1999_N50_4K_90_20  # 4 kHz median
+    assert _ANNEX_D[(90.0, 20.0)][4][2] == ISO1999_N10_4K_90_20  # 4 kHz, worst 10 %
+    assert _ANNEX_D[(100.0, 40.0)][3][2] == ISO1999_N10_3K_100_40  # 3 kHz, worst 10 %
 
 
 @pytest.mark.parametrize(("key", "expected"), _ANNEX_D.items())

--- a/tests/test_parametric_filters.py
+++ b/tests/test_parametric_filters.py
@@ -116,7 +116,7 @@ def test_a_weighting_response() -> None:
     test_freqs = [100, 1000, 8000]
     expected_gain = [-19.1, 0.0, -1.1]
     
-    for f, expected in zip(test_freqs, expected_gain):
+    for f, expected in zip(test_freqs, expected_gain, strict=True):
         # Generate tone
         x = np.sin(2 * np.pi * f * t)
         y = weighting_filter(x, fs, curve="A")
@@ -148,7 +148,7 @@ def test_c_weighting_response() -> None:
     test_freqs = [31.5, 1000, 8000]
     expected_gain = [-3.0, 0.0, -3.0]
     
-    for f, expected in zip(test_freqs, expected_gain):
+    for f, expected in zip(test_freqs, expected_gain, strict=True):
         x = np.sin(2 * np.pi * f * t)
         y = weighting_filter(x, fs, curve="C")
         

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -60,9 +60,14 @@ def test_filterbank_reuse_performance() -> None:
     print(f"Class Filter Only Time: {time_class_filter:.4f}s")
     print(f"Class Total Time: {time_class_total:.4f}s")
     
-    # The class-based filtering (after init) should be significantly faster
-    # than the functional API calls which include init every time.
-    assert time_class_filter < time_func
-    
-    # Even including init, it should be comparable or better for multiple iterations
-    assert time_class_total < time_func
+    # The class-based filtering (after init) should not be slower than the
+    # functional API calls which include a full redesign every time. Wall-clock
+    # timing on shared CI runners jitters, and the two paths can land within
+    # fractions of a millisecond of each other, so a zero-margin comparison
+    # flakes; a 1.5x allowance still fails if the design cache regresses (a
+    # redesign per call costs ~10x the filtering itself).
+    assert time_class_filter < time_func * 1.5
+
+    # Even including init, it should be comparable or better for multiple
+    # iterations (same 1.5x jitter allowance as above).
+    assert time_class_total < time_func * 1.5

--- a/tests/test_road_absorption.py
+++ b/tests/test_road_absorption.py
@@ -116,9 +116,13 @@ def test_reflected_path_delay() -> None:
 
 
 def test_geometry_guards() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'source_height' and 'mic_height' must be positive"
+    ):
         geometric_spreading_factor(0.0, 0.25)
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'source_height' must exceed 'mic_height'"
+    ):
         geometric_spreading_factor(0.25, 1.25)  # source must exceed mic
 
 
@@ -209,9 +213,9 @@ def test_reference_correction_cancels_kr_and_chain(recwarn: pytest.WarningsRecor
 
 
 def test_reflection_input_guards() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Impulse responses must be non-empty"):
         insitu_reflection_factor([], [1.0, 2.0])
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'fs' is required to apply 'delay'"):
         insitu_reflection_factor([1.0, 2.0], [1.0, 2.0], delay=1e-3)  # no fs
 
 
@@ -294,13 +298,13 @@ def test_adrienne_blackman_harris_edges_meet_flat_at_unity() -> None:
 
 
 def test_adrienne_window_guards() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'fs' must be positive"):
         adrienne_window(0.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'flat_duration' must be positive"):
         adrienne_window(FS, flat_duration=0.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Edge durations must be non-negative"):
         adrienne_window(FS, leading_duration=-1e-3)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Edge shapes must be one of"):
         adrienne_window(FS, trailing_edge="triangular")
 
 
@@ -335,9 +339,13 @@ def test_one_third_octave_clipping() -> None:
 
 
 def test_one_third_octave_guards() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="must be non-empty and equal-length"
+    ):
         one_third_octave_absorption([250.0, 500.0], [0.1])
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="must be non-empty and equal-length"
+    ):
         one_third_octave_absorption([], [])
 
 
@@ -361,9 +369,9 @@ def test_insitu_absorption_spectrum_mid_bands_are_one_minus_r0_sq() -> None:
 def test_insitu_absorption_spectrum_rejects_nonpositive_fs() -> None:
     hi = _incident_ir()
     hr = 0.4 * np.roll(hi, 96)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'fs' must be positive"):
         insitu_absorption_spectrum(hi, hr, 0.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'fs' must be positive"):
         insitu_absorption_spectrum(hi, hr, -48000.0)
 
 
@@ -403,9 +411,11 @@ def test_msa_major_axis_reduces_to_normal_at_zero_projection() -> None:
 
 
 def test_msa_guards() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'window_width' must be positive"):
         max_sampled_area_radius(0.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'projected_distance' must be non-negative"
+    ):
         msa_major_axis(5e-3, -1.0)
 
 
@@ -469,11 +479,13 @@ def test_spot_internal_loss_clips_negative() -> None:
 
 
 def test_spot_guards() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'diameter' must be positive"):
         spot_tube_upper_frequency(0.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'f_min' must be less than 'f_max'"
+    ):
         spot_microphone_spacing_bounds(340.0, f_min=1800.0, f_max=220.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="must share a shape"):
         spot_internal_loss_correction([0.1, 0.2], [0.1])
 
 

--- a/tests/test_room_ir.py
+++ b/tests/test_room_ir.py
@@ -341,59 +341,85 @@ def test_mls_multi_period_recording_averages_internally() -> None:
 
 
 def test_invalid_arguments() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="f2 must be greater than f1"):
         sweep_signal(FS, 100.0, 100.0, 1.0)  # f1 == f2
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="f2 must be greater than f1"):
         sweep_signal(FS, 100.0, 50.0, 1.0)  # f1 > f2
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="must not exceed the Nyquist frequency"
+    ):
         sweep_signal(FS, 20.0, 30000.0, 1.0)  # f2 > Nyquist
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="order must be one of"):
         mls_signal(1)  # order too small
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="order must be one of"):
         mls_signal(99)  # unsupported order
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="unknown method"):
         impulse_response(np.zeros(10), np.zeros(10), FS, method="bogus")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="requires f_range"):
         impulse_response(np.zeros(10), np.zeros(10), FS, method="farina")  # no f_range
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match="recorded length must be a positive multiple of the MLS length",
+    ):
         mls_impulse_response(np.zeros(10), mls_signal(4))  # not a multiple of L
 
 
 def test_inverse_filter_empty_band_raises() -> None:
     # A very short sweep over a razor-thin band yields no in-band FFT bin:
     # the median of an empty slice would be NaN, so this must raise instead.
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="no frequency bin falls within the sweep band"
+    ):
         inverse_filter(FS, 1000.0, 1000.5, 0.001)
     # The error must propagate through the Farina deconvolution path too.
-    with pytest.raises(ValueError):
+    # The reference must be non-zero, or the zero-padding guard fires first.
+    with pytest.raises(
+        ValueError, match="no frequency bin falls within the sweep band"
+    ):
         impulse_response(
-            np.zeros(48), np.zeros(48), FS,
+            np.zeros(48), np.ones(48), FS,
             method="farina", f_range=(1000.0, 1000.5),
         )
 
 
 def test_impulse_response_rejects_bad_shapes() -> None:
     good = np.zeros(10)
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'recorded' and 'reference' must be one-dimensional"
+    ):
         impulse_response(np.zeros((2, 5)), good, FS)  # 2-D recorded
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'recorded' and 'reference' must be one-dimensional"
+    ):
         impulse_response(good, np.zeros((2, 5)), FS)  # 2-D reference
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'recorded' and 'reference' must be non-empty"
+    ):
         impulse_response(np.zeros(0), good, FS)  # empty recorded
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'recorded' and 'reference' must be non-empty"
+    ):
         impulse_response(good, np.zeros(0), FS)  # empty reference
 
 
 def test_mls_impulse_response_rejects_bad_shapes() -> None:
     seq = mls_signal(4)
     good = np.tile(seq, 2)
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'recorded' and 'mls' must be one-dimensional"
+    ):
         mls_impulse_response(np.zeros((2, seq.size)), seq)  # 2-D recorded
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'recorded' and 'mls' must be one-dimensional"
+    ):
         mls_impulse_response(good, np.zeros((2, seq.size)))  # 2-D mls
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'recorded' and 'mls' must be non-empty"
+    ):
         mls_impulse_response(np.zeros(0), seq)  # empty recorded
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'recorded' and 'mls' must be non-empty"
+    ):
         mls_impulse_response(good, np.zeros(0))  # empty mls
 
 

--- a/tests/test_room_noise.py
+++ b/tests/test_room_noise.py
@@ -12,6 +12,11 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
+from reference_data import (
+    ANSIS12_2_NC40_SELF,
+    ANSIS12_2_RC31_63HZ,
+    ANSIS12_2_RC35_LMF,
+)
 
 from phonometry import room_noise as rn
 
@@ -30,7 +35,7 @@ def test_nc_table_row_matches_standard() -> None:
     )
 
 
-@pytest.mark.parametrize("index", [15.0, 25.0, 40.0, 50.0, 70.0])
+@pytest.mark.parametrize("index", [15.0, 25.0, ANSIS12_2_NC40_SELF, 50.0, 70.0])
 def test_nc_curve_returns_its_own_rating(index: float) -> None:
     # Feeding an NC curve back through the tangency method returns its value.
     result = rn.noise_criterion(rn.nc_curve(index))
@@ -63,6 +68,9 @@ def test_rc_curves_match_table_d1() -> None:
     }
     for index, row in expected.items():
         np.testing.assert_allclose(rn.rc_curve(index), row)
+    # Pin the inline Table D.1 transcription to the shared reference_data
+    # constant used by the CI conformance report (RC-31 curve at 63 Hz).
+    assert expected[31.0][2] == ANSIS12_2_RC31_63HZ
 
 
 def test_rc_low_frequency_floor() -> None:
@@ -75,7 +83,7 @@ def test_rc_low_frequency_floor() -> None:
 def test_rc_neutral_spectrum() -> None:
     result = rn.room_criterion(rn.rc_curve(35.0))
     assert result.rating == 35
-    assert result.lmf == pytest.approx(35.0)
+    assert result.lmf == pytest.approx(ANSIS12_2_RC35_LMF)
     assert result.classification == "N"
     assert result.label == "RC-35(N)"
 

--- a/tests/test_roughness_ecma.py
+++ b/tests/test_roughness_ecma.py
@@ -69,6 +69,16 @@ def test_calibration_1khz_70hz_is_one_asper(ref_calibration: EcmaRoughness) -> N
     assert ref_calibration.roughness == pytest.approx(1.0735, abs=0.01)
 
 
+def test_calibration_constant_is_the_tabulated_c_r() -> None:
+    # Formula 104 tabulates c_R = 0.0180685; the implementation must use the
+    # standard's value verbatim (shared oracle in tests/reference_data.py).
+    from reference_data import ECMA418_2_ROUGHNESS_C_R
+
+    from phonometry.roughness_ecma import _C_R
+
+    assert _C_R == ECMA418_2_ROUGHNESS_C_R
+
+
 # --------------------------------------------------------------------------
 # Standard's qualitative behaviours
 # --------------------------------------------------------------------------

--- a/tests/test_scattering_diffusion.py
+++ b/tests/test_scattering_diffusion.py
@@ -24,6 +24,11 @@ import warnings
 
 import numpy as np
 import pytest
+from reference_data import (
+    ISO17497_1_CHAIN_ALPHA_S,
+    ISO17497_1_CHAIN_ALPHA_SPEC,
+    ISO17497_1_CHAIN_SCATTERING,
+)
 
 from phonometry.scattering_diffusion import (
     BASE_PLATE_BANDS,
@@ -122,9 +127,10 @@ def test_scattering_end_to_end_synthetic() -> None:
     alpha_spec = specular_absorption_coefficient(V, S, c3=C, T3=T3, c4=C, T4=T4)
     s = scattering_coefficient(alpha_spec, alpha_s)
 
-    assert float(alpha_s) == pytest.approx(0.1342754467754468)
-    assert float(alpha_spec) == pytest.approx(0.21484071484071485)
-    assert float(s) == pytest.approx(0.09306108711505018)
+    # Shared oracles from tests/reference_data.py (used by the CI report too).
+    assert float(alpha_s) == pytest.approx(ISO17497_1_CHAIN_ALPHA_S)
+    assert float(alpha_spec) == pytest.approx(ISO17497_1_CHAIN_ALPHA_SPEC)
+    assert float(s) == pytest.approx(ISO17497_1_CHAIN_SCATTERING)
     # And it matches the independent re-derivation.
     assert float(alpha_s) == pytest.approx(expected_alpha_s)
     assert float(alpha_spec) == pytest.approx(expected_alpha_spec)
@@ -359,68 +365,86 @@ def test_random_incidence_two_dimensional_weighting() -> None:
 # Input-validation guards.
 # ---------------------------------------------------------------------------
 def test_diffusion_requires_two_receivers() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'levels' needs at least two receivers"
+    ):
         directional_diffusion_coefficient([80.0])
 
 
 def test_diffusion_weight_length_mismatch() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'area_weights' must match the number of receivers"
+    ):
         directional_diffusion_coefficient([70.0, 72.0], area_weights=[1.0])
 
 
 def test_reverberation_uncertainty_requires_two() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'times' needs at least two measurements"
+    ):
         reverberation_time_uncertainty([6.0])
 
 
 def test_absorption_rejects_nonpositive_geometry() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'volume' must be a positive, finite number"
+    ):
         random_incidence_absorption(0.0, S, c1=C, T1=8.0, c2=C, T2=6.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'area' must be a positive, finite number"
+    ):
         random_incidence_absorption(V, -1.0, c1=C, T1=8.0, c2=C, T2=6.0)
 
 
 def test_absorption_rejects_nonpositive_time_and_speed() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'T' values must be positive"):
         random_incidence_absorption(V, S, c1=C, T1=0.0, c2=C, T2=6.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'c' values must be positive"):
         random_incidence_absorption(V, S, c1=-1.0, T1=8.0, c2=C, T2=6.0)
 
 
 def test_scattering_rejects_alpha_s_equal_one() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'alpha_s' must not equal 1"):
         scattering_coefficient(0.5, 1.0)
 
 
 def test_normalization_rejects_reference_one() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'d_theta_reference' must not equal 1"
+    ):
         normalized_diffusion_coefficient(0.5, 1.0)
 
 
 def test_area_factors_rejects_nonpositive_spacing() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'delta_theta' must be a positive, finite number"
+    ):
         area_factors([0.0, 30.0], delta_theta=0.0)
 
 
 def test_area_factors_rejects_empty_elevations() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'elevations' must be a non-empty 1-D sequence"
+    ):
         area_factors([], delta_theta=5.0)
 
 
 def test_diffusion_coefficient_rejects_zero_energy() -> None:
     # All -inf levels means zero energy everywhere; the coefficient is undefined.
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="The polar response carries no energy"
+    ):
         directional_diffusion_coefficient([float("-inf"), float("-inf")])
 
 
 def test_base_plate_checker_rejects_wrong_length() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="values for bands"):
         check_base_plate_scattering([0.1, 0.2, 0.3])
 
 
 def test_base_plate_checker_rejects_missing_band() -> None:
     incomplete = {b: 0.0 for b in BASE_PLATE_BANDS if b != 500}
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="missing band 500 Hz"):
         check_base_plate_scattering(incomplete)
 
 
@@ -446,19 +470,25 @@ def test_scattering_spectrum_recomputes_s_per_band() -> None:
 
 
 def test_scattering_spectrum_length_mismatch_raises() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="non-empty, 1-D and equal-length"
+    ):
         scattering_coefficient_spectrum([250.0, 500.0], [0.2], [0.1])
 
 
 def test_scattering_spectrum_empty_raises() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="non-empty, 1-D and equal-length"
+    ):
         scattering_coefficient_spectrum([], [], [])
 
 
 def test_scattering_spectrum_rejects_2d_input() -> None:
     # frequencies is documented 1-D; equal-shaped 2-D arrays must be rejected.
     two_d = [[250.0, 500.0], [1000.0, 2000.0]]
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="non-empty, 1-D and equal-length"
+    ):
         scattering_coefficient_spectrum(two_d, two_d, two_d)
 
 
@@ -493,7 +523,9 @@ def test_directional_diffusion_coefficient_matches_scalar() -> None:
 
 
 def test_directional_diffusion_length_mismatch_raises() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'angles' and 'levels' must have the same length"
+    ):
         directional_diffusion([-30.0, 0.0, 30.0], [70.0, 72.0])
 
 

--- a/tests/test_sii.py
+++ b/tests/test_sii.py
@@ -12,13 +12,20 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
+from reference_data import (
+    ANSIS3_5_BAND_IMPORTANCE_SUM,
+    ANSIS3_5_LOUD_1KHZ,
+    ANSIS3_5_STANDARD_QUIET,
+)
 
 from phonometry import sii
 
 
 def test_band_importance_sums_to_one() -> None:
     # ANSI S3.5-1997 Table 3: the band-importance function is normalised.
-    assert sii.BAND_IMPORTANCE.sum() == pytest.approx(1.0, abs=1e-12)
+    assert sii.BAND_IMPORTANCE.sum() == pytest.approx(
+        ANSIS3_5_BAND_IMPORTANCE_SUM, abs=1e-12
+    )
     assert sii.BAND_IMPORTANCE.size == 18
     np.testing.assert_allclose(
         sii.BAND_CENTERS,
@@ -31,7 +38,7 @@ def test_band_importance_sums_to_one() -> None:
 def test_sii_standard_speech_in_quiet() -> None:
     # Standard normal-effort spectrum, quiet field, normal hearing.
     result = sii.speech_intelligibility_index("normal")
-    assert result.sii == pytest.approx(0.9958, abs=5e-4)
+    assert result.sii == pytest.approx(ANSIS3_5_STANDARD_QUIET, abs=5e-4)
     assert 0.0 <= result.sii <= 1.0
 
 
@@ -82,7 +89,7 @@ def test_vocal_effort_spectra_spot_values() -> None:
     # ANSI S3.5-1997 Table 3, cross-verified against reference implementations
     # (Google speech_intelligibility_index, R CRAN SII) at 1 kHz (band 8).
     assert sii.standard_speech_spectrum("raised")[8] == pytest.approx(33.86)
-    assert sii.standard_speech_spectrum("loud")[8] == pytest.approx(42.16)
+    assert sii.standard_speech_spectrum("loud")[8] == pytest.approx(ANSIS3_5_LOUD_1KHZ)
     assert sii.standard_speech_spectrum("shout")[8] == pytest.approx(51.31)
     assert sii.VOCAL_EFFORTS == ("normal", "raised", "loud", "shout")
 

--- a/tests/test_sound_power_precision.py
+++ b/tests/test_sound_power_precision.py
@@ -87,17 +87,19 @@ def test_precision_positions_hemisphere_z_nonnegative() -> None:
 
 
 def test_precision_positions_invalid_surface_raises() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'surface' must be 'sphere' or 'hemisphere'"
+    ):
         precision_positions("box", radius=1.0)  # type: ignore[arg-type]
 
 
 def test_precision_positions_missing_radius_raises() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="A positive 'radius' is required"):
         precision_positions("sphere")
 
 
 def test_precision_positions_bad_count_raises() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="'count' must be 20"):
         precision_positions("sphere", radius=1.0, count=30)
 
 
@@ -158,7 +160,9 @@ def test_k1_is_per_position() -> None:
 
 
 def test_k1_frequency_length_mismatch_raises() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="must match the number of 'frequencies'"
+    ):
         precision_background_correction(
             np.array([[56.0, 57.0]]), np.array([[50.0, 50.0]]), np.array([200.0])
         )
@@ -204,7 +208,9 @@ def test_c3_from_air_absorption() -> None:
 
 
 def test_meteorological_invalid_pressure_raises() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'static_pressure' must be positive"
+    ):
         meteorological_corrections(23.0, 0.0)
 
 
@@ -224,7 +230,9 @@ def test_uncertainty_one_sided_k_1p6() -> None:
 
 
 def test_uncertainty_bad_coverage_factor_raises() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'coverage_factor' must be positive"
+    ):
         precision_uncertainty(0.5, 2.0, 0.0)
 
 
@@ -301,7 +309,10 @@ def test_hemisphere_per_band_uncertainty_uses_table2() -> None:
 
 def test_anechoic_background_requires_frequencies() -> None:
     """K1 needs the band centres to pick the 6/10 dB floor."""
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match="'frequencies' are required with 'background_levels'",
+    ):
         sound_power_anechoic(
             np.full((40, 1), 80.0),
             "hemisphere",
@@ -328,17 +339,22 @@ def test_anechoic_full_chain_with_k1() -> None:
 
 
 def test_anechoic_invalid_surface_raises() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'surface' must be 'sphere' or 'hemisphere'"
+    ):
         sound_power_anechoic(np.full((40, 1), 70.0), "box", radius=1.0)  # type: ignore[arg-type]
 
 
 def test_anechoic_missing_radius_raises() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="A positive 'radius' is required"):
         sound_power_anechoic(np.full((40, 1), 70.0), "sphere")
 
 
 def test_anechoic_areas_wrong_length_raises() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match="'areas' must have one value per microphone position",
+    ):
         sound_power_anechoic(
             np.full((40, 1), 70.0), "sphere", radius=1.0, areas=np.full(10, 1.0)
         )
@@ -407,12 +423,14 @@ def test_lw0_shift_off_reference() -> None:
 
 
 def test_intensity_areas_mismatch_raises() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="'partial_intensity' first axis"
+    ):
         sound_power_intensity_precision(np.full((3,), 1e-5), np.array([1.0, 1.0]))
 
 
 def test_intensity_nonpositive_area_raises() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="All 'areas' must be positive"):
         sound_power_intensity_precision(np.full((2,), 1e-5), np.array([1.0, 0.0]))
 
 
@@ -575,7 +593,9 @@ def test_criterion_1_without_limit_raises() -> None:
     i_n = np.full((4, 1), 2.0e-6)
     lp = np.full((4, 1), 60.0)
     ind = precision_field_indicators(i_n, lp)
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError, match="Criterion 1 needs the limit s"
+    ):
         precision_qualification(
             ind,
             scan_intensity_level_1=np.array([70.0]),
@@ -584,7 +604,10 @@ def test_criterion_1_without_limit_raises() -> None:
 
 
 def test_field_indicators_shape_mismatch_raises() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match="'segment_intensity' and 'segment_pressure_levels' must have",
+    ):
         precision_field_indicators(np.full((4, 1), 1e-6), np.full((3, 1), 60.0))
 
 

--- a/tests/test_stateful_weighting_filter.py
+++ b/tests/test_stateful_weighting_filter.py
@@ -115,3 +115,26 @@ def test_weighting_filter_multichannel():
     stateful_out = np.concatenate(blocks, axis=-1)
     np.testing.assert_allclose(stateful_out, ref_out, rtol=1e-10, atol=1e-12)
 
+
+def test_stateful_weighting_invalid_fs_raises():
+    """Non-positive sample rates must be rejected at construction."""
+    from phonometry import WeightingFilter
+    with pytest.raises(ValueError, match="must be positive"):
+        WeightingFilter(fs=0, stateful=True)
+    with pytest.raises(ValueError, match="must be positive"):
+        WeightingFilter(fs=-48000, stateful=True)
+
+
+def test_stateful_weighting_high_accuracy_raises():
+    """high_accuracy resampling is incompatible with block processing."""
+    from phonometry import WeightingFilter
+    with pytest.raises(ValueError, match="not compatible with stateful"):
+        WeightingFilter(fs=48000, stateful=True, high_accuracy=True)
+
+
+def test_stateful_weighting_invalid_curve_raises():
+    """Unknown weighting curves must be rejected at construction."""
+    from phonometry import WeightingFilter
+    with pytest.raises(ValueError, match="must be 'A', 'C', 'G' or 'Z'"):
+        WeightingFilter(fs=48000, curve="B", stateful=True)
+

--- a/tests/test_sti.py
+++ b/tests/test_sti.py
@@ -16,6 +16,7 @@ Validation vectors:
 """
 
 import warnings
+from itertools import pairwise
 
 import numpy as np
 import pytest
@@ -153,7 +154,7 @@ def test_exponential_decay_matches_analytic_schroeder_mtf():
         assert got == pytest.approx(_analytic_decay_sti(t60), abs=0.01)
         stis.append(got)
     # Monotonic: longer reverberation always degrades intelligibility.
-    assert all(a > b for a, b in zip(stis, stis[1:]))
+    assert all(a > b for a, b in pairwise(stis))
 
 
 def test_snr_degradation_on_impulse_response():
@@ -219,8 +220,14 @@ def test_masking_amdb_is_vectorized_and_continuous():
 # STIPA: direct method and test-signal generator
 # ---------------------------------------------------------------------------
 
-def test_stipa_loopback_ideal_channel():
-    x = stipa_signal(FS, seconds=18.0, seed=1234)
+@pytest.fixture(scope="module")
+def stipa_18s_seed1234() -> np.ndarray:
+    """The 18 s seed-1234 STIPA test signal, generated once for the module."""
+    return stipa_signal(FS, seconds=18.0, seed=1234)
+
+
+def test_stipa_loopback_ideal_channel(stipa_18s_seed1234: np.ndarray):
+    x = stipa_18s_seed1234
     result = stipa(x, FS)
     # Ideal loopback recovers STI 0.998 and min MTF 0.943 at 18 s; lock those
     # in (was >= 0.95 / > 0.9, several x looser than the achieved accuracy).
@@ -230,7 +237,7 @@ def test_stipa_loopback_ideal_channel():
     assert np.all(result.mtf > 0.93)
 
 
-def test_stipa_short_recording_warns():
+def test_stipa_short_recording_warns(stipa_18s_seed1234: np.ndarray):
     """A recording shorter than the recommended 15 s biases the recovered
     modulation depths (and STI) low; stipa should warn (IEC 60268-16 STIPA
     practice recommends 15 s to 25 s)."""
@@ -238,21 +245,20 @@ def test_stipa_short_recording_warns():
     with pytest.warns(UserWarning, match="15"):
         stipa(short, FS)
     # No warning at the recommended length.
-    long = stipa_signal(FS, seconds=18.0, seed=1234)
     with warnings.catch_warnings():
         warnings.simplefilter("error")
-        stipa(long, FS)
+        stipa(stipa_18s_seed1234, FS)
 
 
-def test_stipa_with_noise_is_monotonic():
-    x = stipa_signal(FS, seconds=18.0, seed=1234)
+def test_stipa_with_noise_is_monotonic(stipa_18s_seed1234: np.ndarray):
+    x = stipa_18s_seed1234
     rng = np.random.default_rng(7)
     rms = float(np.sqrt(np.mean(x**2)))
     stis = []
     for snr_db in (30.0, 10.0, 0.0):
         noise = rng.standard_normal(x.size) * rms * 10.0 ** (-snr_db / 20.0)
         stis.append(stipa(x + noise, FS).sti)
-    assert all(a > b for a, b in zip(stis, stis[1:]))
+    assert all(a > b for a, b in pairwise(stis))
     assert stis[-1] < 0.7  # 0 dB broadband SNR is clearly degraded
 
 

--- a/tests/test_tonality.py
+++ b/tests/test_tonality.py
@@ -12,6 +12,14 @@ Anchors transcribed from the official PDF:
 
 import numpy as np
 import pytest
+from reference_data import (
+    ECMA418_1_DFC_500HZ,
+    ECMA418_1_DFC_1KHZ,
+    ECMA418_1_F1_1KHZ,
+    ECMA418_1_F2_1KHZ,
+    ECMA418_1_PROX_150HZ,
+    ECMA418_1_PROX_850HZ,
+)
 
 from phonometry import prominence_ratio, tone_to_noise_ratio
 from phonometry.tonality import _critical_band, _proximity_spacing
@@ -20,8 +28,11 @@ FS = 48000
 
 
 def _tone_in_noise(
-    tone_freq: float, tone_rms: float, noise_rms: float, seconds: float = 30.0
+    tone_freq: float, tone_rms: float, noise_rms: float, seconds: float = 8.0
 ) -> np.ndarray:
+    # 8 s default (was 30 s): enough averaging for the qualitative criteria
+    # tests and the 0.4 dB TNR anchor (re-measured error ~0.15 dB at 8 s);
+    # the two 0.1 dB exact anchors request 16 s explicitly below.
     rng = np.random.default_rng(1234)
     t = np.arange(int(FS * seconds)) / FS
     tone = np.sqrt(2.0) * tone_rms * np.sin(2 * np.pi * tone_freq * t)
@@ -30,20 +41,21 @@ def _tone_in_noise(
 
 
 def test_critical_band_examples() -> None:
-    """Clause 10 and 12.2 worked examples from the standard text."""
+    """Clause 10 and 12.2 worked examples from the standard text (shared
+    oracles in tests/reference_data.py, also used by the CI report)."""
     _, _, dfc_1k = _critical_band(1000.0)
-    assert dfc_1k == pytest.approx(162.2, abs=0.05)
+    assert dfc_1k == pytest.approx(ECMA418_1_DFC_1KHZ, abs=0.05)
     _, _, dfc_500 = _critical_band(500.0)
-    assert dfc_500 == pytest.approx(117.3, abs=0.05)
+    assert dfc_500 == pytest.approx(ECMA418_1_DFC_500HZ, abs=0.05)
     f1, f2, _ = _critical_band(1000.0)
-    assert f1 == pytest.approx(922.2, abs=0.05)
-    assert f2 == pytest.approx(1084.4, abs=0.05)
+    assert f1 == pytest.approx(ECMA418_1_F1_1KHZ, abs=0.05)
+    assert f2 == pytest.approx(ECMA418_1_F2_1KHZ, abs=0.05)
 
 
 def test_proximity_spacing_examples() -> None:
     """Clause 11.6 Formula (14) worked examples."""
-    assert _proximity_spacing(150.0) == pytest.approx(23.0, abs=0.5)
-    assert _proximity_spacing(850.0) == pytest.approx(63.8, abs=0.5)
+    assert _proximity_spacing(150.0) == pytest.approx(ECMA418_1_PROX_150HZ, abs=0.5)
+    assert _proximity_spacing(850.0) == pytest.approx(ECMA418_1_PROX_850HZ, abs=0.5)
 
 
 def test_tnr_of_synthetic_tone_matches_analytic() -> None:
@@ -79,7 +91,9 @@ def test_tnr_prominence_criteria() -> None:
 def test_pr_of_synthetic_tone_matches_analytic() -> None:
     """PR = 10*lg((Pt + N0*dfM) / (0.5*N0*(dfL + dfU)))."""
     tone_rms, noise_rms = 0.1, 0.05
-    x = _tone_in_noise(1000.0, tone_rms, noise_rms)
+    # 16 s (was 30 s): the 0.1 dB tolerance needs more spectral averaging than
+    # the 8 s default (measured error: 0.12 dB at 8 s, 0.037 dB at 16 s).
+    x = _tone_in_noise(1000.0, tone_rms, noise_rms, seconds=16.0)
     n0 = noise_rms**2 / (FS / 2)
     from phonometry.tonality import _LOWER_EDGE_COEFFS, _UPPER_EDGE_COEFFS, _fitted_edge
 
@@ -102,7 +116,7 @@ def test_pr_criteria_and_noise_only() -> None:
     assert loud.prominent
 
     rng = np.random.default_rng(7)
-    noise = rng.standard_normal(FS * 20)
+    noise = rng.standard_normal(FS * 8)
     result = prominence_ratio(noise, FS, tone_freq=1000.0)
     assert not result.prominent
     assert abs(result.ratio_db) < 3.0  # flat spectrum: bands nearly equal
@@ -122,7 +136,9 @@ def test_tnr_proximate_tones_combine() -> None:
     """Clause 11.6: two tones 30 Hz apart at 1 kHz (always proximate at
     1 kHz+) are assessed as one tone with their combined level."""
     rng = np.random.default_rng(99)
-    t = np.arange(FS * 30) / FS
+    # 16 s (was 30 s): the 0.1 dB tolerance needs more spectral averaging than
+    # the 8 s default (measured error: 0.18 dB at 8 s, 0.025 dB at 16 s).
+    t = np.arange(FS * 16) / FS
     x = (
         np.sqrt(2) * 0.1 * np.sin(2 * np.pi * 1000 * t)
         + np.sqrt(2) * 0.1 * np.sin(2 * np.pi * 1030 * t)

--- a/tests/test_tonality_ecma.py
+++ b/tests/test_tonality_ecma.py
@@ -41,8 +41,12 @@ def ref_1k_40() -> EcmaTonality:
 
 @pytest.fixture(scope="module")
 def broadband_noise() -> EcmaTonality:
-    """A broadband-noise result, computed once for the module."""
-    return tonality_ecma(_noise(60.0), FS)
+    """A broadband-noise result, computed once for the module.
+
+    0.8 s: a qualitative reference (noise stays far below a tone), so it only
+    needs to clear the transient-discard window, not the calibration length.
+    """
+    return tonality_ecma(_noise(60.0, seconds=0.8), FS)
 
 
 # --------------------------------------------------------------------------
@@ -55,6 +59,16 @@ def test_calibration_1khz_40db_is_one_tu(ref_1k_40: EcmaTonality) -> None:
     # allows c_T to vary within 0.25 %, and implementation differences add a
     # little more, so a 3 % window is comfortably tight.
     assert ref_1k_40.tonality == pytest.approx(1.0, abs=0.03)
+
+
+def test_calibration_constant_is_the_tabulated_c_t() -> None:
+    # Clause 6.2.8 tabulates c_T = 2.8758615; the implementation must use the
+    # standard's value verbatim (shared oracle in tests/reference_data.py).
+    from reference_data import ECMA418_2_TONALITY_C_T
+
+    from phonometry.tonality_ecma import _C_T
+
+    assert _C_T == ECMA418_2_TONALITY_C_T
 
 
 # --------------------------------------------------------------------------
@@ -81,7 +95,8 @@ def test_tonal_frequency_tracks_tone(ref_1k_40: EcmaTonality) -> None:
 
 
 def test_tonal_frequency_tracks_a_second_tone() -> None:
-    result = tonality_ecma(_tone(2000.0, 50.0), FS)
+    # Frequency tracking is spectral, not duration-driven: 0.7 s suffices.
+    result = tonality_ecma(_tone(2000.0, 50.0, seconds=0.7), FS)
     peak_band = int(np.argmax(result.specific_tonality))
     assert result.tonal_frequencies[peak_band] == pytest.approx(2000.0, rel=0.05)
 
@@ -103,7 +118,9 @@ def test_short_signal_averages_over_all_blocks() -> None:
 
 
 def test_silence_is_zero() -> None:
-    result = tonality_ecma(np.zeros(int(FS * 1.2)), FS)
+    # Pure-property check: zero in, zero out at any length past the
+    # transient-discard window, so 0.6 s is enough.
+    result = tonality_ecma(np.zeros(int(FS * 0.6)), FS)
     assert result.tonality == 0.0
     assert np.all(result.specific_tonality == 0.0)
 
@@ -115,8 +132,9 @@ def test_specific_tonality_peaks_near_tone(ref_1k_40: EcmaTonality) -> None:
 
 def test_user_band_excluding_tone_lowers_tonality() -> None:
     # Restricting the time-dependent maximum search (Formulae 56-61) to bands
-    # above the tone removes the tonal event, driving T towards 0.
-    restricted = tonality_ecma(_tone(1000.0, 40.0), FS, f_low=3000.0)
+    # above the tone removes the tonal event, driving T towards 0. A 0.7 s
+    # segment is enough: the property is spectral, not duration-driven.
+    restricted = tonality_ecma(_tone(1000.0, 40.0, seconds=0.7), FS, f_low=3000.0)
     assert restricted.tonality < 0.2
 
 
@@ -148,8 +166,11 @@ def test_band_range_uses_edge_midpoints() -> None:
 
 
 def test_free_and_diffuse_fields_differ() -> None:
-    free = tonality_ecma(_tone(1000.0, 60.0), FS, field="free").tonality
-    diffuse = tonality_ecma(_tone(1000.0, 60.0), FS, field="diffuse").tonality
+    # Property check (ear-filter difference), not a calibration: 0.7 s is
+    # enough for a stable value in both fields.
+    x = _tone(1000.0, 60.0, seconds=0.7)
+    free = tonality_ecma(x, FS, field="free").tonality
+    diffuse = tonality_ecma(x, FS, field="diffuse").tonality
     assert free > 0.5 and diffuse > 0.5
     assert free != diffuse
 

--- a/tests/test_uncertainty.py
+++ b/tests/test_uncertainty.py
@@ -14,6 +14,7 @@ import math
 
 import numpy as np
 import pytest
+from reference_data import GUM_ADDITIVE_UC, GUM_COVERAGE_K99_16, GUM_WELCH_VEFF
 
 from phonometry import uncertainty as u
 
@@ -27,13 +28,13 @@ def test_additive_model_combined_uncertainty() -> None:
     qs = [u.Quantity(0.0, 1.0) for _ in range(4)]
     result = u.combine_uncertainty(_add4, qs)
     assert result.value == pytest.approx(0.0)
-    assert result.combined_uncertainty == pytest.approx(2.0, abs=1e-6)
+    assert result.combined_uncertainty == pytest.approx(GUM_ADDITIVE_UC, abs=1e-6)
     np.testing.assert_allclose(result.sensitivities, 1.0, atol=1e-6)
 
 
 def test_coverage_factor_matches_gum_table() -> None:
     # GUM Annex H.1 / Table G.2: t at p=0.99, v=16 -> k = 2.92.
-    assert u.coverage_factor(0.99, 16) == pytest.approx(2.92, abs=5e-3)
+    assert u.coverage_factor(0.99, 16) == pytest.approx(GUM_COVERAGE_K99_16, abs=5e-3)
     # Large dof approaches the normal quantile.
     assert u.coverage_factor(0.95) == pytest.approx(1.960, abs=1e-3)
     assert u.coverage_factor(0.9545) == pytest.approx(2.0, abs=1e-3)
@@ -49,7 +50,7 @@ def test_welch_satterthwaite_effective_dof() -> None:
     # Equal contributions each with dof v -> v_eff = N*v (Annex G.4).
     qs = [u.Quantity(0.0, 1.0, dof=10) for _ in range(4)]
     result = u.combine_uncertainty(_add4, qs)
-    assert result.effective_dof == pytest.approx(40.0, abs=1e-6)
+    assert result.effective_dof == pytest.approx(GUM_WELCH_VEFF, abs=1e-6)
 
 
 def test_all_type_b_gives_infinite_dof() -> None:


### PR DESCRIPTION
Ninth execution batch: the test layer hardens — `src/` numerics untouched.

## reference_data drift closure
The audit found only 8/71 test files importing `reference_data` while several duplicated oracle values as hardcoded literals (silent-drift risk). Now: 11 test files import the shared constants, the module docstring describes the actual regime, the EN 12354-6 Annex E surfaces move into `reference_data` (test + conformance script import them), and **all 8 previously-dead constants are wired into asserts** instead of deleted.

## Conformance: 90 → 95 checks, 22 domains, byte-stable
- **New checks** (each with a tolerance-rationale comment — new convention): ECMA-418-1 critical-band + proximity anchors (new *Prominent discrete tones* domain) · ISO 10534-2 synthesize→recover identity (1e-9) · ISO 717-2 Annex C.1 impact rating · ISO 18233 sweep-deconvolution vs `freqz` (0.1 dB, demonstrated bound).
- Cosmetics: the STI domain is now *Speech transmission (IEC 60268-16)* (it sat confusingly next to the SII one), the ISO 9613-1 checks live under outdoor propagation, registry floors raised to ≥90/≥20.

## match= backfill — 98 sites
Every bare `pytest.raises(ValueError)` in the eight flagged files now pins the actual message (taken verbatim from src). Bonus find: one room_ir test was passing via the **wrong validation path** — fixed to exercise the intended error.

## Performance: full suite 360 s → **288 s** (1785 tests, +25 vs baseline)
Module-scoped STIPA fixture; property-test signals shortened with measured-margin comments (exact anchors kept at the length their tolerance genuinely needs — measurements documented in comments); the zero-margin `cached < uncached` performance assert gains a 1.5× margin (it flaked on CI by 0.06 ms).

## Small gaps
13 zips gain `strict=True`, 3 become `itertools.pairwise`; `StatefulWeightingFilter` gains its three missing invalid-input tests; `utils.py` verified as having no raising paths.

## Gate
`ruff` · `mypy src scripts` · full `pytest` (**1785 passed, 288 s**) · conformance regenerated and **byte-stable across two runs** (95/95) · `test_conformance_report.py` green (107 tests).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded standards conformance reporting to **95/95**, including updated IEC labeling.
  * Added new swept-sine room acoustics, **ISO 10534-2** round-trip, and **ECMA-418-1:2024** prominent discrete tone checks.

* **Bug Fixes**
  * Corrected conformance domain registration for ISO 9613-1 air-attenuation checks.
  * Improved conformance pass/fail logic and rebuilt expected reference comparisons.

* **Tests**
  * Centralized more standard reference values.
  * Strengthened assertions with `strict` sequence checks, tighter validation of error messages, and reduced performance flakiness.

* **Documentation**
  * Updated the conformance documentation totals and domain descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->