### PR TITLE
perf: vectorise the airport noise contour grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `EPNLResult.bandsharing_adjustment`, and a `start_band` parameter on
   `tone_correction` for the helicopter 50 Hz procedure.
 
+### Changed
+
+- ECAC Doc 29 `noise_contour` now evaluates the grid with one vectorised pass
+  per flight-path segment instead of a per-point Python loop; numerically
+  identical (guarded by the golden baseline and a scalar-equivalence test)
+  and ~45x faster on small grids, several hundred times on production-size
+  grids (30 000 points in ~0.2 s).
+
 ### Fixed
 
 - ECAC Doc 29: behind takeoff ground-roll segments the lateral attenuation and

--- a/src/phonometry/aircraft/airport_noise.py
+++ b/src/phonometry/aircraft/airport_noise.py
@@ -622,6 +622,200 @@ def _event_level_core(
     return total, seg_arr
 
 
+def _npd_level_grid(
+    p: "NDArray[np.float64]", lv: "NDArray[np.float64]",
+    logd_tab: "NDArray[np.float64]", pq: "NDArray[np.float64]",
+    dq: "NDArray[np.float64]",
+) -> "NDArray[np.float64]":
+    """Vectorised NPD lookup ``L(P, d)`` for per-observer power and distance.
+
+    Same arithmetic as :func:`npd_level` (Eq. 4-3/4-4), expression for
+    expression, so the scalar and grid paths agree to machine precision;
+    ``pq`` and ``dq`` are 1-D arrays of equal length.
+    """
+    logdq = np.log10(dq)
+    k = np.clip(np.searchsorted(logd_tab, logdq) - 1, 0, logd_tab.size - 2)
+    x0, x1 = logd_tab[k], logd_tab[k + 1]
+    j = np.clip(np.searchsorted(p, pq) - 1, 0, p.size - 2)
+    row_j = lv[j, k] + (lv[j, k + 1] - lv[j, k]) / (x1 - x0) * (logdq - x0)
+    row_j1 = lv[j + 1, k] + (lv[j + 1, k + 1] - lv[j + 1, k]) / (x1 - x0) * (logdq - x0)
+    frac = (pq - p[j]) / (p[j + 1] - p[j])
+    return np.asarray(row_j + (row_j1 - row_j) * frac, dtype=np.float64)
+
+
+def _grid_event_levels(
+    pts: "NDArray[np.float64]", obs: "NDArray[np.float64]",
+    p: "NDArray[np.float64]", d: "NDArray[np.float64]",
+    le: "NDArray[np.float64]", lm: "NDArray[np.float64]",
+    vref: float, imp: float, mounting: str, key: str,
+    ground_roll: "NDArray[np.bool_] | None" = None,
+    landing_roll: "NDArray[np.bool_] | None" = None,
+    bank: "NDArray[np.float64] | None" = None,
+) -> "NDArray[np.float64]":
+    """Vectorised counterpart of :func:`_event_level_core` over many observers.
+
+    ``obs`` has shape ``(G, 3)``; returns the event level per observer, shape
+    ``(G,)``. One pass per segment with every quantity broadcast over the
+    observers, mirroring the scalar loop expression for expression (geometry,
+    §4.5.5 nearest-end selection, Eq. 4-14/4-15/4-18..4-25 corrections and the
+    NPD lookups), so both paths agree to machine precision; the golden
+    baseline and the scalar-equivalence test guard that.
+    """
+    mount_key = mounting.strip().lower()
+    engine_installation_correction(0.0, mounting)   # validate 'mounting' once
+    if not (np.isfinite(vref) and vref > 0.0):
+        raise ValueError("'reference_speed' must be positive.")
+    engine_jet = mount_key not in ("propeller", "prop")
+    logd_tab = np.log10(d)
+    n_obs = obs.shape[0]
+    total = np.full(n_obs, -np.inf)
+    energy = np.zeros(n_obs)
+    any_segment = False
+    for i in range(pts.shape[0] - 1):
+        s1, s2 = pts[i, :3], pts[i + 1, :3]
+        p1, p2 = pts[i, 3], pts[i + 1, 3]
+        v1, v2 = pts[i, 4], pts[i + 1, 4]
+        eps = float(bank[i]) if bank is not None else 0.0
+        seg = s2 - s1
+        length = float(np.linalg.norm(seg))
+        if length <= 0.0:  # degenerate (duplicate waypoints): skip
+            continue
+        any_segment = True
+        u = seg / length
+        q = (obs - s1) @ u
+        foot = s1 + q[:, None] * u
+        dp_ = np.linalg.norm(obs - foot, axis=1)
+        behind, ahead = q < 0.0, q > length
+        ds = np.where(behind, np.linalg.norm(obs - s1, axis=1),
+                      np.where(ahead, np.linalg.norm(obs - s2, axis=1), dp_))
+        # _ground_track_offset over all observers.
+        seg_g = seg.copy()
+        seg_g[2] = 0.0
+        gl = float(np.linalg.norm(seg_g))
+        if gl > 0.0:
+            ug = seg_g / gl
+            og = obs - s1
+            og[:, 2] = 0.0
+            lateral = np.linalg.norm(og - np.outer(og @ ug, ug), axis=1)
+        else:  # vertical ground track (degenerate)
+            lateral = np.hypot(obs[:, 0] - s1[0], obs[:, 1] - s1[1])
+        z_foot = foot[:, 2] - obs[:, 2]
+        z_near = np.where(behind, s1[2], np.where(ahead, s2[2], foot[:, 2])) - obs[:, 2]
+        # _segment_angles over all observers.
+        with np.errstate(divide="ignore", invalid="ignore"):
+            ratio = np.where(dp_ > 0.0, lateral / np.where(dp_ > 0.0, dp_, 1.0), 0.0)
+            eq_angle = np.where(dp_ > 0.0,
+                                np.degrees(np.arccos(np.clip(ratio, 0.0, 1.0))), 90.0)
+        eq_angle = np.where(z_foot >= 0.0, eq_angle, -eq_angle)
+        beta = np.where(behind | ahead,
+                        np.degrees(np.arctan2(z_near, lateral)), eq_angle)
+        side = np.sign(u[0] * (obs[:, 1] - s1[1]) - u[1] * (obs[:, 0] - s1[0]))
+        phi = eq_angle + side * eps
+        overhead = lateral <= 0.0
+        beta = np.where(overhead, np.where(z_near >= 0.0, 90.0, -90.0), beta)
+        phi = np.where(overhead, np.where(z_foot >= 0.0, 90.0, -90.0) - eps, phi)
+        # _attenuation_geometry over all observers (§4.5.5 nearest-end cases).
+        is_takeoff = ground_roll is not None and bool(ground_roll[i])
+        is_landing = landing_roll is not None and bool(landing_roll[i])
+        roll_behind = behind if is_takeoff else np.zeros(n_obs, dtype=bool)
+        roll_ahead = ahead if is_landing else np.zeros(n_obs, dtype=bool)
+        use_end = roll_behind | roll_ahead
+        if key == "maximum":
+            use_end = use_end | behind | ahead
+        end = np.where(ahead[:, None], s2, s1)
+        d_end = np.linalg.norm(obs - end, axis=1)
+        z_end = end[:, 2] - obs[:, 2]
+        degenerate = d_end <= 0.0
+        with np.errstate(divide="ignore", invalid="ignore"):
+            beta_end = np.degrees(np.arcsin(np.clip(
+                np.where(degenerate, 0.0, z_end / np.where(degenerate, 1.0, d_end)),
+                -1.0, 1.0)))
+        beta_end = np.where(degenerate, 90.0, beta_end)
+        oc = np.where(degenerate, 0.0,
+                      np.hypot(obs[:, 0] - end[:, 0], obs[:, 1] - end[:, 1]))
+        beta_att = np.where(use_end, beta_end, beta)
+        ell_att = np.where(use_end, oc, lateral)
+        phi_att = np.where(use_end, beta_end, phi)
+        # lateral_attenuation (Eq. 4-18/4-19) over all observers.
+        gamma = np.where(ell_att <= 914.0,
+                         1.089 * (1.0 - np.exp(-0.00274 * ell_att)), 1.0)
+        lam = np.where(beta_att < 0.0, 10.857,
+                       np.where(beta_att <= 50.0,
+                                1.137 - 0.0229 * beta_att
+                                + 9.72 * np.exp(-0.142 * beta_att), 0.0))
+        lam_att = gamma * lam
+        # engine_installation_correction (Eq. 4-15/4-16) over all observers.
+        if not engine_jet:
+            di = 0.0
+        else:
+            a_i, b_i, c_i = _INSTALLATION[mount_key]
+            phi_eff = np.radians(np.maximum(phi_att, 0.0))
+            num = (a_i * np.cos(phi_eff) ** 2 + np.sin(phi_eff) ** 2) ** b_i
+            den = c_i * np.sin(2.0 * phi_eff) ** 2 + np.cos(2.0 * phi_eff) ** 2
+            di = 10.0 * np.log10(num / den)
+        frac = np.clip(q / length, 0.0, 1.0)
+        p_seg = np.sqrt(np.maximum(p1**2 + frac * (p2**2 - p1**2), 0.0))
+        # start_of_roll_directivity (Eq. 4-22..4-25) behind takeoff roll.
+        if is_takeoff:
+            with np.errstate(divide="ignore", invalid="ignore"):
+                psi = np.degrees(np.arccos(np.clip(
+                    q / np.where(ds > 0.0, ds, 1e-9), -1.0, 1.0)))
+            psi_c = np.clip(psi, 90.0, 180.0)
+            if engine_jet:
+                r = np.pi * psi_c / 180.0
+                d0 = (2329.44 - 8.0573 * psi_c + 11.51 * np.exp(r)
+                      - 3.4601 * psi_c / np.log(r)
+                      - 17403338.3 * np.log(r) / psi_c**2)
+            else:
+                d0 = (-34643.898 + 30722161.987 / psi_c
+                      - 11491573930.510 / psi_c**2 + 2349285669062.0 / psi_c**3
+                      - 283584441904272.0 / psi_c**4
+                      + 20227150391251300.0 / psi_c**5
+                      - 790084471305203000.0 / psi_c**6
+                      + 13050687178273800000.0 / psi_c**7)
+            dsor = np.maximum(ds, 1e-9)
+            d0 = np.where(dsor > _DSOR0_M, d0 * (_DSOR0_M / dsor), d0)
+            sor = np.where(roll_behind & (psi >= 90.0), d0, 0.0)
+        else:
+            sor = np.zeros(n_obs)
+        if key == "maximum":
+            base = _npd_level_grid(p, lm, logd_tab, p_seg,
+                                   np.maximum(ds, _NPD_FLOOR_M))
+            total = np.maximum(total, base + imp + di - lam_att + sor)
+        else:
+            dist = np.maximum(np.where(roll_behind | roll_ahead, ds, dp_),
+                              _NPD_FLOOR_M)
+            le_d = _npd_level_grid(p, le, logd_tab, p_seg, dist)
+            lm_d = _npd_level_grid(p, lm, logd_tab, p_seg, dist)
+            if is_takeoff or is_landing:
+                # Eq. 4-13b: runway segments use the arithmetic mean speed.
+                v_seg = np.full(n_obs, 0.5 * (v1 + v2))
+            else:
+                v_seg = np.sqrt(np.maximum(v1**2 + frac * (v2**2 - v1**2), 0.0))
+            if np.any(v_seg <= 0.0):
+                raise ValueError(
+                    "segment with zero mean speed (stationary segment in 'path').")
+            dv = 10.0 * np.log10(vref / v_seg)
+            d_lambda = _D0_M * 10.0 ** ((le_d - lm_d) / 10.0)
+            # _segment_noise_fraction (Eq. 4-20/4-21a/4-21b) over all observers.
+            qf = np.where(roll_behind, 0.0, np.where(roll_ahead, length, q))
+            a1 = -qf / d_lambda
+            a2 = (length - qf) / d_lambda
+            frac_f = (a2 / (1.0 + a2**2) + np.arctan(a2)
+                      - a1 / (1.0 + a1**2) - np.arctan(a1)) / np.pi
+            with np.errstate(divide="ignore", invalid="ignore"):
+                df = np.where(frac_f <= 0.0, -150.0,
+                              np.maximum(10.0 * np.log10(
+                                  np.where(frac_f > 0.0, frac_f, 1.0)), -150.0))
+            energy += 10.0 ** ((le_d + imp + dv + di - lam_att + df + sor) / 10.0)
+    if not any_segment:
+        return np.full(n_obs, -np.inf)
+    if key == "maximum":
+        return total
+    with np.errstate(divide="ignore"):
+        return np.asarray(10.0 * np.log10(energy), dtype=np.float64)
+
+
 def event_level(
     path: "NDArray[np.float64] | list[list[float]]",
     observer: "NDArray[np.float64] | list[float]",
@@ -771,13 +965,12 @@ def noise_contour(
     _, _, lm = _clean_table(powers, distances, maximum_levels)
     vref = float(reference_speed)
     imp = impedance_adjustment(temperature, pressure)
-    grid = np.empty((gy.size, gx.size), dtype=np.float64)
-    obs = np.empty(3, dtype=np.float64)
-    obs[2] = 0.0
-    for iy in range(gy.size):
-        obs[1] = gy[iy]
-        for ix in range(gx.size):
-            obs[0] = gx[ix]
-            grid[iy, ix] = _event_level_core(
-                pts, obs, p, d, le, lm, vref, imp, mounting, key, gr, lr, bk)[0]
-    return NoiseContourResult(x=gx, y=gy, level=grid, metric=key)
+    # One vectorised pass per flight-path segment over the whole grid (the
+    # per-point scalar loop is O(grid × segments) Python calls; this is
+    # numerically identical, see _grid_event_levels).
+    xx, yy = np.meshgrid(gx, gy)
+    obs = np.column_stack([xx.ravel(), yy.ravel(), np.zeros(xx.size)])
+    levels = _grid_event_levels(
+        pts, obs, p, d, le, lm, vref, imp, mounting, key, gr, lr, bk)
+    return NoiseContourResult(
+        x=gx, y=gy, level=levels.reshape(gy.size, gx.size), metric=key)

--- a/src/phonometry/aircraft/airport_noise.py
+++ b/src/phonometry/aircraft/airport_noise.py
@@ -33,7 +33,7 @@ Doc 29 5th ed. Vol 3 Part 1 reference workbook.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 import numpy as np
 
@@ -784,6 +784,76 @@ def _grid_noise_fraction(
             dtype=np.float64)
 
 
+class _GridContext(NamedTuple):
+    """Per-call constants of the vectorised contour kernel."""
+
+    obs: "NDArray[np.float64]"
+    p: "NDArray[np.float64]"
+    le: "NDArray[np.float64]"
+    lm: "NDArray[np.float64]"
+    logd_tab: "NDArray[np.float64]"
+    vref: float
+    imp: float
+    mount_key: str
+    engine_jet: bool
+    maximum: bool
+
+
+def _grid_segment_level(
+    ctx: _GridContext, seg_pts: "NDArray[np.float64]", eps: float,
+    is_takeoff: bool, is_landing: bool,
+) -> "NDArray[np.float64]":
+    """Per-observer event level of one non-degenerate segment (Eq. 4-8/4-9).
+
+    Assembles the NPD baseline and every correction through the ``_grid_*``
+    helpers, mirroring one iteration of the scalar :func:`_event_level_core`
+    loop expression for expression.
+    """
+    s1, s2 = seg_pts[0, :3], seg_pts[1, :3]
+    seg = s2 - s1
+    length = float(np.linalg.norm(seg))
+    u = seg / length
+    obs = ctx.obs
+    q, dp_, ds, behind, ahead, lateral, z_foot, z_near = _grid_segment_frame(
+        s1, s2, u, length, obs)
+    beta, phi = _grid_angles(u, s1, obs, dp_, lateral, z_foot, z_near,
+                             behind, ahead, eps)
+    roll_behind = behind & is_takeoff
+    roll_ahead = ahead & is_landing
+    use_end = roll_behind | roll_ahead
+    if ctx.maximum:
+        use_end = use_end | behind | ahead
+    beta_att, ell_att, phi_att = _grid_attenuation_geometry(
+        s1, s2, obs, beta, phi, lateral, ahead, use_end)
+    lam_att = _grid_lateral_attenuation(beta_att, ell_att)
+    di = _grid_installation(phi_att, ctx.mount_key)
+    frac = np.clip(q / length, 0.0, 1.0)
+    p1, p2 = seg_pts[0, 3], seg_pts[1, 3]
+    p_seg = np.sqrt(np.maximum(p1**2 + frac * (p2**2 - p1**2), 0.0))
+    sor = _grid_sor(q, ds, roll_behind, ctx.engine_jet) if is_takeoff else 0.0
+    if ctx.maximum:
+        base = _npd_level_grid(ctx.p, ctx.lm, ctx.logd_tab, p_seg,
+                               np.maximum(ds, _NPD_FLOOR_M))
+        return np.asarray(base + ctx.imp + di - lam_att + sor, dtype=np.float64)
+    dist = np.maximum(np.where(use_end, ds, dp_), _NPD_FLOOR_M)
+    le_d = _npd_level_grid(ctx.p, ctx.le, ctx.logd_tab, p_seg, dist)
+    lm_d = _npd_level_grid(ctx.p, ctx.lm, ctx.logd_tab, p_seg, dist)
+    v1, v2 = seg_pts[0, 4], seg_pts[1, 4]
+    if is_takeoff or is_landing:
+        # Eq. 4-13b: runway segments use the arithmetic mean speed.
+        v_seg = np.full(obs.shape[0], 0.5 * (v1 + v2))
+    else:
+        v_seg = np.sqrt(np.maximum(v1**2 + frac * (v2**2 - v1**2), 0.0))
+    if np.any(v_seg <= 0.0):
+        raise ValueError(
+            "segment with zero mean speed (stationary segment in 'path').")
+    dv = 10.0 * np.log10(ctx.vref / v_seg)
+    d_lambda = _D0_M * 10.0 ** ((le_d - lm_d) / 10.0)
+    df = _grid_noise_fraction(q, length, d_lambda, roll_behind, roll_ahead)
+    return np.asarray(le_d + ctx.imp + dv + di - lam_att + df + sor,
+                      dtype=np.float64)
+
+
 def _grid_event_levels(
     pts: "NDArray[np.float64]", obs: "NDArray[np.float64]",
     p: "NDArray[np.float64]", d: "NDArray[np.float64]",
@@ -797,73 +867,37 @@ def _grid_event_levels(
 
     ``obs`` has shape ``(G, 3)``; returns the event level per observer, shape
     ``(G,)``. One pass per segment with every quantity broadcast over the
-    observers through the ``_grid_*`` helpers, each of which mirrors its
-    scalar counterpart expression for expression, so both paths agree to
-    machine precision; the golden baseline and the scalar-equivalence test
-    guard that.
+    observers through :func:`_grid_segment_level` and the ``_grid_*`` helpers,
+    each of which mirrors its scalar counterpart expression for expression, so
+    both paths agree to machine precision; the golden baseline and the
+    scalar-equivalence test guard that.
     """
     mount_key = mounting.strip().lower()
     engine_installation_correction(0.0, mounting)   # validate 'mounting' once
     if not (np.isfinite(vref) and vref > 0.0):
         raise ValueError("'reference_speed' must be positive.")
-    engine_jet = mount_key not in ("propeller", "prop")
-    logd_tab = np.log10(d)
+    ctx = _GridContext(obs, p, le, lm, np.log10(d), vref, imp, mount_key,
+                       mount_key not in ("propeller", "prop"), key == "maximum")
     n_obs = obs.shape[0]
     total = np.full(n_obs, -np.inf)
     energy = np.zeros(n_obs)
     any_segment = False
     for i in range(pts.shape[0] - 1):
-        s1, s2 = pts[i, :3], pts[i + 1, :3]
-        seg = s2 - s1
-        length = float(np.linalg.norm(seg))
-        if length <= 0.0:  # degenerate (duplicate waypoints): skip
-            continue
+        if float(np.linalg.norm(pts[i + 1, :3] - pts[i, :3])) <= 0.0:
+            continue  # degenerate (duplicate waypoints): skip
         any_segment = True
-        u = seg / length
         eps = float(bank[i]) if bank is not None else 0.0
-        q, dp_, ds, behind, ahead, lateral, z_foot, z_near = _grid_segment_frame(
-            s1, s2, u, length, obs)
-        beta, phi = _grid_angles(u, s1, obs, dp_, lateral, z_foot, z_near,
-                                 behind, ahead, eps)
-        is_takeoff = ground_roll is not None and bool(ground_roll[i])
-        is_landing = landing_roll is not None and bool(landing_roll[i])
-        roll_behind = behind & is_takeoff
-        roll_ahead = ahead & is_landing
-        use_end = roll_behind | roll_ahead
-        if key == "maximum":
-            use_end = use_end | behind | ahead
-        beta_att, ell_att, phi_att = _grid_attenuation_geometry(
-            s1, s2, obs, beta, phi, lateral, ahead, use_end)
-        lam_att = _grid_lateral_attenuation(beta_att, ell_att)
-        di = _grid_installation(phi_att, mount_key)
-        frac = np.clip(q / length, 0.0, 1.0)
-        p1, p2 = pts[i, 3], pts[i + 1, 3]
-        p_seg = np.sqrt(np.maximum(p1**2 + frac * (p2**2 - p1**2), 0.0))
-        sor = _grid_sor(q, ds, roll_behind, engine_jet) if is_takeoff else 0.0
-        if key == "maximum":
-            base = _npd_level_grid(p, lm, logd_tab, p_seg,
-                                   np.maximum(ds, _NPD_FLOOR_M))
-            total = np.maximum(total, base + imp + di - lam_att + sor)
-            continue
-        dist = np.maximum(np.where(use_end, ds, dp_), _NPD_FLOOR_M)
-        le_d = _npd_level_grid(p, le, logd_tab, p_seg, dist)
-        lm_d = _npd_level_grid(p, lm, logd_tab, p_seg, dist)
-        v1, v2 = pts[i, 4], pts[i + 1, 4]
-        if is_takeoff or is_landing:
-            # Eq. 4-13b: runway segments use the arithmetic mean speed.
-            v_seg = np.full(n_obs, 0.5 * (v1 + v2))
+        seg_level = _grid_segment_level(
+            ctx, pts[i:i + 2], eps,
+            ground_roll is not None and bool(ground_roll[i]),
+            landing_roll is not None and bool(landing_roll[i]))
+        if ctx.maximum:
+            total = np.maximum(total, seg_level)
         else:
-            v_seg = np.sqrt(np.maximum(v1**2 + frac * (v2**2 - v1**2), 0.0))
-        if np.any(v_seg <= 0.0):
-            raise ValueError(
-                "segment with zero mean speed (stationary segment in 'path').")
-        dv = 10.0 * np.log10(vref / v_seg)
-        d_lambda = _D0_M * 10.0 ** ((le_d - lm_d) / 10.0)
-        df = _grid_noise_fraction(q, length, d_lambda, roll_behind, roll_ahead)
-        energy += 10.0 ** ((le_d + imp + dv + di - lam_att + df + sor) / 10.0)
+            energy += 10.0 ** (seg_level / 10.0)
     if not any_segment:
         return np.full(n_obs, -np.inf)
-    if key == "maximum":
+    if ctx.maximum:
         return total
     with np.errstate(divide="ignore"):
         return np.asarray(10.0 * np.log10(energy), dtype=np.float64)

--- a/src/phonometry/aircraft/airport_noise.py
+++ b/src/phonometry/aircraft/airport_noise.py
@@ -643,6 +643,147 @@ def _npd_level_grid(
     return np.asarray(row_j + (row_j1 - row_j) * frac, dtype=np.float64)
 
 
+def _grid_segment_frame(
+    s1: "NDArray[np.float64]", s2: "NDArray[np.float64]",
+    u: "NDArray[np.float64]", length: float, obs: "NDArray[np.float64]",
+) -> "tuple[NDArray[np.float64], NDArray[np.float64], NDArray[np.float64], NDArray[np.bool_], NDArray[np.bool_], NDArray[np.float64], NDArray[np.float64], NDArray[np.float64]]":
+    """Per-observer geometry of one segment, the array form of :func:`_segment_geometry`.
+
+    Returns ``(q, dp, ds, behind, ahead, lateral, z_foot, z_near)`` with one
+    entry per observer row of ``obs``.
+    """
+    q = (obs - s1) @ u
+    foot = s1 + q[:, None] * u
+    dp_ = np.linalg.norm(obs - foot, axis=1)
+    behind, ahead = q < 0.0, q > length
+    ds = np.where(behind, np.linalg.norm(obs - s1, axis=1),
+                  np.where(ahead, np.linalg.norm(obs - s2, axis=1), dp_))
+    # _ground_track_offset over all observers.
+    seg_g = (s2 - s1).copy()
+    seg_g[2] = 0.0
+    gl = float(np.linalg.norm(seg_g))
+    if gl > 0.0:
+        ug = seg_g / gl
+        og = obs - s1
+        og[:, 2] = 0.0
+        lateral = np.linalg.norm(og - np.outer(og @ ug, ug), axis=1)
+    else:  # vertical ground track (degenerate)
+        lateral = np.hypot(obs[:, 0] - s1[0], obs[:, 1] - s1[1])
+    z_foot = foot[:, 2] - obs[:, 2]
+    z_near = np.where(behind, s1[2], np.where(ahead, s2[2], foot[:, 2])) - obs[:, 2]
+    return q, dp_, ds, behind, ahead, lateral, z_foot, z_near
+
+
+def _grid_angles(
+    u: "NDArray[np.float64]", s1: "NDArray[np.float64]", obs: "NDArray[np.float64]",
+    dp_: "NDArray[np.float64]", lateral: "NDArray[np.float64]",
+    z_foot: "NDArray[np.float64]", z_near: "NDArray[np.float64]",
+    behind: "NDArray[np.bool_]", ahead: "NDArray[np.bool_]", eps: float,
+) -> "tuple[NDArray[np.float64], NDArray[np.float64]]":
+    """``beta``/``phi`` per observer (§4.5.2/4.5.5), array form of :func:`_segment_angles`."""
+    with np.errstate(divide="ignore", invalid="ignore"):
+        ratio = np.where(dp_ > 0.0, lateral / np.where(dp_ > 0.0, dp_, 1.0), 0.0)
+        eq_angle = np.where(dp_ > 0.0,
+                            np.degrees(np.arccos(np.clip(ratio, 0.0, 1.0))), 90.0)
+    eq_angle = np.where(z_foot >= 0.0, eq_angle, -eq_angle)
+    beta = np.where(behind | ahead,
+                    np.degrees(np.arctan2(z_near, lateral)), eq_angle)
+    side = np.sign(u[0] * (obs[:, 1] - s1[1]) - u[1] * (obs[:, 0] - s1[0]))
+    phi = eq_angle + side * eps
+    overhead = lateral <= 0.0
+    beta = np.where(overhead, np.where(z_near >= 0.0, 90.0, -90.0), beta)
+    phi = np.where(overhead, np.where(z_foot >= 0.0, 90.0, -90.0) - eps, phi)
+    return beta, phi
+
+
+def _grid_attenuation_geometry(
+    s1: "NDArray[np.float64]", s2: "NDArray[np.float64]", obs: "NDArray[np.float64]",
+    beta: "NDArray[np.float64]", phi: "NDArray[np.float64]",
+    lateral: "NDArray[np.float64]", ahead: "NDArray[np.bool_]",
+    use_end: "NDArray[np.bool_]",
+) -> "tuple[NDArray[np.float64], NDArray[np.float64], NDArray[np.float64]]":
+    """Nearest-end ``beta``/``l``/``phi`` (§4.5.5), array form of :func:`_attenuation_geometry`."""
+    end = np.where(ahead[:, None], s2, s1)
+    d_end = np.linalg.norm(obs - end, axis=1)
+    z_end = end[:, 2] - obs[:, 2]
+    degenerate = d_end <= 0.0
+    with np.errstate(divide="ignore", invalid="ignore"):
+        beta_end = np.degrees(np.arcsin(np.clip(
+            np.where(degenerate, 0.0, z_end / np.where(degenerate, 1.0, d_end)),
+            -1.0, 1.0)))
+    beta_end = np.where(degenerate, 90.0, beta_end)
+    oc = np.where(degenerate, 0.0,
+                  np.hypot(obs[:, 0] - end[:, 0], obs[:, 1] - end[:, 1]))
+    return (np.where(use_end, beta_end, beta), np.where(use_end, oc, lateral),
+            np.where(use_end, beta_end, phi))
+
+
+def _grid_lateral_attenuation(
+    beta_att: "NDArray[np.float64]", ell_att: "NDArray[np.float64]",
+) -> "NDArray[np.float64]":
+    """``Λ(β, ℓ)`` (Eq. 4-18/4-19), the array form of :func:`lateral_attenuation`."""
+    gamma = np.where(ell_att <= 914.0,
+                     1.089 * (1.0 - np.exp(-0.00274 * ell_att)), 1.0)
+    lam = np.where(beta_att < 0.0, 10.857,
+                   np.where(beta_att <= 50.0,
+                            1.137 - 0.0229 * beta_att
+                            + 9.72 * np.exp(-0.142 * beta_att), 0.0))
+    return np.asarray(gamma * lam, dtype=np.float64)
+
+
+def _grid_installation(
+    phi_att: "NDArray[np.float64]", mount_key: str,
+) -> "NDArray[np.float64] | float":
+    """``ΔI(φ)`` (Eq. 4-15/4-16), the array form of :func:`engine_installation_correction`."""
+    if mount_key in ("propeller", "prop"):
+        return 0.0
+    a_i, b_i, c_i = _INSTALLATION[mount_key]
+    phi_eff = np.radians(np.maximum(phi_att, 0.0))
+    num = (a_i * np.cos(phi_eff) ** 2 + np.sin(phi_eff) ** 2) ** b_i
+    den = c_i * np.sin(2.0 * phi_eff) ** 2 + np.cos(2.0 * phi_eff) ** 2
+    return np.asarray(10.0 * np.log10(num / den), dtype=np.float64)
+
+
+def _grid_sor(
+    q: "NDArray[np.float64]", ds: "NDArray[np.float64]",
+    roll_behind: "NDArray[np.bool_]", engine_jet: bool,
+) -> "NDArray[np.float64]":
+    """``ΔSOR`` (Eq. 4-22..4-25), the array form of :func:`start_of_roll_directivity`."""
+    with np.errstate(divide="ignore", invalid="ignore"):
+        psi = np.degrees(np.arccos(np.clip(
+            q / np.where(ds > 0.0, ds, 1e-9), -1.0, 1.0)))
+    psi_c = np.clip(psi, 90.0, 180.0)
+    if engine_jet:
+        r = np.pi * psi_c / 180.0
+        d0 = (2329.44 - 8.0573 * psi_c + 11.51 * np.exp(r)
+              - 3.4601 * psi_c / np.log(r) - 17403338.3 * np.log(r) / psi_c**2)
+    else:
+        d0 = (-34643.898 + 30722161.987 / psi_c - 11491573930.510 / psi_c**2
+              + 2349285669062.0 / psi_c**3 - 283584441904272.0 / psi_c**4
+              + 20227150391251300.0 / psi_c**5 - 790084471305203000.0 / psi_c**6
+              + 13050687178273800000.0 / psi_c**7)
+    dsor = np.maximum(ds, 1e-9)
+    d0 = np.where(dsor > _DSOR0_M, d0 * (_DSOR0_M / dsor), d0)
+    return np.asarray(np.where(roll_behind & (psi >= 90.0), d0, 0.0), dtype=np.float64)
+
+
+def _grid_noise_fraction(
+    q: "NDArray[np.float64]", length: float, d_lambda: "NDArray[np.float64]",
+    roll_behind: "NDArray[np.bool_]", roll_ahead: "NDArray[np.bool_]",
+) -> "NDArray[np.float64]":
+    """``ΔF`` (Eq. 4-20/4-21a/4-21b), the array form of :func:`_segment_noise_fraction`."""
+    qf = np.where(roll_behind, 0.0, np.where(roll_ahead, length, q))
+    a1 = -qf / d_lambda
+    a2 = (length - qf) / d_lambda
+    frac = (a2 / (1.0 + a2**2) + np.arctan(a2)
+            - a1 / (1.0 + a1**2) - np.arctan(a1)) / np.pi
+    with np.errstate(divide="ignore", invalid="ignore"):
+        return np.asarray(np.where(
+            frac <= 0.0, -150.0,
+            np.maximum(10.0 * np.log10(np.where(frac > 0.0, frac, 1.0)), -150.0)),
+            dtype=np.float64)
+
+
 def _grid_event_levels(
     pts: "NDArray[np.float64]", obs: "NDArray[np.float64]",
     p: "NDArray[np.float64]", d: "NDArray[np.float64]",
@@ -656,10 +797,10 @@ def _grid_event_levels(
 
     ``obs`` has shape ``(G, 3)``; returns the event level per observer, shape
     ``(G,)``. One pass per segment with every quantity broadcast over the
-    observers, mirroring the scalar loop expression for expression (geometry,
-    §4.5.5 nearest-end selection, Eq. 4-14/4-15/4-18..4-25 corrections and the
-    NPD lookups), so both paths agree to machine precision; the golden
-    baseline and the scalar-equivalence test guard that.
+    observers through the ``_grid_*`` helpers, each of which mirrors its
+    scalar counterpart expression for expression, so both paths agree to
+    machine precision; the golden baseline and the scalar-equivalence test
+    guard that.
     """
     mount_key = mounting.strip().lower()
     engine_installation_correction(0.0, mounting)   # validate 'mounting' once
@@ -673,141 +814,53 @@ def _grid_event_levels(
     any_segment = False
     for i in range(pts.shape[0] - 1):
         s1, s2 = pts[i, :3], pts[i + 1, :3]
-        p1, p2 = pts[i, 3], pts[i + 1, 3]
-        v1, v2 = pts[i, 4], pts[i + 1, 4]
-        eps = float(bank[i]) if bank is not None else 0.0
         seg = s2 - s1
         length = float(np.linalg.norm(seg))
         if length <= 0.0:  # degenerate (duplicate waypoints): skip
             continue
         any_segment = True
         u = seg / length
-        q = (obs - s1) @ u
-        foot = s1 + q[:, None] * u
-        dp_ = np.linalg.norm(obs - foot, axis=1)
-        behind, ahead = q < 0.0, q > length
-        ds = np.where(behind, np.linalg.norm(obs - s1, axis=1),
-                      np.where(ahead, np.linalg.norm(obs - s2, axis=1), dp_))
-        # _ground_track_offset over all observers.
-        seg_g = seg.copy()
-        seg_g[2] = 0.0
-        gl = float(np.linalg.norm(seg_g))
-        if gl > 0.0:
-            ug = seg_g / gl
-            og = obs - s1
-            og[:, 2] = 0.0
-            lateral = np.linalg.norm(og - np.outer(og @ ug, ug), axis=1)
-        else:  # vertical ground track (degenerate)
-            lateral = np.hypot(obs[:, 0] - s1[0], obs[:, 1] - s1[1])
-        z_foot = foot[:, 2] - obs[:, 2]
-        z_near = np.where(behind, s1[2], np.where(ahead, s2[2], foot[:, 2])) - obs[:, 2]
-        # _segment_angles over all observers.
-        with np.errstate(divide="ignore", invalid="ignore"):
-            ratio = np.where(dp_ > 0.0, lateral / np.where(dp_ > 0.0, dp_, 1.0), 0.0)
-            eq_angle = np.where(dp_ > 0.0,
-                                np.degrees(np.arccos(np.clip(ratio, 0.0, 1.0))), 90.0)
-        eq_angle = np.where(z_foot >= 0.0, eq_angle, -eq_angle)
-        beta = np.where(behind | ahead,
-                        np.degrees(np.arctan2(z_near, lateral)), eq_angle)
-        side = np.sign(u[0] * (obs[:, 1] - s1[1]) - u[1] * (obs[:, 0] - s1[0]))
-        phi = eq_angle + side * eps
-        overhead = lateral <= 0.0
-        beta = np.where(overhead, np.where(z_near >= 0.0, 90.0, -90.0), beta)
-        phi = np.where(overhead, np.where(z_foot >= 0.0, 90.0, -90.0) - eps, phi)
-        # _attenuation_geometry over all observers (§4.5.5 nearest-end cases).
+        eps = float(bank[i]) if bank is not None else 0.0
+        q, dp_, ds, behind, ahead, lateral, z_foot, z_near = _grid_segment_frame(
+            s1, s2, u, length, obs)
+        beta, phi = _grid_angles(u, s1, obs, dp_, lateral, z_foot, z_near,
+                                 behind, ahead, eps)
         is_takeoff = ground_roll is not None and bool(ground_roll[i])
         is_landing = landing_roll is not None and bool(landing_roll[i])
-        roll_behind = behind if is_takeoff else np.zeros(n_obs, dtype=bool)
-        roll_ahead = ahead if is_landing else np.zeros(n_obs, dtype=bool)
+        roll_behind = behind & is_takeoff
+        roll_ahead = ahead & is_landing
         use_end = roll_behind | roll_ahead
         if key == "maximum":
             use_end = use_end | behind | ahead
-        end = np.where(ahead[:, None], s2, s1)
-        d_end = np.linalg.norm(obs - end, axis=1)
-        z_end = end[:, 2] - obs[:, 2]
-        degenerate = d_end <= 0.0
-        with np.errstate(divide="ignore", invalid="ignore"):
-            beta_end = np.degrees(np.arcsin(np.clip(
-                np.where(degenerate, 0.0, z_end / np.where(degenerate, 1.0, d_end)),
-                -1.0, 1.0)))
-        beta_end = np.where(degenerate, 90.0, beta_end)
-        oc = np.where(degenerate, 0.0,
-                      np.hypot(obs[:, 0] - end[:, 0], obs[:, 1] - end[:, 1]))
-        beta_att = np.where(use_end, beta_end, beta)
-        ell_att = np.where(use_end, oc, lateral)
-        phi_att = np.where(use_end, beta_end, phi)
-        # lateral_attenuation (Eq. 4-18/4-19) over all observers.
-        gamma = np.where(ell_att <= 914.0,
-                         1.089 * (1.0 - np.exp(-0.00274 * ell_att)), 1.0)
-        lam = np.where(beta_att < 0.0, 10.857,
-                       np.where(beta_att <= 50.0,
-                                1.137 - 0.0229 * beta_att
-                                + 9.72 * np.exp(-0.142 * beta_att), 0.0))
-        lam_att = gamma * lam
-        # engine_installation_correction (Eq. 4-15/4-16) over all observers.
-        if not engine_jet:
-            di = 0.0
-        else:
-            a_i, b_i, c_i = _INSTALLATION[mount_key]
-            phi_eff = np.radians(np.maximum(phi_att, 0.0))
-            num = (a_i * np.cos(phi_eff) ** 2 + np.sin(phi_eff) ** 2) ** b_i
-            den = c_i * np.sin(2.0 * phi_eff) ** 2 + np.cos(2.0 * phi_eff) ** 2
-            di = 10.0 * np.log10(num / den)
+        beta_att, ell_att, phi_att = _grid_attenuation_geometry(
+            s1, s2, obs, beta, phi, lateral, ahead, use_end)
+        lam_att = _grid_lateral_attenuation(beta_att, ell_att)
+        di = _grid_installation(phi_att, mount_key)
         frac = np.clip(q / length, 0.0, 1.0)
+        p1, p2 = pts[i, 3], pts[i + 1, 3]
         p_seg = np.sqrt(np.maximum(p1**2 + frac * (p2**2 - p1**2), 0.0))
-        # start_of_roll_directivity (Eq. 4-22..4-25) behind takeoff roll.
-        if is_takeoff:
-            with np.errstate(divide="ignore", invalid="ignore"):
-                psi = np.degrees(np.arccos(np.clip(
-                    q / np.where(ds > 0.0, ds, 1e-9), -1.0, 1.0)))
-            psi_c = np.clip(psi, 90.0, 180.0)
-            if engine_jet:
-                r = np.pi * psi_c / 180.0
-                d0 = (2329.44 - 8.0573 * psi_c + 11.51 * np.exp(r)
-                      - 3.4601 * psi_c / np.log(r)
-                      - 17403338.3 * np.log(r) / psi_c**2)
-            else:
-                d0 = (-34643.898 + 30722161.987 / psi_c
-                      - 11491573930.510 / psi_c**2 + 2349285669062.0 / psi_c**3
-                      - 283584441904272.0 / psi_c**4
-                      + 20227150391251300.0 / psi_c**5
-                      - 790084471305203000.0 / psi_c**6
-                      + 13050687178273800000.0 / psi_c**7)
-            dsor = np.maximum(ds, 1e-9)
-            d0 = np.where(dsor > _DSOR0_M, d0 * (_DSOR0_M / dsor), d0)
-            sor = np.where(roll_behind & (psi >= 90.0), d0, 0.0)
-        else:
-            sor = np.zeros(n_obs)
+        sor = _grid_sor(q, ds, roll_behind, engine_jet) if is_takeoff else 0.0
         if key == "maximum":
             base = _npd_level_grid(p, lm, logd_tab, p_seg,
                                    np.maximum(ds, _NPD_FLOOR_M))
             total = np.maximum(total, base + imp + di - lam_att + sor)
+            continue
+        dist = np.maximum(np.where(use_end, ds, dp_), _NPD_FLOOR_M)
+        le_d = _npd_level_grid(p, le, logd_tab, p_seg, dist)
+        lm_d = _npd_level_grid(p, lm, logd_tab, p_seg, dist)
+        v1, v2 = pts[i, 4], pts[i + 1, 4]
+        if is_takeoff or is_landing:
+            # Eq. 4-13b: runway segments use the arithmetic mean speed.
+            v_seg = np.full(n_obs, 0.5 * (v1 + v2))
         else:
-            dist = np.maximum(np.where(roll_behind | roll_ahead, ds, dp_),
-                              _NPD_FLOOR_M)
-            le_d = _npd_level_grid(p, le, logd_tab, p_seg, dist)
-            lm_d = _npd_level_grid(p, lm, logd_tab, p_seg, dist)
-            if is_takeoff or is_landing:
-                # Eq. 4-13b: runway segments use the arithmetic mean speed.
-                v_seg = np.full(n_obs, 0.5 * (v1 + v2))
-            else:
-                v_seg = np.sqrt(np.maximum(v1**2 + frac * (v2**2 - v1**2), 0.0))
-            if np.any(v_seg <= 0.0):
-                raise ValueError(
-                    "segment with zero mean speed (stationary segment in 'path').")
-            dv = 10.0 * np.log10(vref / v_seg)
-            d_lambda = _D0_M * 10.0 ** ((le_d - lm_d) / 10.0)
-            # _segment_noise_fraction (Eq. 4-20/4-21a/4-21b) over all observers.
-            qf = np.where(roll_behind, 0.0, np.where(roll_ahead, length, q))
-            a1 = -qf / d_lambda
-            a2 = (length - qf) / d_lambda
-            frac_f = (a2 / (1.0 + a2**2) + np.arctan(a2)
-                      - a1 / (1.0 + a1**2) - np.arctan(a1)) / np.pi
-            with np.errstate(divide="ignore", invalid="ignore"):
-                df = np.where(frac_f <= 0.0, -150.0,
-                              np.maximum(10.0 * np.log10(
-                                  np.where(frac_f > 0.0, frac_f, 1.0)), -150.0))
-            energy += 10.0 ** ((le_d + imp + dv + di - lam_att + df + sor) / 10.0)
+            v_seg = np.sqrt(np.maximum(v1**2 + frac * (v2**2 - v1**2), 0.0))
+        if np.any(v_seg <= 0.0):
+            raise ValueError(
+                "segment with zero mean speed (stationary segment in 'path').")
+        dv = 10.0 * np.log10(vref / v_seg)
+        d_lambda = _D0_M * 10.0 ** ((le_d - lm_d) / 10.0)
+        df = _grid_noise_fraction(q, length, d_lambda, roll_behind, roll_ahead)
+        energy += 10.0 ** ((le_d + imp + dv + di - lam_att + df + sor) / 10.0)
     if not any_segment:
         return np.full(n_obs, -np.inf)
     if key == "maximum":
@@ -969,7 +1022,9 @@ def noise_contour(
     # per-point scalar loop is O(grid × segments) Python calls; this is
     # numerically identical, see _grid_event_levels).
     xx, yy = np.meshgrid(gx, gy)
-    obs = np.column_stack([xx.ravel(), yy.ravel(), np.zeros(xx.size)])
+    obs = np.zeros((xx.size, 3))
+    obs[:, 0] = xx.ravel()
+    obs[:, 1] = yy.ravel()
     levels = _grid_event_levels(
         pts, obs, p, d, le, lm, vref, imp, mounting, key, gr, lr, bk)
     return NoiseContourResult(

--- a/tests/aircraft/test_airport_noise.py
+++ b/tests/aircraft/test_airport_noise.py
@@ -490,3 +490,45 @@ def test_noise_contour_accepts_bank() -> None:
     assert level.level[0, 0] == pytest.approx(level.level[1, 0])
     with pytest.raises(ValueError, match="bank"):
         noise_contour(path, _NP, _ND, _NSEL, _NMAX, bank=[1.0, 2.0], **kw)
+
+
+def test_contour_grid_matches_scalar_event_level() -> None:
+    # The vectorised grid kernel must reproduce the per-point scalar path to
+    # machine precision for every feature combination: takeoff roll (SOR,
+    # Eq. 4-21a), landing rollout (Eq. 4-21b), bank, both metrics and both
+    # engine mountings.
+    path = [
+        [-500.0, 0.0, 0.0, 8000.0, 0.0],       # takeoff ground roll
+        [800.0, 0.0, 0.0, 10000.0, 80.0],      # rotation
+        [2500.0, 100.0, 300.0, 10000.0, _VREF],  # climb, slight turn
+        [4500.0, 400.0, 700.0, 9000.0, _VREF],
+    ]
+    gr = [True, False, False]
+    lr = [False, False, False]
+    bank = [0.0, 0.0, 8.0]
+    x = np.linspace(-2000.0, 5000.0, 9)
+    y = np.linspace(-1500.0, 1500.0, 7)
+    for metric in ("exposure", "maximum"):
+        for mounting in ("wing", "propeller"):
+            res = noise_contour(path, _NP, _ND, _NSEL, _NMAX, x=x, y=y,
+                                metric=metric, mounting=mounting,
+                                ground_roll=gr, landing_roll=lr, bank=bank)
+            for iy, yv in enumerate(y):
+                for ix, xv in enumerate(x):
+                    ref = event_level(path, [xv, yv, 0.0], _NP, _ND, _NSEL,
+                                      _NMAX, metric=metric, mounting=mounting,
+                                      ground_roll=gr, landing_roll=lr,
+                                      bank=bank).level
+                    assert res.level[iy, ix] == pytest.approx(ref, abs=1e-9), (
+                        metric, mounting, xv, yv)
+    # Landing rollout branch, separately (ahead-of-rollout geometry).
+    land = [[0.0, 0.0, 300.0, 9000.0, _VREF], [2000.0, 0.0, 0.0, 8000.0, 70.0],
+            [3200.0, 0.0, 0.0, 4000.0, 0.0]]
+    lmask = [False, True]
+    res = noise_contour(land, _NP, _ND, _NSEL, _NMAX, x=[1000.0, 4000.0],
+                        y=[-200.0, 200.0], landing_roll=lmask)
+    for iy, yv in enumerate([-200.0, 200.0]):
+        for ix, xv in enumerate([1000.0, 4000.0]):
+            ref = event_level(land, [xv, yv, 0.0], _NP, _ND, _NSEL, _NMAX,
+                              landing_roll=lmask).level
+            assert res.level[iy, ix] == pytest.approx(ref, abs=1e-9)


### PR DESCRIPTION
ECAC Doc 29 noise_contour evaluated the grid with a per-point Python loop over the scalar segment kernel, O(grid x segments) interpreted calls; the 10x8 benchmark grid took ~212 ms and production-size grids were impractical.

The new _grid_event_levels kernel runs one vectorised pass per flight-path segment with every term broadcast over the observers: segment geometry, the section 4.5.5 nearest-end selection for maximum-level metrics and runway rolls, lateral attenuation (Eq. 4-18/4-19), engine-installation directivity (Eq. 4-15/4-16), duration (Eq. 4-14), finite-segment fraction (Eq. 4-20/4-21), start-of-roll directivity (Eq. 4-22..4-25) and the NPD lookups through a per-observer power/distance variant of the Eq. 4-3/4-4 arithmetic. The scalar kernel remains the implementation of event_level for single receivers.

The grid path mirrors the scalar loop expression for expression, so results are numerically identical:

- the frozen golden values (including the 10x8 contour case) pass unchanged at rtol 1e-9, and
- a new test compares every grid point against event_level across takeoff ground roll, landing rollout, bank angle, both metrics and both engine mountings, at 1e-9 absolute.

Measured: the benchmark 10x8 grid drops from ~212 ms to ~5 ms, and a 200x150 grid (30 000 points) evaluates in ~0.2 s.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

