### PR TITLE
fix: zero-phase STI analysis bank, verified against the IEC 60268-16 certified test bench

### DIFF
--- a/.github/images/sti_vs_t60.svg
+++ b/.github/images/sti_vs_t60.svg
@@ -470,13 +470,13 @@ z
 " style="stroke: #d62728; stroke-width: 1.6"/>
     </defs>
     <g clip-path="url(#p5d3ff2cb05)">
-     <use xlink:href="#m0124a2d90b" x="76.11499" y="75.490626" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
-     <use xlink:href="#m0124a2d90b" x="165.80532" y="114.611007" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
-     <use xlink:href="#m0124a2d90b" x="248.328159" y="160.064438" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
-     <use xlink:href="#m0124a2d90b" x="319.519379" y="192.051878" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
-     <use xlink:href="#m0124a2d90b" x="409.20971" y="240.5855" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
-     <use xlink:href="#m0124a2d90b" x="480.40093" y="272.313651" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
-     <use xlink:href="#m0124a2d90b" x="570.09126" y="309.875797" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
+     <use xlink:href="#m0124a2d90b" x="76.11499" y="74.676741" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
+     <use xlink:href="#m0124a2d90b" x="165.80532" y="114.543951" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
+     <use xlink:href="#m0124a2d90b" x="248.328159" y="159.238799" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
+     <use xlink:href="#m0124a2d90b" x="319.519379" y="191.939728" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
+     <use xlink:href="#m0124a2d90b" x="409.20971" y="240.277331" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
+     <use xlink:href="#m0124a2d90b" x="480.40093" y="271.547682" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
+     <use xlink:href="#m0124a2d90b" x="570.09126" y="309.463406" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
     </g>
    </g>
    <g id="patch_15">

--- a/.github/images/sti_vs_t60_dark.svg
+++ b/.github/images/sti_vs_t60_dark.svg
@@ -470,13 +470,13 @@ z
 " style="stroke: #d62728; stroke-width: 1.6"/>
     </defs>
     <g clip-path="url(#p5d3ff2cb05)">
-     <use xlink:href="#m0124a2d90b" x="76.11499" y="75.490626" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
-     <use xlink:href="#m0124a2d90b" x="165.80532" y="114.611007" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
-     <use xlink:href="#m0124a2d90b" x="248.328159" y="160.064438" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
-     <use xlink:href="#m0124a2d90b" x="319.519379" y="192.051878" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
-     <use xlink:href="#m0124a2d90b" x="409.20971" y="240.5855" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
-     <use xlink:href="#m0124a2d90b" x="480.40093" y="272.313651" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
-     <use xlink:href="#m0124a2d90b" x="570.09126" y="309.875797" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
+     <use xlink:href="#m0124a2d90b" x="76.11499" y="74.676741" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
+     <use xlink:href="#m0124a2d90b" x="165.80532" y="114.543951" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
+     <use xlink:href="#m0124a2d90b" x="248.328159" y="159.238799" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
+     <use xlink:href="#m0124a2d90b" x="319.519379" y="191.939728" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
+     <use xlink:href="#m0124a2d90b" x="409.20971" y="240.277331" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
+     <use xlink:href="#m0124a2d90b" x="480.40093" y="271.547682" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
+     <use xlink:href="#m0124a2d90b" x="570.09126" y="309.463406" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
     </g>
    </g>
    <g id="patch_15">

--- a/.github/images/sti_vs_t60_es.svg
+++ b/.github/images/sti_vs_t60_es.svg
@@ -470,13 +470,13 @@ z
 " style="stroke: #d62728; stroke-width: 1.6"/>
     </defs>
     <g clip-path="url(#pe2102e52f6)">
-     <use xlink:href="#m0124a2d90b" x="76.11499" y="75.970626" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
-     <use xlink:href="#m0124a2d90b" x="165.80532" y="115.091007" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
-     <use xlink:href="#m0124a2d90b" x="248.328159" y="160.544438" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
-     <use xlink:href="#m0124a2d90b" x="319.519379" y="192.531878" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
-     <use xlink:href="#m0124a2d90b" x="409.20971" y="241.0655" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
-     <use xlink:href="#m0124a2d90b" x="480.40093" y="272.793651" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
-     <use xlink:href="#m0124a2d90b" x="570.09126" y="310.355797" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
+     <use xlink:href="#m0124a2d90b" x="76.11499" y="75.156741" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
+     <use xlink:href="#m0124a2d90b" x="165.80532" y="115.023951" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
+     <use xlink:href="#m0124a2d90b" x="248.328159" y="159.718799" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
+     <use xlink:href="#m0124a2d90b" x="319.519379" y="192.419728" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
+     <use xlink:href="#m0124a2d90b" x="409.20971" y="240.757331" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
+     <use xlink:href="#m0124a2d90b" x="480.40093" y="272.027682" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
+     <use xlink:href="#m0124a2d90b" x="570.09126" y="309.943406" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
     </g>
    </g>
    <g id="patch_15">

--- a/.github/images/sti_vs_t60_es_dark.svg
+++ b/.github/images/sti_vs_t60_es_dark.svg
@@ -470,13 +470,13 @@ z
 " style="stroke: #d62728; stroke-width: 1.6"/>
     </defs>
     <g clip-path="url(#pe2102e52f6)">
-     <use xlink:href="#m0124a2d90b" x="76.11499" y="75.970626" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
-     <use xlink:href="#m0124a2d90b" x="165.80532" y="115.091007" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
-     <use xlink:href="#m0124a2d90b" x="248.328159" y="160.544438" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
-     <use xlink:href="#m0124a2d90b" x="319.519379" y="192.531878" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
-     <use xlink:href="#m0124a2d90b" x="409.20971" y="241.0655" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
-     <use xlink:href="#m0124a2d90b" x="480.40093" y="272.793651" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
-     <use xlink:href="#m0124a2d90b" x="570.09126" y="310.355797" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
+     <use xlink:href="#m0124a2d90b" x="76.11499" y="75.156741" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
+     <use xlink:href="#m0124a2d90b" x="165.80532" y="115.023951" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
+     <use xlink:href="#m0124a2d90b" x="248.328159" y="159.718799" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
+     <use xlink:href="#m0124a2d90b" x="319.519379" y="192.419728" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
+     <use xlink:href="#m0124a2d90b" x="409.20971" y="240.757331" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
+     <use xlink:href="#m0124a2d90b" x="480.40093" y="272.027682" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
+     <use xlink:href="#m0124a2d90b" x="570.09126" y="309.943406" style="fill: #ffffff; stroke: #d62728; stroke-width: 1.6"/>
     </g>
    </g>
    <g id="patch_15">

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,6 +224,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   EPNL: the bandsharing adjustment ΔB (App. 2 §4.4.2/4.4.3), exposed as
   `EPNLResult.bandsharing_adjustment`, and a `start_band` parameter on
   `tone_correction` for the helicopter 50 Hz procedure.
+- STIPA certified-bench verification: the IEC 60268-16 rev 5 verification
+  test-bench signals from stipa.info (Embedded Acoustics BV) run as a local
+  end-to-end oracle over `stipa` / `sti_from_impulse_response` (49 WAVs
+  across Annexes C.3.2 modulation-depth staircase, C.3.3 exponential decays,
+  C.4.2 filter slope, A.2.2 weighting factors and A.3.1.2 phase distortion;
+  the suite skips cleanly when the local data is absent), plus six synthetic
+  conformance checks that re-derive the same constructions in CI: the C.3.2
+  staircase at m = 0,2/0,5/0,8 (±0,01 STI), the C.3.3 RT60 = 1 s decay
+  against the closed-form Schroeder MTF (±0,005), the C.4.2 slope criterion
+  (m ≥ 0,5 under a +41 dB unmodulated adjacent-octave tone) and the
+  A.2.2/A.3.1.2 audio-path checks (257 checks total).
 
 ### Changed
 
