### PR TITLE
docs: bibliography page, References convention and Standards footer normalization

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -63,6 +63,7 @@ Full documentation for phonometry. Also available as a website:
   - [Environment and transport](theory-environment-transport.md) — environmental descriptors, impulsive adjustment, outdoor propagation, occupational exposure, sound power
   - [Vibration](theory-vibration.md) — human vibration weightings and metrics, multiple-shock spinal model
 - [Why phonometry](why-phonometry.md) — IEC compliance vs other libraries
+- [Bibliography](references.md) — the books and papers behind the guides, grouped by domain, every entry with a verified DOI or official publisher link
 - [Conformance report](CONFORMANCE.md) — auto-generated numerical validation: every check pins a standard clause's expected value against the library's computed value, regenerated in CI
 - [Standards errata](ERRATA.md) — defects found in the published standards themselves during implementation: misprints, examples contradicting their own normative text, ambiguous wording, each with evidence and the library's disposition
 

--- a/docs/block-processing.md
+++ b/docs/block-processing.md
@@ -104,3 +104,15 @@ for x in audio_stream(block):            # your capture callback
 | `zero_phase` | unsupported | Forward-backward filtering needs the whole signal |
 | `high_accuracy` (weighting) | resolves to `False` by default — the legacy bilinear design, see [Frequency Weighting](weighting.md); explicitly passing `True` raises `ValueError` | The polyphase resampling inside is block-incompatible |
 | `steady_ic` | optional | Starts the filters in step-response steady state |
+
+---
+
+**Standards.** IEC 61260-1:2014, *Electroacoustics — Octave-band and
+fractional-octave-band filters — Part 1: Specifications*, and IEC 61672-1:2013,
+*Electroacoustics — Sound level meters — Part 1: Specifications* — block
+processing adds no normative content of its own: the streamed filters are the
+same designs those standards govern (see [Filter Banks](filter-banks.md),
+[Frequency Weighting](weighting.md) and [Time Weighting](time-weighting.md)),
+and carrying the internal filter state across blocks is exactly what makes the
+concatenated output identical to a single full-signal pass, so every class and
+tolerance claim of the underlying pages holds unchanged in streaming use.

--- a/docs/multichannel.md
+++ b/docs/multichannel.md
@@ -83,3 +83,13 @@ Additional performance notes:
   [Theory](theory-signal-analysis.md)).
 - **Optional numba**: the `impulse` time weighting kernel is JIT-compiled when
   numba is installed (`pip install phonometry[perf]`).
+
+---
+
+**Standards.** IEC 61260-1:2014, *Electroacoustics — Octave-band and
+fractional-octave-band filters — Part 1: Specifications*, and IEC 61672-1:2013,
+*Electroacoustics — Sound level meters — Part 1: Specifications* —
+multichannel support adds no normative content of its own: each channel is
+filtered, weighted and time-integrated exactly as the single-channel standards
+prescribe (see [Filter Banks](filter-banks.md) and [Levels](levels.md)); the
+vectorization only batches the computation across the channel axis.

