### PR TITLE
perf: vectorise ECMA-418-2 per-band loops with bit-identical output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -227,6 +227,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- ECMA-418-2 chain: the per-lag Python loop of the unbiased ACF
+  normalization (Formulae 27-29) is now column-vectorised, the Clause 6.2.3
+  neighbour-band averaging accumulates without the stacked copy, the block
+  RMS reuses the ACF energy array, and the roughness Clause 7.1.7 pchip
+  interpolation runs all 53 bands in one call. Outputs are bit-identical
+  (guarded by bitwise equivalence tests against retained reference loops and
+  the golden baseline); on the 0.5 s bench signal `loudness_ecma` drops from
+  2.78 s to 2.00 s, `tonality_ecma` from 2.74 s to 2.01 s and
+  `roughness_ecma` from 0.24 s to 0.23 s. The remaining runtime is the
+  standard-mandated 16384-point DFTs, which no bit-preserving reformulation
+  (rfft, one-sided magnitudes, batched or alternative FFT backends) can
+  reduce.
 - ECAC Doc 29 `noise_contour` now evaluates the grid with one vectorised pass
   per flight-path segment instead of a per-point Python loop; numerically
   identical (guarded by the golden baseline and a scalar-equivalence test)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -229,8 +229,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - ECMA-418-2 chain: the per-lag Python loop of the unbiased ACF
   normalization (Formulae 27-29) is now column-vectorised, the Clause 6.2.3
-  neighbour-band averaging accumulates without the stacked copy, the block
-  RMS reuses the ACF energy array, and the roughness Clause 7.1.7 pchip
+  neighbour-band averaging accumulates without the stacked copy, the ACF
+  normalization reuses the block-RMS energy array, and the roughness
+  Clause 7.1.7 pchip
   interpolation runs all 53 bands in one call. Outputs are bit-identical
   (guarded by bitwise equivalence tests against retained reference loops and
   the golden baseline); on the 0.5 s bench signal `loudness_ecma` drops from

--- a/src/phonometry/psychoacoustics/loudness_ecma.py
+++ b/src/phonometry/psychoacoustics/loudness_ecma.py
@@ -326,27 +326,32 @@ def _specific_basis_loudness(rms: np.ndarray, band: int) -> np.ndarray:
 # --------------------------------------------------------------------------
 
 
-def _band_acf(rect: np.ndarray, s_b: int) -> np.ndarray:
+def _band_acf(rect: np.ndarray, s_b: int, energy: np.ndarray | None = None) -> np.ndarray:
     """Unbiased, normalized ACF of the rectified blocks (Formulae 27-29).
 
     ``rect`` is (n_blocks, s_b). Returns phi_z(m) of shape
     ``(n_blocks, 2*s_b)`` with valid values for 0 <= m < 3/4 s_b.
+    ``energy`` optionally passes a precomputed ``rect**2``.
     """
     n_fft = 2 * s_b
     spec = np.fft.fft(rect, n=n_fft, axis=1)
     unscaled = np.real(np.fft.ifft(np.abs(spec) ** 2, axis=1))  # Formula 27/28
     # Cumulative block energy from both ends for the unbiased normalization.
-    energy = rect**2
+    if energy is None:
+        energy = rect**2
     csum = np.cumsum(energy[:, ::-1], axis=1)[:, ::-1]  # sum_{n'>=m} p^2(n')
-    m_max = (3 * s_b) // 4
+    m_max = (3 * s_b) // 4  # 0 <= m < m_max < s_b
     out = np.zeros_like(unscaled)
-    # sum_{n'=0..s_b-m-1} p^2(n') = total - sum_{n'>=s_b-m}
-    total = csum[:, 0:1]
-    for m in range(m_max):
-        left = total[:, 0] - (csum[:, s_b - m] if (s_b - m) < s_b else 0.0)
-        right = csum[:, m] if m < s_b else 0.0
-        denom = np.sqrt(left * right + _EPS)
-        out[:, m] = unscaled[:, m] / denom
+    # sum_{n'=0..s_b-m-1} p^2(n') = total - sum_{n'>=s_b-m}; the lag loop is
+    # written as elementwise column arithmetic (bit-identical to a per-lag
+    # loop): m = 0 keeps the full energy, m >= 1 subtracts csum[:, s_b - m].
+    total = csum[:, 0]
+    left = np.empty((rect.shape[0], m_max))
+    left[:, 0] = total
+    left[:, 1:] = total[:, None] - csum[:, s_b - m_max + 1 : s_b][:, ::-1]
+    right = csum[:, :m_max]
+    denom = np.sqrt(left * right + _EPS)
+    out[:, :m_max] = unscaled[:, :m_max] / denom
     return out
 
 
