### PR TITLE
docs(site): give animation videos the same responsive widths as the figures

### DIFF
--- a/site/src/styles/theme-images.css
+++ b/site/src/styles/theme-images.css
@@ -14,7 +14,9 @@
 /* Tier-1 animations embedded as autoplaying, looping, muted WebM with native
    controls (a keyboard-accessible pause/stop for the motion, WCAG 2.2.2).
    Match the figure treatment: centred block, rounded, never wider than the
-   reading column. Authored inline as <video style="width:NN%">. */
+   reading column. Authored inline as <video style="width:88%">; the
+   responsive tiers below give videos the same widths as the detailed
+   plots (100% on phones, 92% on the capped desktop column). */
 .sl-markdown-content video {
   max-width: 100%;
   height: auto;
@@ -46,7 +48,8 @@
 @media (max-width: 50rem) {
   .sl-markdown-content img[style*="width:80%"],
   .sl-markdown-content img[style*="width:88%"],
-  .sl-markdown-content img[style*="width:92%"] { width: 100% !important; }
+  .sl-markdown-content img[style*="width:92%"],
+  .sl-markdown-content video[style*="width:88%"] { width: 100% !important; }
   /* keep the small schematics subordinate, but larger than on desktop */
   .sl-markdown-content img[style*="width:70%"] { width: 90% !important; }
   .sl-markdown-content img[style*="width:60%"] { width: 80% !important; }
@@ -56,5 +59,6 @@
    give the detailed plots a gentle boost, aligning them with the wide
    diagrams. Everything else keeps its authored width. */
 @media (min-width: 50.0625rem) {
-  .sl-markdown-content img[style*="width:80%"] { width: 92% !important; }
+  .sl-markdown-content img[style*="width:80%"],
+  .sl-markdown-content video[style*="width:88%"] { width: 92% !important; }
 }


### PR DESCRIPTION
## Summary

Animation videos rendered slightly narrower than the figures around them: the responsive sizing tiers in `theme-images.css` boost `img` widths (100% on phones, detailed plots to 92% on the capped desktop column) but had no rules for `video`, so the clips stayed at their authored 88% everywhere.

The two media-query tiers now include `video[style*="width:88%"]`, giving animations exactly the figure treatment: full width on narrow screens and 92% on desktop, aligned with the detailed plots.

## Test plan

CSS-only change; the selectors mirror the existing image rules in the same blocks. Verified the built page carries the rules and that videos and adjacent figures now share the same rendered width at both breakpoints.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive sizing for Tier-1 videos to match plot images.
  * Videos now expand appropriately on mobile screens and use consistent sizing on desktop layouts.
  * Updated sizing guidance to clearly reflect the 88% video width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->