### PR TITLE
fix: Francois-Garrison boric coefficient per the original paper, with printed JASA oracles

### DIFF
--- a/.github/images/underwater_transmission_loss.svg
+++ b/.github/images/underwater_transmission_loss.svg
@@ -184,8 +184,8 @@ L 675.543544 28.318125
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_19">
-      <path d="M 40.925781 44.566267 
-L 705.763438 44.566267 
+      <path d="M 40.925781 44.566202 
+L 705.763438 44.566202 
 " clip-path="url(#p98f6410962)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8"/>
      </g>
      <g id="line2d_20">
@@ -195,71 +195,71 @@ L -3.5 0
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mef640d9f3a" x="40.925781" y="44.566267" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mef640d9f3a" x="40.925781" y="44.566202" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="33.925781" y="48.365095" transform="rotate(-0 33.925781 48.365095)">0</text>
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="33.925781" y="48.36503" transform="rotate(-0 33.925781 48.36503)">0</text>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_21">
-      <path d="M 40.925781 115.386172 
-L 705.763438 115.386172 
+      <path d="M 40.925781 115.350423 
+L 705.763438 115.350423 
 " clip-path="url(#p98f6410962)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mef640d9f3a" x="40.925781" y="115.386172" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mef640d9f3a" x="40.925781" y="115.350423" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="33.925781" y="119.185" transform="rotate(-0 33.925781 119.185)">20</text>
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="33.925781" y="119.149252" transform="rotate(-0 33.925781 119.149252)">20</text>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_23">
-      <path d="M 40.925781 186.206077 
-L 705.763438 186.206077 
+      <path d="M 40.925781 186.134645 
+L 705.763438 186.134645 
 " clip-path="url(#p98f6410962)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mef640d9f3a" x="40.925781" y="186.206077" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mef640d9f3a" x="40.925781" y="186.134645" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="33.925781" y="190.004905" transform="rotate(-0 33.925781 190.004905)">40</text>
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="33.925781" y="189.933473" transform="rotate(-0 33.925781 189.933473)">40</text>
      </g>
     </g>
     <g id="ytick_4">
      <g id="line2d_25">
-      <path d="M 40.925781 257.025982 
-L 705.763438 257.025982 
+      <path d="M 40.925781 256.918866 
+L 705.763438 256.918866 
 " clip-path="url(#p98f6410962)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mef640d9f3a" x="40.925781" y="257.025982" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mef640d9f3a" x="40.925781" y="256.918866" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="33.925781" y="260.82481" transform="rotate(-0 33.925781 260.82481)">60</text>
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="33.925781" y="260.717694" transform="rotate(-0 33.925781 260.717694)">60</text>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_27">
-      <path d="M 40.925781 327.845887 
-L 705.763438 327.845887 
+      <path d="M 40.925781 327.703088 
+L 705.763438 327.703088 
 " clip-path="url(#p98f6410962)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mef640d9f3a" x="40.925781" y="327.845887" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mef640d9f3a" x="40.925781" y="327.703088" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="33.925781" y="331.644715" transform="rotate(-0 33.925781 331.644715)">80</text>
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="33.925781" y="331.501916" transform="rotate(-0 33.925781 331.501916)">80</text>
      </g>
     </g>
     <g id="text_16">
@@ -267,101 +267,101 @@ L 705.763438 327.845887
     </g>
    </g>
    <g id="line2d_29">
-    <path d="M 71.145675 115.419742 
-L 72.660456 170.747869 
-L 74.175238 189.563449 
-L 75.69002 201.257713 
-L 77.204801 209.790594 
-L 78.719583 216.528174 
-L 80.234364 222.106555 
-L 81.749146 226.874115 
-L 83.263928 231.042511 
-L 84.778709 234.75001 
-L 86.293491 238.09193 
-L 89.323054 243.935426 
-L 92.352617 248.940986 
-L 95.382181 253.330247 
-L 98.411744 257.247094 
-L 99.926526 259.060448 
-L 101.441307 260.606734 
-L 105.985652 263.240757 
-L 110.529997 265.615454 
-L 116.589124 268.473212 
-L 122.64825 271.058785 
-L 130.222158 273.998117 
-L 137.796066 276.685191 
-L 146.884756 279.65182 
-L 157.488227 282.83659 
-L 168.091699 285.789304 
-L 180.209952 288.940765 
-L 193.842987 292.260998 
-L 208.990803 295.728874 
-L 227.168182 299.648059 
-L 246.860343 303.658996 
-L 269.582068 308.048836 
-L 295.333356 312.781652 
-L 324.114206 317.832197 
-L 355.924621 323.183531 
-L 392.27938 329.065703 
-L 433.178484 335.44853 
-L 478.621932 342.311052 
-L 530.124508 349.858355 
-L 587.68621 358.065136 
-L 652.82182 367.122341 
+    <path d="M 71.145675 115.384058 
+L 72.660456 170.684719 
+L 74.175238 189.49123 
+L 75.69002 201.180012 
+L 77.204801 209.709005 
+L 78.719583 216.443602 
+L 80.234364 222.019583 
+L 81.749146 226.785153 
+L 83.263928 230.95186 
+L 84.778709 234.657901 
+L 86.293491 237.998549 
+L 89.323054 243.839923 
+L 92.352617 248.843783 
+L 95.382181 253.231655 
+L 98.411744 257.147351 
+L 99.926526 258.960202 
+L 101.441307 260.50612 
+L 105.985652 263.14005 
+L 110.529997 265.514784 
+L 116.589124 268.372747 
+L 122.64825 270.958662 
+L 130.222158 273.898569 
+L 137.796066 276.586345 
+L 146.884756 279.553947 
+L 157.488227 282.739991 
+L 168.091699 285.694095 
+L 180.209952 288.847258 
+L 193.842987 292.169519 
+L 208.990803 295.63976 
+L 227.168182 299.561905 
+L 246.860343 303.576167 
+L 269.582068 307.969963 
+L 295.333356 312.707385 
+L 324.114206 317.763198 
+L 355.924621 323.120471 
+L 392.27938 329.009548 
+L 433.178484 335.400262 
+L 478.621932 342.271663 
+L 530.124508 349.829144 
+L 587.68621 358.047417 
+L 652.82182 367.11774 
 L 675.543544 370.23407 
 L 675.543544 370.23407 
 " clip-path="url(#p98f6410962)" style="fill: none; stroke: #1f77b4; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_30">
-    <path d="M 71.145675 115.386172 
-L 72.660456 170.546116 
-L 74.175238 189.193513 
-L 75.69002 200.719594 
-L 77.204801 209.084292 
-L 78.719583 215.653689 
-L 80.234364 221.063886 
-L 81.749146 225.663263 
-L 83.263928 229.663476 
-L 84.778709 233.202791 
-L 86.293491 236.376529 
-L 87.808273 239.253189 
-L 90.837836 244.306774 
-L 93.867399 248.646008 
-L 96.896962 252.448059 
-L 99.926526 255.831397 
-L 101.441307 257.2095 
-L 105.985652 259.338974 
-L 110.529997 261.209121 
-L 115.074342 262.876301 
-L 121.133468 264.850616 
-L 127.192595 266.60006 
-L 134.766503 268.539465 
-L 142.340411 270.261451 
-L 151.429101 272.101708 
-L 162.032572 274.002699 
-L 174.150825 275.921502 
-L 187.78386 277.827734 
-L 202.931676 279.7009 
-L 219.594274 281.527885 
-L 237.771654 283.300872 
-L 258.978597 285.140071 
-L 283.215103 287.003576 
-L 310.481172 288.861132 
-L 340.776804 290.691875 
-L 374.102 292.482077 
-L 411.971541 294.291682 
-L 454.385426 296.093886 
-L 502.858439 297.924081 
-L 557.390577 299.752158 
-L 617.981842 301.557083 
-L 675.543544 303.095392 
-L 675.543544 303.095392 
+    <path d="M 71.145675 115.350423 
+L 72.660456 170.482575 
+L 74.175238 189.120576 
+L 75.69002 200.640849 
+L 77.204801 209.001332 
+L 78.719583 215.567419 
+L 80.234364 220.97489 
+L 81.749146 225.57195 
+L 83.263928 229.570147 
+L 84.778709 233.107679 
+L 86.293491 236.279817 
+L 87.808273 239.155028 
+L 90.837836 244.206067 
+L 93.867399 248.543114 
+L 96.896962 252.34325 
+L 99.926526 255.724883 
+L 101.441307 257.102292 
+L 105.985652 259.230693 
+L 110.529997 261.099897 
+L 115.074342 262.766237 
+L 121.133468 264.739558 
+L 127.192595 266.48812 
+L 134.766503 268.426548 
+L 142.340411 270.147666 
+L 151.429101 271.986996 
+L 162.032572 273.88703 
+L 174.150825 275.804865 
+L 187.78386 277.710137 
+L 202.931676 279.58236 
+L 219.594274 281.408424 
+L 237.771654 283.180517 
+L 258.978597 285.01879 
+L 283.215103 286.881355 
+L 310.481172 288.737976 
+L 340.776804 290.567796 
+L 374.102 292.357096 
+L 411.971541 294.165789 
+L 454.385426 295.967085 
+L 502.858439 297.796358 
+L 557.390577 299.623514 
+L 617.981842 301.42753 
+L 675.543544 302.965064 
+L 675.543544 302.965064 
 " clip-path="url(#p98f6410962)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #8c8c8c; stroke-width: 1.4"/>
    </g>
    <g id="line2d_31">
     <path d="M 71.145675 44.599837 
-L 675.543544 111.704945 
-L 675.543544 111.704945 
+L 675.543544 111.835208 
+L 675.543544 111.835208 
 " clip-path="url(#p98f6410962)" style="fill: none; stroke-dasharray: 1.6,2.64; stroke-dashoffset: 0; stroke: #d62728; stroke-width: 1.6"/>
    </g>
    <g id="patch_3">

--- a/.github/images/underwater_transmission_loss_dark.svg
+++ b/.github/images/underwater_transmission_loss_dark.svg
@@ -184,8 +184,8 @@ L 675.543544 28.318125
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_19">
-      <path d="M 40.925781 44.566267 
-L 705.763438 44.566267 
+      <path d="M 40.925781 44.566202 
+L 705.763438 44.566202 
 " clip-path="url(#p98f6410962)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8"/>
      </g>
      <g id="line2d_20">
@@ -195,71 +195,71 @@ L -3.5 0
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5e07181663" x="40.925781" y="44.566267" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m5e07181663" x="40.925781" y="44.566202" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #ffffff" x="33.925781" y="48.365095" transform="rotate(-0 33.925781 48.365095)">0</text>
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #ffffff" x="33.925781" y="48.36503" transform="rotate(-0 33.925781 48.36503)">0</text>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_21">
-      <path d="M 40.925781 115.386172 
-L 705.763438 115.386172 
+      <path d="M 40.925781 115.350423 
+L 705.763438 115.350423 
 " clip-path="url(#p98f6410962)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m5e07181663" x="40.925781" y="115.386172" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m5e07181663" x="40.925781" y="115.350423" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #ffffff" x="33.925781" y="119.185" transform="rotate(-0 33.925781 119.185)">20</text>
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #ffffff" x="33.925781" y="119.149252" transform="rotate(-0 33.925781 119.149252)">20</text>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_23">
-      <path d="M 40.925781 186.206077 
-L 705.763438 186.206077 
+      <path d="M 40.925781 186.134645 
+L 705.763438 186.134645 
 " clip-path="url(#p98f6410962)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m5e07181663" x="40.925781" y="186.206077" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m5e07181663" x="40.925781" y="186.134645" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #ffffff" x="33.925781" y="190.004905" transform="rotate(-0 33.925781 190.004905)">40</text>
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #ffffff" x="33.925781" y="189.933473" transform="rotate(-0 33.925781 189.933473)">40</text>
      </g>
     </g>
     <g id="ytick_4">
      <g id="line2d_25">
-      <path d="M 40.925781 257.025982 
-L 705.763438 257.025982 
+      <path d="M 40.925781 256.918866 
+L 705.763438 256.918866 
 " clip-path="url(#p98f6410962)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m5e07181663" x="40.925781" y="257.025982" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m5e07181663" x="40.925781" y="256.918866" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #ffffff" x="33.925781" y="260.82481" transform="rotate(-0 33.925781 260.82481)">60</text>
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #ffffff" x="33.925781" y="260.717694" transform="rotate(-0 33.925781 260.717694)">60</text>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_27">
-      <path d="M 40.925781 327.845887 
-L 705.763438 327.845887 
+      <path d="M 40.925781 327.703088 
+L 705.763438 327.703088 
 " clip-path="url(#p98f6410962)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m5e07181663" x="40.925781" y="327.845887" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m5e07181663" x="40.925781" y="327.703088" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #ffffff" x="33.925781" y="331.644715" transform="rotate(-0 33.925781 331.644715)">80</text>
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #ffffff" x="33.925781" y="331.501916" transform="rotate(-0 33.925781 331.501916)">80</text>
      </g>
     </g>
     <g id="text_16">
@@ -267,101 +267,101 @@ L 705.763438 327.845887
     </g>
    </g>
    <g id="line2d_29">
-    <path d="M 71.145675 115.419742 
-L 72.660456 170.747869 
-L 74.175238 189.563449 
-L 75.69002 201.257713 
-L 77.204801 209.790594 
-L 78.719583 216.528174 
-L 80.234364 222.106555 
-L 81.749146 226.874115 
-L 83.263928 231.042511 
-L 84.778709 234.75001 
-L 86.293491 238.09193 
-L 89.323054 243.935426 
-L 92.352617 248.940986 
-L 95.382181 253.330247 
-L 98.411744 257.247094 
-L 99.926526 259.060448 
-L 101.441307 260.606734 
-L 105.985652 263.240757 
-L 110.529997 265.615454 
-L 116.589124 268.473212 
-L 122.64825 271.058785 
-L 130.222158 273.998117 
-L 137.796066 276.685191 
-L 146.884756 279.65182 
-L 157.488227 282.83659 
-L 168.091699 285.789304 
-L 180.209952 288.940765 
-L 193.842987 292.260998 
-L 208.990803 295.728874 
-L 227.168182 299.648059 
-L 246.860343 303.658996 
-L 269.582068 308.048836 
-L 295.333356 312.781652 
-L 324.114206 317.832197 
-L 355.924621 323.183531 
-L 392.27938 329.065703 
-L 433.178484 335.44853 
-L 478.621932 342.311052 
-L 530.124508 349.858355 
-L 587.68621 358.065136 
-L 652.82182 367.122341 
+    <path d="M 71.145675 115.384058 
+L 72.660456 170.684719 
+L 74.175238 189.49123 
+L 75.69002 201.180012 
+L 77.204801 209.709005 
+L 78.719583 216.443602 
+L 80.234364 222.019583 
+L 81.749146 226.785153 
+L 83.263928 230.95186 
+L 84.778709 234.657901 
+L 86.293491 237.998549 
+L 89.323054 243.839923 
+L 92.352617 248.843783 
+L 95.382181 253.231655 
+L 98.411744 257.147351 
+L 99.926526 258.960202 
+L 101.441307 260.50612 
+L 105.985652 263.14005 
+L 110.529997 265.514784 
+L 116.589124 268.372747 
+L 122.64825 270.958662 
+L 130.222158 273.898569 
+L 137.796066 276.586345 
+L 146.884756 279.553947 
+L 157.488227 282.739991 
+L 168.091699 285.694095 
+L 180.209952 288.847258 
+L 193.842987 292.169519 
+L 208.990803 295.63976 
+L 227.168182 299.561905 
+L 246.860343 303.576167 
+L 269.582068 307.969963 
+L 295.333356 312.707385 
+L 324.114206 317.763198 
+L 355.924621 323.120471 
+L 392.27938 329.009548 
+L 433.178484 335.400262 
+L 478.621932 342.271663 
+L 530.124508 349.829144 
+L 587.68621 358.047417 
+L 652.82182 367.11774 
 L 675.543544 370.23407 
 L 675.543544 370.23407 
 " clip-path="url(#p98f6410962)" style="fill: none; stroke: #1f77b4; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_30">
-    <path d="M 71.145675 115.386172 
-L 72.660456 170.546116 
-L 74.175238 189.193513 
-L 75.69002 200.719594 
-L 77.204801 209.084292 
-L 78.719583 215.653689 
-L 80.234364 221.063886 
-L 81.749146 225.663263 
-L 83.263928 229.663476 
-L 84.778709 233.202791 
-L 86.293491 236.376529 
-L 87.808273 239.253189 
-L 90.837836 244.306774 
-L 93.867399 248.646008 
-L 96.896962 252.448059 
-L 99.926526 255.831397 
-L 101.441307 257.2095 
-L 105.985652 259.338974 
-L 110.529997 261.209121 
-L 115.074342 262.876301 
-L 121.133468 264.850616 
-L 127.192595 266.60006 
-L 134.766503 268.539465 
-L 142.340411 270.261451 
-L 151.429101 272.101708 
-L 162.032572 274.002699 
-L 174.150825 275.921502 
-L 187.78386 277.827734 
-L 202.931676 279.7009 
-L 219.594274 281.527885 
-L 237.771654 283.300872 
-L 258.978597 285.140071 
-L 283.215103 287.003576 
-L 310.481172 288.861132 
-L 340.776804 290.691875 
-L 374.102 292.482077 
-L 411.971541 294.291682 
-L 454.385426 296.093886 
-L 502.858439 297.924081 
-L 557.390577 299.752158 
-L 617.981842 301.557083 
-L 675.543544 303.095392 
-L 675.543544 303.095392 
+    <path d="M 71.145675 115.350423 
+L 72.660456 170.482575 
+L 74.175238 189.120576 
+L 75.69002 200.640849 
+L 77.204801 209.001332 
+L 78.719583 215.567419 
+L 80.234364 220.97489 
+L 81.749146 225.57195 
+L 83.263928 229.570147 
+L 84.778709 233.107679 
+L 86.293491 236.279817 
+L 87.808273 239.155028 
+L 90.837836 244.206067 
+L 93.867399 248.543114 
+L 96.896962 252.34325 
+L 99.926526 255.724883 
+L 101.441307 257.102292 
+L 105.985652 259.230693 
+L 110.529997 261.099897 
+L 115.074342 262.766237 
+L 121.133468 264.739558 
+L 127.192595 266.48812 
+L 134.766503 268.426548 
+L 142.340411 270.147666 
+L 151.429101 271.986996 
+L 162.032572 273.88703 
+L 174.150825 275.804865 
+L 187.78386 277.710137 
+L 202.931676 279.58236 
+L 219.594274 281.408424 
+L 237.771654 283.180517 
+L 258.978597 285.01879 
+L 283.215103 286.881355 
+L 310.481172 288.737976 
+L 340.776804 290.567796 
+L 374.102 292.357096 
+L 411.971541 294.165789 
+L 454.385426 295.967085 
+L 502.858439 297.796358 
+L 557.390577 299.623514 
+L 617.981842 301.42753 
+L 675.543544 302.965064 
+L 675.543544 302.965064 
 " clip-path="url(#p98f6410962)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #8c8c8c; stroke-width: 1.4"/>
    </g>
    <g id="line2d_31">
     <path d="M 71.145675 44.599837 
-L 675.543544 111.704945 
-L 675.543544 111.704945 
+L 675.543544 111.835208 
+L 675.543544 111.835208 
 " clip-path="url(#p98f6410962)" style="fill: none; stroke-dasharray: 1.6,2.64; stroke-dashoffset: 0; stroke: #d62728; stroke-width: 1.6"/>
    </g>
    <g id="patch_3">

--- a/.github/images/underwater_transmission_loss_es.svg
+++ b/.github/images/underwater_transmission_loss_es.svg
@@ -184,8 +184,8 @@ L 675.943544 28.798125
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_19">
-      <path d="M 41.325781 45.046267 
-L 706.163437 45.046267 
+      <path d="M 41.325781 45.046202 
+L 706.163437 45.046202 
 " clip-path="url(#p314f927017)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8"/>
      </g>
      <g id="line2d_20">
@@ -195,71 +195,71 @@ L -3.5 0
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mef640d9f3a" x="41.325781" y="45.046267" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mef640d9f3a" x="41.325781" y="45.046202" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="34.325781" y="48.845095" transform="rotate(-0 34.325781 48.845095)">0</text>
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="34.325781" y="48.84503" transform="rotate(-0 34.325781 48.84503)">0</text>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_21">
-      <path d="M 41.325781 115.866172 
-L 706.163437 115.866172 
+      <path d="M 41.325781 115.830423 
+L 706.163437 115.830423 
 " clip-path="url(#p314f927017)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#mef640d9f3a" x="41.325781" y="115.866172" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mef640d9f3a" x="41.325781" y="115.830423" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="34.325781" y="119.665" transform="rotate(-0 34.325781 119.665)">20</text>
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="34.325781" y="119.629252" transform="rotate(-0 34.325781 119.629252)">20</text>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_23">
-      <path d="M 41.325781 186.686077 
-L 706.163437 186.686077 
+      <path d="M 41.325781 186.614645 
+L 706.163437 186.614645 
 " clip-path="url(#p314f927017)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#mef640d9f3a" x="41.325781" y="186.686077" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mef640d9f3a" x="41.325781" y="186.614645" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="34.325781" y="190.484905" transform="rotate(-0 34.325781 190.484905)">40</text>
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="34.325781" y="190.413473" transform="rotate(-0 34.325781 190.413473)">40</text>
      </g>
     </g>
     <g id="ytick_4">
      <g id="line2d_25">
-      <path d="M 41.325781 257.505982 
-L 706.163437 257.505982 
+      <path d="M 41.325781 257.398866 
+L 706.163437 257.398866 
 " clip-path="url(#p314f927017)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mef640d9f3a" x="41.325781" y="257.505982" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mef640d9f3a" x="41.325781" y="257.398866" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="34.325781" y="261.30481" transform="rotate(-0 34.325781 261.30481)">60</text>
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="34.325781" y="261.197694" transform="rotate(-0 34.325781 261.197694)">60</text>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_27">
-      <path d="M 41.325781 328.325887 
-L 706.163437 328.325887 
+      <path d="M 41.325781 328.183088 
+L 706.163437 328.183088 
 " clip-path="url(#p314f927017)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mef640d9f3a" x="41.325781" y="328.325887" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mef640d9f3a" x="41.325781" y="328.183088" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="34.325781" y="332.124715" transform="rotate(-0 34.325781 332.124715)">80</text>
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end" x="34.325781" y="331.981916" transform="rotate(-0 34.325781 331.981916)">80</text>
      </g>
     </g>
     <g id="text_16">
@@ -267,101 +267,101 @@ L 706.163437 328.325887
     </g>
    </g>
    <g id="line2d_29">
-    <path d="M 71.545675 115.899742 
-L 73.060456 171.227869 
-L 74.575238 190.043449 
-L 76.09002 201.737713 
-L 77.604801 210.270594 
-L 79.119583 217.008174 
-L 80.634364 222.586555 
-L 82.149146 227.354115 
-L 83.663928 231.522511 
-L 85.178709 235.23001 
-L 86.693491 238.57193 
-L 89.723054 244.415426 
-L 92.752617 249.420986 
-L 95.782181 253.810247 
-L 98.811744 257.727094 
-L 100.326526 259.540448 
-L 101.841307 261.086734 
-L 106.385652 263.720757 
-L 110.929997 266.095454 
-L 116.989124 268.953212 
-L 123.04825 271.538785 
-L 130.622158 274.478117 
-L 138.196066 277.165191 
-L 147.284756 280.13182 
-L 157.888227 283.31659 
-L 168.491699 286.269304 
-L 180.609952 289.420765 
-L 194.242987 292.740998 
-L 209.390803 296.208874 
-L 227.568182 300.128059 
-L 247.260343 304.138996 
-L 269.982068 308.528836 
-L 295.733356 313.261652 
-L 324.514206 318.312197 
-L 356.324621 323.663531 
-L 392.67938 329.545703 
-L 433.578484 335.92853 
-L 479.021932 342.791052 
-L 530.524508 350.338355 
-L 588.08621 358.545136 
-L 653.22182 367.602341 
+    <path d="M 71.545675 115.864058 
+L 73.060456 171.164719 
+L 74.575238 189.97123 
+L 76.09002 201.660012 
+L 77.604801 210.189005 
+L 79.119583 216.923602 
+L 80.634364 222.499583 
+L 82.149146 227.265153 
+L 83.663928 231.43186 
+L 85.178709 235.137901 
+L 86.693491 238.478549 
+L 89.723054 244.319923 
+L 92.752617 249.323783 
+L 95.782181 253.711655 
+L 98.811744 257.627351 
+L 100.326526 259.440202 
+L 101.841307 260.98612 
+L 106.385652 263.62005 
+L 110.929997 265.994784 
+L 116.989124 268.852747 
+L 123.04825 271.438662 
+L 130.622158 274.378569 
+L 138.196066 277.066345 
+L 147.284756 280.033947 
+L 157.888227 283.219991 
+L 168.491699 286.174095 
+L 180.609952 289.327258 
+L 194.242987 292.649519 
+L 209.390803 296.11976 
+L 227.568182 300.041905 
+L 247.260343 304.056167 
+L 269.982068 308.449963 
+L 295.733356 313.187385 
+L 324.514206 318.243198 
+L 356.324621 323.600471 
+L 392.67938 329.489548 
+L 433.578484 335.880262 
+L 479.021932 342.751663 
+L 530.524508 350.309144 
+L 588.08621 358.527417 
+L 653.22182 367.59774 
 L 675.943544 370.71407 
 L 675.943544 370.71407 
 " clip-path="url(#p314f927017)" style="fill: none; stroke: #1f77b4; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_30">
-    <path d="M 71.545675 115.866172 
-L 73.060456 171.026116 
-L 74.575238 189.673513 
-L 76.09002 201.199594 
-L 77.604801 209.564292 
-L 79.119583 216.133689 
-L 80.634364 221.543886 
-L 82.149146 226.143263 
-L 83.663928 230.143476 
-L 85.178709 233.682791 
-L 86.693491 236.856529 
-L 88.208273 239.733189 
-L 91.237836 244.786774 
-L 94.267399 249.126008 
-L 97.296962 252.928059 
-L 100.326526 256.311397 
-L 101.841307 257.6895 
-L 106.385652 259.818974 
-L 110.929997 261.689121 
-L 115.474342 263.356301 
-L 121.533468 265.330616 
-L 127.592595 267.08006 
-L 135.166503 269.019465 
-L 142.740411 270.741451 
-L 151.829101 272.581708 
-L 162.432572 274.482699 
-L 174.550825 276.401502 
-L 188.18386 278.307734 
-L 203.331676 280.1809 
-L 219.994274 282.007885 
-L 238.171654 283.780872 
-L 259.378597 285.620071 
-L 283.615103 287.483576 
-L 310.881172 289.341132 
-L 341.176804 291.171875 
-L 374.502 292.962077 
-L 412.371541 294.771682 
-L 454.785426 296.573886 
-L 503.258439 298.404081 
-L 557.790577 300.232158 
-L 618.381842 302.037083 
-L 675.943544 303.575392 
-L 675.943544 303.575392 
+    <path d="M 71.545675 115.830423 
+L 73.060456 170.962575 
+L 74.575238 189.600576 
+L 76.09002 201.120849 
+L 77.604801 209.481332 
+L 79.119583 216.047419 
+L 80.634364 221.45489 
+L 82.149146 226.05195 
+L 83.663928 230.050147 
+L 85.178709 233.587679 
+L 86.693491 236.759817 
+L 88.208273 239.635028 
+L 91.237836 244.686067 
+L 94.267399 249.023114 
+L 97.296962 252.82325 
+L 100.326526 256.204883 
+L 101.841307 257.582292 
+L 106.385652 259.710693 
+L 110.929997 261.579897 
+L 115.474342 263.246237 
+L 121.533468 265.219558 
+L 127.592595 266.96812 
+L 135.166503 268.906548 
+L 142.740411 270.627666 
+L 151.829101 272.466996 
+L 162.432572 274.36703 
+L 174.550825 276.284865 
+L 188.18386 278.190137 
+L 203.331676 280.06236 
+L 219.994274 281.888424 
+L 238.171654 283.660517 
+L 259.378597 285.49879 
+L 283.615103 287.361355 
+L 310.881172 289.217976 
+L 341.176804 291.047796 
+L 374.502 292.837096 
+L 412.371541 294.645789 
+L 454.785426 296.447085 
+L 503.258439 298.276358 
+L 557.790577 300.103514 
+L 618.381842 301.90753 
+L 675.943544 303.445064 
+L 675.943544 303.445064 
 " clip-path="url(#p314f927017)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #8c8c8c; stroke-width: 1.4"/>
    </g>
    <g id="line2d_31">
     <path d="M 71.545675 45.079837 
-L 675.943544 112.184945 
-L 675.943544 112.184945 
+L 675.943544 112.315208 
+L 675.943544 112.315208 
 " clip-path="url(#p314f927017)" style="fill: none; stroke-dasharray: 1.6,2.64; stroke-dashoffset: 0; stroke: #d62728; stroke-width: 1.6"/>
    </g>
    <g id="patch_3">

--- a/.github/images/underwater_transmission_loss_es_dark.svg
+++ b/.github/images/underwater_transmission_loss_es_dark.svg
@@ -184,8 +184,8 @@ L 675.943544 28.798125
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_19">
-      <path d="M 41.325781 45.046267 
-L 706.163437 45.046267 
+      <path d="M 41.325781 45.046202 
+L 706.163437 45.046202 
 " clip-path="url(#p314f927017)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8"/>
      </g>
      <g id="line2d_20">
@@ -195,71 +195,71 @@ L -3.5 0
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5e07181663" x="41.325781" y="45.046267" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m5e07181663" x="41.325781" y="45.046202" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #ffffff" x="34.325781" y="48.845095" transform="rotate(-0 34.325781 48.845095)">0</text>
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #ffffff" x="34.325781" y="48.84503" transform="rotate(-0 34.325781 48.84503)">0</text>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_21">
-      <path d="M 41.325781 115.866172 
-L 706.163437 115.866172 
+      <path d="M 41.325781 115.830423 
+L 706.163437 115.830423 
 " clip-path="url(#p314f927017)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m5e07181663" x="41.325781" y="115.866172" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m5e07181663" x="41.325781" y="115.830423" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #ffffff" x="34.325781" y="119.665" transform="rotate(-0 34.325781 119.665)">20</text>
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #ffffff" x="34.325781" y="119.629252" transform="rotate(-0 34.325781 119.629252)">20</text>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_23">
-      <path d="M 41.325781 186.686077 
-L 706.163437 186.686077 
+      <path d="M 41.325781 186.614645 
+L 706.163437 186.614645 
 " clip-path="url(#p314f927017)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m5e07181663" x="41.325781" y="186.686077" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m5e07181663" x="41.325781" y="186.614645" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #ffffff" x="34.325781" y="190.484905" transform="rotate(-0 34.325781 190.484905)">40</text>
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #ffffff" x="34.325781" y="190.413473" transform="rotate(-0 34.325781 190.413473)">40</text>
      </g>
     </g>
     <g id="ytick_4">
      <g id="line2d_25">
-      <path d="M 41.325781 257.505982 
-L 706.163437 257.505982 
+      <path d="M 41.325781 257.398866 
+L 706.163437 257.398866 
 " clip-path="url(#p314f927017)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m5e07181663" x="41.325781" y="257.505982" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m5e07181663" x="41.325781" y="257.398866" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #ffffff" x="34.325781" y="261.30481" transform="rotate(-0 34.325781 261.30481)">60</text>
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #ffffff" x="34.325781" y="261.197694" transform="rotate(-0 34.325781 261.197694)">60</text>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_27">
-      <path d="M 41.325781 328.325887 
-L 706.163437 328.325887 
+      <path d="M 41.325781 328.183088 
+L 706.163437 328.183088 
 " clip-path="url(#p314f927017)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m5e07181663" x="41.325781" y="328.325887" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m5e07181663" x="41.325781" y="328.183088" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
-      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #ffffff" x="34.325781" y="332.124715" transform="rotate(-0 34.325781 332.124715)">80</text>
+      <text style="font-size: 10px; font-family: 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: end; fill: #ffffff" x="34.325781" y="331.981916" transform="rotate(-0 34.325781 331.981916)">80</text>
      </g>
     </g>
     <g id="text_16">
@@ -267,101 +267,101 @@ L 706.163437 328.325887
     </g>
    </g>
    <g id="line2d_29">
-    <path d="M 71.545675 115.899742 
-L 73.060456 171.227869 
-L 74.575238 190.043449 
-L 76.09002 201.737713 
-L 77.604801 210.270594 
-L 79.119583 217.008174 
-L 80.634364 222.586555 
-L 82.149146 227.354115 
-L 83.663928 231.522511 
-L 85.178709 235.23001 
-L 86.693491 238.57193 
-L 89.723054 244.415426 
-L 92.752617 249.420986 
-L 95.782181 253.810247 
-L 98.811744 257.727094 
-L 100.326526 259.540448 
-L 101.841307 261.086734 
-L 106.385652 263.720757 
-L 110.929997 266.095454 
-L 116.989124 268.953212 
-L 123.04825 271.538785 
-L 130.622158 274.478117 
-L 138.196066 277.165191 
-L 147.284756 280.13182 
-L 157.888227 283.31659 
-L 168.491699 286.269304 
-L 180.609952 289.420765 
-L 194.242987 292.740998 
-L 209.390803 296.208874 
-L 227.568182 300.128059 
-L 247.260343 304.138996 
-L 269.982068 308.528836 
-L 295.733356 313.261652 
-L 324.514206 318.312197 
-L 356.324621 323.663531 
-L 392.67938 329.545703 
-L 433.578484 335.92853 
-L 479.021932 342.791052 
-L 530.524508 350.338355 
-L 588.08621 358.545136 
-L 653.22182 367.602341 
+    <path d="M 71.545675 115.864058 
+L 73.060456 171.164719 
+L 74.575238 189.97123 
+L 76.09002 201.660012 
+L 77.604801 210.189005 
+L 79.119583 216.923602 
+L 80.634364 222.499583 
+L 82.149146 227.265153 
+L 83.663928 231.43186 
+L 85.178709 235.137901 
+L 86.693491 238.478549 
+L 89.723054 244.319923 
+L 92.752617 249.323783 
+L 95.782181 253.711655 
+L 98.811744 257.627351 
+L 100.326526 259.440202 
+L 101.841307 260.98612 
+L 106.385652 263.62005 
+L 110.929997 265.994784 
+L 116.989124 268.852747 
+L 123.04825 271.438662 
+L 130.622158 274.378569 
+L 138.196066 277.066345 
+L 147.284756 280.033947 
+L 157.888227 283.219991 
+L 168.491699 286.174095 
+L 180.609952 289.327258 
+L 194.242987 292.649519 
+L 209.390803 296.11976 
+L 227.568182 300.041905 
+L 247.260343 304.056167 
+L 269.982068 308.449963 
+L 295.733356 313.187385 
+L 324.514206 318.243198 
+L 356.324621 323.600471 
+L 392.67938 329.489548 
+L 433.578484 335.880262 
+L 479.021932 342.751663 
+L 530.524508 350.309144 
+L 588.08621 358.527417 
+L 653.22182 367.59774 
 L 675.943544 370.71407 
 L 675.943544 370.71407 
 " clip-path="url(#p314f927017)" style="fill: none; stroke: #1f77b4; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="line2d_30">
-    <path d="M 71.545675 115.866172 
-L 73.060456 171.026116 
-L 74.575238 189.673513 
-L 76.09002 201.199594 
-L 77.604801 209.564292 
-L 79.119583 216.133689 
-L 80.634364 221.543886 
-L 82.149146 226.143263 
-L 83.663928 230.143476 
-L 85.178709 233.682791 
-L 86.693491 236.856529 
-L 88.208273 239.733189 
-L 91.237836 244.786774 
-L 94.267399 249.126008 
-L 97.296962 252.928059 
-L 100.326526 256.311397 
-L 101.841307 257.6895 
-L 106.385652 259.818974 
-L 110.929997 261.689121 
-L 115.474342 263.356301 
-L 121.533468 265.330616 
-L 127.592595 267.08006 
-L 135.166503 269.019465 
-L 142.740411 270.741451 
-L 151.829101 272.581708 
-L 162.432572 274.482699 
-L 174.550825 276.401502 
-L 188.18386 278.307734 
-L 203.331676 280.1809 
-L 219.994274 282.007885 
-L 238.171654 283.780872 
-L 259.378597 285.620071 
-L 283.615103 287.483576 
-L 310.881172 289.341132 
-L 341.176804 291.171875 
-L 374.502 292.962077 
-L 412.371541 294.771682 
-L 454.785426 296.573886 
-L 503.258439 298.404081 
-L 557.790577 300.232158 
-L 618.381842 302.037083 
-L 675.943544 303.575392 
-L 675.943544 303.575392 
+    <path d="M 71.545675 115.830423 
+L 73.060456 170.962575 
+L 74.575238 189.600576 
+L 76.09002 201.120849 
+L 77.604801 209.481332 
+L 79.119583 216.047419 
+L 80.634364 221.45489 
+L 82.149146 226.05195 
+L 83.663928 230.050147 
+L 85.178709 233.587679 
+L 86.693491 236.759817 
+L 88.208273 239.635028 
+L 91.237836 244.686067 
+L 94.267399 249.023114 
+L 97.296962 252.82325 
+L 100.326526 256.204883 
+L 101.841307 257.582292 
+L 106.385652 259.710693 
+L 110.929997 261.579897 
+L 115.474342 263.246237 
+L 121.533468 265.219558 
+L 127.592595 266.96812 
+L 135.166503 268.906548 
+L 142.740411 270.627666 
+L 151.829101 272.466996 
+L 162.432572 274.36703 
+L 174.550825 276.284865 
+L 188.18386 278.190137 
+L 203.331676 280.06236 
+L 219.994274 281.888424 
+L 238.171654 283.660517 
+L 259.378597 285.49879 
+L 283.615103 287.361355 
+L 310.881172 289.217976 
+L 341.176804 291.047796 
+L 374.502 292.837096 
+L 412.371541 294.645789 
+L 454.785426 296.447085 
+L 503.258439 298.276358 
+L 557.790577 300.103514 
+L 618.381842 301.90753 
+L 675.943544 303.445064 
+L 675.943544 303.445064 
 " clip-path="url(#p314f927017)" style="fill: none; stroke-dasharray: 5.18,2.24; stroke-dashoffset: 0; stroke: #8c8c8c; stroke-width: 1.4"/>
    </g>
    <g id="line2d_31">
     <path d="M 71.545675 45.079837 
-L 675.943544 112.184945 
-L 675.943544 112.184945 
+L 675.943544 112.315208 
+L 675.943544 112.315208 
 " clip-path="url(#p314f927017)" style="fill: none; stroke-dasharray: 1.6,2.64; stroke-dashoffset: 0; stroke: #d62728; stroke-width: 1.6"/>
    </g>
    <g id="patch_3">

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   report: the Wong & Zhu (1995) ITS-90 check tables pin the UNESCO and
   Del Grosso sound-speed refits at 17 printed grid points each (agreement
   within the printed 0.001 m/s resolution), the Francois & Garrison (1982,
-  Part II) Table IV pins the total seawater absorption at 18 printed points
+  Part II) Table IV pins the total seawater absorption at 21 printed points
   spanning 0.4 kHz-1 MHz (within half a unit of the last printed digit), and
   the Wales & Heitmeyer (2002) ensemble merchant-ship mean spectrum is pinned
   against the paper's printed closed form and asymptote statements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Underwater Francois-Garrison absorption used the Medwin & Clay textbook
+  transcription of the boric-acid factor (8.68/c); the original paper prints
+  8.86/c and only that value reproduces the paper's own Table IV (the
+  transcription biased boric-dominated bands at 0.6-30 kHz by up to 1.7 %).
 - ISO 10846-3 indirect method returned out-of-validity results silently:
   `transfer_stiffness_indirect` now computes the per-band transmissibility
   magnitude and emits a `PhonometryWarning` where |T| > 0,1 (Inequality (2):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Underwater printed-source oracles promoted to tests and the conformance
+  report: the Wong & Zhu (1995) ITS-90 check tables pin the UNESCO and
+  Del Grosso sound-speed refits at 17 printed grid points each (agreement
+  within the printed 0.001 m/s resolution), the Francois & Garrison (1982,
+  Part II) Table IV pins the total seawater absorption at 18 printed points
+  spanning 0.4 kHz-1 MHz (within half a unit of the last printed digit), and
+  the Wales & Heitmeyer (2002) ensemble merchant-ship mean spectrum is pinned
+  against the paper's printed closed form and asymptote statements
+  (exponents -3.6/-1.76, 340 Hz breakpoint).
 - `docs/ERRATA.md`: a versioned registry of the defects found in published
   standards and guidance documents during implementation (misprints, worked
   examples contradicting their own normative text, ambiguous wording), each

--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -15,7 +15,7 @@
 
 ## Numerical conformance report
 
-&#9989; **229/229 conformance checks pass** across 32 domains and 131 standards - filters class 1 - weightings within IEC 61672-1 class 1.
+&#9989; **232/232 conformance checks pass** across 32 domains and 134 standards - filters class 1 - weightings within IEC 61672-1 class 1.
 
 ### Numerical validation - filters &amp; weightings
 
@@ -449,7 +449,7 @@ Only **Butterworth** (the library default) and **Chebyshev-II** are class-compli
 </details>
 
 <details>
-<summary>&#9989; <b>Underwater sound propagation (transmission loss)</b> — 100% (12/12)</summary>
+<summary>&#9989; <b>Underwater sound propagation (transmission loss)</b> — 100% (15/15)</summary>
 
 | Standard | Quantity | Expected (norm) | Computed | &#916; | Status |
 |:---|:---|:---|:---|:---|:---:|
@@ -459,6 +459,9 @@ Only **Butterworth** (the library default) and **Chebyshev-II** are class-compli
 | Spherical spreading 20·lg(R) | Geometrical spreading loss at R = 1000 m, dB | 60 dB (+/-0 dB) | 60 dB | 0 dB | &#9989; |
 | Thorp (1967) absorption | Volume absorption α at 10 kHz (cold deep water), dB/km | 1.1498 dB/km (+/-0 dB/km) | 1.1498 dB/km | 0 dB/km | &#9989; |
 | Ainslie-McColm (1998) vs Francois-Garrison (1982) | Absorption agreement at 10 kHz, 10 °C, 35 ‰, 0 m, pH 8, dB/km | 0.9603 dB/km (+/-0.096 dB/km) | 0.9866 dB/km | 0.026 dB/km | &#9989; |
+| Francois-Garrison (1982) Part II Table IV | Absorption α at 100 kHz, 10 °C, 35 ‰, 0 m, pH 8 (printed value), dB/km | 33.6 dB/km (+/-0.05 dB/km) | 33.628 dB/km | 0.028 dB/km | &#9989; |
+| Del Grosso refit (Wong-Zhu 1995 Table IV) | c(t90 = 20 °C, S = 35, P = 500 bar) vs the printed check table, m/s | 1603.679 m/s (+/-0.001 m/s) | 1603.679 m/s | 0 m/s | &#9989; |
+| Wales-Heitmeyer (2002) ensemble spectrum | Merchant-ship source PSD at 100 Hz (printed equation), dB re 1 µPa²/Hz | 158.45 dB (+/-0.001 dB) | 158.45 dB | 0 dB | &#9989; |
 | Passive sonar equation (Urick/Etter) | Figure of merit SL − (NL − DI) − DT, dB | 85 dB (+/-0 dB) | 85 dB | 0 dB | &#9989; |
 | Seabed reflection (Rayleigh, normal incidence) | Bottom loss at 90° grazing, sand ρ=1900 c=1650 over water, dB | 9.0506 dB (+/-0 dB) | 9.0506 dB | 0 dB | &#9989; |
 | Wenz wind noise (rule of fives) | Wind spectrum level at 1 kHz, 5 kn (canonical anchor), dB re 1 µPa²/Hz | 51.0206 dB (+/-0.0001 dB) | 51.0206 dB | 0 dB | &#9989; |

--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -458,8 +458,8 @@ Only **Butterworth** (the library default) and **Chebyshev-II** are class-compli
 | Del Grosso (1974) vs Mackenzie | Sound-speed agreement at 10 °C, 35 ‰, 1000 m (cross-model), m/s | 1506.264 m/s (+/-1 m/s) | 1506.313 m/s | 0.049 m/s | &#9989; |
 | Spherical spreading 20·lg(R) | Geometrical spreading loss at R = 1000 m, dB | 60 dB (+/-0 dB) | 60 dB | 0 dB | &#9989; |
 | Thorp (1967) absorption | Volume absorption α at 10 kHz (cold deep water), dB/km | 1.1498 dB/km (+/-0 dB/km) | 1.1498 dB/km | 0 dB/km | &#9989; |
-| Ainslie-McColm (1998) vs Francois-Garrison (1982) | Absorption agreement at 10 kHz, 10 °C, 35 ‰, 0 m, pH 8, dB/km | 0.9603 dB/km (+/-0.096 dB/km) | 0.9866 dB/km | 0.026 dB/km | &#9989; |
-| Francois-Garrison (1982) Part II Table IV | Absorption α at 100 kHz, 10 °C, 35 ‰, 0 m, pH 8 (printed value), dB/km | 33.6 dB/km (+/-0.05 dB/km) | 33.628 dB/km | 0.028 dB/km | &#9989; |
+| Ainslie-McColm (1998) vs Francois-Garrison (1982) | Absorption agreement at 10 kHz, 10 °C, 35 ‰, 0 m, pH 8, dB/km | 0.9626 dB/km (+/-0.0963 dB/km) | 0.9866 dB/km | 0.024 dB/km | &#9989; |
+| Francois-Garrison (1982) Part II Table IV | Absorption α at 100 kHz, 10 °C, 35 ‰, 0 m, pH 8 (printed value), dB/km | 33.6 dB/km (+/-0.05 dB/km) | 33.63 dB/km | 0.03 dB/km | &#9989; |
 | Del Grosso refit (Wong-Zhu 1995 Table IV) | c(t90 = 20 °C, S = 35, P = 500 bar) vs the printed check table, m/s | 1603.679 m/s (+/-0.001 m/s) | 1603.679 m/s | 0 m/s | &#9989; |
 | Wales-Heitmeyer (2002) ensemble spectrum | Merchant-ship source PSD at 100 Hz (printed equation), dB re 1 µPa²/Hz | 158.45 dB (+/-0.001 dB) | 158.45 dB | 0 dB | &#9989; |
 | Passive sonar equation (Urick/Etter) | Figure of merit SL − (NL − DI) − DT, dB | 85 dB (+/-0 dB) | 85 dB | 0 dB | &#9989; |

--- a/docs/ERRATA.md
+++ b/docs/ERRATA.md
@@ -1,14 +1,18 @@
 ← [Documentation index](README.md)
 
-# Errata found in published standards and guidance documents
+# Errata found in published sources
 
 During the clean-room implementation of this library, every formula, constant
 and worked example is re-derived and recomputed independently from the source
 documents. That process occasionally surfaces defects in the sources
 themselves: misprints, worked examples that contradict their own normative
 text, and ambiguous wording. This file records each confirmed case with the
-evidence, what the library does about it, and whether it has been reported to
-the issuing body.
+evidence, what the library does about it, and whether it has been reported.
+
+The registry covers every kind of published source the library implements
+from: standards (ISO, IEC, EN), guidance documents and technical reports
+(EASA, ECAC, NRL), textbooks and journal papers. Non-normative sources are
+marked as such in their entry.
 
 Entries describe the specific printed editions cited. A defect listed here is
 not a defect of the method; in every case the intended reading could be

--- a/docs/ERRATA.md
+++ b/docs/ERRATA.md
@@ -196,6 +196,22 @@ to the issuing body, with date and reference).
   excludes the contradicting cells with the rationale in the test.
 - **Status:** unreported (technical report rather than a standard).
 
+## Medwin & Clay, Fundamentals of Acoustical Oceanography (1998) — Eq. 3.4.29
+
+- **Location:** the Francois-Garrison boric-acid term as transcribed by the
+  textbook (Eq. 3.4.29).
+- **The print:** the boric-acid factor is printed as A1 = (8,68/c)·10^(0,78 pH − 5).
+- **The problem:** the original paper (Francois & Garrison 1982, JASA 72,
+  Part II, Eq. (10) and Fig. 7) prints 8,86; the digits are transposed. Only
+  8,86 reproduces the paper's own Table IV: with 8,68 the boric-dominated
+  cells at 0,6 to 30 kHz sit up to 1,7 % below the printed totals (worst
+  relative case 2 kHz, 10 °C, S = 35: 0,1209 vs the printed 0,123 dB/km).
+- **Evidence:** recomputation of all sampled Table IV cells under both
+  coefficients against the paper's printed values.
+- **Library behaviour:** implements the paper's 8,86 with a defensive note;
+  the pinned Table IV set includes the boric-dominated rows.
+- **Status:** unreported (textbook rather than a standard).
+
 ---
 
 ## Related source properties that are not errata

--- a/scripts/conformance_report.py
+++ b/scripts/conformance_report.py
@@ -3483,6 +3483,47 @@ def _chk_uwp_absorption_agreement() -> Outcome:
 
 @register(
     _UW_PROP,
+    "Francois-Garrison (1982) Part II Table IV",
+    "Absorption α at 100 kHz, 10 °C, 35 ‰, 0 m, pH 8 (printed value), dB/km",
+)
+def _chk_uwp_fg_printed_table() -> Outcome:
+    # Oracle: the printed absorption table of the source paper (J. Acoust.
+    # Soc. Am. 72(6), 1982); tolerance is half a unit of the last printed
+    # digit, i.e. the print's own rounding.
+    kw = dict(temperature=10.0, salinity=35.0, depth=0.0, ph=8.0)
+    got = float(ph.seawater_absorption(100_000.0, model="francois-garrison", **kw)[0])
+    return numeric(33.6, got, 0.05, unit="dB/km", places=3)
+
+
+@register(
+    _UW_PROP,
+    "Del Grosso refit (Wong-Zhu 1995 Table IV)",
+    "c(t90 = 20 °C, S = 35, P = 500 bar) vs the printed check table, m/s",
+)
+def _chk_uwp_del_grosso_printed_check() -> Outcome:
+    # Oracle: the printed ITS-90 check table of the refit the module
+    # implements (J. Acoust. Soc. Am. 97(3), 1995); the table lists pressure
+    # in bars, Del Grosso's polynomial takes kg/cm² (1 bar = 1.019716 kg/cm²).
+    from phonometry.underwater.sound_speed import _del_grosso
+
+    got = float(_del_grosso(20.0, 35.0, 500.0 * 1.019716))
+    return numeric(1603.679, got, 1e-3, unit="m/s", places=3)
+
+
+@register(
+    _UW_PROP,
+    "Wales-Heitmeyer (2002) ensemble spectrum",
+    "Merchant-ship source PSD at 100 Hz (printed equation), dB re 1 µPa²/Hz",
+)
+def _chk_uwp_wales_heitmeyer() -> Outcome:
+    # Oracle: the mean-spectrum closed form printed in J. Acoust. Soc. Am.
+    # 111(3), 2002, hand-evaluated at 100 Hz.
+    s = ph.ship_source_spectrum(model="wales-heitmeyer", frequency_hz=[100.0])
+    return numeric(158.4504, float(s.source_psd[0]), 1e-3, unit="dB", places=3)
+
+
+@register(
+    _UW_PROP,
     "Passive sonar equation (Urick/Etter)",
     "Figure of merit SL − (NL − DI) − DT, dB",
 )

--- a/src/phonometry/underwater/propagation.py
+++ b/src/phonometry/underwater/propagation.py
@@ -99,7 +99,11 @@ def _francois_garrison(
     f_khz: "NDArray[np.float64]", t: float, s: float, z_m: float, ph: float
 ) -> "NDArray[np.float64]":
     c = 1412.0 + 3.21 * t + 1.19 * s + 0.0167 * z_m
-    a1 = (8.68 / c) * 10.0 ** (0.78 * ph - 5.0)
+    # Boric-acid factor A1 = (8.86/c)*10^(0.78 pH - 5) per the original paper
+    # (Francois & Garrison 1982 Part II, Eq. (10)/Fig. 7), whose own Table IV
+    # reproduces only with 8.86; the Medwin & Clay transcription prints 8.68
+    # (digit transposition), biasing boric-dominated bands by up to 1.7 %.
+    a1 = (8.86 / c) * 10.0 ** (0.78 * ph - 5.0)
     f1 = 2.8 * (s / 35.0) ** 0.5 * 10.0 ** (4.0 - 1245.0 / (273.0 + t))
     a2 = 21.44 * (s / c) * (1.0 + 0.025 * t)
     p2 = 1.0 - 1.37e-4 * z_m + 6.2e-9 * z_m**2

--- a/tests/underwater/test_ship_traffic_noise.py
+++ b/tests/underwater/test_ship_traffic_noise.py
@@ -3,8 +3,9 @@
 
 Oracle for JOMOPANS-ECHO: the authors' own Excel reference implementation
 (File S1 of MacGillivray & de Jong 2021), cached values for a Bulker sailing at
-13.5 kn with length 211 m, in decidecade bands. RANDI and Wales-Heitmeyer are
-checked for their qualitative source-model behaviour.
+13.5 kn with length 211 m, in decidecade bands. RANDI is pinned against the
+printed Table 2 of the RANDI 3.1 physics report, and Wales-Heitmeyer against
+the mean-spectrum equation and asymptote statements printed in the 2002 paper.
 """
 
 from __future__ import annotations
@@ -78,6 +79,49 @@ def test_randi_and_wales_heitmeyer_run() -> None:
     # Both give physically plausible source PSD near 100-160 dB at 1 kHz.
     assert 100.0 < _at(r, 1000.0)[0] < 200.0
     assert 100.0 < _at(w, 1000.0)[0] < 200.0
+
+
+# Wales & Heitmeyer, J. Acoust. Soc. Am. 111 (3), 2002: the printed ensemble
+# mean-spectrum equation S(f) = 230.0 - 10 lg(f^3.594)
+# + 10 lg((1 + (f/340)^2)^0.917), dB re 1 uPa^2/Hz at 1 m, valid 30-1200 Hz
+# (factual reference values). Anchors below are hand-evaluated from that
+# printed closed form at frequencies spanning the validity band.
+_WALES_HEITMEYER_EQ = [
+    (30.0, 176.9431),
+    (50.0, 169.0242),
+    (100.0, 158.4504),
+    (200.0, 148.4844),
+    (340.0, 141.7791),  # printed breakpoint frequency
+    (400.0, 139.9420),
+    (600.0, 135.7862),
+    (1000.0, 131.2083),
+    (1200.0, 129.6866),
+]
+
+
+def test_wales_heitmeyer_printed_equation_values() -> None:
+    freqs = [f for f, _ in _WALES_HEITMEYER_EQ]
+    s = ship_source_spectrum(model="wales-heitmeyer", frequency_hz=freqs)
+    for (_, psd_ref), psd in zip(_WALES_HEITMEYER_EQ, s.source_psd):
+        assert float(psd) == pytest.approx(psd_ref, abs=1e-3)
+
+
+def test_wales_heitmeyer_printed_asymptotes() -> None:
+    # The paper states the low-frequency power-law exponent is -3.6, the
+    # high-frequency exponent -1.76 (= 3.594 - 2 x 0.917) and the breakpoint
+    # between the asymptotes 340 Hz.
+    lo = ship_source_spectrum(model="wales-heitmeyer", frequency_hz=[30.0, 60.0])
+    lo_exp = float(lo.source_psd[1] - lo.source_psd[0]) / (10.0 * np.log10(2.0))
+    assert lo_exp == pytest.approx(-3.6, abs=0.05)
+    hi = ship_source_spectrum(model="wales-heitmeyer", frequency_hz=[6800.0, 13600.0])
+    hi_exp = float(hi.source_psd[1] - hi.source_psd[0]) / (10.0 * np.log10(2.0))
+    assert hi_exp == pytest.approx(-1.76, abs=0.01)
+    # At the 340 Hz breakpoint the correction term lifts the pure power law
+    # by 10 lg(2^0.917) = 2.7604 dB.
+    at = ship_source_spectrum(model="wales-heitmeyer", frequency_hz=[340.0])
+    power_law_only = 230.0 - 10.0 * 3.594 * np.log10(340.0)
+    assert float(at.source_psd[0]) - power_law_only == pytest.approx(
+        10.0 * np.log10(2.0**0.917), abs=1e-9)
 
 
 def test_wales_heitmeyer_ignores_speed_and_length() -> None:

--- a/tests/underwater/test_underwater_propagation.py
+++ b/tests/underwater/test_underwater_propagation.py
@@ -1,7 +1,8 @@
 #  Copyright (c) 2026. Jose M. Requena-Plens
 """Tests for underwater transmission loss (spreading + volume absorption).
 
-Oracles: the closed-form spreading laws (hand recomputation), the Thorp,
+Oracles: the printed Francois & Garrison (1982, Part II) Table IV absorption
+values, the closed-form spreading laws (hand recomputation), the Thorp,
 Francois-Garrison and Ainslie-McColm absorption formulae (independent inline
 recomputation), and the mutual agreement of Francois-Garrison and Ainslie-McColm
 (the latter's paper states within 10 % of the former).
@@ -54,8 +55,59 @@ def test_thorp_absorption_recompute() -> None:
     assert got[0] == pytest.approx(1.1498, abs=1e-3)
 
 
+# Francois & Garrison, J. Acoust. Soc. Am. 72 (6), 1982, Part II, Table IV:
+# total absorption alpha in dB/km at depth 0, pH 8 (factual reference values,
+# transcribed from the printed page and cross-checked by recomputation).
+# Points selected to span 0.4 kHz - 1 MHz, -1.8 to 30 degC and both tabulated
+# salinities; each entry carries the unit of its last printed digit (ULP) and
+# the module agrees within half of it, i.e. to the print's own rounding
+# (measured max |dev| 0.45 ULP).
+#
+# NOTE (documented discrepancy, not tested): the module implements the
+# Medwin & Clay transcription with the boric-acid factor A1 = (8.68/c)
+# x 10^(0.78 pH - 5), while the paper's Fig. 7 / Eq. (10) print 8.86/c. With
+# 8.86 every Table IV cell agrees within 0.5 ULP; with 8.68 the boric-
+# dominated cells at 0.6-30 kHz sit up to 4.6 ULP below the print (worst
+# 10 kHz, 30 degC, S = 35: 0.6014 vs the printed 0.606 dB/km; largest
+# relative gap -1.7 % at 2 kHz, 10 degC, S = 35: 0.1209 vs 0.123). Those
+# cells are therefore excluded here rather than forced.
+_FG_TABLE_IV = [
+    # (f kHz, T degC, S ppt, alpha dB/km, ULP)
+    (0.4, 10.0, 30.0, 0.015, 0.001),
+    (10.0, -1.8, 35.0, 1.36, 0.01),
+    (14.0, 20.0, 35.0, 1.29, 0.01),
+    (20.0, -1.8, 35.0, 4.40, 0.01),
+    (20.0, 10.0, 35.0, 3.35, 0.01),
+    (40.0, 4.0, 35.0, 11.5, 0.1),
+    (50.0, 20.0, 35.0, 13.0, 0.1),
+    (60.0, -1.8, 30.0, 13.6, 0.1),
+    (80.0, 16.0, 35.0, 28.6, 0.1),
+    (100.0, 0.0, 30.0, 21.0, 0.1),
+    (100.0, 10.0, 35.0, 33.6, 0.1),
+    (140.0, 25.0, 35.0, 58.4, 0.1),
+    (200.0, 0.0, 35.0, 40.6, 0.1),
+    (200.0, 30.0, 30.0, 79.3, 0.1),
+    (300.0, 10.0, 35.0, 73.1, 0.1),
+    (500.0, 10.0, 35.0, 125.0, 1.0),
+    (700.0, 4.0, 35.0, 228.0, 1.0),
+    (1000.0, 0.0, 30.0, 513.0, 1.0),
+    (1000.0, 30.0, 35.0, 344.0, 1.0),
+]
+
+
+@pytest.mark.parametrize(("f_khz", "t", "s", "alpha_ref", "ulp"), _FG_TABLE_IV)
+def test_francois_garrison_part2_table_iv_printed_values(
+    f_khz: float, t: float, s: float, alpha_ref: float, ulp: float,
+) -> None:
+    got = seawater_absorption(f_khz * 1000.0, temperature=t, salinity=s,
+                              depth=0.0, ph=8.0, model="francois-garrison")
+    assert float(got[0]) == pytest.approx(alpha_ref, abs=0.5 * ulp)
+
+
 def test_francois_garrison_recompute() -> None:
     # Independent inline recomputation at 10 kHz, 10 C, 35 ppt, 0 m, pH 8.
+    # (8.68 is the Medwin & Clay transcription the module implements; the
+    # paper's own Fig. 7 prints 8.86 -- see the note above _FG_TABLE_IV.)
     f = 10.0
     t, s, z, ph = 10.0, 35.0, 0.0, 8.0
     c = 1412 + 3.21 * t + 1.19 * s + 0.0167 * z

--- a/tests/underwater/test_underwater_propagation.py
+++ b/tests/underwater/test_underwater_propagation.py
@@ -63,17 +63,16 @@ def test_thorp_absorption_recompute() -> None:
 # the module agrees within half of it, i.e. to the print's own rounding
 # (measured max |dev| 0.45 ULP).
 #
-# NOTE (documented discrepancy, not tested): the module implements the
-# Medwin & Clay transcription with the boric-acid factor A1 = (8.68/c)
-# x 10^(0.78 pH - 5), while the paper's Fig. 7 / Eq. (10) print 8.86/c. With
-# 8.86 every Table IV cell agrees within 0.5 ULP; with 8.68 the boric-
-# dominated cells at 0.6-30 kHz sit up to 4.6 ULP below the print (worst
-# 10 kHz, 30 degC, S = 35: 0.6014 vs the printed 0.606 dB/km; largest
-# relative gap -1.7 % at 2 kHz, 10 degC, S = 35: 0.1209 vs 0.123). Those
-# cells are therefore excluded here rather than forced.
+# The module implements the ORIGINAL paper's boric-acid factor A1 = (8.86/c)
+# x 10^(0.78 pH - 5) (Eq. (10)/Fig. 7); the Medwin & Clay transcription
+# prints 8.68 (digit transposition), which sits up to 4.6 ULP below the
+# print in the boric-dominated 0.6-30 kHz cells (see docs/ERRATA.md). The
+# boric-dominated rows below therefore pin the corrected constant directly.
 _FG_TABLE_IV = [
     # (f kHz, T degC, S ppt, alpha dB/km, ULP)
     (0.4, 10.0, 30.0, 0.015, 0.001),
+    (2.0, 10.0, 35.0, 0.123, 0.001),   # boric-dominated
+    (10.0, 30.0, 35.0, 0.606, 0.001),  # boric-dominated
     (10.0, -1.8, 35.0, 1.36, 0.01),
     (14.0, 20.0, 35.0, 1.29, 0.01),
     (20.0, -1.8, 35.0, 4.40, 0.01),
@@ -105,13 +104,14 @@ def test_francois_garrison_part2_table_iv_printed_values(
 
 
 def test_francois_garrison_recompute() -> None:
-    # Independent inline recomputation at 10 kHz, 10 C, 35 ppt, 0 m, pH 8.
-    # (8.68 is the Medwin & Clay transcription the module implements; the
-    # paper's own Fig. 7 prints 8.86 -- see the note above _FG_TABLE_IV.)
+    # Independent inline recomputation at 10 kHz, 10 C, 35 ppt, 0 m, pH 8,
+    # with the ORIGINAL paper's boric coefficient 8.86 (F&G 1982 Part II,
+    # Eq. (10)/Fig. 7; the Medwin & Clay transcription prints 8.68, a digit
+    # transposition -- see the note above _FG_TABLE_IV and docs/ERRATA.md).
     f = 10.0
     t, s, z, ph = 10.0, 35.0, 0.0, 8.0
     c = 1412 + 3.21 * t + 1.19 * s + 0.0167 * z
-    a1 = (8.68 / c) * 10 ** (0.78 * ph - 5)
+    a1 = (8.86 / c) * 10 ** (0.78 * ph - 5)
     f1 = 2.8 * (s / 35) ** 0.5 * 10 ** (4 - 1245 / (273 + t))
     a2 = 21.44 * (s / c) * (1 + 0.025 * t)
     f2 = 8.17 * 10 ** (8 - 1990 / (273 + t)) / (1 + 0.0018 * (s - 35))

--- a/tests/underwater/test_underwater_sound_speed.py
+++ b/tests/underwater/test_underwater_sound_speed.py
@@ -1,9 +1,11 @@
 #  Copyright (c) 2026. Jose M. Requena-Plens
 """Tests for the speed of sound in sea water (UNESCO / Del Grosso / Mackenzie).
 
-Oracles: the canonical Mackenzie check value 1550.744 m/s (published, absolute),
-mutual agreement of the three independent equations within their common domain,
-and the Leroy & Parthiot standard-ocean pressure.
+Oracles: the printed Wong & Zhu (1995) ITS-90 check tables (Tables III and IV,
+the exact refit the module implements), the canonical Mackenzie check value
+1550.744 m/s (published, absolute), mutual agreement of the three independent
+equations within their common domain, and the Leroy & Parthiot standard-ocean
+pressure.
 """
 
 from __future__ import annotations
@@ -16,10 +18,77 @@ import pytest
 
 from phonometry.underwater.sound_speed import (
     SoundSpeedProfile,
+    _del_grosso,
+    _unesco,
     depth_to_pressure,
     sea_water_sound_speed,
     sound_speed_profile,
 )
+
+# Wong & Zhu, J. Acoust. Soc. Am. 97 (3), 1995, Table III: speed of sound in
+# sea water (m/s) from the t90-corrected UNESCO/Chen-Millero polynomial
+# (factual reference values, transcribed from the printed page and
+# cross-checked by recomputation). Grid: (pressure bar, t90 degC, S PSU, m/s).
+_WONG_ZHU_TABLE_III = [
+    (0, 0, 25, 1435.790),
+    (100, 10, 25, 1494.127),
+    (500, 20, 25, 1593.613),
+    (1000, 40, 25, 1719.171),
+    (0, 30, 30, 1540.416),
+    (200, 0, 30, 1475.448),
+    (600, 20, 30, 1615.686),
+    (1000, 10, 30, 1653.261),
+    (0, 0, 35, 1449.139),
+    (300, 30, 35, 1595.909),
+    (500, 20, 35, 1604.492),
+    (900, 40, 35, 1712.175),
+    (1000, 0, 35, 1623.150),
+    (0, 40, 40, 1568.141),
+    (400, 10, 40, 1562.547),
+    (700, 30, 40, 1666.500),
+    (1000, 20, 40, 1692.195),
+]
+
+# Wong & Zhu 1995, Table IV: same check grid for the t90-corrected Del Grosso
+# polynomial (factual reference values). The table lists pressure in bars;
+# Del Grosso's equation takes kg/cm2 (1 bar = 1.019716 kg/cm2).
+_WONG_ZHU_TABLE_IV = [
+    (0, 0, 25, 1435.711),
+    (100, 10, 25, 1494.457),
+    (500, 20, 25, 1597.743),
+    (1000, 40, 25, 1734.533),
+    (0, 40, 30, 1558.221),
+    (200, 0, 30, 1475.105),
+    (500, 30, 30, 1622.209),
+    (1000, 10, 30, 1653.848),
+    (0, 0, 35, 1449.083),
+    (300, 30, 35, 1593.159),
+    (500, 20, 35, 1603.679),
+    (900, 40, 35, 1704.948),
+    (1000, 0, 35, 1622.269),
+    (0, 40, 40, 1568.053),
+    (400, 10, 40, 1562.595),
+    (700, 30, 40, 1665.789),
+    (1000, 20, 40, 1695.212),
+]
+
+
+@pytest.mark.parametrize(("p_bar", "t90", "s", "c_ref"), _WONG_ZHU_TABLE_III)
+def test_unesco_wong_zhu_table_iii_printed_check_values(
+    p_bar: float, t90: float, s: float, c_ref: float,
+) -> None:
+    # The module implements exactly this refit, so it must agree at the
+    # table's printed resolution (0.001 m/s; measured max |dev| 0.0005 m/s).
+    assert float(_unesco(t90, s, p_bar)) == pytest.approx(c_ref, abs=1e-3)
+
+
+@pytest.mark.parametrize(("p_bar", "t90", "s", "c_ref"), _WONG_ZHU_TABLE_IV)
+def test_del_grosso_wong_zhu_table_iv_printed_check_values(
+    p_bar: float, t90: float, s: float, c_ref: float,
+) -> None:
+    # Same printed-decimal tolerance (measured max |dev| 0.0005 m/s).
+    assert float(_del_grosso(t90, s, p_bar * 1.019716)) == pytest.approx(
+        c_ref, abs=1e-3)
 
 
 def test_mackenzie_canonical_check_value() -> None:
@@ -90,7 +159,5 @@ def test_unesco_published_canonical_check_value() -> None:
     # SVEL(S = 40, T68 = 40 C, P = 10000 dbar) = 1731.995 m/s. The module uses
     # the Wong-Zhu ITS-90 refit, so convert T90 = T68/1.00024; the tolerance
     # covers the published refit residual (~0.01 m/s).
-    from phonometry.underwater.sound_speed import _unesco
-
     assert float(_unesco(40.0 / 1.00024, 40.0, 1000.0)) == pytest.approx(
         1731.995, abs=0.02)

--- a/tests/underwater/test_underwater_sound_speed.py
+++ b/tests/underwater/test_underwater_sound_speed.py
@@ -17,6 +17,7 @@ import numpy as np
 import pytest
 
 from phonometry.underwater.sound_speed import (
+    _KGCM2_PER_BAR,
     SoundSpeedProfile,
     _del_grosso,
     _unesco,
@@ -51,7 +52,7 @@ _WONG_ZHU_TABLE_III = [
 
 # Wong & Zhu 1995, Table IV: same check grid for the t90-corrected Del Grosso
 # polynomial (factual reference values). The table lists pressure in bars;
-# Del Grosso's equation takes kg/cm2 (1 bar = 1.019716 kg/cm2).
+# Del Grosso's equation takes kg/cm2 (1 bar = _KGCM2_PER_BAR kg/cm2).
 _WONG_ZHU_TABLE_IV = [
     (0, 0, 25, 1435.711),
     (100, 10, 25, 1494.457),
@@ -87,7 +88,7 @@ def test_del_grosso_wong_zhu_table_iv_printed_check_values(
     p_bar: float, t90: float, s: float, c_ref: float,
 ) -> None:
     # Same printed-decimal tolerance (measured max |dev| 0.0005 m/s).
-    assert float(_del_grosso(t90, s, p_bar * 1.019716)) == pytest.approx(
+    assert float(_del_grosso(t90, s, p_bar * _KGCM2_PER_BAR)) == pytest.approx(
         c_ref, abs=1e-3)
 
 


### PR DESCRIPTION
Pins the underwater models to the printed tables of their original papers, and fixes a real constant the pinning exposed.

## Fixed

- **Francois-Garrison boric-acid coefficient.** The module carried the Medwin & Clay textbook transcription A1 = (8.68/c) 10^(0.78 pH - 5); the original paper (Francois & Garrison 1982, JASA 72, Part II, Eq. (10) and Fig. 7) prints 8.86, a digit transposition in the textbook. Only 8.86 reproduces the paper's own Table IV: with the transcription the boric-dominated 0.6-30 kHz cells sit up to 1.7 percent below the printed totals. The corrected constant is pinned by the boric-dominated Table IV rows and recorded in docs/ERRATA.md.

## Added

- **Printed-source oracles for the underwater domain**, from the original papers:
  - Francois & Garrison 1982 Part II, Table IV: 21 printed total-absorption values spanning 0.4 kHz to 1 MHz, -1.8 to 30 C and both tabulated salinities, each within half a unit of its last printed digit.
  - Wong & Zhu 1995 check tables: 17 + 17 printed grid points pinning the UNESCO/Chen-Millero and Del Grosso ITS-90 refits to the print's 0.001 m/s resolution (measured max deviation 0.0005 m/s), including the bar-to-kg/cm2 pressure conversion.
  - Wales & Heitmeyer 2002: the printed ensemble mean-spectrum closed form pinned at nine frequencies across the stated 30-1200 Hz validity, plus the paper's asymptote statements (exponents -3.6 and -1.76, 340 Hz breakpoint).
  - One representative conformance check per paper (232 checks total).

Full suite green (2911 tests), ruff and mypy clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the Francois–Garrison boric-acid coefficient used for seawater absorption, improving alignment with published reference tables and associated transmission-loss outcomes.

- **Documentation**
  - Updated errata guidance and added an entry for a corrected boric-acid term in *Medwin & Clay (1998)*.
  - Expanded conformance reporting for underwater sound propagation and transmission loss.

- **Tests**
  - Strengthened validation against published underwater acoustics check tables, including seawater absorption, sound-speed refits, and ship-source noise spectra (with added oracle coverage and tighter conformance expectations).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->