@@ -260,6 +271,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- STI analysis filter bank is now zero-phase (forward-backward filtering):
+  the single-pass bank failed two normative verification criteria of
+  IEC 60268-16:2020 on the certified test bench - the C.4.2 filter-slope
+  test (an unmodulated tone one octave below the observed band, 41 dB
+  louder, leaked with only ~31 dB attenuation and dragged the measured m
+  down to ~0,1 against the m ≥ 0,5 criterion) and the A.3.1.2
+  phase-distortion limit (STI bias reached -0,020 at TI = 0,9 against the
+  < 0,01 criterion). Zero-phase filtering removes the phase bias by
+  construction and doubles the effective skirt attenuation to ~63 dB one
+  octave out; all 49 certified bench signals now pass (worst slope-test
+  m = 0,937, worst edge-carrier bias -0,0029). STI values on ordinary
+  signals shift by well under 0,001 (the sti_vs_t60 figures are
+  regenerated accordingly).
+- `stipa` no longer raises when an octave band of the recording carries no
+  energy: dead bands read m = 0 (TI = 0, the worst-case reading of a real
+  meter) under an `STIWarning`, so component-level verification signals
+  that deliberately occupy only some bands (IEC 60268-16 C.4.2) remain
+  measurable.
 - DIN 45681 / ISO PAS 20065 single-line tones: the tone level of a K = 1 run
   is the line level itself (Formula (7)); the Hanning bandwidth correction
   applies only to K > 1 sums (Formula (8)). The unconditional -1,76 dB

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -282,8 +282,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   construction and doubles the effective skirt attenuation to ~63 dB one
   octave out; all 49 certified bench signals now pass (worst slope-test
   m = 0,937, worst edge-carrier bias -0,0029). STI values on ordinary
-  signals shift by well under 0,001 (the sti_vs_t60 figures are
-  regenerated accordingly).
+  signals of the recommended >= 15 s duration shift by at most ~0,003
+  (larger only below the minimum-duration warning threshold; the
+  sti_vs_t60 figures are regenerated accordingly).
 - `stipa` no longer raises when an octave band of the recording carries no
   energy: dead bands read m = 0 (TI = 0, the worst-case reading of a real
   meter) under an `STIWarning`, so component-level verification signals

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -229,9 +229,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   end-to-end oracle over `stipa` / `sti_from_impulse_response` (49 WAVs
   across Annexes C.3.2 modulation-depth staircase, C.3.3 exponential decays,
   C.4.2 filter slope, A.2.2 weighting factors and A.3.1.2 phase distortion;
-  the suite skips cleanly when the local data is absent), plus six synthetic
-  conformance checks that re-derive the same constructions in CI: the C.3.2
-  staircase at m = 0,2/0,5/0,8 (±0,01 STI), the C.3.3 RT60 = 1 s decay
+  the suite skips cleanly when the local data is absent), plus seven synthetic
+  conformance checks that re-derive the same constructions in CI (one of them
+  replacing the previous C.3.2 m = 0,5 check, so the total grows by six): the
+  C.3.2 staircase at m = 0,2/0,5/0,8 (±0,01 STI), the C.3.3 RT60 = 1 s decay
   against the closed-form Schroeder MTF (±0,005), the C.4.2 slope criterion
   (m ≥ 0,5 under a +41 dB unmodulated adjacent-octave tone) and the
   A.2.2/A.3.1.2 audio-path checks (257 checks total).

--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -15,7 +15,7 @@
 
 ## Numerical conformance report
 
-&#9989; **251/251 conformance checks pass** across 32 domains and 139 standards - filters class 1 - weightings within IEC 61672-1 class 1.
+&#9989; **257/257 conformance checks pass** across 32 domains and 139 standards - filters class 1 - weightings within IEC 61672-1 class 1.
 
 ### Numerical validation - filters &amp; weightings
 
@@ -102,13 +102,19 @@ Only **Butterworth** (the library default) and **Chebyshev-II** are class-compli
 </details>
 
 <details>
-<summary>&#9989; <b>Speech transmission (IEC 60268-16)</b> — 100% (3/3)</summary>
+<summary>&#9989; <b>Speech transmission (IEC 60268-16)</b> — 100% (9/9)</summary>
 
 | Standard | Quantity | Expected (norm) | Computed | &#916; | Status |
 |:---|:---|:---|:---|:---|:---:|
 | IEC 60268-16:2020 A.2.2 | STI weighting-factor pair (500 Hz + 1 kHz bands) | 0.398 (+/-0.001) | 0.398 | 0 | &#9989; |
 | IEC 60268-16:2020 A.3.1.2 | Uniform MTF m=0.5 maps to STI=0.5 | 0.5 (+/-0.01) | 0.5 | 0 | &#9989; |
-| IEC 60268-16:2020 C.3.2 | STIPA direct method, Formula (C.1) signal at m=0.5 | 0.5 (+/-0.05) | 0.4993 | -0.001 | &#9989; |
+| IEC 60268-16:2020 C.3.2 | STIPA direct method, Formula (C.1) signal at m=0.2 | 0.3 (+/-0.01) | 0.2992 | -0.001 | &#9989; |
+| IEC 60268-16:2020 C.3.2 | STIPA direct method, Formula (C.1) signal at m=0.5 | 0.5 (+/-0.01) | 0.4998 | 0 | &#9989; |
+| IEC 60268-16:2020 C.3.2 | STIPA direct method, Formula (C.1) signal at m=0.8 | 0.7 (+/-0.01) | 0.7002 | 0 | &#9989; |
+| IEC 60268-16:2020 C.3.3 | Indirect method: exponential decay RT60=1 s vs Schroeder MTF | 0.5885 (+/-0.005) | 0.5885 | 0 | &#9989; |
+| IEC 60268-16:2020 C.4.2 | Filter-bank slope: +41 dB unmodulated tone one octave below 125 Hz | m >= 0.5 (C.4.2 pass criterion) | 0.9812 | 0.481 | &#9989; |
+| IEC 60268-16:2020 A.2.2 (audio path) | Weighting factors: modulated 500 Hz + 1 kHz pair through stipa() | 0.398 (+/-0.005) | 0.398 | 0 | &#9989; |
+| IEC 60268-16:2020 A.3.1.2 (audio path) | Filter-bank phase: half-octave edge carriers at TI=0.9 | 0.9 (+/-0.01) | 0.8975 | -0.003 | &#9989; |
 
 </details>
 

--- a/docs/speech-transmission.md
+++ b/docs/speech-transmission.md
@@ -92,7 +92,7 @@ plt.show()
 `stipa` emits a `UserWarning` when the recording is shorter than the
 recommended 15 s (IEC 60268-16 STIPA practice, 15 s to 25 s): below that the
 slow modulation components are averaged over too few periods and the STI is
-biased low (an ideal loopback gives STI ≈ 0.944 at 5 s vs ≈ 0.998 at 18 s).
+biased low (an ideal loopback gives STI ≈ 0.956 at 5 s vs ≈ 0.998 at 18 s).
 
 The implementation follows **Edition 5 (2020)**: Edition 4's normative PDF
 is the base and every Ed. 5 change is source-attributed in the code — the
@@ -100,6 +100,18 @@ only numeric delta is the revised male speech spectrum of clause A.6.1.
 CI checks the standard's own verification vectors: the six weighting-factor
 band pairs to ±0.001 STI, the m ↔ STI mapping table, the level-dependent
 masking control points, and Schroeder-form decays at four T₆₀ values.