--- a/docs/references.md
+++ b/docs/references.md
@@ -1,0 +1,65 @@
+← [Documentation index](README.md)
+
+# Bibliography
+
+Every guide in this documentation closes with two citation blocks: a
+`## References` section listing the books and papers that support the physics
+on the page (APA style, one bullet per source, each with a DOI or an official
+publisher link, and half a sentence on what the entry supports), followed by a
+final **Standards.** paragraph naming the normative documents the page
+implements, clause by clause. This page collects the References entries of all
+guides in one place, grouped by domain: a curated reading list, and the single
+source of truth for link checking. Each entry lists the guide pages that cite
+it; the list grows as guides gain their References sections.
+
+## General acoustics
+
+- Kinsler, L. E., Frey, A. R., Coppens, A. B., & Sanders, J. V. (2000).
+  *Fundamentals of acoustics* (4th ed.). Wiley. ISBN 978-0-471-84789-2.
+  [Publisher page](https://www.wiley.com/en-us/Fundamentals+of+Acoustics%2C+4th+Edition-p-9780471847892).
+  The standard first course in acoustics: plane and spherical waves, acoustic
+  impedance and the level definitions assumed throughout the guides.
+- Rossing, T. D. (Ed.). (2014). *Springer handbook of acoustics* (2nd ed.).
+  Springer. ISBN 978-1-4939-0754-0.
+  [doi:10.1007/978-1-4939-0755-7](https://doi.org/10.1007/978-1-4939-0755-7).
+  A one-volume survey of every domain this library touches, from room
+  acoustics to psychoacoustics and underwater sound; the cross-domain
+  reference of first resort.
+- Beranek, L. L., & Mellow, T. J. (2012). *Acoustics: Sound fields and
+  transducers*. Academic Press. ISBN 978-0-12-391421-7.
+  [doi:10.1016/C2011-0-05897-0](https://doi.org/10.1016/C2011-0-05897-0).
+  Sound fields, radiation and electroacoustic transducers; supports the
+  electroacoustics and sound-power material.
+
+## Signal processing
+
+- Oppenheim, A. V., & Schafer, R. W. (2010). *Discrete-time signal processing*
+  (3rd ed.). Pearson. ISBN 978-0-13-198842-2.
+  [Open Library record](https://openlibrary.org/isbn/9780131988422).
+  The digital-filter theory behind the SOS cascades, the bilinear transform
+  and the multirate decimation used by the filter banks.
+- Smith, J. O. *Introduction to digital filters with audio applications*
+  (online book). Center for Computer Research in Music and Acoustics (CCRMA),
+  Stanford University.
+  [ccrma.stanford.edu/~jos/filters](https://ccrma.stanford.edu/~jos/filters/).
+  Free companion treatment of digital-filter design and analysis, a good next
+  step after the filter-bank guides.
+
+## Metrology
+
+- Joint Committee for Guides in Metrology. (2008). *Evaluation of measurement
+  data — Guide to the expression of uncertainty in measurement* (JCGM
+  100:2008, the GUM). BIPM.
+  [doi:10.59161/JCGM100-2008E](https://doi.org/10.59161/JCGM100-2008E),
+  [free PDF](https://www.bipm.org/documents/20126/2071204/JCGM_100_2008_E.pdf).
+  The law of propagation of uncertainty implemented by the uncertainty module.
+  Cited by [Measurement uncertainty](gum-uncertainty.md).
+- Joint Committee for Guides in Metrology. (2008). *Evaluation of measurement
+  data — Supplement 1 to the "Guide to the expression of uncertainty in
+  measurement" — Propagation of distributions using a Monte Carlo method*
+  (JCGM 101:2008). BIPM.
+  [doi:10.59161/JCGM101-2008](https://doi.org/10.59161/JCGM101-2008),
+  [free PDF](https://www.bipm.org/documents/20126/2071204/JCGM_101_2008_E.pdf).
+  The Monte Carlo propagation of distributions implemented by the Monte Carlo
+  uncertainty engine.
+  Cited by [Measurement uncertainty](gum-uncertainty.md).

--- a/docs/surface-scattering.md
+++ b/docs/surface-scattering.md
@@ -403,7 +403,7 @@ print(round(s_min, 3), round(s_max, 3))    # 0.078 0.086  (metres)
 
 ---
 
-**Standards implemented on this page:** ISO 17497-1:2004 (scattering
+**Standards.** ISO 17497-1:2004 (scattering
 coefficient), ISO 17497-2:2012 (diffusion coefficient), ISO 13472-1:2002 (in-situ
 absorption, extended surface), ISO 13472-2:2010 (in-situ absorption, spot
 method), and ISO 9613-1:1993 — only the pure-tone attenuation coefficient

--- a/site/.pa11yci.json
+++ b/site/.pa11yci.json
@@ -39,6 +39,8 @@
     "http://localhost:4321/phonometry/es/reference/api/levels/levels/",
     "http://localhost:4321/phonometry/es/guides/insulation-field/",
     "http://localhost:4321/phonometry/es/guides/loudness/",
-    "http://localhost:4321/phonometry/es/reference/theory/"
+    "http://localhost:4321/phonometry/es/reference/theory/",
+    "http://localhost:4321/phonometry/reference/bibliography/",
+    "http://localhost:4321/phonometry/es/reference/bibliography/"
   ]
 }

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -435,6 +435,7 @@ export default defineConfig({
               ],
             },
             'reference/conformance',
+            'reference/bibliography',
           ],
         },
       ],

--- a/site/src/content/docs/es/guides/block-processing.md
+++ b/site/src/content/docs/es/guides/block-processing.md
@@ -108,6 +108,21 @@ for x in audio_stream(block):            # tu callback de captura
 | `high_accuracy` (ponderación) | por defecto se resuelve a `False` — el diseño bilineal clásico, consulta [Ponderación frecuencial](/phonometry/es/guides/weighting/); pasar `True` explícito lanza `ValueError` | El remuestreo polifásico interno es incompatible con bloques |
 | `steady_ic` | opcional | Arranca los filtros en el régimen permanente de la respuesta al escalón |
 
+---
+
+**Normas.** IEC 61260-1:2014, *Electroacoustics — Octave-band and
+fractional-octave-band filters — Part 1: Specifications*, e IEC 61672-1:2013,
+*Electroacoustics — Sound level meters — Part 1: Specifications* — el
+procesado por bloques no añade contenido normativo propio: los filtros en
+streaming son los mismos diseños que rigen esas normas (consulta
+[Bancos de filtros](/phonometry/es/guides/filter-banks/),
+[Ponderación frecuencial](/phonometry/es/guides/weighting/) y
+[Ponderación temporal](/phonometry/es/guides/time-weighting/)), y conservar el
+estado interno del filtro entre bloques es exactamente lo que hace que la
+salida concatenada sea idéntica a una pasada única sobre la señal completa,
+por lo que toda afirmación de clase y tolerancia de las páginas subyacentes se
+mantiene sin cambios en uso streaming.
+
 ## Véase también
 
 - Referencia de la API: [`metrology.parametric_filters`](/phonometry/es/reference/api/filters/parametric-filters/) y [`metrology.core`](/phonometry/es/reference/api/filters/core/).

--- a/site/src/content/docs/es/guides/multichannel.md
+++ b/site/src/content/docs/es/guides/multichannel.md
@@ -84,6 +84,17 @@ Notas adicionales de rendimiento:
 - **numba opcional**: el kernel del modo `impulse` de la ponderación temporal se
   compila JIT cuando numba está instalado (`pip install phonometry[perf]`).
 
+---
+
+**Normas.** IEC 61260-1:2014, *Electroacoustics — Octave-band and
+fractional-octave-band filters — Part 1: Specifications*, e IEC 61672-1:2013,
+*Electroacoustics — Sound level meters — Part 1: Specifications* — el soporte
+multicanal no añade contenido normativo propio: cada canal se filtra, pondera
+e integra en el tiempo exactamente como prescriben las normas monocanal
+(consulta [Bancos de filtros](/phonometry/es/guides/filter-banks/) y
+[Niveles](/phonometry/es/guides/levels/)); la vectorización solo agrupa el
+cálculo a lo largo del eje de canales.
+
 ## Véase también
 
 - Referencia de la API: [`phonometry`](/phonometry/es/reference/api/filters/phonometry/) y [`metrology.core`](/phonometry/es/reference/api/filters/core/).

--- a/site/src/content/docs/es/guides/psychoacoustic-annoyance.md
+++ b/site/src/content/docs/es/guides/psychoacoustic-annoyance.md
@@ -218,9 +218,9 @@ Para **ruido de banda ancha AM** el modelo de señal sobreestima el nivel absolu
 `fluctuation_strength_am_noise` (§3.1) para ese estímulo.
 :::
 
-## Normas
+---
 
-Fastl y Zwicker (2006), *Psychoacoustics: Facts and Models* (Springer): la
+**Normas.** Fastl y Zwicker (2006), *Psychoacoustics: Facts and Models* (Springer): la
 molestia psicoacústica `PA = N5·(1 + √(wS² + wFR²))` con la ponderación de nitidez
 `wS` y la ponderación de aspereza/fluctuación `wFR` (Ecs 16.2–16.4; origen
 Widmann 1992), y la forma cerrada para la intensidad de fluctuación del ruido de

--- a/site/src/content/docs/es/guides/surface-scattering.md
+++ b/site/src/content/docs/es/guides/surface-scattering.md
@@ -414,7 +414,7 @@ print(round(s_min, 3), round(s_max, 3))    # 0.078 0.086  (metros)
 
 ---
 
-**Normas implementadas en esta página:** ISO 17497-1:2004 (coeficiente de
+**Normas.** ISO 17497-1:2004 (coeficiente de
 dispersión), ISO 17497-2:2012 (coeficiente de difusión), ISO 13472-1:2002
 (absorción in situ, superficie extensa), ISO 13472-2:2010 (absorción in situ,
 método puntual), e ISO 9613-1:1993 — solo el coeficiente de atenuación de

--- a/site/src/content/docs/es/guides/tone-audibility.md
+++ b/site/src/content/docs/es/guides/tone-audibility.md
@@ -210,9 +210,9 @@ y se verifican contra el programa de referencia del Anexo J de
 137,3 Hz) los mantiene combinados, coherente con la agrupación FG de ese ejemplo.
 :::
 
-## Normas
+---
 
-ISO/PAS 20065:2016, *Acoustics — Objective method for assessing the audibility
+**Normas.** ISO/PAS 20065:2016, *Acoustics — Objective method for assessing the audibility
 of tones in noise — Engineering method*: el ancho de banda crítico `Δfc`
 (Fórmula 2) y sus frecuencias de esquina (Fórmulas 3–5), el nivel de banda
 crítica `LG` (Fórmula 12), el índice de enmascaramiento `av` (Fórmula 13), la

--- a/site/src/content/docs/es/reference/bibliography.md
+++ b/site/src/content/docs/es/reference/bibliography.md
@@ -20,13 +20,14 @@ que las guías incorporan sus secciones de Referencias.
   *Fundamentals of acoustics* (4.ª ed.). Wiley. ISBN 978-0-471-84789-2.
   [Página del editor](https://www.wiley.com/en-us/Fundamentals+of+Acoustics%2C+4th+Edition-p-9780471847892).
   El primer curso clásico de acústica: ondas planas y esféricas, impedancia
-  acústica y las definiciones de nivel que asumen todas las guías.
+  acústica y las definiciones de nivel sobre las que se apoyan todas las
+  guías.
 - Rossing, T. D. (Ed.). (2014). *Springer handbook of acoustics* (2.ª ed.).
   Springer. ISBN 978-1-4939-0754-0.
   [doi:10.1007/978-1-4939-0755-7](https://doi.org/10.1007/978-1-4939-0755-7).
   Un panorama en un solo volumen de todos los dominios que toca esta
   biblioteca, desde la acústica de salas hasta la psicoacústica y el sonido
-  submarino; la referencia transversal de primer recurso.
+  submarino; la referencia transversal de consulta obligada.
 - Beranek, L. L., & Mellow, T. J. (2012). *Acoustics: Sound fields and
   transducers*. Academic Press. ISBN 978-0-12-391421-7.
   [doi:10.1016/C2011-0-05897-0](https://doi.org/10.1016/C2011-0-05897-0).
@@ -39,13 +40,13 @@ que las guías incorporan sus secciones de Referencias.
   (3.ª ed.). Pearson. ISBN 978-0-13-198842-2.
   [Ficha en Open Library](https://openlibrary.org/isbn/9780131988422).
   La teoría de filtros digitales tras las cascadas SOS, la transformada
-  bilineal y la diezma multitasa que usan los bancos de filtros.
+  bilineal y el diezmado multitasa que usan los bancos de filtros.
 - Smith, J. O. *Introduction to digital filters with audio applications*
   (libro en línea). Center for Computer Research in Music and Acoustics
   (CCRMA), Universidad de Stanford.
   [ccrma.stanford.edu/~jos/filters](https://ccrma.stanford.edu/~jos/filters/).
   Tratamiento gratuito y complementario del diseño y análisis de filtros
-  digitales, un buen paso siguiente tras las guías de bancos de filtros.
+  digitales, el paso natural tras las guías de bancos de filtros.
 
 ## Metrología
 
@@ -54,7 +55,7 @@ que las guías incorporan sus secciones de Referencias.
   100:2008, la GUM). BIPM.
   [doi:10.59161/JCGM100-2008E](https://doi.org/10.59161/JCGM100-2008E),
   [PDF gratuito](https://www.bipm.org/documents/20126/2071204/JCGM_100_2008_E.pdf).
-  La ley de propagación de la incertidumbre que implementa el módulo de
+  La ley de propagación de la incertidumbre implementada por el módulo de
   incertidumbre.
   Citado por [Incertidumbre de medida](/phonometry/es/guides/gum-uncertainty/).
 - Joint Committee for Guides in Metrology. (2008). *Evaluation of measurement
@@ -63,6 +64,6 @@ que las guías incorporan sus secciones de Referencias.
   (JCGM 101:2008). BIPM.
   [doi:10.59161/JCGM101-2008](https://doi.org/10.59161/JCGM101-2008),
   [PDF gratuito](https://www.bipm.org/documents/20126/2071204/JCGM_101_2008_E.pdf).
-  La propagación de distribuciones por Monte Carlo que implementa el motor de
-  incertidumbre por Monte Carlo.
+  La propagación de distribuciones mediante Monte Carlo implementada por el
+  motor de incertidumbre de Monte Carlo.
   Citado por [Incertidumbre de medida](/phonometry/es/guides/gum-uncertainty/).

--- a/site/src/content/docs/es/reference/bibliography.md
+++ b/site/src/content/docs/es/reference/bibliography.md
@@ -1,0 +1,68 @@
+---
+title: "Bibliografía"
+description: "Los libros y artículos que sustentan las guías, agrupados por dominio: cada entrada con un DOI verificado o un enlace oficial del editor y una nota sobre qué sustenta."
+---
+
+Cada guía de este sitio se cierra con dos bloques de citas: una sección
+**Referencias** que lista los libros y artículos que sustentan la física de la
+página (estilo APA, un punto por fuente, cada uno con un DOI o un enlace
+oficial del editor, y media frase sobre qué sustenta la entrada), seguida de
+un párrafo final **Normas.** que nombra los documentos normativos que la
+página implementa, apartado por apartado. Esta página reúne las entradas de
+Referencias de todas las guías en un solo lugar, agrupadas por dominio: una
+lista de lectura curada y la fuente única de verdad para la comprobación de
+enlaces. Cada entrada lista las guías que la citan; la lista crece a medida
+que las guías incorporan sus secciones de Referencias.
+
+## Acústica general
+
+- Kinsler, L. E., Frey, A. R., Coppens, A. B., & Sanders, J. V. (2000).
+  *Fundamentals of acoustics* (4.ª ed.). Wiley. ISBN 978-0-471-84789-2.
+  [Página del editor](https://www.wiley.com/en-us/Fundamentals+of+Acoustics%2C+4th+Edition-p-9780471847892).
+  El primer curso clásico de acústica: ondas planas y esféricas, impedancia
+  acústica y las definiciones de nivel que asumen todas las guías.
+- Rossing, T. D. (Ed.). (2014). *Springer handbook of acoustics* (2.ª ed.).
+  Springer. ISBN 978-1-4939-0754-0.
+  [doi:10.1007/978-1-4939-0755-7](https://doi.org/10.1007/978-1-4939-0755-7).
+  Un panorama en un solo volumen de todos los dominios que toca esta
+  biblioteca, desde la acústica de salas hasta la psicoacústica y el sonido
+  submarino; la referencia transversal de primer recurso.
+- Beranek, L. L., & Mellow, T. J. (2012). *Acoustics: Sound fields and
+  transducers*. Academic Press. ISBN 978-0-12-391421-7.
+  [doi:10.1016/C2011-0-05897-0](https://doi.org/10.1016/C2011-0-05897-0).
+  Campos sonoros, radiación y transductores electroacústicos; sustenta el
+  material de electroacústica y potencia sonora.
+
+## Procesado de señal
+
+- Oppenheim, A. V., & Schafer, R. W. (2010). *Discrete-time signal processing*
+  (3.ª ed.). Pearson. ISBN 978-0-13-198842-2.
+  [Ficha en Open Library](https://openlibrary.org/isbn/9780131988422).
+  La teoría de filtros digitales tras las cascadas SOS, la transformada
+  bilineal y la diezma multitasa que usan los bancos de filtros.
+- Smith, J. O. *Introduction to digital filters with audio applications*
+  (libro en línea). Center for Computer Research in Music and Acoustics
+  (CCRMA), Universidad de Stanford.
+  [ccrma.stanford.edu/~jos/filters](https://ccrma.stanford.edu/~jos/filters/).
+  Tratamiento gratuito y complementario del diseño y análisis de filtros
+  digitales, un buen paso siguiente tras las guías de bancos de filtros.
+
+## Metrología
+
+- Joint Committee for Guides in Metrology. (2008). *Evaluation of measurement
+  data — Guide to the expression of uncertainty in measurement* (JCGM
+  100:2008, la GUM). BIPM.
+  [doi:10.59161/JCGM100-2008E](https://doi.org/10.59161/JCGM100-2008E),
+  [PDF gratuito](https://www.bipm.org/documents/20126/2071204/JCGM_100_2008_E.pdf).
+  La ley de propagación de la incertidumbre que implementa el módulo de
+  incertidumbre.
+  Citado por [Incertidumbre de medida](/phonometry/es/guides/gum-uncertainty/).
+- Joint Committee for Guides in Metrology. (2008). *Evaluation of measurement
+  data — Supplement 1 to the "Guide to the expression of uncertainty in
+  measurement" — Propagation of distributions using a Monte Carlo method*
+  (JCGM 101:2008). BIPM.
+  [doi:10.59161/JCGM101-2008](https://doi.org/10.59161/JCGM101-2008),
+  [PDF gratuito](https://www.bipm.org/documents/20126/2071204/JCGM_101_2008_E.pdf).
+  La propagación de distribuciones por Monte Carlo que implementa el motor de
+  incertidumbre por Monte Carlo.
+  Citado por [Incertidumbre de medida](/phonometry/es/guides/gum-uncertainty/).

--- a/site/src/content/docs/guides/block-processing.md
+++ b/site/src/content/docs/guides/block-processing.md
@@ -106,6 +106,20 @@ for x in audio_stream(block):            # your capture callback
 | `high_accuracy` (weighting) | resolves to `False` by default — the legacy bilinear design, see [Frequency Weighting](/phonometry/guides/weighting/); explicitly passing `True` raises `ValueError` | The polyphase resampling inside is block-incompatible |
 | `steady_ic` | optional | Starts the filters in step-response steady state |
 
+---
+
+**Standards.** IEC 61260-1:2014, *Electroacoustics — Octave-band and
+fractional-octave-band filters — Part 1: Specifications*, and IEC 61672-1:2013,
+*Electroacoustics — Sound level meters — Part 1: Specifications* — block
+processing adds no normative content of its own: the streamed filters are the
+same designs those standards govern (see
+[Filter Banks](/phonometry/guides/filter-banks/),
+[Frequency Weighting](/phonometry/guides/weighting/) and
+[Time Weighting](/phonometry/guides/time-weighting/)), and carrying the
+internal filter state across blocks is exactly what makes the concatenated
+output identical to a single full-signal pass, so every class and tolerance
+claim of the underlying pages holds unchanged in streaming use.
+
 ## See also
 
 - API reference: [`metrology.parametric_filters`](/phonometry/reference/api/filters/parametric-filters/) and [`metrology.core`](/phonometry/reference/api/filters/core/).

--- a/site/src/content/docs/guides/multichannel.md
+++ b/site/src/content/docs/guides/multichannel.md
@@ -85,6 +85,17 @@ Additional performance notes:
 - **Optional numba**: the `impulse` time weighting kernel is JIT-compiled when
   numba is installed (`pip install phonometry[perf]`).
 
+---
+
+**Standards.** IEC 61260-1:2014, *Electroacoustics — Octave-band and
+fractional-octave-band filters — Part 1: Specifications*, and IEC 61672-1:2013,
+*Electroacoustics — Sound level meters — Part 1: Specifications* —
+multichannel support adds no normative content of its own: each channel is
+filtered, weighted and time-integrated exactly as the single-channel standards
+prescribe (see [Filter Banks](/phonometry/guides/filter-banks/) and
+[Levels](/phonometry/guides/levels/)); the vectorization only batches the
+computation across the channel axis.
+
 ## See also
 
 - API reference: [`phonometry`](/phonometry/reference/api/filters/phonometry/) and [`metrology.core`](/phonometry/reference/api/filters/core/).

--- a/site/src/content/docs/guides/psychoacoustic-annoyance.md
+++ b/site/src/content/docs/guides/psychoacoustic-annoyance.md
@@ -213,9 +213,9 @@ level (it spreads the modulated energy across bands) — quote the closed form
 `fluctuation_strength_am_noise` (§3.1) for that stimulus.
 :::
 
-## Standards
+---
 
-Fastl & Zwicker (2006), *Psychoacoustics: Facts and Models* (Springer):
+**Standards.** Fastl & Zwicker (2006), *Psychoacoustics: Facts and Models* (Springer):
 psychoacoustic annoyance `PA = N5·(1 + √(wS² + wFR²))` with the sharpness weighting
 `wS` and roughness/fluctuation weighting `wFR` (Eqs 16.2–16.4; origin
 Widmann 1992), and the closed form for the fluctuation strength of

--- a/site/src/content/docs/guides/surface-scattering.md
+++ b/site/src/content/docs/guides/surface-scattering.md
@@ -404,7 +404,7 @@ print(round(s_min, 3), round(s_max, 3))    # 0.078 0.086  (metres)
 
 ---
 
-**Standards implemented on this page:** ISO 17497-1:2004 (scattering
+**Standards.** ISO 17497-1:2004 (scattering
 coefficient), ISO 17497-2:2012 (diffusion coefficient), ISO 13472-1:2002 (in-situ
 absorption, extended surface), ISO 13472-2:2010 (in-situ absorption, spot
 method), and ISO 9613-1:1993 — only the pure-tone attenuation coefficient

--- a/site/src/content/docs/guides/tone-audibility.md
+++ b/site/src/content/docs/guides/tone-audibility.md
@@ -200,9 +200,9 @@ evaluated at the Annex E tones the threshold (`≈ 24 Hz` at 137.3 Hz) keeps the
 combined, consistent with that example's FG grouping.
 :::
 
-## Standards
+---
 
-ISO/PAS 20065:2016, *Acoustics — Objective method for assessing the audibility
+**Standards.** ISO/PAS 20065:2016, *Acoustics — Objective method for assessing the audibility
 of tones in noise — Engineering method*: the critical bandwidth `Δfc`
 (Formula 2) and its corner frequencies (Formulae 3–5), the critical-band level
 `LG` (Formula 12), the masking index `av` (Formula 13), the audibility

--- a/site/src/content/docs/reference/bibliography.md
+++ b/site/src/content/docs/reference/bibliography.md
@@ -1,0 +1,66 @@
+---
+title: "Bibliography"
+description: "The books and papers behind the guides, grouped by domain: every entry with a verified DOI or official publisher link and a note on what it supports."
+---
+
+Every guide on this site closes with two citation blocks: a **References**
+section listing the books and papers that support the physics on the page
+(APA style, one bullet per source, each with a DOI or an official publisher
+link, and half a sentence on what the entry supports), followed by a final
+**Standards.** paragraph naming the normative documents the page implements,
+clause by clause. This page collects the References entries of all guides in
+one place, grouped by domain: a curated reading list, and the single source of
+truth for link checking. Each entry lists the guide pages that cite it; the
+list grows as guides gain their References sections.
+
+## General acoustics
+
+- Kinsler, L. E., Frey, A. R., Coppens, A. B., & Sanders, J. V. (2000).
+  *Fundamentals of acoustics* (4th ed.). Wiley. ISBN 978-0-471-84789-2.
+  [Publisher page](https://www.wiley.com/en-us/Fundamentals+of+Acoustics%2C+4th+Edition-p-9780471847892).
+  The standard first course in acoustics: plane and spherical waves, acoustic
+  impedance and the level definitions assumed throughout the guides.
+- Rossing, T. D. (Ed.). (2014). *Springer handbook of acoustics* (2nd ed.).
+  Springer. ISBN 978-1-4939-0754-0.
+  [doi:10.1007/978-1-4939-0755-7](https://doi.org/10.1007/978-1-4939-0755-7).
+  A one-volume survey of every domain this library touches, from room
+  acoustics to psychoacoustics and underwater sound; the cross-domain
+  reference of first resort.
+- Beranek, L. L., & Mellow, T. J. (2012). *Acoustics: Sound fields and
+  transducers*. Academic Press. ISBN 978-0-12-391421-7.
+  [doi:10.1016/C2011-0-05897-0](https://doi.org/10.1016/C2011-0-05897-0).
+  Sound fields, radiation and electroacoustic transducers; supports the
+  electroacoustics and sound-power material.
+
+## Signal processing
+
+- Oppenheim, A. V., & Schafer, R. W. (2010). *Discrete-time signal processing*
+  (3rd ed.). Pearson. ISBN 978-0-13-198842-2.
+  [Open Library record](https://openlibrary.org/isbn/9780131988422).
+  The digital-filter theory behind the SOS cascades, the bilinear transform
+  and the multirate decimation used by the filter banks.
+- Smith, J. O. *Introduction to digital filters with audio applications*
+  (online book). Center for Computer Research in Music and Acoustics (CCRMA),
+  Stanford University.
+  [ccrma.stanford.edu/~jos/filters](https://ccrma.stanford.edu/~jos/filters/).
+  Free companion treatment of digital-filter design and analysis, a good next
+  step after the filter-bank guides.
+
+## Metrology
+
+- Joint Committee for Guides in Metrology. (2008). *Evaluation of measurement
+  data — Guide to the expression of uncertainty in measurement* (JCGM
+  100:2008, the GUM). BIPM.
+  [doi:10.59161/JCGM100-2008E](https://doi.org/10.59161/JCGM100-2008E),
+  [free PDF](https://www.bipm.org/documents/20126/2071204/JCGM_100_2008_E.pdf).
+  The law of propagation of uncertainty implemented by the uncertainty module.
+  Cited by [Measurement uncertainty](/phonometry/guides/gum-uncertainty/).
+- Joint Committee for Guides in Metrology. (2008). *Evaluation of measurement
+  data — Supplement 1 to the "Guide to the expression of uncertainty in
+  measurement" — Propagation of distributions using a Monte Carlo method*
+  (JCGM 101:2008). BIPM.
+  [doi:10.59161/JCGM101-2008](https://doi.org/10.59161/JCGM101-2008),
+  [free PDF](https://www.bipm.org/documents/20126/2071204/JCGM_101_2008_E.pdf).
+  The Monte Carlo propagation of distributions implemented by the Monte Carlo
+  uncertainty engine.
+  Cited by [Measurement uncertainty](/phonometry/guides/gum-uncertainty/).


### PR DESCRIPTION
## Summary

Establishes the citation infrastructure for the documentation: a bibliography page and a per-page References convention, plus normalization of the closing Standards paragraph on the pages that deviated.

- New bibliography page in the three trees (`docs/references.md`, site EN `reference/bibliography`, ES twin), seeded with the general-acoustics, signal-processing and metrology canon (7 entries). Each entry is APA style with a DOI or an official publisher link and half a sentence on what it supports; guides gain their own `## References` sections in follow-up changes and this page collects them.
- Every link was verified at authoring time against the resolved record title, not just an HTTP 200: two JCGM DOI variants that return 404 were rejected in favor of the working forms plus the free BIPM PDFs, and a publisher catalog page that cannot be verified headlessly was replaced by the Open Library record.
- Standards-footer normalization: `block-processing` and `multichannel` gain the closing paragraph, `surface-scattering` drops a divergent lead-in, and `psychoacoustic-annoyance` and `tone-audibility` on the site trade their heading-style section for the bold-paragraph convention, matching their GitHub mirrors.
- Sidebar Reference group and the accessibility audit include the new page (EN and ES).

## Test plan

ruff, mypy, conformance byte-identical (257/257), i18n parity (56 pairs), site build with links validator at 0 errors (277 pages), html-validate and pa11y (including both bibliography pages) all green.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new English and Spanish bibliography pages with curated, domain-grouped references and consolidated citation entries.
  * Linked the new bibliography page from documentation navigation and the reference area.
* **Documentation**
  * Expanded and standardized end-of-page “Standards”/norms text across relevant guides.
  * Clarified that block (streaming) and multichannel processing do not add additional normative requirements beyond the cited IEC standards.
* **Tests**
  * Updated accessibility checks to include the new bibliography pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->