### PR TITLE
docs(site): audit generated API and split pages in the accessibility gate

### DIFF
--- a/site/.pa11yci.json
+++ b/site/.pa11yci.json
@@ -21,6 +21,12 @@
     "http://localhost:4321/phonometry/reference/theory/",
     "http://localhost:4321/phonometry/es/",
     "http://localhost:4321/phonometry/es/getting-started/",
-    "http://localhost:4321/phonometry/es/guides/filter-banks/"
+    "http://localhost:4321/phonometry/es/guides/filter-banks/",
+    "http://localhost:4321/phonometry/reference/api/levels/levels/",
+    "http://localhost:4321/phonometry/reference/api/psychoacoustics/loudness-zwicker/",
+    "http://localhost:4321/phonometry/guides/insulation-field/",
+    "http://localhost:4321/phonometry/guides/loudness/",
+    "http://localhost:4321/phonometry/es/reference/api/levels/levels/",
+    "http://localhost:4321/phonometry/es/guides/insulation-field/"
   ]
 }

--- a/site/.pa11yci.json
+++ b/site/.pa11yci.json
@@ -27,6 +27,7 @@
     "http://localhost:4321/phonometry/guides/insulation-field/",
     "http://localhost:4321/phonometry/guides/loudness/",
     "http://localhost:4321/phonometry/es/reference/api/levels/levels/",
-    "http://localhost:4321/phonometry/es/guides/insulation-field/"
+    "http://localhost:4321/phonometry/es/guides/insulation-field/",
+    "http://localhost:4321/phonometry/es/guides/loudness/"
   ]
 }


### PR DESCRIPTION
## Summary

Validation hardening to close out the documentation IA work: the accessibility gate now audits the new page families. `site/.pa11yci.json` grows from 10 to 17 URLs, adding two generated API module pages (levels, Zwicker loudness), two split guide pages (field insulation, loudness) and their Spanish twins (including the API locale-fallback route).

The other closure items were already in place and are verified rather than changed: `llms.txt` links the generated API reference in its Documentation list, and `docs/README.md` points at it with the English-only note.

## Test plan

- `pnpm pa11y`: 17/17 URLs pass WCAG2AA on a fresh build.
- `pnpm build` (links validator 0 errors), `html-validate` and `check:i18n` (50/50) green; dist size steady at 52M.

## Summary by Sourcery

Tests:
- Extend pa11y accessibility gate configuration to validate 16 documentation URLs, including new generated API and split guide pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded accessibility testing coverage to include additional documentation pages, including Spanish guides and reference content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->