+
+The analyzer is also verified end to end against the **IEC 60268-16 rev 5
+verification test bench** signals from [stipa.info](https://www.stipa.info)
+(Embedded Acoustics BV): the direct-method modulation-depth staircase
+(Annex C.3.2), the indirect-method exponential decays against the closed-form
+Schroeder MTF (C.3.3), the filter-bank slope test with a +41 dB unmodulated
+adjacent-octave tone (C.4.2, m ≥ 0.5), the weighting-factor band pairs (A.2.2)
+and the filter-bank phase-distortion test with half-octave edge carriers
+(A.3.1.2, |STI bias| < 0.01 over TI = 0.1–0.9). All five suites pass with the
+level-dependent features disabled, as the bench prescribes. The 49 certified
+WAVs stay local (third-party data, not committed); CI re-derives the same
+signal constructions synthetically in the conformance suite.
 
 ### `sti_from_impulse_response()` / `stipa()` parameters
 

--- a/scripts/conformance_report.py
+++ b/scripts/conformance_report.py
@@ -822,35 +822,182 @@ def _chk_sti_uniform() -> Outcome:
     return numeric(0.5, computed, 0.01, places=4)
 
 
+# Ed.5 STIPA verification-signal parameters (restating the standard, not
+# the implementation): Table B.1 modulation pairs, A.6.1 male spectrum.
+_STI_CENTERS = [125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0]
+_STI_F1 = [1.60, 1.00, 0.63, 2.00, 1.25, 0.80, 2.50]
+_STI_F2 = [8.00, 5.00, 3.15, 10.00, 6.25, 4.00, 12.50]
+_STI_LEVELS = [-2.5, 0.5, 0.0, -6.0, -12.0, -18.0, -24.0]
+# m <-> STI staircase of the Ed.5 verification bench (m in 0,1 steps;
+# TI = (10 lg(m/(1-m)) + 15)/30, rounded as published).
+_STI_STAIRCASE = {0.0: 0.00, 0.1: 0.18, 0.2: 0.30, 0.3: 0.38, 0.4: 0.44,
+                  0.5: 0.50, 0.6: 0.56, 0.7: 0.62, 0.8: 0.70, 0.9: 0.82,
+                  1.0: 1.00}
+
+
+def _stipa_sine_signal(
+    m: float,
+    seconds: float = 16.0,
+    bands: Optional[tuple[int, ...]] = None,
+    edge_carriers: bool = False,
+    flat_levels: bool = False,
+) -> np.ndarray:
+    """Ed.5 Formula (C.1)-style verification signal with sine carriers.
+
+    A_k(t) = g_k c_k(t) sqrt(0,5 (1 + 0,55 m (sin 2 pi f1_k t -
+    sin 2 pi f2_k t))). ``bands`` limits the modulation (m = 0 elsewhere,
+    as in the A.2.2 pair signals); ``edge_carriers`` uses the two
+    half-octave edge carriers fc 2^(+/-1/4) per band (A.3.1.2);
+    ``flat_levels`` uses g_k = 1 as the A.2.2/A.3.1.2 bench does.
+    """
+    t = np.arange(int(round(seconds * _FS))) / _FS
+    x = np.zeros(t.size)
+    for k, (fc, fa, fb, level) in enumerate(
+        zip(_STI_CENTERS, _STI_F1, _STI_F2, _STI_LEVELS)
+    ):
+        mk = m if bands is None or k in bands else 0.0
+        env = 0.5 * (
+            1.0 + 0.55 * mk * (np.sin(2 * np.pi * fa * t) - np.sin(2 * np.pi * fb * t))
+        )
+        if edge_carriers:
+            carrier = np.sin(2 * np.pi * fc / 2**0.25 * t) + np.sin(
+                2 * np.pi * fc * 2**0.25 * t
+            )
+        else:
+            carrier = np.sin(2 * np.pi * fc * t)
+        gain = 1.0 if flat_levels else 10.0 ** (level / 20.0)
+        x += gain * carrier * np.sqrt(np.maximum(env, 0.0))
+    return x
+
+
+def _chk_stipa_staircase(m: float) -> Outcome:
+    # Ed.5 modulation-depth verification: the Formula (C.1) signal with
+    # sinusoidal carriers at the A.6.1 male levels and modulation scale m
+    # must read the published staircase STI through the full stipa()
+    # audio path (octave bank, envelopes, correlation, TI chain). The
+    # certified stipa.info WAV bench (same construction) measures a worst
+    # deviation of 0,0031 STI; tolerance +/-0,01.
+    computed = float(ph.stipa(_stipa_sine_signal(m), _FS).sti)
+    return numeric(_STI_STAIRCASE[m], computed, 0.01, places=4)
+
+
+@register(
+    "Speech transmission (IEC 60268-16)",
+    "IEC 60268-16:2020 C.3.2",
+    "STIPA direct method, Formula (C.1) signal at m=0.2",
+)
+def _chk_stipa_staircase_m02() -> Outcome:
+    return _chk_stipa_staircase(0.2)
+
+
 @register(
     "Speech transmission (IEC 60268-16)",
     "IEC 60268-16:2020 C.3.2",
     "STIPA direct method, Formula (C.1) signal at m=0.5",
 )
-def _chk_stipa_direct_method() -> Outcome:
-    # Ed.5 modulation-depth verification: the Formula (C.1) signal with
-    # sinusoidal carriers at the A.6.1 male levels, modulation scale m=0.5,
-    # must read STI = 0.50 within the published +/-0.05 through the full
-    # stipa() audio path (octave bank, envelopes, correlation, TI chain).
-    fs = 48000
-    centers = [125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0]
-    f1 = [1.60, 1.00, 0.63, 2.00, 1.25, 0.80, 2.50]
-    f2 = [8.00, 5.00, 3.15, 10.00, 6.25, 4.00, 12.50]
-    levels_db = [-2.5, 0.5, 0.0, -6.0, -12.0, -18.0, -24.0]
-    t = np.arange(16 * fs) / fs
-    x = np.zeros(t.size)
-    for fc, fa, fb, level in zip(centers, f1, f2, levels_db):
-        env = 0.5 * (
-            1.0
-            + 0.55 * 0.5 * (np.sin(2 * np.pi * fa * t) - np.sin(2 * np.pi * fb * t))
-        )
-        x += (
-            10.0 ** (level / 20.0)
-            * np.sin(2 * np.pi * fc * t)
-            * np.sqrt(np.maximum(env, 0.0))
-        )
-    computed = float(ph.stipa(x, fs).sti)
-    return numeric(0.50, computed, 0.05, places=4)
+def _chk_stipa_staircase_m05() -> Outcome:
+    return _chk_stipa_staircase(0.5)
+
+
+@register(
+    "Speech transmission (IEC 60268-16)",
+    "IEC 60268-16:2020 C.3.2",
+    "STIPA direct method, Formula (C.1) signal at m=0.8",
+)
+def _chk_stipa_staircase_m08() -> Outcome:
+    return _chk_stipa_staircase(0.8)
+
+
+@register(
+    "Speech transmission (IEC 60268-16)",
+    "IEC 60268-16:2020 C.3.3",
+    "Indirect method: exponential decay RT60=1 s vs Schroeder MTF",
+)
+def _chk_sti_indirect_expdecay() -> Outcome:
+    # Ed.5 indirect-method verification: sine carriers in all seven bands
+    # with an amplitude decay 1000^(-t/RT60) (60 dB intensity decay in
+    # RT60) must reproduce the closed-form Schroeder MTF
+    # m(F) = 1/sqrt(1 + (2 pi F RT60 / (6 ln 10))^2) through the octave
+    # bank and Schroeder integral. Certified WAV bench worst deviation:
+    # 0,0002 STI; tolerance +/-0,005.
+    rt60 = 1.0
+    t = np.arange(int(3.0 * _FS)) / _FS
+    x = np.sum(
+        [np.sin(2 * np.pi * fc * t) for fc in _STI_CENTERS], axis=0
+    ) * 10.0 ** (-3.0 * t / rt60)
+    # The 14 modulation frequencies 0,63 - 12,5 Hz (Ed.5 A.2.2).
+    mod_freqs = np.array(
+        [0.63, 0.80, 1.00, 1.25, 1.60, 2.00, 2.50, 3.15, 4.00, 5.00, 6.30,
+         8.00, 10.0, 12.5]
+    )
+    m_formula = 1.0 / np.sqrt(
+        1.0 + (2.0 * np.pi * mod_freqs * rt60 / (6.0 * np.log(10.0))) ** 2
+    )
+    expected = float(_sti_from_mtf(np.tile(m_formula, (_NUM_STI_BANDS, 1))).sti)
+    computed = float(ph.sti_from_impulse_response(x, _FS).sti)
+    return numeric(expected, computed, 0.005, places=4)
+
+
+@register(
+    "Speech transmission (IEC 60268-16)",
+    "IEC 60268-16:2020 C.4.2",
+    "Filter-bank slope: +41 dB unmodulated tone one octave below 125 Hz",
+)
+def _chk_sti_filter_slope() -> Outcome:
+    # Ed.5 filter-slope verification (worst case of the certified bench
+    # pre-fix): a fully modulated 125 Hz carrier plus an unmodulated
+    # 62,5 Hz tone 41 dB louder must still read m >= 0,5 in the 125 Hz
+    # band, i.e. the analysis filter must be > 41 dB down one octave out
+    # (steeper than IEC 61260-1 class 1; the zero-phase bank achieves
+    # m >= 0,94 on all 14 certified signals).
+    t = np.arange(int(16.0 * _FS)) / _FS
+    env = 0.5 * (
+        1.0 + 0.55 * (np.sin(2 * np.pi * 1.60 * t) - np.sin(2 * np.pi * 8.00 * t))
+    )
+    x = 10.0 ** (-41.0 / 20.0) * np.sin(2 * np.pi * 125.0 * t) * np.sqrt(
+        np.maximum(env, 0.0)
+    ) + np.sin(2 * np.pi * 62.5 * t)
+    with warnings.catch_warnings():
+        # Bands other than 125 Hz are legitimately (near-)empty here.
+        warnings.simplefilter("ignore", UserWarning)
+        m_observed = float(np.min(ph.stipa(x, _FS).mtf[0]))
+    return Outcome(
+        expected="m >= 0.5 (C.4.2 pass criterion)",
+        computed=_fmt(m_observed, places=4),
+        delta=_fmt(m_observed - 0.5, "", _DELTA_PLACES),
+        passed=m_observed >= 0.5,
+    )
+
+
+@register(
+    "Speech transmission (IEC 60268-16)",
+    "IEC 60268-16:2020 A.2.2 (audio path)",
+    "Weighting factors: modulated 500 Hz + 1 kHz pair through stipa()",
+)
+def _chk_sti_weighting_pair_audio() -> Outcome:
+    # Ed.5 weighting-factor verification through the full audio path:
+    # sine carriers in all seven bands, only the 500/1000 Hz pair
+    # modulated (m = 1) -> STI = alpha_3 + alpha_4 - beta_3 = 0,398.
+    # Certified WAV bench worst deviation vs the identity: 0,0002 STI.
+    x = _stipa_sine_signal(1.0, bands=(2, 3), flat_levels=True)
+    computed = float(ph.stipa(x, _FS).sti)
+    return numeric(0.398, computed, 0.005, places=4)
+
+
+@register(
+    "Speech transmission (IEC 60268-16)",
+    "IEC 60268-16:2020 A.3.1.2 (audio path)",
+    "Filter-bank phase: half-octave edge carriers at TI=0.9",
+)
+def _chk_sti_edge_carriers() -> Outcome:
+    # Ed.5 filter-bank phase-distortion verification: two sine carriers
+    # per band at fc 2^(+/-1/4) (the extremes of the half-octave STIPA
+    # generation band), modulation depth m = 0,94065 (TI = 0,9). The
+    # normative criterion is |STI bias| < 0,01 over TI = 0,1 .. 0,9; the
+    # zero-phase bank measures -0,0029 worst on the certified WAVs.
+    x = _stipa_sine_signal(0.94065, edge_carriers=True, flat_levels=True)
+    computed = float(ph.stipa(x, _FS).sti)
+    return numeric(0.9, computed, 0.01, places=4)
 
 
 # ===========================================================================

--- a/site/src/content/docs/es/guides/speech-transmission.md
+++ b/site/src/content/docs/es/guides/speech-transmission.md
@@ -96,7 +96,7 @@ plt.show()
 `stipa` emite un `UserWarning` cuando la grabación es más corta que los 15 s
 recomendados (práctica STIPA de IEC 60268-16, de 15 s a 25 s): por debajo de eso
 las componentes de modulación lentas se promedian sobre muy pocos periodos y el
-STI queda sesgado a la baja (un lazo ideal da STI ≈ 0,944 a 5 s frente a
+STI queda sesgado a la baja (un lazo ideal da STI ≈ 0,956 a 5 s frente a
 ≈ 0,998 a 18 s).
 
 La implementación sigue la **Edición 5 (2020)**: el PDF normativo de la
@@ -107,6 +107,20 @@ los seis pares de bandas de los factores de ponderación a ±0,001 STI, la tabla
 de correspondencia m ↔ STI, los puntos de control del enmascaramiento
 dependiente del nivel y decaimientos con la forma de Schroeder a cuatro valores
 de T₆₀.
+
+El analizador también se verifica de extremo a extremo con las señales del
+**banco de verificación de IEC 60268-16 rev 5** de
+[stipa.info](https://www.stipa.info) (Embedded Acoustics BV): la escalera de
+profundidad de modulación del método directo (Anexo C.3.2), los decaimientos
+exponenciales del método indirecto frente a la MTF de Schroeder en forma
+cerrada (C.3.3), la prueba de pendiente del banco de filtros con un tono
+adyacente sin modular a +41 dB (C.4.2, m ≥ 0,5), los pares de bandas de los
+factores de ponderación (A.2.2) y la prueba de distorsión de fase del banco de
+filtros con portadoras en los bordes de media octava (A.3.1.2,
+|sesgo de STI| < 0,01 en TI = 0,1–0,9). Las cinco series pasan con las
+funciones dependientes del nivel desactivadas, como prescribe el banco. Los 49
+WAV certificados permanecen en local (datos de terceros, no versionados); CI
+reconstruye las mismas señales de forma sintética en la serie de conformidad.
 
 ### Parámetros de `sti_from_impulse_response()` / `stipa()`
 

--- a/site/src/content/docs/guides/speech-transmission.md
+++ b/site/src/content/docs/guides/speech-transmission.md
@@ -94,7 +94,7 @@ plt.show()
 `stipa` emits a `UserWarning` when the recording is shorter than the
 recommended 15 s (IEC 60268-16 STIPA practice, 15 s to 25 s): below that the
 slow modulation components are averaged over too few periods and the STI is
-biased low (an ideal loopback gives STI ≈ 0.944 at 5 s vs ≈ 0.998 at 18 s).
+biased low (an ideal loopback gives STI ≈ 0.956 at 5 s vs ≈ 0.998 at 18 s).
 
 The implementation follows **Edition 5 (2020)**: Edition 4's normative PDF
 is the base and every Ed. 5 change is source-attributed in the code — the
@@ -102,6 +102,18 @@ only numeric delta is the revised male speech spectrum of clause A.6.1.
 CI checks the standard's own verification vectors: the six weighting-factor
 band pairs to ±0.001 STI, the m ↔ STI mapping table, the level-dependent
 masking control points, and Schroeder-form decays at four T₆₀ values.
+
+The analyzer is also verified end to end against the **IEC 60268-16 rev 5
+verification test bench** signals from [stipa.info](https://www.stipa.info)
+(Embedded Acoustics BV): the direct-method modulation-depth staircase
+(Annex C.3.2), the indirect-method exponential decays against the closed-form
+Schroeder MTF (C.3.3), the filter-bank slope test with a +41 dB unmodulated
+adjacent-octave tone (C.4.2, m ≥ 0.5), the weighting-factor band pairs (A.2.2)
+and the filter-bank phase-distortion test with half-octave edge carriers
+(A.3.1.2, |STI bias| < 0.01 over TI = 0.1–0.9). All five suites pass with the
+level-dependent features disabled, as the bench prescribes. The 49 certified
+WAVs stay local (third-party data, not committed); CI re-derives the same
+signal constructions synthetically in the conformance suite.
 
 ### `sti_from_impulse_response()` / `stipa()` parameters
 

--- a/src/phonometry/hearing/sti.py
+++ b/src/phonometry/hearing/sti.py
@@ -306,6 +306,10 @@ def sti_from_impulse_response(
        about T60 = 4 s, reaching ~+0.012 STI only in very reverberant rooms
        (T60 ~ 8 s, STI ~ 0.19). It is a property of the finite IR, not of the
        (exact) Schroeder integration, and does not depend on IR truncation.
+       At very short reverberation times (T60 < 0.25 s) the zero-phase
+       analysis bank smears h^2 slightly, biasing individual low-band
+       high-modulation-frequency MTF cells by up to ~0.02-0.04 while the
+       STI itself stays within ~0.001.
 
     :param ir: Impulse response (1D).
     :param fs: Sample rate in Hz (>= 22,5 kHz so the 8 kHz band fits).
@@ -411,7 +415,7 @@ def _stipa_modulation_depths(env: np.ndarray, fs: int) -> np.ndarray:
             "index 0-6): modulation depths set to 0 (TI = 0) there. A full "
             "STIPA measurement needs all seven carriers of the test signal.",
             STIWarning,
-            stacklevel=4,
+            stacklevel=3,
         )
     return mdr
 

--- a/src/phonometry/hearing/sti.py
+++ b/src/phonometry/hearing/sti.py
@@ -70,7 +70,7 @@ _STIPA_MOD_INDEX = 0.55  # Annex B: m = 0.55 per component, unchanged in Ed.5
 #: recommends 15 s to 25 s). Below this the recovered modulation depths are
 #: biased low - and hence the STI too - because the slow modulation
 #: components are averaged over too few periods: on an ideal loopback the
-#: recovered STI is ~0.944 at 5 s, ~0.991 at 15 s and ~0.998 at 18 s.
+#: recovered STI is ~0.956 at 5 s, ~0.994 at 15 s and ~0.998 at 18 s.
 _STIPA_MIN_SECONDS = 15.0
 
 # Ed.5 male speech test-signal spectrum, clause A.6.1, in dB relative to
@@ -336,7 +336,7 @@ def sti_from_impulse_response(
 
     bank = _octave_bank(fs)
     _, _, bands = bank.filter(
-        ir_proc, sigbands=True, detrend=False, calculate_level=False
+        ir_proc, sigbands=True, detrend=False, calculate_level=False, zero_phase=True
     )
     p_bands = np.asarray(bands) ** 2  # h_k^2(t), shape (7, n)
     denom = p_bands.sum(axis=1)
@@ -353,9 +353,17 @@ def sti_from_impulse_response(
 
 def _intensity_envelopes(x: np.ndarray, fs: int) -> np.ndarray:
     """Octave-band intensity envelopes I_k(t) = x_k^2(t) low-passed at
-    ~100 Hz (Ed.4 A.5.2 = Ed.5), shape (7, n)."""
+    ~100 Hz (Ed.4 A.5.2 = Ed.5), shape (7, n).
+
+    Zero-phase band filtering: forward-backward filtering has no phase
+    distortion (the A.3.1.2 edge-carrier bias criterion, < 0,01 STI over
+    TI 0,1-0,9) and doubles the effective skirt attenuation to >= 41 dB
+    at the adjacent octave (the C.4.2 filter-slope criterion, m >= 0,5,
+    steeper than IEC 61260-1 class 1). Single-pass filtering fails both
+    verification criteria of IEC 60268-16:2020.
+    """
     bank = _octave_bank(fs)
-    _, _, bands = bank.filter(x, sigbands=True, calculate_level=False)
+    _, _, bands = bank.filter(x, sigbands=True, calculate_level=False, zero_phase=True)
     sos = signal.butter(4, _ENVELOPE_LPF_HZ, btype="lowpass", fs=fs, output="sos")
     env = np.empty((_NUM_BANDS, x.shape[-1]))
     for k, band in enumerate(bands):
@@ -370,6 +378,7 @@ def _stipa_modulation_depths(env: np.ndarray, fs: int) -> np.ndarray:
     n = env.shape[-1]
     duration = n / fs
     mdr = np.empty((_NUM_BANDS, 2))
+    empty_bands: list[int] = []
     for k in range(_NUM_BANDS):
         for j, fm in enumerate((float(_STIPA_F1[k]), float(_STIPA_F2[k]))):
             periods = int(np.floor(duration * fm))
@@ -383,14 +392,27 @@ def _stipa_modulation_depths(env: np.ndarray, fs: int) -> np.ndarray:
             seg = env[k, :n_use]
             total = float(np.sum(seg))
             if total <= 0.0:
-                raise ValueError(
-                    "An octave band of the signal has no energy; STIPA needs "
-                    "all seven carriers of the test signal."
-                )
+                # A band without energy has an undefined modulation depth.
+                # Report m = 0 (TI = 0, the worst-case reading of a real
+                # STIPA meter on a dead band) and warn: the IEC 60268-16
+                # C.4.2 filter-slope verification signals legitimately
+                # carry energy in only two of the seven bands.
+                if k not in empty_bands:
+                    empty_bands.append(k)
+                mdr[k, j] = 0.0
+                continue
             t = np.arange(n_use) / fs
             s = float(np.dot(seg, np.sin(2.0 * np.pi * fm * t)))
             c = float(np.dot(seg, np.cos(2.0 * np.pi * fm * t)))
             mdr[k, j] = 2.0 * float(np.hypot(s, c)) / total
+    if empty_bands:
+        warnings.warn(
+            f"No energy in octave band(s) {empty_bands} (125 Hz - 8 kHz, "
+            "index 0-6): modulation depths set to 0 (TI = 0) there. A full "
+            "STIPA measurement needs all seven carriers of the test signal.",
+            STIWarning,
+            stacklevel=4,
+        )
     return mdr
 
 
@@ -422,7 +444,7 @@ def stipa(
     the recommended 15 s (IEC 60268-16 STIPA practice, 15 s to 25 s),
     because the slow modulation components are then averaged over too few
     periods and the recovered modulation depths - and hence the STI - are
-    biased low (an ideal loopback gives STI ~0.944 at 5 s vs ~0.998 at 18 s).
+    biased low (an ideal loopback gives STI ~0.956 at 5 s vs ~0.998 at 18 s).
 
     :param x: Recorded STIPA signal (1D), 15 s to 25 s recommended.
     :param fs: Sample rate in Hz (>= 22,5 kHz).

--- a/tests/hearing/test_sti.py
+++ b/tests/hearing/test_sti.py
@@ -23,6 +23,7 @@ import pytest
 
 from phonometry import STIResult, sti_from_impulse_response, stipa, stipa_signal
 from phonometry.hearing.sti import (
+    STIWarning,
     _ALPHA_MALE,
     _BETA_MALE,
     _MOD_FREQS,
@@ -342,7 +343,7 @@ def test_invalid_inputs_raise():
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", UserWarning)
             stipa(stipa_signal(FS, seconds=18.0, seed=3)[: FS // 2], FS)
-    with pytest.warns(UserWarning, match="No energy in octave band"):
+    with pytest.warns(STIWarning, match="No energy in octave band"):
         # A pure tone leaves other octave bands empty: those bands read
         # m = 0 (TI = 0) with a warning rather than a hard error, so the
         # IEC 60268-16 C.4.2 verification signals (energy in only two

--- a/tests/hearing/test_sti.py
+++ b/tests/hearing/test_sti.py
@@ -229,7 +229,7 @@ def stipa_18s_seed1234() -> np.ndarray:
 def test_stipa_loopback_ideal_channel(stipa_18s_seed1234: np.ndarray):
     x = stipa_18s_seed1234
     result = stipa(x, FS)
-    # Ideal loopback recovers STI 0.998 and min MTF 0.943 at 18 s; lock those
+    # Ideal loopback recovers STI 0.998 and min MTF 0.945 at 18 s; lock those
     # in (was >= 0.95 / > 0.9, several x looser than the achieved accuracy).
     assert result.sti >= 0.99
     assert result.rating == "A+"
@@ -342,14 +342,19 @@ def test_invalid_inputs_raise():
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", UserWarning)
             stipa(stipa_signal(FS, seconds=18.0, seed=3)[: FS // 2], FS)
-    with pytest.raises(ValueError, match="no energy"):
-        # A pure tone leaves other octave bands empty. The 4 s clip also
-        # triggers the (correct) sub-15 s STIPA warning; silence it so the
-        # test output stays clean while we assert on the ValueError.
+    with pytest.warns(UserWarning, match="No energy in octave band"):
+        # A pure tone leaves other octave bands empty: those bands read
+        # m = 0 (TI = 0) with a warning rather than a hard error, so the
+        # IEC 60268-16 C.4.2 verification signals (energy in only two
+        # bands) remain measurable. The 4 s clip also triggers the
+        # (correct) sub-15 s STIPA warning; both are UserWarnings.
         t = np.arange(4 * FS) / FS
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", UserWarning)
-            stipa(np.sin(2 * np.pi * 1000.0 * t), FS)
+        res_tone = stipa(np.sin(2 * np.pi * 1000.0 * t), FS)
+    # The 1 kHz band carries the tone (unmodulated: m ~ 0); at least one
+    # dead band integrates to non-positive envelope energy and is pinned
+    # to exactly m = 0 instead of raising.
+    assert np.any(res_tone.mtf == 0.0)
+    assert np.all(res_tone.mtf[3] < 0.01)
 
     with pytest.raises(ValueError, match="positive"):
         stipa_signal(FS, seconds=0.0)

--- a/tests/hearing/test_stipa_certified.py
+++ b/tests/hearing/test_stipa_certified.py
@@ -1,0 +1,236 @@
+#  Copyright (c) 2026. Jose M. Requena-Plens
+"""
+End-to-end STIPA verification against the IEC 60268-16:2020 (rev 5)
+certified test bench signals from stipa.info (Embedded Acoustics BV).
+
+The 49 WAV oracles (48 kHz mono, free-of-charge verification licence) are
+third-party data and are not committed; the whole module skips cleanly
+when ``plan/stipa-verification/`` is absent (CI) and runs locally where
+the signals are kept. Expected values come from the accompanying signal
+description (Jan Verhave, Embedded Acoustics, v1.0 June 2020) and from
+the filenames; only the WAVs, filenames and that description were used
+(the bundled reference .m sources were consulted solely to resolve the
+envelope convention of C.3.2: the signals encode a STIPA channel of
+MTF = m, i.e. envelope index 0,55 m, so an analyzer normalizing by 0,55
+must read back m itself).
+
+Suites:
+
+- Annex C.3.2 - direct-method modulation depth: sine-carrier STIPA
+  signals at m = 0,0 .. 1,0; the analyzer must recover m per band and the
+  published m <-> STI staircase.
+- Annex C.3.3 - indirect-method modulation depth: exponentially decayed
+  sine carriers (RT60 = 0,125 .. 8 s) against the closed-form Schroeder
+  MTF m(F) = 1/sqrt(1 + (2 pi F T/13,8)^2).
+- Annex C.4.2 - filter-bank slope: modulated carrier plus an unmodulated
+  adjacent-octave tone 41 dB louder; normative criterion m >= 0,5 in the
+  observed band (needs > 41 dB effective slope, steeper than class 1).
+- Annex A.2.2 - weighting/redundancy factors: modulated octave-band
+  pairs; STI = alpha_k + alpha_{k+1} - beta_k.
+- Annex A.3.1.2 - filter-bank phase distortion: two sine carriers per
+  band at the half-octave edges fc*2^(+/-1/4); normative criterion
+  |STI bias| < 0,01 over TI = 0,1 .. 0,9.
+
+Measured worst-case deviations with this implementation (zero-phase
+analysis bank), on which the tolerances are based:
+C.3.2 |dSTI| 0,0031 / per-m 0,004; C.3.3 |dSTI| 0,0002 / per-m 0,018;
+C.4.2 min m 0,937; A.2.2 |dSTI| 0,0002 vs the exact alpha/beta identity;
+A.3.1.2 worst bias -0,0029.
+"""
+
+import os
+import pathlib
+import warnings
+
+import numpy as np
+import pytest
+from scipy.io import wavfile
+
+from phonometry import STIResult, sti_from_impulse_response, stipa
+from phonometry.hearing.sti import _MOD_FREQS, _NUM_BANDS, _sti_from_mtf
+
+FS = 48000
+_BANDS = (125, 250, 500, 1000, 2000, 4000, 8000)
+
+# Local-only oracle data: the stipa.info verification WAVs live under
+# plan/ (gitignored). STIPA_VERIFICATION_DATA overrides the location.
+DATA = pathlib.Path(
+    os.environ.get(
+        "STIPA_VERIFICATION_DATA",
+        str(pathlib.Path(__file__).parents[2] / "plan" / "stipa-verification"),
+    )
+)
+_DATA_PRESENT = (DATA / "Annex C.3.2").is_dir()
+
+pytestmark = pytest.mark.skipif(
+    not _DATA_PRESENT,
+    reason="stipa.info certified verification WAVs absent (local-only oracle; "
+    "download from stipa.info into plan/stipa-verification/)",
+)
+
+
+def _load(path: pathlib.Path) -> np.ndarray:
+    """Read a verification WAV as float64 in [-1, 1) at 48 kHz mono."""
+    fs, x = wavfile.read(path)
+    assert fs == FS, f"{path.name}: expected 48 kHz, got {fs}"
+    assert x.ndim == 1, f"{path.name}: expected mono"
+    if x.dtype == np.int16:
+        return x.astype(np.float64) / 32768.0
+    return np.asarray(x, dtype=np.float64)
+
+
+def _stipa_quiet(x: np.ndarray) -> STIResult:
+    """stipa() with the expected verification-bench warnings silenced
+    (dead bands and junk m > 1,3 in the two-band C.4.2 signals)."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        return stipa(x, FS)
+
+
+# ---------------------------------------------------------------------------
+# Annex C.3.2 - direct-method modulation depth (sine carriers, m = 0 .. 1)
+# ---------------------------------------------------------------------------
+
+# m <-> STI staircase from the signal description (Table with related m,
+# SNR and STI values); m and TI = (10 lg(m/(1-m)) + 15)/30 in 0,1 steps.
+_C32_EXPECTED = {
+    0.0: 0.00, 0.1: 0.18, 0.2: 0.30, 0.3: 0.38, 0.4: 0.44, 0.5: 0.50,
+    0.6: 0.56, 0.7: 0.62, 0.8: 0.70, 0.9: 0.82, 1.0: 1.00,
+}
+
+
+@pytest.mark.parametrize("m", sorted(_C32_EXPECTED))
+def test_c32_direct_method_modulation_depth(m: float) -> None:
+    x = _load(DATA / "Annex C.3.2" / f"STIPA-sinecarrier-M={m:g}.wav")
+    res = stipa(x, FS)
+    # Published staircase (worst measured |dSTI| = 0,0031 -> tol 0,01).
+    assert res.sti == pytest.approx(_C32_EXPECTED[m], abs=0.01)
+    # MTF extraction: every band/modulation-frequency cell must read back
+    # the encoded m (worst measured deviation 0,004 -> tol 0,01). At
+    # m = 1,0 the cells are clipped to at most 1.
+    assert res.mtf.shape == (7, 2)
+    np.testing.assert_allclose(res.mtf, m, atol=0.01)
+
+
+# ---------------------------------------------------------------------------
+# Annex C.3.3 - indirect-method modulation depth (exponential decays)
+# ---------------------------------------------------------------------------
+
+_C33_RT60 = (0.125, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0)
+
+
+def _schroeder_m(rt60: float) -> np.ndarray:
+    """Closed-form MTF of an exponential intensity decay of 60 dB in RT60:
+    I(t) ~ e^(-a t), a = 6 ln(10)/RT60, m(F) = 1/sqrt(1 + (2 pi F/a)^2)."""
+    a = 6.0 * np.log(10.0) / rt60
+    return np.asarray(1.0 / np.sqrt(1.0 + (2.0 * np.pi * _MOD_FREQS / a) ** 2))
+
+
+@pytest.mark.parametrize("rt60", _C33_RT60)
+def test_c33_indirect_method_exponential_decay(rt60: float) -> None:
+    x = _load(DATA / "Annex C.3.3" / f"STIPA-expdecay-RT60={rt60:g}.wav")
+    res = sti_from_impulse_response(x, FS)
+    m_expected = _schroeder_m(rt60)
+    # Per-band, per-modulation-frequency MTF against the closed form
+    # (worst measured deviation 0,018 at RT60 = 0,125 s -> tol 0,03).
+    np.testing.assert_allclose(
+        res.mtf, np.tile(m_expected, (_NUM_BANDS, 1)), atol=0.03
+    )
+    # STI derived from the closed-form MTF through the standard TI chain
+    # (worst measured |dSTI| = 0,0002 -> tol 0,005).
+    sti_expected = _sti_from_mtf(np.tile(m_expected, (_NUM_BANDS, 1))).sti
+    assert res.sti == pytest.approx(sti_expected, abs=0.005)
+
+
+# ---------------------------------------------------------------------------
+# Annex C.4.2 - filter-bank slope (m >= 0,5 with a +41 dB adjacent tone)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("slope", ["lowslope", "highslope"])
+@pytest.mark.parametrize("band", _BANDS)
+def test_c42_filter_slope(slope: str, band: int) -> None:
+    x = _load(DATA / "Annex C.4.2" / f"Filtertest_{slope} {band}.wav")
+    res = _stipa_quiet(x)
+    k = _BANDS.index(band)
+    m_observed = res.mtf[k]
+    # Normative pass criterion of the bench: m >= 0,5 in the observed
+    # band (an unmodulated tone one octave away, 41 dB louder, must not
+    # leak enough to halve the modulation depth).
+    assert np.all(m_observed >= 0.5), f"m = {m_observed} in the {band} Hz band"
+    # Regression lock well above the criterion: the zero-phase bank
+    # achieves m >= 0,937 on all 14 signals.
+    assert np.all(m_observed >= 0.85)
+
+
+# ---------------------------------------------------------------------------
+# Annex A.2.2 - weighting and redundancy factors (octave-band pairs)
+# ---------------------------------------------------------------------------
+
+# Exact Ed.5 Table A.1 identity alpha_k + alpha_{k+1} - beta_k; the
+# filename STI values are these rounded to two decimals.
+_A22_EXPECTED = {
+    (125, 250): 0.127,
+    (250, 500): 0.279,
+    (500, 1000): 0.398,
+    (1000, 2000): 0.531,
+    (2000, 4000): 0.486,
+    (4000, 8000): 0.302,
+}
+
+
+@pytest.mark.parametrize("pair", sorted(_A22_EXPECTED))
+def test_a22_weighting_factor_pairs(pair: tuple[int, int]) -> None:
+    lo, hi = pair
+    name = f"STIPA-sine-pair[{lo}+{hi}]STI={round(_A22_EXPECTED[pair], 2):g}.wav"
+    res = stipa(_load(DATA / "Annex A.2.2 - weight factor test" / name), FS)
+    # Worst measured deviation vs the exact identity: 0,0002 (the visible
+    # 0,004 vs the filename is its 2-decimal rounding) -> tol 0,005.
+    assert res.sti == pytest.approx(_A22_EXPECTED[pair], abs=0.005)
+
+
+# ---------------------------------------------------------------------------
+# Annex A.3.1.2 - filter-bank phase distortion (half-octave edge carriers)
+# ---------------------------------------------------------------------------
+
+# TI -> encoded m from the filenames (m = 1/(1 + 10^(-SNR/10)),
+# SNR = 30 TI - 15; endpoints clipped to 0 and 1 by the bench).
+_A312_FILES = {
+    0.0: "STIPA-sine-edge-carriers-TI=0[m=0].wav",
+    0.1: "STIPA-sine-edge-carriers-TI=0.1[m=0.059351].wav",
+    0.2: "STIPA-sine-edge-carriers-TI=0.2[m=0.11182].wav",
+    0.3: "STIPA-sine-edge-carriers-TI=0.3[m=0.20076].wav",
+    0.4: "STIPA-sine-edge-carriers-TI=0.4[m=0.33386].wav",
+    0.5: "STIPA-sine-edge-carriers-TI=0.5[m=0.5].wav",
+    0.6: "STIPA-sine-edge-carriers-TI=0.6[m=0.66614].wav",
+    0.7: "STIPA-sine-edge-carriers-TI=0.7[m=0.79924].wav",
+    0.8: "STIPA-sine-edge-carriers-TI=0.8[m=0.88818].wav",
+    0.9: "STIPA-sine-edge-carriers-TI=0.9[m=0.94065].wav",
+    1.0: "STIPA-sine-edge-carriers-TI=1[m=1].wav",
+}
+
+
+@pytest.mark.parametrize("ti", sorted(_A312_FILES))
+def test_a312_filter_bank_phase(ti: float) -> None:
+    res = stipa(_load(DATA / "Annex A.3.1.2 - filter bank phase test" / _A312_FILES[ti]), FS)
+    # Normative criterion: |STI bias| < 0,01 over TI = 0,1 .. 0,9; the
+    # endpoints (clipped m) hold trivially and are asserted at the same
+    # tolerance. Worst measured bias with the zero-phase bank: -0,0029.
+    assert res.sti == pytest.approx(ti, abs=0.01)
+
+
+# ---------------------------------------------------------------------------
+# Inventory guard: all 49 oracles must be seen when the data is present
+# ---------------------------------------------------------------------------
+
+def test_certified_bench_inventory() -> None:
+    """Guard against a silent partial download: 11 + 7 + 14 + 6 + 11."""
+    counts = {
+        "Annex C.3.2": 11,
+        "Annex C.3.3": 7,
+        "Annex C.4.2": 14,
+        "Annex A.2.2 - weight factor test": 6,
+        "Annex A.3.1.2 - filter bank phase test": 11,
+    }
+    for sub, n in counts.items():
+        found = len(list((DATA / sub).glob("*.wav")))
+        assert found == n, f"{sub}: expected {n} WAVs, found {found}"

--- a/tests/hearing/test_stipa_certified.py
+++ b/tests/hearing/test_stipa_certified.py
@@ -75,8 +75,13 @@ def _load(path: pathlib.Path) -> np.ndarray:
     assert fs == FS, f"{path.name}: expected 48 kHz, got {fs}"
     assert x.ndim == 1, f"{path.name}: expected mono"
     if x.dtype == np.int16:
-        return x.astype(np.float64) / 32768.0
-    return np.asarray(x, dtype=np.float64)
+        y = x.astype(np.float64) / 32768.0
+    else:
+        y = np.asarray(x, dtype=np.float64)
+    # Every bench signal carries at least an unmodulated carrier; a silent
+    # file (corrupt download) must fail loudly, not read as m = 0.
+    assert float(np.sqrt(np.mean(y**2))) > 1e-3, f"{path.name}: silent file"
+    return y
 
 
 def _stipa_quiet(x: np.ndarray) -> STIResult:


### PR DESCRIPTION
## Summary

Wires the IEC 60268-16 rev 5 verification test bench from stipa.info (Embedded Acoustics, free-of-charge licence) as an end-to-end black-box oracle for the STIPA analyzer, and fixes the two real defects it caught. The 49 certified WAVs (Annexes C.3.2, C.3.3, C.4.2, A.2.2 and A.3.1.2) now all pass, with worst-case deviations of a few thousandths of STI.

## Defects caught and fixed

- The order-6 Butterworth analysis bank applied single-pass gave only ~31 dB attenuation one octave below band centre and enough phase distortion to bias the STI by up to -0.020 at TI = 0.9. That fails two normative criteria: the C.4.2 filter-slope test (all 7 lowslope signals read m = 0.09-0.24 against the m >= 0.5 requirement) and the A.3.1.2 phase-distortion limit (bias < 0.01). Band filtering in `stipa()` and `sti_from_impulse_response()` is now zero-phase: no phase bias by construction and ~63 dB skirt attenuation. On ordinary signals of the recommended duration the STI shifts by at most ~0.003.
- `stipa()` raised `ValueError` on recordings whose octave bands carry no energy, making two-band verification signals unmeasurable. Dead bands now read m = 0 (TI = 0, the worst-case reading of a real meter) under an `STIWarning`.

## Verification results (all 49 signals)

- C.3.2 direct-method staircase (m = 0..1): worst |dSTI| 0.0031 against the published m/STI table; every MTF cell within 0.004 of the encoded m.
- C.3.3 exponential decays (RT60 = 0.125..8 s): worst |dSTI| 0.0002 against the closed-form Schroeder MTF, re-derived independently in the test.
- C.4.2 filter slope: worst m = 0.937 against the normative m >= 0.5 (was 0.09 before the fix).
- A.2.2 weighting-factor pairs: deviations ~0.0002 against the exact alpha/beta identity (the filename values are 2-decimal roundings of it).
- A.3.1.2 edge carriers: worst bias -0.0029 against the normative < 0.01 (was -0.0196).

Tolerances are evidence-based (2-3x the measured worst case, stated per suite); the two normative criteria are asserted as printed. Nothing was loosened to make a suite pass.

## Structure

- `tests/hearing/test_stipa_certified.py` (50 tests): local-only oracle, skipped cleanly when the WAVs are absent (they are not committed; free download from stipa.info). Includes a 49-file inventory guard and a silent-file guard so a corrupt download fails loudly.
- 6 new CI-runnable conformance checks with deterministic in-code sine-carrier constructions of the same annex scenarios (no external data). Conformance grows 251 -> 257.
- Docs: verification-bench subsection in the STI guide (EN/ES); the loopback figures in prose and docstrings updated; the four `sti_vs_t60` figure variants regenerated (sub-visual shift from the zero-phase change).

The Matlab reference files bundled with the bench were consulted only to resolve signal-construction ambiguities; no code was ported.

## Test plan

Suite 3158 passed (the 50 oracle tests running against the local WAVs, not skipped); ruff and mypy clean; conformance 257/257 regenerated byte-identical; `check_figures.py` all 624 match. An adversarial pass reproduced both defects on the certified signals, verified the zero-phase choice against synthetic impulse responses with known closed-form MTF (closer than the previous filtering everywhere at RT60 >= 0.25 s, STI within 0.001 elsewhere), confirmed masking/level paths are unaffected, and re-derived the expected values independently from the m/SNR/TI relations.

## Summary by Sourcery

Verify the STIPA analyzer end-to-end against the IEC 60268-16 rev 5 certified test bench and adjust the STI analysis to meet the standard’s normative criteria while exposing these checks in conformance reporting and docs.

New Features:
- Add a local-only STIPA certified-bench test suite that validates stipa() and sti_from_impulse_response() against 49 IEC 60268-16 rev 5 verification WAVs across multiple annex scenarios.
- Add six synthetic, CI-runnable IEC 60268-16 conformance checks covering direct and indirect STIPA methods, filter-bank slope and phase, and weighting-factor audio-path behavior.
- Introduce helper signal generators for IEC 60268-16-style STIPA sine-carrier verification signals used in conformance tests.

Bug Fixes:
- Change the STI octave-band analysis filters to zero-phase operation to eliminate phase-induced STI bias and ensure sufficient out-of-band attenuation per IEC 60268-16 criteria.
- Allow STIPA processing of signals with octave bands that carry no energy by treating those bands as m = 0 with an STIWarning instead of raising an error.

Enhancements:
- Tighten and document the expected STI values for ideal loopback and short-duration recordings in comments and tests to reflect the zero-phase filter behavior.
- Improve STIPA validation by comparing indirect-method exponential decays to the closed-form Schroeder MTF across all bands and modulation frequencies.
- Strengthen tests for pure-tone STIPA inputs to assert correct handling of dead bands and low modulation depths in the occupied band.

CI:
- Expand the numerical conformance suite with six additional IEC 60268-16 STIPA checks and update the reported totals in the conformance documentation.

Documentation:
- Extend the English and Spanish speech-transmission guides with a description of the IEC 60268-16 rev 5 verification test bench, how it is applied, and its coverage of direct, indirect, slope, weighting, and phase tests.
- Update documentation and regenerated STI vs T60 figures to reflect the zero-phase analysis bank behavior and revised loopback STI values.
- Update the conformance report to describe the expanded IEC 60268-16 speech-transmission coverage and new check counts.

Tests:
- Add comprehensive oracle-based tests against all 49 certified IEC 60268-16 STIPA verification WAVs, including guards for data presence and file integrity.
- Add parametrized tests for direct-method modulation-depth staircase, indirect-method exponential decays, filter-bank slope, weighting-factor pairs, and filter-bank phase distortion based on the certified bench.
- Update existing STIPA tests to assert new loopback STI/MTF reference values and to expect warnings instead of errors for dead-band scenarios.

Chores:
- Document and wire in a configurable local path for the external STIPA verification data, ensuring tests skip cleanly when the third-party WAVs are absent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end IEC 60268-16 STIPA certified-bench verification suite with local-oracle execution and synthetic CI conformance checks.

* **Bug Fixes**
  * Improved STI/STIPA verification alignment via zero-phase octave-band filtering.
  * STIPA no longer errors on silent octave bands; it reports zero modulation depth and emits a warning.
  
* **Performance**
  * Accelerated conformance computations and documentation figure generation while preserving byte-identical output.

* **Tests**
  * Added comprehensive STIPA verification tests across multiple certified annexes.

* **Documentation**
  * Updated STI/STIPA example values and expanded verification/conformance reporting details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->