@@ -370,9 +375,10 @@ def _scaled_acf_at(
         return cached
     seg = _segment_bs(p_bands[band], block_size, n_new)
     rect = np.where(seg > 0.0, seg, 0.0)  # Formula 21
-    rms = np.sqrt((2.0 / block_size) * np.sum(rect**2, axis=1))  # Formula 22
+    energy = rect**2  # shared by Formula 22 and the ACF normalization
+    rms = np.sqrt((2.0 / block_size) * np.sum(energy, axis=1))  # Formula 22
     basis = _specific_basis_loudness(rms, band)  # Formulae 23-25
-    acf = _band_acf(rect, block_size)  # Formulae 27-29
+    acf = _band_acf(rect, block_size, energy)  # Formulae 27-29
     scaled = np.asarray(acf * basis[:, None], dtype=np.float64)  # Formula 30
     cache[key] = scaled
     return scaled
@@ -411,11 +417,13 @@ def _average_bands_full(
         if reach == 0:
             out.append(native)
             continue
-        stack = [
-            _scaled_acf_at(p_bands, band + off, block_size, n_new, cache)
-            for off in range(-reach, reach + 1)
-        ]
-        out.append(np.mean(np.stack(stack, axis=0), axis=0))
+        # Sequential accumulation; bit-identical to np.mean over a stacked
+        # axis for <= 8 terms (below numpy's pairwise-summation block) while
+        # avoiding the stacked copy.
+        acc = _scaled_acf_at(p_bands, band - reach, block_size, n_new, cache).copy()
+        for off in range(-reach + 1, reach + 1):
+            acc += _scaled_acf_at(p_bands, band + off, block_size, n_new, cache)
+        out.append(acc / float(2 * reach + 1))
     return out
 
 

--- a/src/phonometry/psychoacoustics/loudness_ecma.py
+++ b/src/phonometry/psychoacoustics/loudness_ecma.py
@@ -345,8 +345,10 @@ def _band_acf(rect: np.ndarray, s_b: int, energy: np.ndarray | None = None) -> n
     # sum_{n'=0..s_b-m-1} p^2(n') = total - sum_{n'>=s_b-m}; the lag loop is
     # written as elementwise column arithmetic (bit-identical to a per-lag
     # loop): m = 0 keeps the full energy, m >= 1 subtracts csum[:, s_b - m].
+    if m_max == 0:
+        return out
     total = csum[:, 0]
-    left = np.empty((rect.shape[0], m_max))
+    left = np.empty((rect.shape[0], m_max), dtype=csum.dtype)
     left[:, 0] = total
     left[:, 1:] = total[:, None] - csum[:, s_b - m_max + 1 : s_b][:, ::-1]
     right = csum[:, :m_max]
@@ -418,8 +420,8 @@ def _average_bands_full(
             out.append(native)
             continue
         # Sequential accumulation; bit-identical to np.mean over a stacked
-        # axis for <= 8 terms (below numpy's pairwise-summation block) while
-        # avoiding the stacked copy.
+        # axis-0 (numpy reduces a non-contiguous axis sequentially, so
+        # pairwise summation never applies) while avoiding the stacked copy.
         acc = _scaled_acf_at(p_bands, band - reach, block_size, n_new, cache).copy()
         for off in range(-reach + 1, reach + 1):
             acc += _scaled_acf_at(p_bands, band + off, block_size, n_new, cache)

--- a/src/phonometry/psychoacoustics/loudness_ecma.py
+++ b/src/phonometry/psychoacoustics/loudness_ecma.py
@@ -350,7 +350,8 @@ def _band_acf(rect: np.ndarray, s_b: int, energy: np.ndarray | None = None) -> n
     total = csum[:, 0]
     left = np.empty((rect.shape[0], m_max), dtype=csum.dtype)
     left[:, 0] = total
-    left[:, 1:] = total[:, None] - csum[:, s_b - m_max + 1 : s_b][:, ::-1]
+    left[:, 1:] = total[:, None]
+    left[:, 1:] -= csum[:, s_b - m_max + 1 : s_b][:, ::-1]
     right = csum[:, :m_max]
     denom = np.sqrt(left * right + _EPS)
     out[:, :m_max] = unscaled[:, :m_max] / denom

--- a/src/phonometry/psychoacoustics/roughness_ecma.py
+++ b/src/phonometry/psychoacoustics/roughness_ecma.py
@@ -449,8 +449,10 @@ def _time_dependent(
     grid = np.arange(n50) / _R_S50
     r_est = np.zeros((n50, _CBF))
     if block_times.size >= 2:
-        for band in range(_CBF):  # piecewise cubic Hermite (Clause 7.1.7)
-            r_est[:, band] = PchipInterpolator(block_times, a_lz[:, band])(grid)
+        # Piecewise cubic Hermite (Clause 7.1.7), all 53 bands in one
+        # interpolator; pchip treats every column independently, so the
+        # result is bit-identical to a per-band loop.
+        r_est = PchipInterpolator(block_times, a_lz, axis=0)(grid)
     r_est = np.maximum(r_est, 0.0)  # negatives -> 0 (Clause 7.1.7)
 
     # Distribution-dependent nonlinear transform + calibration (Formulae 104-108).

--- a/src/phonometry/psychoacoustics/roughness_ecma.py
+++ b/src/phonometry/psychoacoustics/roughness_ecma.py
@@ -447,12 +447,13 @@ def _time_dependent(
     t_end = float(block_times[-1])
     n50 = int(np.floor(t_end * _R_S50)) + 1
     grid = np.arange(n50) / _R_S50
-    r_est = np.zeros((n50, _CBF))
     if block_times.size >= 2:
         # Piecewise cubic Hermite (Clause 7.1.7), all 53 bands in one
         # interpolator; pchip treats every column independently, so the
         # result is bit-identical to a per-band loop.
         r_est = PchipInterpolator(block_times, a_lz, axis=0)(grid)
+    else:
+        r_est = np.zeros((n50, _CBF))
     r_est = np.maximum(r_est, 0.0)  # negatives -> 0 (Clause 7.1.7)
 
     # Distribution-dependent nonlinear transform + calibration (Formulae 104-108).

--- a/tests/psychoacoustics/test_loudness_ecma.py
+++ b/tests/psychoacoustics/test_loudness_ecma.py
@@ -158,3 +158,104 @@ def test_plot_smoke(ref_1k_40: EcmaLoudness) -> None:
     matplotlib.use("Agg")
     axes = ref_1k_40.plot()
     assert axes.shape == (2,)
+
+
+# --------------------------------------------------------------------------
+# Vectorized-kernel equivalence (bitwise) against retained reference loops
+# --------------------------------------------------------------------------
+
+
+def _reference_band_acf(rect: np.ndarray, s_b: int) -> np.ndarray:
+    """Per-lag loop form of the unbiased normalized ACF (Formulae 27-29).
+
+    Retained reference for the column-vectorized ``_band_acf``: the
+    production kernel must reproduce this loop bit for bit.
+    """
+    from phonometry.psychoacoustics.loudness_ecma import _EPS
+
+    n_fft = 2 * s_b
+    spec = np.fft.fft(rect, n=n_fft, axis=1)
+    unscaled = np.real(np.fft.ifft(np.abs(spec) ** 2, axis=1))
+    energy = rect**2
+    csum = np.cumsum(energy[:, ::-1], axis=1)[:, ::-1]
+    m_max = (3 * s_b) // 4
+    out = np.zeros_like(unscaled)
+    total = csum[:, 0:1]
+    for m in range(m_max):
+        left = total[:, 0] - (csum[:, s_b - m] if (s_b - m) < s_b else 0.0)
+        right = csum[:, m] if m < s_b else 0.0
+        denom = np.sqrt(left * right + _EPS)
+        out[:, m] = unscaled[:, m] / denom
+    return out
+
+
+def _short_band_signals() -> tuple[list, int]:
+    """Clause 5 front-end band-pass signals for a short two-tone signal."""
+    from scipy import signal as sp_signal
+
+    from phonometry.psychoacoustics.loudness_ecma import (
+        _CBF,
+        _auditory_bandpass,
+        _ear_filter_sos,
+        _preprocess,
+    )
+
+    t = np.arange(int(FS * 0.15)) / FS
+    x = 0.02 * np.sin(2.0 * np.pi * 1000.0 * t) + 0.01 * np.sin(
+        2.0 * np.pi * 4000.0 * t
+    )
+    padded, _, n_new = _preprocess(x)
+    p_om = sp_signal.sosfilt(_ear_filter_sos("free"), padded)
+    return [_auditory_bandpass(p_om, band) for band in range(_CBF)], n_new
+
+
+def test_band_acf_matches_reference_loop_bitwise() -> None:
+    # The vectorized lag normalization must be bit-identical to the per-lag
+    # reference loop for every block size (1024 and 8192 cover the extremes).
+    from phonometry.psychoacoustics.loudness_ecma import (
+        _band_acf,
+        _S_B,
+        _segment_bs,
+    )
+
+    p_bands, n_new = _short_band_signals()
+    for band in (0, 20, 30, 52):
+        s_b = int(_S_B[band])
+        seg = _segment_bs(p_bands[band], s_b, n_new)
+        rect = np.where(seg > 0.0, seg, 0.0)
+        got = _band_acf(rect, s_b, rect**2)
+        ref = _reference_band_acf(rect, s_b)
+        assert np.array_equal(got, ref), band
+
+
+def test_average_bands_matches_stacked_mean_bitwise() -> None:
+    # The sequential neighbour accumulation of _average_bands_full must be
+    # bit-identical to the stacked np.mean formulation it replaced.
+    import importlib
+
+    le = importlib.import_module("phonometry.psychoacoustics.loudness_ecma")
+
+    p_bands, n_new = _short_band_signals()
+    got = le._average_bands_full(p_bands, n_new)
+
+    cache: dict = {}
+    for band in range(le._CBF):
+        block_size = int(le._S_B[band])
+        n_b = le._N_B_BY_SB[block_size]
+        native = le._scaled_acf_at(p_bands, band, block_size, n_new, cache)
+        if n_b == 0:
+            ref = native
+        elif band == 0:
+            other = le._scaled_acf_at(p_bands, 1, block_size, n_new, cache)
+            ref = 0.5 * (native + other)
+        else:
+            reach = min(n_b, band, le._CBF - 1 - band)
+            if reach == 0:
+                ref = native
+            else:
+                stack = [
+                    le._scaled_acf_at(p_bands, band + off, block_size, n_new, cache)
+                    for off in range(-reach, reach + 1)
+                ]
+                ref = np.mean(np.stack(stack, axis=0), axis=0)
+        assert np.array_equal(got[band], ref), band

--- a/tests/psychoacoustics/test_loudness_ecma.py
+++ b/tests/psychoacoustics/test_loudness_ecma.py
@@ -211,7 +211,7 @@ def _short_band_signals() -> tuple[list, int]:
 
 def test_band_acf_matches_reference_loop_bitwise() -> None:
     # The vectorized lag normalization must be bit-identical to the per-lag
-    # reference loop for every block size (1024 and 8192 cover the extremes).
+    # reference loop for all four block sizes (8192/4096/2048/1024).
     from phonometry.psychoacoustics.loudness_ecma import (
         _band_acf,
         _S_B,
@@ -219,7 +219,7 @@ def test_band_acf_matches_reference_loop_bitwise() -> None:
     )
 
     p_bands, n_new = _short_band_signals()
-    for band in (0, 20, 30, 52):
+    for band in (0, 10, 20, 30, 52):
         s_b = int(_S_B[band])
         seg = _segment_bs(p_bands[band], s_b, n_new)
         rect = np.where(seg > 0.0, seg, 0.0)

--- a/tests/psychoacoustics/test_roughness_ecma.py
+++ b/tests/psychoacoustics/test_roughness_ecma.py
@@ -149,3 +149,24 @@ def test_free_and_diffuse_differ() -> None:
     free = roughness_ecma(sig, FS, field="free").roughness
     diffuse = roughness_ecma(sig, FS, field="diffuse").roughness
     assert free != diffuse
+
+
+def test_time_dependent_pchip_batch_matches_per_band_bitwise() -> None:
+    # _time_dependent interpolates all 53 bands with one axis-0 pchip; that
+    # must stay bit-identical to the per-band interpolator loop it replaced.
+    from scipy.interpolate import PchipInterpolator
+
+    from phonometry.psychoacoustics.roughness_ecma import _CBF, _R_S50
+
+    rng = np.random.default_rng(20260715)
+    block_times = np.arange(9) * (4096.0 / FS)
+    a_lz = np.abs(rng.standard_normal((block_times.size, _CBF)))
+    grid = np.arange(int(np.floor(block_times[-1] * _R_S50)) + 1) / _R_S50
+    batched = PchipInterpolator(block_times, a_lz, axis=0)(grid)
+    per_band = np.column_stack(
+        [
+            PchipInterpolator(block_times, a_lz[:, band])(grid)
+            for band in range(_CBF)
+        ]
+    )
+    assert np.array_equal(batched, per_band)


### PR DESCRIPTION
## Summary

Vectorises the per-band Python loops that dominated the ECMA-418-2 runtime, with bit-identical output as a hard constraint: every batched stage is guarded by a permanent equivalence test against a retained reference-loop implementation, and the full-chain outputs (loudness, tonality, roughness: singles, specific arrays and *_vs_time, 36-42 arrays over three signals) were verified with `np.array_equal` against `main`. Golden baseline and all 624 figure variants unchanged.

## What changed

- `_band_acf` (Formulae 27-29): the per-lag unbiased-normalization loop (up to 6144 iterations per call) is now column arithmetic over the energy cumsum. Elementwise ops only, so IEEE-identical; this is the bulk of the win.
- `_scaled_acf_at`: `rect**2` is computed once and shared between the Formula 22 block RMS and the ACF normalization.
- `_average_bands_full` (Clause 6.2.3): neighbour averaging accumulates sequentially instead of `np.mean(np.stack(...))`, avoiding the stacked copy (bit-identical: numpy reduces a non-contiguous axis sequentially, so pairwise summation never applies).
- Roughness Clause 7.1.7: the 53 per-band `PchipInterpolator` calls collapse to a single `axis=0` call (pchip treats columns independently; verified bit-identical).
- Hardening from review: `m_max == 0` guard and dtype propagation in the new ACF kernel (both unreachable in production, kept for robustness).

Deliberately NOT batched, with measured reasons: the 16384-point DFTs (cross-band FFT batching is bit-identical but slower on the real shapes due to ~900 MB batch buffers; a half-spectrum trick showed ULP drift and was reverted), the band-specific IIR filterbanks, and the branchy roughness peak-picking/recurrence stages.

## Measured times (0.5 s bench signal, best of 3)

| case | before | after |
|---|---|---|
| ecma_loudness_0.5s | 2784.8 ms | 2000.7 ms (-28%) |
| ecma_tonality_0.5s | 2739.9 ms | 2008.2 ms (-27%) |
| ecma_roughness_0.5s | 241.0 ms | 232.8 ms (-3%) |

## Test plan

- 3 new bitwise equivalence tests (ACF kernel across all four block sizes, neighbour averaging vs stacked mean, batched pchip vs per-band loops); suite 3102 passed.
- Goldens matched bitwise (well inside the shipped rtol 1e-7); conformance regenerated byte-identical (251/251); `scripts/check_figures.py` all 624 match.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Optimized ECMA-418-2 loudness ACF processing to reduce redundant work and intermediate allocations.
  - Improved ECMA-418-2 roughness interpolation by batching across all frequency bands.
  - Updated benchmarks in the changelog, with remaining runtime still largely driven by the required DFT stage.
- **Reliability**
  - Expanded bitwise regression coverage to confirm results remain bit-identical to prior reference implementations.
- **Documentation**
  - Enhanced the changelog entry with performance timings and equivalence validation notes.
- **Tests**
  - Added new loudness and roughness regression tests focused on vectorized vs. reference behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->