### PR TITLE
docs: didactic depth and verified references for the vibration and uncertainty guides

### DIFF
--- a/docs/gum-uncertainty.md
+++ b/docs/gum-uncertainty.md
@@ -61,11 +61,19 @@ coverage factor $k = t_p(\nu_\text{eff})$ from the $t$-distribution at the
 (Annex G.4). Here the single Type A input (9 degrees of freedom) pulls
 $\nu_\text{eff}$ down to about 16, so $k = 2.11$ rather than the large-sample
 1.96. Correlated inputs are handled by passing a correlation matrix; a fully
-correlated sum then adds linearly instead of in quadrature. Because the GUM
-defines Welch–Satterthwaite for *independent* inputs only, a correlated budget
-falls back to $\nu_\text{eff} = \infty$ (GUM 6.3.3): `expanded()` then uses
-the normal-distribution coverage factor, and a warning reports that finite
-input degrees of freedom were not propagated. This chain reproduces the GUM's
+correlated sum then adds linearly instead of in quadrature. Correlation is the
+classic silent error in a budget: two corrections traceable to the *same*
+calibrator, or two channels sharing one instrument, do not average away the
+way independent terms would, and combining them in quadrature as if they were
+uncorrelated typically understates $u_c$ (with sensitivities of opposite sign
+the bias can point the other way). Because the GUM defines Welch–Satterthwaite
+for *independent* inputs only, a correlated budget with finite input degrees
+of freedom carries no effective degrees of freedom at all: `effective_dof` is
+NaN, a warning is issued, and `expanded()` requires an explicit
+`coverage_factor_override` (e.g. $k = 2$) rather than inventing one. Only when
+every input is Type B with infinite degrees of freedom does a correlated
+budget keep $\nu_\text{eff} = \infty$ and use the normal-distribution coverage
+factor. This chain reproduces the GUM's
 own worked examples end to end: the Annex H.1 end-gauge budget
 ($u_c = 31.7$ nm, $U_{99} = 92$ nm against the printed 32/93) and the Annex
 H.2 correlated resistance measurement ($u_c(R) = 0.071\ \Omega$,
@@ -107,6 +115,23 @@ methods are validated against the Guides' own worked examples: the additive
 model of four unit inputs gives $u_c = 2.0$ (Supplement 1 clause 9.2), and four
 rectangular inputs give a Monte Carlo interval of $[-3.88,\, 3.88]$
 (Supplement 1 clause 9.2.3).
+
+When does the Monte Carlo method earn its extra cost? Whenever either of the
+GUM's two simplifications fails: the model is replaced by its first-order
+expansion, and the output distribution by a Gaussian (or a $t$). Both hold
+well for the additive level model above, which is why the two methods agree
+to three digits. They stop holding when the model is strongly non-linear over
+the span of the input uncertainties (energy-to-level conversions with wide
+inputs, products and quotients with large relative uncertainties), when a
+single non-Gaussian input dominates the budget (one large rectangular term
+makes the output nearly rectangular, and a Gaussian $\pm\,2u_c$ interval
+overcovers it), or when the output sits near a physical bound (an absorption
+coefficient near 0 or 1, a level correction that cannot cross zero), where
+the true coverage interval is asymmetric and no $Y \pm U$ statement can
+represent it. In those regimes the Monte Carlo interval is the reference:
+Supplement 1 (clause 8) treats the GUM framework as validated precisely when
+it agrees with the Monte Carlo result, and as superseded by it when it does
+not.
 
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/uncertainty_budget_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/uncertainty_budget.svg" alt="Two panels for the A-weighted level example. Left, the GUM uncertainty budget: a horizontal bar chart of the contribution of each input to the combined uncertainty — Reading contributes nothing, Calibration and Instrument the rectangular corrections, and the Position Type A term the most — with a dashed line marking the combined uncertainty uc of 0.407 dB. Right, the Monte Carlo output distribution as a histogram, overlaid with the GUM Gaussian of the same mean and standard deviation, and the shaded 95 percent coverage interval; the title reads Y equals 74.00 dB, U equals 0.86 dB, k equals 2.11" width="96%"></picture>
 
@@ -166,6 +191,32 @@ retains the output `samples`, and its `.plot()` draws the output histogram
 with the coverage interval marked (the right panel above). The building-acoustics uncertainty
 of ISO 12999-1 — which combines reproducibility terms for a single-number
 rating — is a separate, domain-specific budget.
+
+## References
+
+- Joint Committee for Guides in Metrology. (2008). *Evaluation of measurement
+  data — Guide to the expression of uncertainty in measurement* (JCGM
+  100:2008, the GUM). BIPM.
+  [doi:10.59161/JCGM100-2008E](https://doi.org/10.59161/JCGM100-2008E),
+  [free PDF](https://www.bipm.org/documents/20126/2071204/JCGM_100_2008_E.pdf).
+  The law of propagation, the Type B evaluations and the Annex H worked
+  examples that section 1 implements and reproduces.
+- Joint Committee for Guides in Metrology. (2008). *Evaluation of measurement
+  data — Supplement 1 to the "Guide to the expression of uncertainty in
+  measurement" — Propagation of distributions using a Monte Carlo method*
+  (JCGM 101:2008). BIPM.
+  [doi:10.59161/JCGM101-2008](https://doi.org/10.59161/JCGM101-2008),
+  [free PDF](https://www.bipm.org/documents/20126/2071204/JCGM_101_2008_E.pdf).
+  The Monte Carlo propagation of section 2, its probabilistically symmetric
+  coverage interval and the clause 8 validation of the GUM framework against
+  the Monte Carlo result.
+- International Organization for Standardization. (2020). *Acoustics —
+  Determination and application of measurement uncertainties in building
+  acoustics — Part 1: Sound insulation* (ISO 12999-1:2020).
+  [iso.org catalogue](https://www.iso.org/standard/73930.html).
+  The domain-specific reproducibility budget for building-acoustics
+  single-number ratings, mentioned above as a separate companion to the
+  general GUM machinery.
 
 ---
 

--- a/docs/human-vibration.md
+++ b/docs/human-vibration.md
@@ -102,8 +102,8 @@ value of section 3:
 | Motion sickness (clause 9) | vertical | `Wf` | — | — |
 
 ¹ The health assessment of clause 7 is defined on the seat surface; the
-backrest x measurement with `Wc`, $k = 0.8$ is encouraged but reported
-separately (7.2.3). The remaining weightings live in the companion parts:
+backrest x measurement with `Wc`, $k = 0.8$ is encouraged but excluded
+from the Annex B severity assessment (7.2.3). The remaining weightings live in the companion parts:
 `Wm` for building occupants on all axes (ISO 2631-2), `Wb` for vertical rail
 ride comfort (ISO 2631-4), and `Wh` for hand-transmitted vibration on all
 three hand axes with every $k = 1$ (ISO 5349-1).

--- a/docs/human-vibration.md
+++ b/docs/human-vibration.md
@@ -79,6 +79,35 @@ To weight a time signal, `apply_weighting` applies the exact complex response in
 the frequency domain (so magnitude *and* phase match the standard), which the
 time-domain dose metrics below then consume.
 
+### Which weighting on which axis
+
+The weighting is selected by posture, measurement point and axis, not by
+application alone. ISO 2631-1 (Tables 1 and 2, clauses 7.2.3 and 8.2.2) maps
+them as follows; the multiplying factors $k$ return in the vibration total
+value of section 3:
+
+| Posture, measurement point | Axis | Weighting | $k$ health | $k$ comfort |
+| :--- | :--- | :--- | :--- | :--- |
+| Seated, seat surface | x, y | `Wd` | 1.4 | 1.0 |
+| Seated, seat surface | z | `Wk` | 1.0 | 1.0 |
+| Seated, seat surface (rotation) | rx / ry / rz | `We` | — | 0.63 / 0.40 / 0.20 m/rad |
+| Seated, backrest | x | `Wc` | (0.8)¹ | 0.8 |
+| Seated, backrest | y / z | `Wd` | — | 0.5 / 0.4 |
+| Seated, feet | x / y / z | `Wk` | — | 0.25 / 0.25 / 0.4 |
+| Standing, floor | x, y | `Wd` | — | 1.0 |
+| Standing, floor | z | `Wk` | — | 1.0 |
+| Recumbent, under the pelvis | horizontal | `Wd` | — | 1.0 |
+| Recumbent, under the pelvis | vertical | `Wk` | — | 1.0 |
+| Recumbent, under the head | vertical | `Wj` | — | 1.0 |
+| Motion sickness (clause 9) | vertical | `Wf` | — | — |
+
+¹ The health assessment of clause 7 is defined on the seat surface; the
+backrest x measurement with `Wc`, $k = 0.8$ is encouraged but reported
+separately (7.2.3). The remaining weightings live in the companion parts:
+`Wm` for building occupants on all axes (ISO 2631-2), `Wb` for vertical rail
+ride comfort (ISO 2631-4), and `Wh` for hand-transmitted vibration on all
+three hand axes with every $k = 1$ (ISO 5349-1).
+
 ## 2. Weighted acceleration and dose measures (ISO 2631-1)
 
 The basic evaluation is the **weighted r.m.s. acceleration**. From a
@@ -188,6 +217,23 @@ a_v = ph.vibration_total_value([0.35, 0.28, 0.62], k=[1.4, 1.4, 1.0])
 print(round(a_v, 3))     # 0.882  m/s^2
 ```
 
+**Health or comfort? Two different readings of the same measurement.** The
+*health* assessment of clause 7 stays per axis: each axis-weighted r.m.s.
+(with $k$ = 1.4 / 1.4 / 1.0 seated) is judged by the *highest* single axis
+value against the Annex B health guidance caution zone, a band based mainly on
+4 h to 8 h exposures below which health effects are not clearly documented,
+inside which caution is indicated and above which risks are likely; Directive
+2002/44/EC turns that guidance into the enforceable `A(8)` action and limit
+values used below. The *comfort* assessment of clause 8 instead combines all
+axes (and, where relevant, backrest, feet and rotation) into the vibration
+total value $a_v$ with its own $k$ set and reads it on the Annex C scale for
+public transport, whose deliberately overlapping bands run from "not
+uncomfortable" below 0.315 m/s² to "extremely uncomfortable" above 2 m/s²; the
+standard defines no comfort limit, since acceptable magnitudes depend on trip
+duration and what the passengers are trying to do. For orientation, the median
+perception threshold of a `Wk`-weighted vibration is about 0.015 m/s² peak
+(Annex C).
+
 The **daily exposure** normalises the total value to a reference 8-hour day
 ($T_0 = 28\,800$ s). For a single operation $A(8) = a_v\,\sqrt{T/T_0}$; several
 operations combine through their partial exposures $A_i(8) = a_{vi}\,\sqrt{T_i/T_0}$
@@ -267,6 +313,20 @@ The standards deliberately define no safe limit — `A(8)` and the directive's
 action and limit values are the basis for any exposure criterion. For whole-body
 exposure, `energy_equivalent_acceleration` gives the ISO 2631-1 Eq. (B.3)
 energy-equivalent magnitude across periods of different magnitude and duration.
+
+## References
+
+- Griffin, M. J. (1996). *Handbook of human vibration*. Academic Press.
+  ISBN 978-0-12-303041-2.
+  [Publisher page](https://shop.elsevier.com/books/handbook-of-human-vibration/griffin/978-0-12-303041-2).
+  The standard monograph on whole-body and hand-transmitted vibration:
+  the biodynamics, discomfort and health-effect evidence behind the
+  weightings, dose measures and exposure-response guidance on this page.
+- Mansfield, N. J. (2004). *Human response to vibration*. CRC Press.
+  ISBN 978-0-415-28239-0.
+  [Publisher page](https://www.routledge.com/Human-Response-to-Vibration/Mansfield/p/book/9780415282390).
+  A compact modern textbook on the ISO 2631-1 and ISO 5349 evaluation chains,
+  from perception and comfort to the occupational exposure limits.
 
 ---
 

--- a/docs/multiple-shock-vibration.md
+++ b/docs/multiple-shock-vibration.md
@@ -17,12 +17,12 @@ running r.m.s./MTVV and the VDV beyond it; ISO 2631-5 is the additional method
 for the regime past those, where the record contains repeated shocks. Its
 clause 4 then splits that regime in two: *severe* conditions with possible
 free fall or loss of contact with the seat and a dominant z-axis (military
-off-road vehicles, high-speed marine craft) use the Clause 5 model implemented
+off-road vehicles, high-speed marine craft) use the clause 5 model implemented
 here, while *less severe* conditions in which the occupant stays seated
 throughout (tractors, forestry and earth-moving machinery on rough ground)
 belong to the Annex A finite-element model. In case of doubt the delineation
 is quantitative: when the band-limited vertical peak acceleration exceeds
-9.81 m/s² (1 g, the free-fall threshold), Clause 5 and Annex C apply.
+9.81 m/s² (1 g, the free-fall threshold), clause 5 and Annex C apply.
 
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_iso2631_5_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_iso2631_5.svg" alt="Flow from the vertical seat acceleration az(t), band-limited per ISO 2631-1, through the spinal response Az(t) from the seat-to-spine transfer function (one zero, six poles), the acceleration dose Dz = 1.07 times the sixth root of the sum of the positive response peaks to the sixth power and the daily dose Dzd, the compressive stress Sd = mz times Dzd, the age-cumulated stress variable R, and finally the Weibull probability of lumbar injury" width="86%"></picture>
 

--- a/docs/multiple-shock-vibration.md
+++ b/docs/multiple-shock-vibration.md
@@ -11,6 +11,19 @@ spinal-response model and the **Annex C** health-effect assessment. (The Annex A
 / Annex E finite-element model is distributed by ISO as separate software and is
 out of scope here.)
 
+The boundary with the basic method is explicit. ISO 2631-1 declares its r.m.s.
+evaluation normally sufficient up to a crest factor of 9, and offers the
+running r.m.s./MTVV and the VDV beyond it; ISO 2631-5 is the additional method
+for the regime past those, where the record contains repeated shocks. Its
+clause 4 then splits that regime in two: *severe* conditions with possible
+free fall or loss of contact with the seat and a dominant z-axis (military
+off-road vehicles, high-speed marine craft) use the Clause 5 model implemented
+here, while *less severe* conditions in which the occupant stays seated
+throughout (tractors, forestry and earth-moving machinery on rough ground)
+belong to the Annex A finite-element model. In case of doubt the delineation
+is quantitative: when the band-limited vertical peak acceleration exceeds
+9.81 m/s² (1 g, the free-fall threshold), Clause 5 and Annex C apply.
+
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_iso2631_5_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_iso2631_5.svg" alt="Flow from the vertical seat acceleration az(t), band-limited per ISO 2631-1, through the spinal response Az(t) from the seat-to-spine transfer function (one zero, six poles), the acceleration dose Dz = 1.07 times the sixth root of the sum of the positive response peaks to the sixth power and the daily dose Dzd, the compressive stress Sd = mz times Dzd, the age-cumulated stress variable R, and finally the Weibull probability of lumbar injury" width="86%"></picture>
 
 ## 1. Spinal response (clause 5.2)
@@ -141,6 +154,14 @@ the response peaks, and its `.plot()` draws the injury-probability curve with th
 10/50/90 % risk thresholds of Table C.2. This complements the r.m.s.,
 running-r.m.s./MTVV and VDV metrics of [Human Vibration](human-vibration.md)
 (ISO 2631-1).
+
+## References
+
+- Griffin, M. J. (1996). *Handbook of human vibration*. Academic Press.
+  ISBN 978-0-12-303041-2.
+  [Publisher page](https://shop.elsevier.com/books/handbook-of-human-vibration/griffin/978-0-12-303041-2).
+  Background on whole-body shock exposure, spinal biodynamics and the
+  lumbar health effects that the ISO 2631-5 dose model quantifies.
 
 ---
 

--- a/docs/references.md
+++ b/docs/references.md
@@ -45,6 +45,23 @@ it; the list grows as guides gain their References sections.
   Free companion treatment of digital-filter design and analysis, a good next
   step after the filter-bank guides.
 
+## Human vibration
+
+- Griffin, M. J. (1996). *Handbook of human vibration*. Academic Press.
+  ISBN 978-0-12-303041-2.
+  [Publisher page](https://shop.elsevier.com/books/handbook-of-human-vibration/griffin/978-0-12-303041-2).
+  The standard monograph on whole-body and hand-transmitted vibration: the
+  biodynamics, discomfort and health-effect evidence behind the weightings,
+  dose measures and exposure-response guidance of the vibration guides.
+  Cited by [Human Vibration](human-vibration.md) and
+  [Multiple-shock whole-body vibration](multiple-shock-vibration.md).
+- Mansfield, N. J. (2004). *Human response to vibration*. CRC Press.
+  ISBN 978-0-415-28239-0.
+  [Publisher page](https://www.routledge.com/Human-Response-to-Vibration/Mansfield/p/book/9780415282390).
+  A compact modern textbook on the ISO 2631-1 and ISO 5349 evaluation chains,
+  from perception and comfort to the occupational exposure limits.
+  Cited by [Human Vibration](human-vibration.md).
+
 ## Metrology
 
 - Joint Committee for Guides in Metrology. (2008). *Evaluation of measurement
@@ -62,4 +79,11 @@ it; the list grows as guides gain their References sections.
   [free PDF](https://www.bipm.org/documents/20126/2071204/JCGM_101_2008_E.pdf).
   The Monte Carlo propagation of distributions implemented by the Monte Carlo
   uncertainty engine.
+  Cited by [Measurement uncertainty](gum-uncertainty.md).
+- International Organization for Standardization. (2020). *Acoustics —
+  Determination and application of measurement uncertainties in building
+  acoustics — Part 1: Sound insulation* (ISO 12999-1:2020).
+  [iso.org catalogue](https://www.iso.org/standard/73930.html).
+  The domain-specific reproducibility budget for building-acoustics
+  single-number ratings, the companion to the general GUM machinery.
   Cited by [Measurement uncertainty](gum-uncertainty.md).

--- a/site/src/content/docs/es/guides/gum-uncertainty.md
+++ b/site/src/content/docs/es/guides/gum-uncertainty.md
@@ -64,11 +64,19 @@ los **grados de libertad efectivos** dados por la fórmula de Welch–Satterthwa
 $\nu_\text{ef}$ hasta unos 16, de modo que $k = 2{,}11$ en lugar del 1,96 de
 gran muestra. Las entradas correlacionadas se tratan pasando una matriz de
 correlación; una suma totalmente correlacionada se suma entonces linealmente en
-vez de en cuadratura. Como la GUM define Welch–Satterthwaite solo para
-entradas *independientes*, un presupuesto correlacionado recurre a
-$\nu_\text{ef} = \infty$ (GUM 6.3.3): `expanded()` usa entonces el factor de
-cobertura de la distribución normal, y un aviso informa de que los grados de
-libertad finitos de las entradas no se propagaron. Esta cadena reproduce de
+vez de en cuadratura. La correlación es el error silencioso clásico de un
+balance: dos correcciones trazables al *mismo* calibrador, o dos canales que
+comparten un instrumento, no se promedian como lo harían términos
+independientes, y combinarlas en cuadratura como si no estuvieran
+correlacionadas suele subestimar $u_c$ (con sensibilidades de signo opuesto el
+sesgo puede apuntar al revés). Como la GUM define Welch–Satterthwaite solo
+para entradas *independientes*, un presupuesto correlacionado con grados de
+libertad finitos en sus entradas no tiene grados de libertad efectivos en
+absoluto: `effective_dof` es NaN, se emite un aviso y `expanded()` exige un
+`coverage_factor_override` explícito (p. ej. $k = 2$) en lugar de inventarse
+uno. Solo cuando todas las entradas son de Tipo B con grados de libertad
+infinitos un presupuesto correlacionado conserva $\nu_\text{ef} = \infty$ y
+usa el factor de cobertura de la distribución normal. Esta cadena reproduce de
 principio a fin los ejemplos resueltos de la propia GUM: el presupuesto del
 calibre del anexo H.1 ($u_c = 31{,}7$ nm, $U_{99} = 92$ nm frente a los 32/93
 impresos) y la medida correlacionada de resistencia del anexo H.2
@@ -112,6 +120,24 @@ Ambos métodos se validan frente a los ejemplos resueltos de las propias Guías:
 modelo aditivo de cuatro entradas unidad da $u_c = 2{,}0$ (Suplemento 1,
 cláusula 9.2), y cuatro entradas rectangulares dan un intervalo de Monte Carlo de
 $[-3{,}88,\, 3{,}88]$ (Suplemento 1, cláusula 9.2.3).
+
+¿Cuándo compensa el coste extra del método de Monte Carlo? Siempre que falle
+alguna de las dos simplificaciones de la GUM: el modelo se sustituye por su
+desarrollo de primer orden, y la distribución de salida por una gaussiana (o
+una $t$). Ambas se cumplen bien en el modelo aditivo de niveles de arriba, y
+por eso los dos métodos coinciden con tres cifras. Dejan de cumplirse cuando
+el modelo es fuertemente no lineal en el rango de las incertidumbres de
+entrada (conversiones energía-nivel con entradas anchas, productos y
+cocientes con incertidumbres relativas grandes), cuando una sola entrada no
+gaussiana domina el balance (un término rectangular grande hace la salida
+casi rectangular, y un intervalo gaussiano $\pm\,2u_c$ la sobrecubre), o
+cuando la salida queda cerca de un límite físico (un coeficiente de absorción
+cerca de 0 o 1, una corrección de nivel que no puede cruzar el cero), donde
+el intervalo de cobertura verdadero es asimétrico y ninguna afirmación
+$Y \pm U$ puede representarlo. En esos regímenes el intervalo de Monte Carlo
+es la referencia: el propio Suplemento 1 (cláusula 8) considera el marco de
+la GUM validado precisamente cuando coincide con el resultado de Monte Carlo,
+y superado por este cuando no coincide.
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/uncertainty_budget_es.svg" alt="Dos paneles para el ejemplo del nivel ponderado A. Izquierda: el balance de incertidumbre de la GUM, un diagrama de barras horizontales de la contribución de cada entrada a la incertidumbre combinada con una línea discontinua en uc de 0,407 dB. Derecha: el histograma de salida de Monte Carlo superpuesto con la gaussiana de la GUM y el intervalo de cobertura del 95 por ciento sombreado; el título indica Y igual a 74,00 dB, U igual a 0,86 dB, k igual a 2,11" style="width:96%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/uncertainty_budget_es_dark.svg" alt="Dos paneles para el ejemplo del nivel ponderado A. Izquierda: el balance de incertidumbre de la GUM, un diagrama de barras horizontales de la contribución de cada entrada a la incertidumbre combinada con una línea discontinua en uc de 0,407 dB. Derecha: el histograma de salida de Monte Carlo superpuesto con la gaussiana de la GUM y el intervalo de cobertura del 95 por ciento sombreado; el título indica Y igual a 74,00 dB, U igual a 0,86 dB, k igual a 2,11" style="width:96%">
 
@@ -172,6 +198,32 @@ muestras de salida (`samples`), y su `.plot()` dibuja el histograma de salida
 con el intervalo de cobertura marcado (el panel derecho de arriba). La incertidumbre de acústica de la edificación de
 ISO 12999-1 — que combina términos de reproducibilidad para una magnitud de
 número único — es un balance aparte, específico de ese dominio.
+
+## Referencias
+
+- Joint Committee for Guides in Metrology. (2008). *Evaluation of measurement
+  data — Guide to the expression of uncertainty in measurement* (JCGM
+  100:2008, la GUM). BIPM.
+  [doi:10.59161/JCGM100-2008E](https://doi.org/10.59161/JCGM100-2008E),
+  [PDF gratuito](https://www.bipm.org/documents/20126/2071204/JCGM_100_2008_E.pdf).
+  La ley de propagación, las evaluaciones de Tipo B y los ejemplos resueltos
+  del Anexo H que la sección 1 implementa y reproduce.
+- Joint Committee for Guides in Metrology. (2008). *Evaluation of measurement
+  data — Supplement 1 to the "Guide to the expression of uncertainty in
+  measurement" — Propagation of distributions using a Monte Carlo method*
+  (JCGM 101:2008). BIPM.
+  [doi:10.59161/JCGM101-2008](https://doi.org/10.59161/JCGM101-2008),
+  [PDF gratuito](https://www.bipm.org/documents/20126/2071204/JCGM_101_2008_E.pdf).
+  La propagación de Monte Carlo de la sección 2, su intervalo de cobertura
+  simétrico en probabilidad y la validación del marco de la GUM frente al
+  resultado de Monte Carlo de la cláusula 8.
+- International Organization for Standardization. (2020). *Acoustics —
+  Determination and application of measurement uncertainties in building
+  acoustics — Part 1: Sound insulation* (ISO 12999-1:2020).
+  [Catálogo de iso.org](https://www.iso.org/standard/73930.html).
+  El balance de reproducibilidad específico de la acústica de la edificación
+  para magnitudes de número único, mencionado arriba como complemento aparte
+  de la maquinaria general de la GUM.
 
 ---
 

--- a/site/src/content/docs/es/guides/human-vibration.md
+++ b/site/src/content/docs/es/guides/human-vibration.md
@@ -106,7 +106,7 @@ vibración de la sección 3:
 
 ¹ La evaluación de salud del apartado 7 se define sobre la superficie del
 asiento; la medida en x en el respaldo con `Wc`, $k = 0{,}8$ se recomienda
-pero se informa por separado (7.2.3). Las ponderaciones restantes viven en
+pero queda fuera de la evaluación de severidad del Anexo B (7.2.3). Las ponderaciones restantes viven en
 las partes complementarias: `Wm` para ocupantes de edificios en todos los
 ejes (ISO 2631-2), `Wb` para el confort de marcha ferroviaria vertical
 (ISO 2631-4) y `Wh` para la vibración transmitida a la mano en los tres ejes
@@ -328,9 +328,9 @@ distinta magnitud y duración.
   ISBN 978-0-12-303041-2.
   [Página del editor](https://shop.elsevier.com/books/handbook-of-human-vibration/griffin/978-0-12-303041-2).
   La monografía de referencia sobre vibración de cuerpo completo y transmitida
-  a la mano: la biodinámica, el malestar y la evidencia de efectos sobre la
-  salud tras las ponderaciones, las medidas de dosis y la orientación
-  exposición-respuesta de esta página.
+  a la mano: la biodinámica, la incomodidad y la evidencia de efectos sobre
+  la salud que sustentan las ponderaciones, las medidas de dosis y la
+  orientación exposición-respuesta de esta página.
 - Mansfield, N. J. (2004). *Human response to vibration*. CRC Press.
   ISBN 978-0-415-28239-0.
   [Página del editor](https://www.routledge.com/Human-Response-to-Vibration/Mansfield/p/book/9780415282390).

--- a/site/src/content/docs/es/guides/human-vibration.md
+++ b/site/src/content/docs/es/guides/human-vibration.md
@@ -82,6 +82,36 @@ Para ponderar una señal temporal, `apply_weighting` aplica la respuesta complej
 exacta en el dominio de la frecuencia (de modo que coinciden magnitud *y* fase
 con la norma), que luego consumen las métricas de dosis en el tiempo siguientes.
 
+### Qué ponderación en qué eje
+
+La ponderación se elige por postura, punto de medida y eje, no solo por
+aplicación. ISO 2631-1 (Tablas 1 y 2, apartados 7.2.3 y 8.2.2) las asigna
+así; los factores multiplicadores $k$ reaparecen en el valor total de
+vibración de la sección 3:
+
+| Postura, punto de medida | Eje | Ponderación | $k$ salud | $k$ confort |
+| :--- | :--- | :--- | :--- | :--- |
+| Sentado, superficie del asiento | x, y | `Wd` | 1,4 | 1,0 |
+| Sentado, superficie del asiento | z | `Wk` | 1,0 | 1,0 |
+| Sentado, superficie del asiento (rotación) | rx / ry / rz | `We` | — | 0,63 / 0,40 / 0,20 m/rad |
+| Sentado, respaldo | x | `Wc` | (0,8)¹ | 0,8 |
+| Sentado, respaldo | y / z | `Wd` | — | 0,5 / 0,4 |
+| Sentado, pies | x / y / z | `Wk` | — | 0,25 / 0,25 / 0,4 |
+| De pie, suelo | x, y | `Wd` | — | 1,0 |
+| De pie, suelo | z | `Wk` | — | 1,0 |
+| Tumbado, bajo la pelvis | horizontal | `Wd` | — | 1,0 |
+| Tumbado, bajo la pelvis | vertical | `Wk` | — | 1,0 |
+| Tumbado, bajo la cabeza | vertical | `Wj` | — | 1,0 |
+| Mareo (apartado 9) | vertical | `Wf` | — | — |
+
+¹ La evaluación de salud del apartado 7 se define sobre la superficie del
+asiento; la medida en x en el respaldo con `Wc`, $k = 0{,}8$ se recomienda
+pero se informa por separado (7.2.3). Las ponderaciones restantes viven en
+las partes complementarias: `Wm` para ocupantes de edificios en todos los
+ejes (ISO 2631-2), `Wb` para el confort de marcha ferroviaria vertical
+(ISO 2631-4) y `Wh` para la vibración transmitida a la mano en los tres ejes
+de la mano con todo $k = 1$ (ISO 5349-1).
+
 ## 2. Aceleración ponderada y medidas de dosis (ISO 2631-1)
 
 La evaluación básica es la **aceleración eficaz ponderada**. A partir de un
@@ -191,6 +221,25 @@ a_v = ph.vibration_total_value([0.35, 0.28, 0.62], k=[1.4, 1.4, 1.0])
 print(round(a_v, 3))     # 0.882  m/s^2
 ```
 
+**¿Salud o confort? Dos lecturas distintas de la misma medida.** La evaluación
+de *salud* del apartado 7 se mantiene por eje: cada valor eficaz ponderado por
+eje (con $k$ = 1,4 / 1,4 / 1,0 sentado) se juzga por el valor *más alto* de un
+solo eje frente a la zona de precaución de la guía de salud del Anexo B, una
+banda basada principalmente en exposiciones de 4 h a 8 h por debajo de la cual
+los efectos sobre la salud no están claramente documentados, dentro de la cual
+se indica precaución y por encima de la cual los riesgos son probables; la
+Directiva 2002/44/CE convierte esa guía en los valores de acción y límite
+exigibles de `A(8)` que se usan más abajo. La evaluación de *confort* del
+apartado 8 combina en cambio todos los ejes (y, cuando procede, respaldo, pies
+y rotación) en el valor total de vibración $a_v$ con su propio juego de $k$ y
+lo lee en la escala del Anexo C para transporte público, cuyas bandas
+deliberadamente solapadas van de "no incómodo" por debajo de 0,315 m/s² a
+"extremadamente incómodo" por encima de 2 m/s²; la norma no define ningún
+límite de confort, porque las magnitudes aceptables dependen de la duración
+del trayecto y de lo que los pasajeros intentan hacer. Como orientación, el
+umbral mediano de percepción de una vibración ponderada con `Wk` es de unos
+0,015 m/s² de pico (Anexo C).
+
 La **exposición diaria** normaliza el valor total a una jornada de referencia de
 8 horas ($T_0 = 28\,800$ s). Para una sola operación $A(8) = a_v\,\sqrt{T/T_0}$;
 varias operaciones se combinan mediante sus exposiciones parciales
@@ -272,6 +321,22 @@ de acción y límite de la directiva son la base de cualquier criterio de
 exposición. Para la exposición de cuerpo completo, `energy_equivalent_acceleration`
 da la magnitud energético-equivalente de ISO 2631-1 ec. (B.3) entre periodos de
 distinta magnitud y duración.
+
+## Referencias
+
+- Griffin, M. J. (1996). *Handbook of human vibration*. Academic Press.
+  ISBN 978-0-12-303041-2.
+  [Página del editor](https://shop.elsevier.com/books/handbook-of-human-vibration/griffin/978-0-12-303041-2).
+  La monografía de referencia sobre vibración de cuerpo completo y transmitida
+  a la mano: la biodinámica, el malestar y la evidencia de efectos sobre la
+  salud tras las ponderaciones, las medidas de dosis y la orientación
+  exposición-respuesta de esta página.
+- Mansfield, N. J. (2004). *Human response to vibration*. CRC Press.
+  ISBN 978-0-415-28239-0.
+  [Página del editor](https://www.routledge.com/Human-Response-to-Vibration/Mansfield/p/book/9780415282390).
+  Un manual moderno y compacto sobre las cadenas de evaluación de ISO 2631-1 e
+  ISO 5349, de la percepción y el confort a los límites de exposición
+  laborales.
 
 ---
 

--- a/site/src/content/docs/es/guides/multiple-shock-vibration.md
+++ b/site/src/content/docs/es/guides/multiple-shock-vibration.md
@@ -13,6 +13,21 @@ evaluación de efectos sobre la salud del **Anexo C**. (El modelo de elementos
 finitos de los Anexos A / E lo distribuye ISO como software aparte y queda fuera
 de alcance aquí.)
 
+La frontera con el método básico es explícita. ISO 2631-1 declara su
+evaluación eficaz normalmente suficiente hasta un factor de cresta de 9, y
+ofrece el eficaz móvil/MTVV y el VDV más allá; ISO 2631-5 es el método
+adicional para el régimen posterior, cuando el registro contiene choques
+repetidos. Su cláusula 4 divide después ese régimen en dos: las condiciones
+*severas*, con posible caída libre o pérdida de contacto con el asiento y un
+eje z dominante (vehículos militares todoterreno, embarcaciones rápidas),
+usan el modelo de la cláusula 5 implementado aquí, mientras que las
+condiciones *menos severas*, en las que el ocupante permanece sentado en todo
+momento (tractores, maquinaria forestal y de movimiento de tierras sobre
+terreno irregular), corresponden al modelo de elementos finitos del Anexo A.
+En caso de duda, la delimitación es cuantitativa: cuando la aceleración de
+pico vertical limitada en banda supera 9,81 m/s² (1 g, el umbral de caída
+libre), se aplican la cláusula 5 y el Anexo C.
+
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_iso2631_5_es.svg" alt="Flujo desde la aceleración vertical del asiento az(t) hasta la respuesta espinal, la dosis de aceleración Dz y la dosis diaria Dzd, la tensión compresiva Sd, la variable de tensión R acumulada con la edad, y la probabilidad de lesión lumbar de Weibull" style="width:86%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_iso2631_5_es_dark.svg" alt="Flujo desde la aceleración vertical del asiento az(t) hasta la respuesta espinal, la dosis de aceleración Dz y la dosis diaria Dzd, la tensión compresiva Sd, la variable de tensión R acumulada con la edad, y la probabilidad de lesión lumbar de Weibull" style="width:86%">
 
 ## 1. Respuesta espinal (cláusula 5.2)
@@ -145,6 +160,15 @@ picos de respuesta, y su `.plot()` dibuja la curva de probabilidad de lesión co
 los umbrales de riesgo del 10/50/90 % de la Tabla C.2. Complementa las métricas
 eficaz, eficaz móvil/MTVV y VDV de
 [Vibración en humanos](/phonometry/es/guides/human-vibration/) (ISO 2631-1).
+
+## Referencias
+
+- Griffin, M. J. (1996). *Handbook of human vibration*. Academic Press.
+  ISBN 978-0-12-303041-2.
+  [Página del editor](https://shop.elsevier.com/books/handbook-of-human-vibration/griffin/978-0-12-303041-2).
+  Contexto sobre la exposición a choques de cuerpo completo, la biodinámica
+  espinal y los efectos lumbares sobre la salud que cuantifica el modelo de
+  dosis de ISO 2631-5.
 
 ---
 

--- a/site/src/content/docs/es/reference/bibliography.md
+++ b/site/src/content/docs/es/reference/bibliography.md
@@ -54,9 +54,9 @@ que las guías incorporan sus secciones de Referencias.
   ISBN 978-0-12-303041-2.
   [Página del editor](https://shop.elsevier.com/books/handbook-of-human-vibration/griffin/978-0-12-303041-2).
   La monografía de referencia sobre vibración de cuerpo completo y transmitida
-  a la mano: la biodinámica, el malestar y la evidencia de efectos sobre la
-  salud tras las ponderaciones, las medidas de dosis y la orientación
-  exposición-respuesta de las guías de vibración.
+  a la mano: la biodinámica, la incomodidad y la evidencia de efectos sobre
+  la salud que sustentan las ponderaciones, las medidas de dosis y la
+  orientación exposición-respuesta de las guías de vibración.
   Citado por [Vibración en humanos](/phonometry/es/guides/human-vibration/) y
   [Vibración con choques múltiples](/phonometry/es/guides/multiple-shock-vibration/).
 - Mansfield, N. J. (2004). *Human response to vibration*. CRC Press.

--- a/site/src/content/docs/es/reference/bibliography.md
+++ b/site/src/content/docs/es/reference/bibliography.md
@@ -48,6 +48,25 @@ que las guías incorporan sus secciones de Referencias.
   Tratamiento gratuito y complementario del diseño y análisis de filtros
   digitales, el paso natural tras las guías de bancos de filtros.
 
+## Vibración en humanos
+
+- Griffin, M. J. (1996). *Handbook of human vibration*. Academic Press.
+  ISBN 978-0-12-303041-2.
+  [Página del editor](https://shop.elsevier.com/books/handbook-of-human-vibration/griffin/978-0-12-303041-2).
+  La monografía de referencia sobre vibración de cuerpo completo y transmitida
+  a la mano: la biodinámica, el malestar y la evidencia de efectos sobre la
+  salud tras las ponderaciones, las medidas de dosis y la orientación
+  exposición-respuesta de las guías de vibración.
+  Citado por [Vibración en humanos](/phonometry/es/guides/human-vibration/) y
+  [Vibración con choques múltiples](/phonometry/es/guides/multiple-shock-vibration/).
+- Mansfield, N. J. (2004). *Human response to vibration*. CRC Press.
+  ISBN 978-0-415-28239-0.
+  [Página del editor](https://www.routledge.com/Human-Response-to-Vibration/Mansfield/p/book/9780415282390).
+  Un manual moderno y compacto sobre las cadenas de evaluación de ISO 2631-1 e
+  ISO 5349, de la percepción y el confort a los límites de exposición
+  laborales.
+  Citado por [Vibración en humanos](/phonometry/es/guides/human-vibration/).
+
 ## Metrología
 
 - Joint Committee for Guides in Metrology. (2008). *Evaluation of measurement
@@ -66,4 +85,12 @@ que las guías incorporan sus secciones de Referencias.
   [PDF gratuito](https://www.bipm.org/documents/20126/2071204/JCGM_101_2008_E.pdf).
   La propagación de distribuciones mediante Monte Carlo implementada por el
   motor de incertidumbre de Monte Carlo.
+  Citado por [Incertidumbre de medida](/phonometry/es/guides/gum-uncertainty/).
+- International Organization for Standardization. (2020). *Acoustics —
+  Determination and application of measurement uncertainties in building
+  acoustics — Part 1: Sound insulation* (ISO 12999-1:2020).
+  [Catálogo de iso.org](https://www.iso.org/standard/73930.html).
+  El balance de reproducibilidad específico de la acústica de la edificación
+  para magnitudes de número único, complemento de la maquinaria general de la
+  GUM.
   Citado por [Incertidumbre de medida](/phonometry/es/guides/gum-uncertainty/).

--- a/site/src/content/docs/guides/gum-uncertainty.md
+++ b/site/src/content/docs/guides/gum-uncertainty.md
@@ -62,11 +62,19 @@ coverage factor $k = t_p(\nu_\text{eff})$ from the $t$-distribution at the
 (Annex G.4). Here the single Type A input (9 degrees of freedom) pulls
 $\nu_\text{eff}$ down to about 16, so $k = 2.11$ rather than the large-sample
 1.96. Correlated inputs are handled by passing a correlation matrix; a fully
-correlated sum then adds linearly instead of in quadrature. Because the GUM
-defines Welch–Satterthwaite for *independent* inputs only, a correlated budget
-falls back to $\nu_\text{eff} = \infty$ (GUM 6.3.3): `expanded()` then uses
-the normal-distribution coverage factor, and a warning reports that finite
-input degrees of freedom were not propagated. This chain reproduces the GUM's
+correlated sum then adds linearly instead of in quadrature. Correlation is the
+classic silent error in a budget: two corrections traceable to the *same*
+calibrator, or two channels sharing one instrument, do not average away the
+way independent terms would, and combining them in quadrature as if they were
+uncorrelated typically understates $u_c$ (with sensitivities of opposite sign
+the bias can point the other way). Because the GUM defines Welch–Satterthwaite
+for *independent* inputs only, a correlated budget with finite input degrees
+of freedom carries no effective degrees of freedom at all: `effective_dof` is
+NaN, a warning is issued, and `expanded()` requires an explicit
+`coverage_factor_override` (e.g. $k = 2$) rather than inventing one. Only when
+every input is Type B with infinite degrees of freedom does a correlated
+budget keep $\nu_\text{eff} = \infty$ and use the normal-distribution coverage
+factor. This chain reproduces the GUM's
 own worked examples end to end: the Annex H.1 end-gauge budget
 ($u_c = 31.7$ nm, $U_{99} = 92$ nm against the printed 32/93) and the Annex
 H.2 correlated resistance measurement ($u_c(R) = 0.071\ \Omega$,
@@ -108,6 +116,23 @@ methods are validated against the Guides' own worked examples: the additive
 model of four unit inputs gives $u_c = 2.0$ (Supplement 1 clause 9.2), and four
 rectangular inputs give a Monte Carlo interval of $[-3.88,\, 3.88]$
 (Supplement 1 clause 9.2.3).
+
+When does the Monte Carlo method earn its extra cost? Whenever either of the
+GUM's two simplifications fails: the model is replaced by its first-order
+expansion, and the output distribution by a Gaussian (or a $t$). Both hold
+well for the additive level model above, which is why the two methods agree
+to three digits. They stop holding when the model is strongly non-linear over
+the span of the input uncertainties (energy-to-level conversions with wide
+inputs, products and quotients with large relative uncertainties), when a
+single non-Gaussian input dominates the budget (one large rectangular term
+makes the output nearly rectangular, and a Gaussian $\pm\,2u_c$ interval
+overcovers it), or when the output sits near a physical bound (an absorption
+coefficient near 0 or 1, a level correction that cannot cross zero), where
+the true coverage interval is asymmetric and no $Y \pm U$ statement can
+represent it. In those regimes the Monte Carlo interval is the reference:
+Supplement 1 (clause 8) treats the GUM framework as validated precisely when
+it agrees with the Monte Carlo result, and as superseded by it when it does
+not.
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/uncertainty_budget.svg" alt="Two panels for the A-weighted level example. Left: the GUM uncertainty budget, a horizontal bar chart of each input's contribution to the combined uncertainty with a dashed line at uc of 0.407 dB. Right: the Monte Carlo output histogram overlaid with the GUM Gaussian and the shaded 95 percent coverage interval; the title reads Y equals 74.00 dB, U equals 0.86 dB, k equals 2.11" style="width:96%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/uncertainty_budget_dark.svg" alt="Two panels for the A-weighted level example. Left: the GUM uncertainty budget, a horizontal bar chart of each input's contribution to the combined uncertainty with a dashed line at uc of 0.407 dB. Right: the Monte Carlo output histogram overlaid with the GUM Gaussian and the shaded 95 percent coverage interval; the title reads Y equals 74.00 dB, U equals 0.86 dB, k equals 2.11" style="width:96%">
 
@@ -167,6 +192,32 @@ retains the output `samples`, and its `.plot()` draws the output histogram
 with the coverage interval marked (the right panel above). The building-acoustics uncertainty
 of ISO 12999-1 — which combines reproducibility terms for a single-number
 rating — is a separate, domain-specific budget.
+
+## References
+
+- Joint Committee for Guides in Metrology. (2008). *Evaluation of measurement
+  data — Guide to the expression of uncertainty in measurement* (JCGM
+  100:2008, the GUM). BIPM.
+  [doi:10.59161/JCGM100-2008E](https://doi.org/10.59161/JCGM100-2008E),
+  [free PDF](https://www.bipm.org/documents/20126/2071204/JCGM_100_2008_E.pdf).
+  The law of propagation, the Type B evaluations and the Annex H worked
+  examples that section 1 implements and reproduces.
+- Joint Committee for Guides in Metrology. (2008). *Evaluation of measurement
+  data — Supplement 1 to the "Guide to the expression of uncertainty in
+  measurement" — Propagation of distributions using a Monte Carlo method*
+  (JCGM 101:2008). BIPM.
+  [doi:10.59161/JCGM101-2008](https://doi.org/10.59161/JCGM101-2008),
+  [free PDF](https://www.bipm.org/documents/20126/2071204/JCGM_101_2008_E.pdf).
+  The Monte Carlo propagation of section 2, its probabilistically symmetric
+  coverage interval and the clause 8 validation of the GUM framework against
+  the Monte Carlo result.
+- International Organization for Standardization. (2020). *Acoustics —
+  Determination and application of measurement uncertainties in building
+  acoustics — Part 1: Sound insulation* (ISO 12999-1:2020).
+  [iso.org catalogue](https://www.iso.org/standard/73930.html).
+  The domain-specific reproducibility budget for building-acoustics
+  single-number ratings, mentioned above as a separate companion to the
+  general GUM machinery.
 
 ---
 

--- a/site/src/content/docs/guides/human-vibration.md
+++ b/site/src/content/docs/guides/human-vibration.md
@@ -103,8 +103,8 @@ value of section 3:
 | Motion sickness (clause 9) | vertical | `Wf` | — | — |
 
 ¹ The health assessment of clause 7 is defined on the seat surface; the
-backrest x measurement with `Wc`, $k = 0.8$ is encouraged but reported
-separately (7.2.3). The remaining weightings live in the companion parts:
+backrest x measurement with `Wc`, $k = 0.8$ is encouraged but excluded
+from the Annex B severity assessment (7.2.3). The remaining weightings live in the companion parts:
 `Wm` for building occupants on all axes (ISO 2631-2), `Wb` for vertical rail
 ride comfort (ISO 2631-4), and `Wh` for hand-transmitted vibration on all
 three hand axes with every $k = 1$ (ISO 5349-1).

--- a/site/src/content/docs/guides/human-vibration.md
+++ b/site/src/content/docs/guides/human-vibration.md
@@ -80,6 +80,35 @@ To weight a time signal, `apply_weighting` applies the exact complex response in
 the frequency domain (so magnitude *and* phase match the standard), which the
 time-domain dose metrics below then consume.
 
+### Which weighting on which axis
+
+The weighting is selected by posture, measurement point and axis, not by
+application alone. ISO 2631-1 (Tables 1 and 2, clauses 7.2.3 and 8.2.2) maps
+them as follows; the multiplying factors $k$ return in the vibration total
+value of section 3:
+
+| Posture, measurement point | Axis | Weighting | $k$ health | $k$ comfort |
+| :--- | :--- | :--- | :--- | :--- |
+| Seated, seat surface | x, y | `Wd` | 1.4 | 1.0 |
+| Seated, seat surface | z | `Wk` | 1.0 | 1.0 |
+| Seated, seat surface (rotation) | rx / ry / rz | `We` | — | 0.63 / 0.40 / 0.20 m/rad |
+| Seated, backrest | x | `Wc` | (0.8)¹ | 0.8 |
+| Seated, backrest | y / z | `Wd` | — | 0.5 / 0.4 |
+| Seated, feet | x / y / z | `Wk` | — | 0.25 / 0.25 / 0.4 |
+| Standing, floor | x, y | `Wd` | — | 1.0 |
+| Standing, floor | z | `Wk` | — | 1.0 |
+| Recumbent, under the pelvis | horizontal | `Wd` | — | 1.0 |
+| Recumbent, under the pelvis | vertical | `Wk` | — | 1.0 |
+| Recumbent, under the head | vertical | `Wj` | — | 1.0 |
+| Motion sickness (clause 9) | vertical | `Wf` | — | — |
+
+¹ The health assessment of clause 7 is defined on the seat surface; the
+backrest x measurement with `Wc`, $k = 0.8$ is encouraged but reported
+separately (7.2.3). The remaining weightings live in the companion parts:
+`Wm` for building occupants on all axes (ISO 2631-2), `Wb` for vertical rail
+ride comfort (ISO 2631-4), and `Wh` for hand-transmitted vibration on all
+three hand axes with every $k = 1$ (ISO 5349-1).
+
 ## 2. Weighted acceleration and dose measures (ISO 2631-1)
 
 The basic evaluation is the **weighted r.m.s. acceleration**. From a
@@ -189,6 +218,23 @@ a_v = ph.vibration_total_value([0.35, 0.28, 0.62], k=[1.4, 1.4, 1.0])
 print(round(a_v, 3))     # 0.882  m/s^2
 ```
 
+**Health or comfort? Two different readings of the same measurement.** The
+*health* assessment of clause 7 stays per axis: each axis-weighted r.m.s.
+(with $k$ = 1.4 / 1.4 / 1.0 seated) is judged by the *highest* single axis
+value against the Annex B health guidance caution zone, a band based mainly on
+4 h to 8 h exposures below which health effects are not clearly documented,
+inside which caution is indicated and above which risks are likely; Directive
+2002/44/EC turns that guidance into the enforceable `A(8)` action and limit
+values used below. The *comfort* assessment of clause 8 instead combines all
+axes (and, where relevant, backrest, feet and rotation) into the vibration
+total value $a_v$ with its own $k$ set and reads it on the Annex C scale for
+public transport, whose deliberately overlapping bands run from "not
+uncomfortable" below 0.315 m/s² to "extremely uncomfortable" above 2 m/s²; the
+standard defines no comfort limit, since acceptable magnitudes depend on trip
+duration and what the passengers are trying to do. For orientation, the median
+perception threshold of a `Wk`-weighted vibration is about 0.015 m/s² peak
+(Annex C).
+
 The **daily exposure** normalises the total value to a reference 8-hour day
 ($T_0 = 28\,800$ s). For a single operation $A(8) = a_v\,\sqrt{T/T_0}$; several
 operations combine through their partial exposures $A_i(8) = a_{vi}\,\sqrt{T_i/T_0}$
@@ -268,6 +314,20 @@ The standards deliberately define no safe limit — `A(8)` and the directive's
 action and limit values are the basis for any exposure criterion. For whole-body
 exposure, `energy_equivalent_acceleration` gives the ISO 2631-1 Eq. (B.3)
 energy-equivalent magnitude across periods of different magnitude and duration.
+
+## References
+
+- Griffin, M. J. (1996). *Handbook of human vibration*. Academic Press.
+  ISBN 978-0-12-303041-2.
+  [Publisher page](https://shop.elsevier.com/books/handbook-of-human-vibration/griffin/978-0-12-303041-2).
+  The standard monograph on whole-body and hand-transmitted vibration:
+  the biodynamics, discomfort and health-effect evidence behind the
+  weightings, dose measures and exposure-response guidance on this page.
+- Mansfield, N. J. (2004). *Human response to vibration*. CRC Press.
+  ISBN 978-0-415-28239-0.
+  [Publisher page](https://www.routledge.com/Human-Response-to-Vibration/Mansfield/p/book/9780415282390).
+  A compact modern textbook on the ISO 2631-1 and ISO 5349 evaluation chains,
+  from perception and comfort to the occupational exposure limits.
 
 ---
 

--- a/site/src/content/docs/guides/multiple-shock-vibration.md
+++ b/site/src/content/docs/guides/multiple-shock-vibration.md
@@ -18,12 +18,12 @@ running r.m.s./MTVV and the VDV beyond it; ISO 2631-5 is the additional method
 for the regime past those, where the record contains repeated shocks. Its
 clause 4 then splits that regime in two: *severe* conditions with possible
 free fall or loss of contact with the seat and a dominant z-axis (military
-off-road vehicles, high-speed marine craft) use the Clause 5 model implemented
+off-road vehicles, high-speed marine craft) use the clause 5 model implemented
 here, while *less severe* conditions in which the occupant stays seated
 throughout (tractors, forestry and earth-moving machinery on rough ground)
 belong to the Annex A finite-element model. In case of doubt the delineation
 is quantitative: when the band-limited vertical peak acceleration exceeds
-9.81 m/s² (1 g, the free-fall threshold), Clause 5 and Annex C apply.
+9.81 m/s² (1 g, the free-fall threshold), clause 5 and Annex C apply.
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_iso2631_5.svg" alt="Flow from the vertical seat acceleration az(t) through the spinal response, the acceleration dose Dz and daily dose Dzd, the compressive stress Sd, the age-cumulated stress variable R, and the Weibull probability of lumbar injury" style="width:86%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_iso2631_5_dark.svg" alt="Flow from the vertical seat acceleration az(t) through the spinal response, the acceleration dose Dz and daily dose Dzd, the compressive stress Sd, the age-cumulated stress variable R, and the Weibull probability of lumbar injury" style="width:86%">
 

--- a/site/src/content/docs/guides/multiple-shock-vibration.md
+++ b/site/src/content/docs/guides/multiple-shock-vibration.md
@@ -12,6 +12,19 @@ spinal-response model and the **Annex C** health-effect assessment. (The
 Annex A / Annex E finite-element model is distributed by ISO as separate
 software and is out of scope here.)
 
+The boundary with the basic method is explicit. ISO 2631-1 declares its r.m.s.
+evaluation normally sufficient up to a crest factor of 9, and offers the
+running r.m.s./MTVV and the VDV beyond it; ISO 2631-5 is the additional method
+for the regime past those, where the record contains repeated shocks. Its
+clause 4 then splits that regime in two: *severe* conditions with possible
+free fall or loss of contact with the seat and a dominant z-axis (military
+off-road vehicles, high-speed marine craft) use the Clause 5 model implemented
+here, while *less severe* conditions in which the occupant stays seated
+throughout (tractors, forestry and earth-moving machinery on rough ground)
+belong to the Annex A finite-element model. In case of doubt the delineation
+is quantitative: when the band-limited vertical peak acceleration exceeds
+9.81 m/s² (1 g, the free-fall threshold), Clause 5 and Annex C apply.
+
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_iso2631_5.svg" alt="Flow from the vertical seat acceleration az(t) through the spinal response, the acceleration dose Dz and daily dose Dzd, the compressive stress Sd, the age-cumulated stress variable R, and the Weibull probability of lumbar injury" style="width:86%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_iso2631_5_dark.svg" alt="Flow from the vertical seat acceleration az(t) through the spinal response, the acceleration dose Dz and daily dose Dzd, the compressive stress Sd, the age-cumulated stress variable R, and the Weibull probability of lumbar injury" style="width:86%">
 
 ## 1. Spinal response (clause 5.2)
@@ -142,6 +155,14 @@ response peaks, and its `.plot()` draws the injury-probability curve with the
 10/50/90 % risk thresholds of Table C.2. This complements the r.m.s.,
 running-r.m.s./MTVV and VDV metrics of
 [Human Vibration](/phonometry/guides/human-vibration/) (ISO 2631-1).
+
+## References
+
+- Griffin, M. J. (1996). *Handbook of human vibration*. Academic Press.
+  ISBN 978-0-12-303041-2.
+  [Publisher page](https://shop.elsevier.com/books/handbook-of-human-vibration/griffin/978-0-12-303041-2).
+  Background on whole-body shock exposure, spinal biodynamics and the
+  lumbar health effects that the ISO 2631-5 dose model quantifies.
 
 ---
 

--- a/site/src/content/docs/reference/bibliography.md
+++ b/site/src/content/docs/reference/bibliography.md
@@ -46,6 +46,23 @@ list grows as guides gain their References sections.
   Free companion treatment of digital-filter design and analysis, a good next
   step after the filter-bank guides.
 
+## Human vibration
+
+- Griffin, M. J. (1996). *Handbook of human vibration*. Academic Press.
+  ISBN 978-0-12-303041-2.
+  [Publisher page](https://shop.elsevier.com/books/handbook-of-human-vibration/griffin/978-0-12-303041-2).
+  The standard monograph on whole-body and hand-transmitted vibration: the
+  biodynamics, discomfort and health-effect evidence behind the weightings,
+  dose measures and exposure-response guidance of the vibration guides.
+  Cited by [Human Vibration](/phonometry/guides/human-vibration/) and
+  [Multiple-shock whole-body vibration](/phonometry/guides/multiple-shock-vibration/).
+- Mansfield, N. J. (2004). *Human response to vibration*. CRC Press.
+  ISBN 978-0-415-28239-0.
+  [Publisher page](https://www.routledge.com/Human-Response-to-Vibration/Mansfield/p/book/9780415282390).
+  A compact modern textbook on the ISO 2631-1 and ISO 5349 evaluation chains,
+  from perception and comfort to the occupational exposure limits.
+  Cited by [Human Vibration](/phonometry/guides/human-vibration/).
+
 ## Metrology
 
 - Joint Committee for Guides in Metrology. (2008). *Evaluation of measurement
@@ -63,4 +80,11 @@ list grows as guides gain their References sections.
   [free PDF](https://www.bipm.org/documents/20126/2071204/JCGM_101_2008_E.pdf).
   The Monte Carlo propagation of distributions implemented by the Monte Carlo
   uncertainty engine.
+  Cited by [Measurement uncertainty](/phonometry/guides/gum-uncertainty/).
+- International Organization for Standardization. (2020). *Acoustics —
+  Determination and application of measurement uncertainties in building
+  acoustics — Part 1: Sound insulation* (ISO 12999-1:2020).
+  [iso.org catalogue](https://www.iso.org/standard/73930.html).
+  The domain-specific reproducibility budget for building-acoustics
+  single-number ratings, the companion to the general GUM machinery.
   Cited by [Measurement uncertainty](/phonometry/guides/gum-uncertainty/).


### PR DESCRIPTION
## Summary

Didactic depth and verified references for the vibration and uncertainty guides, in the three content trees (GitHub docs, site EN, site ES).

- Human vibration: a "which weighting on which axis" table mapping posture, measurement point and axis to the ISO 2631-1 weighting and multiplying factor, and a paragraph contrasting the per-axis health assessment (highest-axis rule, Annex B caution zones, Directive 2002/44/EC action values) with the vector-sum comfort assessment and its Annex C scale.
- Multiple shocks: when ISO 2631-5 applies versus ISO 2631-1 (crest factor boundary, severe versus less-severe delineation, the band-limited peak criterion).
- Measurement uncertainty: when Monte Carlo earns its cost over the GUM law of propagation (non-linear models, non-Gaussian dominants, outputs near physical bounds, the JCGM 101 validation logic) and corrected correlation guidance. The previous prose claimed correlated budgets fall back to infinite effective degrees of freedom, which contradicts the implementation: finite-dof correlated budgets report undefined effective dof and require an explicit coverage factor; the text now states the actual behavior.
- New References sections with links verified at authoring time (Griffin's Handbook of Human Vibration and Mansfield's Human Response to Vibration resolved against the publisher records; three plausible-looking DOIs turned out dead or wrong and were rejected), and the global bibliography gains a Human vibration group with back-links.

## Test plan

ruff, mypy, conformance byte-identical (257/257), i18n parity (56 pairs), site build with links validator at 0 errors and html-validate all green. A review pass over the diff produced three wording refinements, applied.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

