### PR TITLE
docs: sound power and intensity didactics with verified references

### DIFF
--- a/docs/intensity.md
+++ b/docs/intensity.md
@@ -136,6 +136,73 @@ print(ld, ld > fi.f2)                                      # 8.0 True (criterion
 
 [Watch the high-resolution video (WebM)](https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_intensity_scan_power.webm)
 
+### The margin over the residual index
+
+The two channels of any real probe and analyzer are never perfectly phase
+matched. Feed both channels the *same* signal (the residual-intensity test
+of IEC 61043): the true intensity is exactly zero, yet the mismatch reports
+a small false intensity. The gap between the pressure level and that false
+intensity level is the **residual pressure-intensity index** `δpI0`, the
+instrument's phase-error floor expressed as an index; IEC 61043 grades
+probes and processors (class 1 / class 2) chiefly by it.
+
+In the field, the measured index `δpI = Lp − LI` says how far the pressure
+level stands above the level of the net flow, and the systematic error of
+the intensity estimate is bounded by the margin between the two indices:
+
+$$
+\varepsilon = 10 \log_{10}\!\left( 1 \pm 10^{(\delta_{pI} - \delta_{pI0})/10} \right)
+$$
+
+A 10 dB margin keeps the bias within about 0.5 dB and a 7 dB margin within
+about 1 dB; these are precisely the bias factors `K` of ISO 9614, and the
+**dynamic capability** `Ld = δpI0 − K` is the largest field index the
+instrument can afford at a given grade. Read it as a budget: every decibel
+the field's `δpI` rises spends a decibel of margin, and when `δpI` reaches
+`δpI0` the reading is pure phase error, of either sign. This is why the
+pressure-intensity index, not the microphone quality, gates the achievable
+accuracy of every intensity measurement.
+
+### Reactive fields near sources
+
+Close to a source the field turns **reactive**: pressure and particle
+velocity drift toward quadrature, so a large pressure carries little net
+flow. For a small source the quadrature component grows as `1/(kr)`; at
+100 Hz and 0.25 m from the source it is already about twice the active one,
+and `δpI` climbs just as it does in the standing wave of the figure above.
+The same happens between a machine and a hard reflecting surface, and in
+reverberant rooms where the diffuse field raises pressure without
+transporting energy outward. This is why ISO 9614-1 keeps the measurement
+surface on average more than 0.5 m away from the source, and why, when a
+scan fails the dynamic-capability criterion, moving the surface outward or
+adding absorption to the room usually lowers `F2` below `Ld` more cheaply
+than better hardware.
+
+### Choosing the spacer
+
+The spacer sets both ends of the usable band, in opposite directions:
+
+- **The top end is geometry.** The finite difference underestimates the
+  gradient by `sin(kΔr)/(kΔr)`, so the ceiling scales as `1/Δr`:
+  `max_valid_frequency ≈ 0.1·c/Δr` keeps the bias within about 0.3 dB,
+  giving roughly 5.7 kHz for a 6 mm spacer, 2.9 kHz for 12 mm and 690 Hz
+  for 50 mm (`bias_correct=True` undoes the known bias somewhat beyond
+  that).
+- **The bottom end is phase.** A progressive wave puts only
+  `360·f·Δr/c` degrees of true phase across the spacer, 0.8° at 63 Hz over
+  12 mm, while the channel mismatch stays fixed. Lowering the frequency
+  shrinks the signal, not the error, so the margin over `δpI0` collapses at
+  low frequency. A larger spacer buys back that margin: the IEC 61043
+  residual-index requirements scale as `10·lg(Δr/25 mm)`, so doubling the
+  spacer is worth 3 dB of low-frequency margin.
+
+No single spacer covers the full audio range: 6 mm suits high-frequency
+work, 50 mm low-frequency work, and the common 12 mm covers the mid band.
+Wide-band surveys are measured twice with two spacers and the band results
+merged; whichever spacer is fitted, verify `δpI0` with that spacer in
+place, since the index belongs to the probe-spacer-analyzer chain, not to
+the microphones alone.
+
 ### `sound_intensity()` parameters
 
 | Parameter | Type | Units | Range / default | Notes |
@@ -152,12 +219,35 @@ print(ld, ld > fi.f2)                                      # 8.0 True (criterion
 See [Theory](theory-signal-analysis.md) for the derivations and [Calibration](calibration.md)
 for absolute scaling of the two channels.
 
+## References
+
+- Fahy, F. J. (1995). *Sound intensity* (2nd ed.). E&FN Spon.
+  ISBN 978-0-419-19810-9.
+  [doi:10.4324/9780203475386](https://doi.org/10.4324/9780203475386).
+  The monograph on the subject: active and reactive intensity, the p-p
+  estimator and the phase-mismatch error budget behind this page.
+- International Electrotechnical Commission. (1993). *Electroacoustics —
+  Instruments for the measurement of sound intensity — Measurements with
+  pairs of pressure sensing microphones* (IEC 61043:1993; adopted in Europe
+  as EN 61043:1994).
+  [IEC webstore](https://webstore.iec.ch/en/publication/4353).
+  The instrument standard: the cross-spectral estimator, the
+  residual-intensity test behind `δpI0` and the class 1 / class 2
+  requirements.
+- International Organization for Standardization. (1993). *Acoustics —
+  Determination of sound power levels of noise sources using sound
+  intensity — Part 1: Measurement at discrete points* (ISO 9614-1:1993).
+  [iso.org catalogue](https://www.iso.org/standard/17427.html).
+  The field indicators F2 to F4, the dynamic-capability criterion and the
+  0.5 m surface-distance rule.
+
 ---
 
-**Standards.** IEC 61043:1994, *Electroacoustics — Instruments for the
-measurement of sound intensity — Measurements with pairs of pressure sensing
-microphones* — the two-microphone cross-spectral intensity estimator, the
-finite-difference bias correction and the usable-bandwidth bound (clause 7.3,
+**Standards.** IEC 61043:1993 (EN 61043:1994), *Electroacoustics —
+Instruments for the measurement of sound intensity — Measurements with pairs
+of pressure sensing microphones* — the two-microphone cross-spectral
+intensity estimator, the finite-difference bias correction and the
+usable-bandwidth bound (clause 7.3,
 Table 3). ISO 9614-1:1993, *Acoustics — Determination of sound power levels
 of noise sources using sound intensity — Part 1: Measurement at discrete
 points* — the pressure-intensity index, the Annex A field indicators F2, F3

--- a/docs/references.md
+++ b/docs/references.md
@@ -30,7 +30,8 @@ it; the list grows as guides gain their References sections.
   [doi:10.1016/C2011-0-05897-0](https://doi.org/10.1016/C2011-0-05897-0).
   Sound fields, radiation and electroacoustic transducers; supports the
   electroacoustics and sound-power material.
-  Cited by [Electroacoustics](electroacoustics.md).
+  Cited by [Electroacoustics](electroacoustics.md) and
+  [Sound Power](sound-power.md).
 
 ## Signal processing
 
@@ -45,6 +46,59 @@ it; the list grows as guides gain their References sections.
   [ccrma.stanford.edu/~jos/filters](https://ccrma.stanford.edu/~jos/filters/).
   Free companion treatment of digital-filter design and analysis, a good next
   step after the filter-bank guides.
+
+## Sound power and intensity
+
+- Fahy, F. J. (1995). *Sound intensity* (2nd ed.). E&FN Spon.
+  ISBN 978-0-419-19810-9.
+  [doi:10.4324/9780203475386](https://doi.org/10.4324/9780203475386).
+  The monograph on sound energy flux: active and reactive intensity, the
+  p-p estimator and its phase-mismatch error budget.
+  Cited by [Sound Power](sound-power.md) and
+  [Sound Intensity (p-p)](intensity.md).
+- International Organization for Standardization. (2019). *Acoustics —
+  Determination of sound power levels of noise sources — Guidelines for the
+  use of basic standards* (ISO 3740:2019).
+  [iso.org catalogue](https://www.iso.org/standard/45107.html).
+  The selection guide for the sound-power family: grades, environments,
+  source-size and background criteria.
+  Cited by [Sound Power](sound-power.md).
+- International Organization for Standardization. (2010). *Acoustics —
+  Determination of sound power levels and sound energy levels of noise
+  sources using sound pressure — Precision methods for reverberation test
+  rooms* (ISO 3741:2010).
+  [iso.org catalogue](https://www.iso.org/standard/52053.html).
+  The precision reverberation-room method.
+  Cited by [Sound Power](sound-power.md).
+- International Organization for Standardization. (2010). *Acoustics —
+  Determination of sound power levels and sound energy levels of noise
+  sources using sound pressure — Engineering methods for an essentially free
+  field over a reflecting plane* (ISO 3744:2010).
+  [iso.org catalogue](https://www.iso.org/standard/52055.html).
+  The enveloping-surface engineering method.
+  Cited by [Sound Power](sound-power.md).
+- International Organization for Standardization. (2012). *Acoustics —
+  Determination of sound power levels and sound energy levels of noise
+  sources using sound pressure — Precision methods for anechoic rooms and
+  hemi-anechoic rooms* (ISO 3745:2012).
+  [iso.org catalogue](https://www.iso.org/standard/45362.html).
+  The precision anechoic-room method.
+  Cited by [Sound Power](sound-power.md).
+- International Organization for Standardization. (1993). *Acoustics —
+  Determination of sound power levels of noise sources using sound
+  intensity — Part 1: Measurement at discrete points* (ISO 9614-1:1993).
+  [iso.org catalogue](https://www.iso.org/standard/17427.html).
+  The field indicators and the dynamic-capability criterion of intensity
+  measurement.
+  Cited by [Sound Intensity (p-p)](intensity.md).
+- International Electrotechnical Commission. (1993). *Electroacoustics —
+  Instruments for the measurement of sound intensity — Measurements with
+  pairs of pressure sensing microphones* (IEC 61043:1993; adopted in Europe
+  as EN 61043:1994).
+  [IEC webstore](https://webstore.iec.ch/en/publication/4353).
+  The p-p instrument standard: the cross-spectral estimator and the
+  residual pressure-intensity index.
+  Cited by [Sound Intensity (p-p)](intensity.md).
 
 ## Building acoustics
 

--- a/docs/sound-power.md
+++ b/docs/sound-power.md
@@ -40,6 +40,59 @@ of the page walks each in turn.
 
 [Watch the high-resolution video (WebM)](https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_power_two_rooms.webm)
 
+### A decision path
+
+The table compresses into a short sequence of questions (ISO 3740 dedicates
+its Table 3 and Annex D to exactly this decision). Work through them in
+order; the first match names the standard.
+
+1. **What is the number for?** A datasheet declaration or a limit check
+   normally asks for engineering grade (grade 2, the preferred grade for
+   noise declarations); a reference source, a product ranking or a dispute
+   calls for precision (grade 1); a first walk-through of a noisy plant
+   tolerates survey grade (grade 3). Grade 1 exists only in a qualified
+   laboratory room (ISO 3741, ISO 3745) or via the precision intensity
+   methods (ISO 9614-1 at discrete points, ISO 9614-3 by scanning).
+2. **Can the source travel to a laboratory?** ISO 3741 wants the source
+   small next to the room (volume no more than about 2 % of the room volume)
+   and its noise steady; ISO 3745 wants it inside a qualified anechoic or
+   hemi-anechoic room with a characteristic dimension below half the
+   measurement radius, and it is the route that also yields directivity. A
+   machine bolted to its foundation rules both out and leaves the in-situ
+   methods.
+3. **How quiet and how dry is the site?** ISO 3744 needs the background at
+   least 6 dB below the source (preferably more than 15 dB) and
+   `K2 ≤ 4 dB`. If only a
+   3 dB margin or `K2 ≤ 7 dB` can be met, the same microphones and formulae
+   degrade gracefully to ISO 3746 at survey grade.
+4. **Is the background the problem?** When neighbouring machines cannot be
+   switched off, or the margin is outright negative, the pressure methods
+   are out. Intensity scanning (ISO 9614-2, or ISO 9614-3 for grade 1)
+   tolerates steady extraneous noise even some 10 dB *above* the source,
+   because only the net energy flux through the surface counts; the
+   per-band field indicators then decide the grade actually achieved.
+
+### What the accuracy grades mean
+
+The grade is a claim about **reproducibility**: `σR0` is the standard
+deviation you would see if different laboratories measured the same source,
+each following the standard correctly. Typical A-weighted values are
+`σR0 ≈ 0.5 dB` for grade 1 (ISO 3741), `1.5 dB` for grade 2 (ISO 3744,
+ISO 9614-2) and `3 dB` or more for grade 3 (larger still when `K2` is
+large or the spectrum is tonal). Per-band values are larger at the
+spectrum edges. The `uncertainty` field of the pressure-method results
+(enveloping surface and anechoic) is the expanded uncertainty
+`U = 2·σtot` (95 % coverage), where
+`σtot = √(σR0² + σomc²)` also folds in the operating/mounting instability
+`σomc` that you estimate and pass in; the grade only bounds the method's
+share of the budget.
+
+In practice: a grade-2 `LWA` of 92.4 dB carries `U ≈ 3 dB`, so two grade-2
+results 2 dB apart are statistically indistinguishable, and checking that
+same source against a 93 dB limit is a coin flip. Choose the grade from the
+decision the number has to support, not from the facility that happens to
+be free.
+
 ## 1. Enveloping surface, sound pressure (ISO 3744 / ISO 3746)
 
 Place the source on a reflecting plane and imagine a **measurement surface**
@@ -151,6 +204,40 @@ data (`reverberation_time` + `volume`, or `absorption_area`, or
 field is treated as free (`K2 = 0`). If the background margin drops below the
 grade criterion or `K2` exceeds the validity limit, a `SoundPowerWarning`
 flags that the levels are upper bounds — the determination still returns.
+
+### K1 and K2 pitfalls
+
+Both corrections subtract energy from the surface level, so overestimating
+either one understates the emission. That is why the standards cap them, and
+why most disputes over an enveloping-surface result trace back to one of
+these habits:
+
+- **K1 has a cliff, not a slope.** At a 15 dB margin the correction is a
+  negligible 0.14 dB; at the 6 dB engineering criterion it is already
+  1.26 dB, the largest value the grade accepts. Below the criterion the
+  standard does not let the formula run on: `K1` is capped and the result is
+  reported as an upper bound. Never extrapolate the subtraction into a
+  smaller margin; raise the margin (quieter site, closer surface) or switch
+  to the intensity method.
+- **K1 assumes a stationary background.** The source-off reading must be
+  taken at the same positions with the room in the same state, and the
+  background energy must be the same during both readings. A ventilation
+  system that cycles or a vehicle passing during either reading invalidates
+  the pair; the energy subtraction also assumes source and background are
+  incoherent, which holds for unrelated noise but not for the source's own
+  reflections.
+- **K2 removes the average room build-up, not discrete reflections.** A
+  nearby wall, a trolley or another machine just outside the surface adds a
+  specular contribution concentrated at a few microphones. That imbalance
+  shows up in the apparent directivity index `DIi*`, and no room-average
+  correction can remove it: move the surface, remove the reflector or treat
+  it with absorption.
+- **K2 is only as good as `A`.** With `A` from Sabine (`0.16·V/T`), errors
+  in the reverberation time or the volume propagate directly. At the
+  `K2 = 4 dB` validity limit about 60 % of the measured energy is room, not
+  source, and a 20 % error in `A` still moves `LW` by about 0.5 dB. Prefer a
+  measured `T60` over a guessed absorption coefficient, and keep the
+  measurement distance small enough that `K2` stays well under the limit.
 
 ### `sound_power_pressure()` parameters
 
@@ -665,6 +752,45 @@ plt.show()
 - [Levels](levels.md) — energy averaging and the A-weighting behind `LWA`.
 - [Theory](theory-environment-transport.md) — the Waterhouse, K1/K2 and C1/C2 derivations.
 - API reference: [`emission.sound_power`](https://jmrplens.github.io/phonometry/reference/api/power/sound-power/), [`emission.sound_power_reverberation`](https://jmrplens.github.io/phonometry/reference/api/power/sound-power-reverberation/) and [`emission.sound_power_intensity`](https://jmrplens.github.io/phonometry/reference/api/power/sound-power-intensity/).
+
+## References
+
+- Fahy, F. J. (1995). *Sound intensity* (2nd ed.). E&FN Spon.
+  ISBN 978-0-419-19810-9.
+  [doi:10.4324/9780203475386](https://doi.org/10.4324/9780203475386).
+  The monograph on sound energy flux: why intensity separates the energy
+  leaving the source from steady energy passing through, behind the
+  scanning methods of sections 3 and 5.
+- Beranek, L. L., & Mellow, T. J. (2012). *Acoustics: Sound fields and
+  transducers*. Academic Press. ISBN 978-0-12-391421-7.
+  [doi:10.1016/C2011-0-05897-0](https://doi.org/10.1016/C2011-0-05897-0).
+  Radiation and sound fields: the free-field and diffuse-field relations
+  between pressure and power that the enveloping-surface and
+  reverberation-room methods rest on.
+- International Organization for Standardization. (2019). *Acoustics —
+  Determination of sound power levels of noise sources — Guidelines for the
+  use of basic standards* (ISO 3740:2019).
+  [iso.org catalogue](https://www.iso.org/standard/45107.html).
+  The selection guide behind "Choosing a method": grades, environments,
+  source-size and background criteria for the whole family.
+- International Organization for Standardization. (2010). *Acoustics —
+  Determination of sound power levels and sound energy levels of noise
+  sources using sound pressure — Precision methods for reverberation test
+  rooms* (ISO 3741:2010).
+  [iso.org catalogue](https://www.iso.org/standard/52053.html).
+  The reverberation-room method of section 2.
+- International Organization for Standardization. (2010). *Acoustics —
+  Determination of sound power levels and sound energy levels of noise
+  sources using sound pressure — Engineering methods for an essentially free
+  field over a reflecting plane* (ISO 3744:2010).
+  [iso.org catalogue](https://www.iso.org/standard/52055.html).
+  The enveloping-surface method of section 1.
+- International Organization for Standardization. (2012). *Acoustics —
+  Determination of sound power levels and sound energy levels of noise
+  sources using sound pressure — Precision methods for anechoic rooms and
+  hemi-anechoic rooms* (ISO 3745:2012).
+  [iso.org catalogue](https://www.iso.org/standard/45362.html).
+  The precision anechoic-room method of section 4.
 
 ---
 

--- a/site/src/content/docs/es/guides/intensity.md
+++ b/site/src/content/docs/es/guides/intensity.md
@@ -98,8 +98,8 @@ plt.show()
 Dos límites físicos acotan toda medición p-p, y el objeto de resultado incluye
 ambos:
 
-- **Alta frecuencia**: el gradiente por diferencias finitas subestima I en
-  $\sin(k\Delta r)/(k\Delta r)$ — verificado en CI contra la Tabla 3 de
+- **Alta frecuencia**: el gradiente por diferencias finitas subestima I en el
+  factor $\sin(k\Delta r)/(k\Delta r)$ — verificado en CI contra la Tabla 3 de
   IEC 61043. `IntensityResult.bias_correction` proporciona el factor y
   `max_valid_frequency` (≈ 0,1·c/Δr; 2,9 kHz para un separador de 12 mm) el
   techo práctico. Los separadores mayores alcanzan frecuencias más bajas; los
@@ -137,7 +137,7 @@ print(ld, ld > fi.f2)                                      # 8.0 True (criterio 
 
 ### El margen sobre el índice residual
 
-Los dos canales de cualquier sonda y analizador reales nunca están
+Los dos canales de cualquier sonda y analizador real nunca están
 perfectamente emparejados en fase. Alimenta ambos canales con la *misma*
 señal (el ensayo de intensidad residual de IEC 61043): la intensidad
 verdadera es exactamente cero y, aun así, el desajuste indica una pequeña
@@ -157,12 +157,12 @@ $$
 Un margen de 10 dB mantiene el sesgo dentro de unos 0,5 dB y uno de 7 dB
 dentro de aproximadamente 1 dB; son precisamente los factores de sesgo `K`
 de ISO 9614, y la **capacidad dinámica** `Ld = δpI0 − K` es el mayor índice
-de campo que el instrumento puede permitirse a un grado dado. Léelo como un
-presupuesto: cada decibelio que sube el `δpI` del campo gasta un decibelio
-de margen, y cuando `δpI` alcanza `δpI0` la lectura es puro error de fase,
-de cualquier signo. Por eso el índice presión-intensidad, y no la calidad de
-los micrófonos, es el que acota la exactitud alcanzable de toda medida de
-intensidad.
+de campo que el instrumento puede tolerar para un grado de precisión dado.
+Léelo como un presupuesto: cada decibelio que sube el `δpI` del campo consume
+un decibelio de margen, y cuando `δpI` alcanza `δpI0` la lectura es puro
+error de fase, de cualquier signo. Por eso el índice presión-intensidad, y
+no la calidad de los micrófonos, es el que acota la exactitud alcanzable de
+toda medida de intensidad.
 
 ### Campos reactivos cerca de la fuente
 
@@ -172,7 +172,7 @@ transporta poco flujo neto. Para una fuente pequeña la componente en
 cuadratura crece como `1/(kr)`; a 100 Hz y 0,25 m de la fuente ya es
 aproximadamente el doble de la activa, y `δpI` sube igual que en la onda
 estacionaria de la figura anterior. Lo mismo ocurre entre una máquina y una
-superficie reflectante dura, y en salas reverberantes donde el campo difuso
+superficie reflectante rígida, y en salas reverberantes donde el campo difuso
 eleva la presión sin transportar energía hacia fuera. Por eso ISO 9614-1
 mantiene la superficie de medida a más de 0,5 m de la fuente en promedio, y
 por eso, cuando un barrido no cumple el criterio de capacidad dinámica,
@@ -185,27 +185,27 @@ El separador fija los dos extremos de la banda utilizable, en sentidos
 opuestos:
 
 - **El extremo alto es geometría.** La diferencia finita subestima el
-  gradiente en `sin(kΔr)/(kΔr)`, así que el techo escala como `1/Δr`:
-  `max_valid_frequency ≈ 0.1·c/Δr` mantiene el sesgo dentro de unos 0,3 dB,
+  gradiente en el factor `sin(kΔr)/(kΔr)`, así que el techo escala como
+  `1/Δr`: `max_valid_frequency ≈ 0.1·c/Δr` mantiene el sesgo dentro de unos 0,3 dB,
   lo que da aproximadamente 5,7 kHz con un separador de 6 mm, 2,9 kHz con
   12 mm y 690 Hz con 50 mm (`bias_correct=True` deshace el sesgo conocido
   algo más allá).
-- **El extremo bajo es fase.** Una onda progresiva pone solo
+- **El extremo bajo es fase.** Una onda progresiva introduce solo
   `360·f·Δr/c` grados de fase verdadera a lo largo del separador, 0,8° a
   63 Hz con 12 mm, mientras el desajuste entre canales permanece fijo. Bajar
   la frecuencia encoge la señal, no el error, así que el margen sobre `δpI0`
-  se derrumba en baja frecuencia. Un separador mayor recupera ese margen:
+  se desploma en baja frecuencia. Un separador mayor recupera ese margen:
   los requisitos de índice residual de IEC 61043 escalan como
-  `10·lg(Δr/25 mm)`, de modo que doblar el separador vale 3 dB de margen en
+  `10·lg(Δr/25 mm)`, de modo que doblar el separador aporta 3 dB de margen en
   baja frecuencia.
 
-Ningún separador cubre por sí solo todo el rango de audio: 6 mm sirve para
-el trabajo en alta frecuencia, 50 mm para la baja frecuencia y el habitual
-de 12 mm cubre la banda media. El trabajo de banda ancha se mide dos
-veces con dos separadores y se combinan los resultados por banda; sea cual
-sea el separador montado, verifica `δpI0` con ese separador puesto, porque
-el índice pertenece a la cadena sonda-separador-analizador, no a los
-micrófonos solos.
+Ningún separador cubre por sí solo todo el rango de audio: el de 6 mm sirve
+para el trabajo en alta frecuencia, el de 50 mm para la baja frecuencia y el
+habitual de 12 mm cubre la banda media. Las mediciones de banda ancha se
+realizan dos veces con dos separadores y se combinan los resultados por
+banda; sea cual sea el separador montado, verifica `δpI0` con ese separador
+instalado, porque el índice pertenece a la cadena
+sonda-separador-analizador, no a los micrófonos por sí solos.
 
 ### Parámetros de `sound_intensity()`
 

--- a/site/src/content/docs/es/guides/intensity.md
+++ b/site/src/content/docs/es/guides/intensity.md
@@ -135,6 +135,78 @@ print(ld, ld > fi.f2)                                      # 8.0 True (criterio 
 
 <video class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_intensity_scan_power_es.webm" preload="none" poster="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_intensity_scan_power_es_poster.jpg" width="2400" height="1350" loop muted controls playsinline title="Animación: una sonda p-p recorre el barrido en serpentina sobre la cara superior de la caja de medición mientras aparecen detrás las flechas de intensidad normal, y las potencias parciales de las cinco caras se acumulan en el nivel de potencia sonora L_W" style="width:88%"></video><video class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_intensity_scan_power_es_dark.webm" preload="none" poster="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_intensity_scan_power_es_dark_poster.jpg" width="2400" height="1350" loop muted controls playsinline title="Animación: una sonda p-p recorre el barrido en serpentina sobre la cara superior de la caja de medición mientras aparecen detrás las flechas de intensidad normal, y las potencias parciales de las cinco caras se acumulan en el nivel de potencia sonora L_W" style="width:88%"></video>
 
+### El margen sobre el índice residual
+
+Los dos canales de cualquier sonda y analizador reales nunca están
+perfectamente emparejados en fase. Alimenta ambos canales con la *misma*
+señal (el ensayo de intensidad residual de IEC 61043): la intensidad
+verdadera es exactamente cero y, aun así, el desajuste indica una pequeña
+intensidad falsa. La distancia entre el nivel de presión y ese nivel de
+intensidad falsa es el **índice presión-intensidad residual** `δpI0`, el
+suelo de error de fase del instrumento expresado como índice; IEC 61043
+clasifica sondas y procesadores (clase 1 / clase 2) sobre todo por él.
+
+En campo, el índice medido `δpI = Lp − LI` dice cuánto sobresale el nivel
+de presión respecto al del flujo neto, y el error sistemático de la
+estimación de intensidad está acotado por el margen entre ambos índices:
+
+$$
+\varepsilon = 10 \log_{10}\!\left( 1 \pm 10^{(\delta_{pI} - \delta_{pI0})/10} \right)
+$$
+
+Un margen de 10 dB mantiene el sesgo dentro de unos 0,5 dB y uno de 7 dB
+dentro de aproximadamente 1 dB; son precisamente los factores de sesgo `K`
+de ISO 9614, y la **capacidad dinámica** `Ld = δpI0 − K` es el mayor índice
+de campo que el instrumento puede permitirse a un grado dado. Léelo como un
+presupuesto: cada decibelio que sube el `δpI` del campo gasta un decibelio
+de margen, y cuando `δpI` alcanza `δpI0` la lectura es puro error de fase,
+de cualquier signo. Por eso el índice presión-intensidad, y no la calidad de
+los micrófonos, es el que acota la exactitud alcanzable de toda medida de
+intensidad.
+
+### Campos reactivos cerca de la fuente
+
+Cerca de una fuente el campo se vuelve **reactivo**: la presión y la
+velocidad de partícula tienden a la cuadratura, así que una presión grande
+transporta poco flujo neto. Para una fuente pequeña la componente en
+cuadratura crece como `1/(kr)`; a 100 Hz y 0,25 m de la fuente ya es
+aproximadamente el doble de la activa, y `δpI` sube igual que en la onda
+estacionaria de la figura anterior. Lo mismo ocurre entre una máquina y una
+superficie reflectante dura, y en salas reverberantes donde el campo difuso
+eleva la presión sin transportar energía hacia fuera. Por eso ISO 9614-1
+mantiene la superficie de medida a más de 0,5 m de la fuente en promedio, y
+por eso, cuando un barrido no cumple el criterio de capacidad dinámica,
+alejar la superficie o añadir absorción a la sala suele bajar `F2` por
+debajo de `Ld` con menos coste que un hardware mejor.
+
+### Elegir el separador
+
+El separador fija los dos extremos de la banda utilizable, en sentidos
+opuestos:
+
+- **El extremo alto es geometría.** La diferencia finita subestima el
+  gradiente en `sin(kΔr)/(kΔr)`, así que el techo escala como `1/Δr`:
+  `max_valid_frequency ≈ 0.1·c/Δr` mantiene el sesgo dentro de unos 0,3 dB,
+  lo que da aproximadamente 5,7 kHz con un separador de 6 mm, 2,9 kHz con
+  12 mm y 690 Hz con 50 mm (`bias_correct=True` deshace el sesgo conocido
+  algo más allá).
+- **El extremo bajo es fase.** Una onda progresiva pone solo
+  `360·f·Δr/c` grados de fase verdadera a lo largo del separador, 0,8° a
+  63 Hz con 12 mm, mientras el desajuste entre canales permanece fijo. Bajar
+  la frecuencia encoge la señal, no el error, así que el margen sobre `δpI0`
+  se derrumba en baja frecuencia. Un separador mayor recupera ese margen:
+  los requisitos de índice residual de IEC 61043 escalan como
+  `10·lg(Δr/25 mm)`, de modo que doblar el separador vale 3 dB de margen en
+  baja frecuencia.
+
+Ningún separador cubre por sí solo todo el rango de audio: 6 mm sirve para
+el trabajo en alta frecuencia, 50 mm para la baja frecuencia y el habitual
+de 12 mm cubre la banda media. El trabajo de banda ancha se mide dos
+veces con dos separadores y se combinan los resultados por banda; sea cual
+sea el separador montado, verifica `δpI0` con ese separador puesto, porque
+el índice pertenece a la cadena sonda-separador-analizador, no a los
+micrófonos solos.
+
 ### Parámetros de `sound_intensity()`
 
 | Parámetro | Tipo | Unidades | Rango / valor por defecto | Notas |
@@ -152,13 +224,35 @@ Consulta [Teoría](/phonometry/es/reference/theory/signal-analysis/) para las de
 [Calibración](/phonometry/es/guides/calibration/) para el escalado absoluto de
 los dos canales.
 
+## Referencias
+
+- Fahy, F. J. (1995). *Sound intensity* (2.ª ed.). E&FN Spon.
+  ISBN 978-0-419-19810-9.
+  [doi:10.4324/9780203475386](https://doi.org/10.4324/9780203475386).
+  La monografía sobre la materia: intensidad activa y reactiva, el estimador
+  p-p y el presupuesto de error por desfase que hay detrás de esta página.
+- International Electrotechnical Commission. (1993). *Electroacoustics —
+  Instruments for the measurement of sound intensity — Measurements with
+  pairs of pressure sensing microphones* (IEC 61043:1993; adoptada en Europa
+  como EN 61043:1994).
+  [Tienda IEC](https://webstore.iec.ch/en/publication/4353).
+  La norma de instrumentación: el estimador por espectro cruzado, el ensayo
+  de intensidad residual detrás de `δpI0` y los requisitos de clase 1 /
+  clase 2.
+- International Organization for Standardization. (1993). *Acoustics —
+  Determination of sound power levels of noise sources using sound
+  intensity — Part 1: Measurement at discrete points* (ISO 9614-1:1993).
+  [Catálogo iso.org](https://www.iso.org/standard/17427.html).
+  Los indicadores de campo F2 a F4, el criterio de capacidad dinámica y la
+  regla de los 0,5 m de distancia de la superficie.
+
 ---
 
-**Normas.** IEC 61043:1994, *Electroacoustics — Instruments for the
-measurement of sound intensity — Measurements with pairs of pressure sensing
-microphones* — el estimador de intensidad por espectro cruzado con dos
-micrófonos, la corrección del sesgo por diferencias finitas y el límite de
-ancho de banda utilizable (cláusula 7.3, Tabla 3). ISO 9614-1:1993,
+**Normas.** IEC 61043:1993 (EN 61043:1994), *Electroacoustics —
+Instruments for the measurement of sound intensity — Measurements with pairs
+of pressure sensing microphones* — el estimador de intensidad por espectro
+cruzado con dos micrófonos, la corrección del sesgo por diferencias finitas
+y el límite de ancho de banda utilizable (cláusula 7.3, Tabla 3). ISO 9614-1:1993,
 *Acoustics — Determination of sound power levels of noise sources using sound
 intensity — Part 1: Measurement at discrete points* — el índice
 presión-intensidad, los indicadores de campo F2, F3 y F4 del Anexo A y el

--- a/site/src/content/docs/es/guides/sound-power.md
+++ b/site/src/content/docs/es/guides/sound-power.md
@@ -41,6 +41,61 @@ turno.
 
 <video class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_power_two_rooms_es.webm" preload="none" poster="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_power_two_rooms_es_poster.jpg" width="2400" height="1350" loop muted controls playsinline title="Animación: la misma fuente en una cámara anecoica y en una cámara reverberante produce presiones de micrófono distintas, y las fórmulas de campo libre y campo difuso convergen al mismo nivel de potencia sonora L_W" style="width:88%"></video><video class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_power_two_rooms_es_dark.webm" preload="none" poster="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_power_two_rooms_es_dark_poster.jpg" width="2400" height="1350" loop muted controls playsinline title="Animación: la misma fuente en una cámara anecoica y en una cámara reverberante produce presiones de micrófono distintas, y las fórmulas de campo libre y campo difuso convergen al mismo nivel de potencia sonora L_W" style="width:88%"></video>
 
+### Una ruta de decisión
+
+La tabla se condensa en una breve secuencia de preguntas (ISO 3740 dedica su
+Tabla 3 y su Anexo D exactamente a esta decisión). Recórrelas en orden; la
+primera coincidencia nombra la norma.
+
+1. **¿Para qué es el número?** Una declaración de ficha técnica o una
+   comprobación frente a un límite piden normalmente grado de ingeniería
+   (grado 2, el grado preferido para las declaraciones de ruido); una fuente
+   de referencia, una clasificación de productos o un litigio piden precisión
+   (grado 1); un primer reconocimiento de una nave ruidosa tolera el grado de
+   control (grado 3). El grado 1 solo existe en una sala de laboratorio
+   cualificada (ISO 3741, ISO 3745) o mediante los métodos de intensidad de
+   precisión (ISO 9614-1 en puntos discretos, ISO 9614-3 por barrido).
+2. **¿Puede la fuente viajar al laboratorio?** ISO 3741 quiere la fuente
+   pequeña frente a la sala (volumen no mayor de aproximadamente el 2 % del
+   volumen de la sala) y su ruido estacionario; ISO 3745 la quiere dentro de
+   una sala anecoica o semianecoica cualificada con una dimensión
+   característica menor que la mitad del radio de medición, y es la vía que
+   además proporciona la directividad. Una máquina anclada a su bancada
+   descarta ambas y deja los métodos in situ.
+3. **¿Cómo de silencioso y de seco es el emplazamiento?** ISO 3744 necesita
+   el fondo al menos 6 dB por debajo de la fuente (preferiblemente más de
+   15 dB) y `K2 ≤ 4 dB`. Si solo se alcanza un margen de 3 dB o `K2 ≤ 7 dB`, los
+   mismos micrófonos y fórmulas pasan sin más a ISO 3746 en grado de
+   control.
+4. **¿Es el fondo el problema?** Cuando las máquinas vecinas no se pueden
+   apagar, o el margen es directamente negativo, los métodos de presión
+   quedan descartados. El barrido de intensidad (ISO 9614-2, o ISO 9614-3
+   para el grado 1) tolera ruido extraño estacionario incluso unos 10 dB
+   *por encima* de la fuente, porque solo cuenta el flujo neto de energía a
+   través de la superficie; los indicadores de campo por banda deciden
+   después el grado realmente alcanzado.
+
+### Qué significan los grados de precisión
+
+El grado es una afirmación sobre la **reproducibilidad**: `σR0` es la
+desviación típica que verías si laboratorios distintos midieran la misma
+fuente, cada uno siguiendo la norma correctamente. Los valores ponderados A
+típicos son `σR0 ≈ 0.5 dB` para el grado 1 (ISO 3741), `1.5 dB` para el
+grado 2 (ISO 3744, ISO 9614-2) y `3 dB` o más para el grado 3 (aún mayores
+cuando `K2` es grande o el espectro es tonal). Los valores
+por banda son mayores en los extremos del espectro. El campo `uncertainty`
+de los resultados de los métodos de presión (superficie envolvente y sala
+anecoica) es la incertidumbre expandida `U = 2·σtot` (95 % de
+cobertura), donde `σtot = √(σR0² + σomc²)` incorpora además la inestabilidad
+de operación/montaje `σomc` que tú estimas y pasas; el grado solo acota la
+parte del presupuesto que corresponde al método.
+
+En la práctica: un `LWA` de grado 2 de 92,4 dB lleva `U ≈ 3 dB`, así que dos
+resultados de grado 2 separados 2 dB son estadísticamente indistinguibles, y
+contrastar esa misma fuente con un límite de 93 dB es cara o cruz. Elige el
+grado por la decisión que el número debe sostener, no por la instalación que
+esté libre.
+
 ## 1. Superficie envolvente, presión sonora (ISO 3744 / ISO 3746)
 
 Coloca la fuente sobre un plano reflectante e imagina una **superficie de
@@ -154,6 +209,41 @@ o `absorption_area`, o `mean_absorption_coefficient` + `room_surface`) habilita
 cae por debajo del criterio del grado o `K2` supera el límite de validez, un
 `SoundPowerWarning` avisa de que los niveles son cotas superiores —la
 determinación se devuelve igualmente.
+
+### Trampas de K1 y K2
+
+Ambas correcciones restan energía al nivel superficial, así que sobreestimar
+cualquiera de las dos subestima la emisión. Por eso las normas las acotan, y
+por eso la mayoría de las disputas sobre un resultado de superficie
+envolvente se remontan a uno de estos hábitos:
+
+- **K1 tiene un precipicio, no una pendiente.** Con 15 dB de margen la
+  corrección es un despreciable 0,14 dB; en el criterio de ingeniería de
+  6 dB ya es 1,26 dB, el mayor valor que acepta el grado. Por debajo del
+  criterio la norma no deja correr la fórmula: `K1` se acota y el resultado
+  se declara cota superior. Nunca extrapoles la resta a un margen menor;
+  aumenta el margen (emplazamiento más silencioso, superficie más cercana) o
+  pásate al método de intensidad.
+- **K1 supone un fondo estacionario.** La lectura con la fuente apagada debe
+  tomarse en las mismas posiciones y con la sala en el mismo estado, y la
+  energía de fondo debe ser la misma durante ambas lecturas. Un sistema de
+  ventilación que cicla o un vehículo que pasa durante cualquiera de las dos
+  invalida la pareja; la resta energética supone además fuente y fondo
+  incoherentes, lo que vale para el ruido ajeno pero no para las reflexiones
+  de la propia fuente.
+- **K2 elimina la acumulación media de la sala, no las reflexiones
+  discretas.** Una pared cercana, un carro u otra máquina justo fuera de la
+  superficie añaden una contribución especular concentrada en unos pocos
+  micrófonos. Ese desequilibrio aflora en el índice de directividad aparente
+  `DIi*`, y ninguna corrección promedio de sala puede eliminarlo: desplaza
+  la superficie, retira el reflector o trátalo con absorción.
+- **K2 vale lo que valga `A`.** Con `A` de Sabine (`0.16·V/T`), los errores
+  en el tiempo de reverberación o en el volumen se propagan directamente. En
+  el límite de validez `K2 = 4 dB` cerca del 60 % de la energía medida es
+  sala, no fuente, y un error del 20 % en `A` aún mueve `LW` unos 0,5 dB.
+  Prefiere un `T60` medido a un coeficiente de absorción estimado, y mantén
+  la distancia de medición lo bastante pequeña para que `K2` quede
+  holgadamente por debajo del límite.
 
 ### Parámetros de `sound_power_pressure()`
 
@@ -679,6 +769,45 @@ plt.show()
 - [Teoría](/phonometry/es/reference/theory/environment-transport/) — las derivaciones de Waterhouse, K1/K2 y
   C1/C2.
 - Referencia de la API: [`emission.sound_power`](/phonometry/es/reference/api/power/sound-power/), [`emission.sound_power_reverberation`](/phonometry/es/reference/api/power/sound-power-reverberation/) y [`emission.sound_power_intensity`](/phonometry/es/reference/api/power/sound-power-intensity/).
+
+## Referencias
+
+- Fahy, F. J. (1995). *Sound intensity* (2.ª ed.). E&FN Spon.
+  ISBN 978-0-419-19810-9.
+  [doi:10.4324/9780203475386](https://doi.org/10.4324/9780203475386).
+  La monografía sobre el flujo de energía sonora: por qué la intensidad
+  separa la energía que sale de la fuente de la energía estacionaria que
+  solo pasa, detrás de los métodos de barrido de las secciones 3 y 5.
+- Beranek, L. L., & Mellow, T. J. (2012). *Acoustics: Sound fields and
+  transducers*. Academic Press. ISBN 978-0-12-391421-7.
+  [doi:10.1016/C2011-0-05897-0](https://doi.org/10.1016/C2011-0-05897-0).
+  Radiación y campos sonoros: las relaciones entre presión y potencia en
+  campo libre y campo difuso sobre las que descansan los métodos de
+  superficie envolvente y de sala reverberante.
+- International Organization for Standardization. (2019). *Acoustics —
+  Determination of sound power levels of noise sources — Guidelines for the
+  use of basic standards* (ISO 3740:2019).
+  [Catálogo iso.org](https://www.iso.org/standard/45107.html).
+  La guía de selección detrás de "Elegir un método": grados, entornos y
+  criterios de tamaño de fuente y de ruido de fondo para toda la familia.
+- International Organization for Standardization. (2010). *Acoustics —
+  Determination of sound power levels and sound energy levels of noise
+  sources using sound pressure — Precision methods for reverberation test
+  rooms* (ISO 3741:2010).
+  [Catálogo iso.org](https://www.iso.org/standard/52053.html).
+  El método en sala reverberante de la sección 2.
+- International Organization for Standardization. (2010). *Acoustics —
+  Determination of sound power levels and sound energy levels of noise
+  sources using sound pressure — Engineering methods for an essentially free
+  field over a reflecting plane* (ISO 3744:2010).
+  [Catálogo iso.org](https://www.iso.org/standard/52055.html).
+  El método de superficie envolvente de la sección 1.
+- International Organization for Standardization. (2012). *Acoustics —
+  Determination of sound power levels and sound energy levels of noise
+  sources using sound pressure — Precision methods for anechoic rooms and
+  hemi-anechoic rooms* (ISO 3745:2012).
+  [Catálogo iso.org](https://www.iso.org/standard/45362.html).
+  El método de precisión en sala anecoica de la sección 4.
 
 ---
 

--- a/site/src/content/docs/es/guides/sound-power.md
+++ b/site/src/content/docs/es/guides/sound-power.md
@@ -24,7 +24,7 @@ prácticas distintos.
 
 | Método | Norma | Magnitud medida | Entorno | Grado de precisión | Cuándo usarlo |
 | :--- | :--- | :--- | :--- | :--- | :--- |
-| Superficie envolvente | **ISO 3744** (ingeniería) / **ISO 3746** (control) | Presión sonora sobre una semiesfera o caja | Campo esencialmente libre sobre uno o varios planos reflectantes | Grado 2 (`σR0 ≈ 1.5 dB`) / grado 3 (`≈ 3.0 dB`) | In situ o en una sala grande; sin instalación de ensayo especial disponible |
+| Superficie envolvente | **ISO 3744** (ingeniería) / **ISO 3746** (inspección) | Presión sonora sobre una semiesfera o caja | Campo esencialmente libre sobre uno o varios planos reflectantes | Grado 2 (`σR0 ≈ 1.5 dB`) / grado 3 (`≈ 3.0 dB`) | In situ o en una sala grande; sin instalación de ensayo especial disponible |
 | Sala reverberante | **ISO 3741** | Presión sonora en el campo difuso | Sala reverberante cualificada de paredes rígidas | Grado 1 (precisión) | Máxima precisión para fuentes estacionarias de banda ancha en laboratorio |
 | Barrido de intensidad | **ISO 9614-2** | Intensidad sonora normal barrida sobre una superficie | Casi cualquiera, tolerante al ruido extraño estacionario | Grado 2 / 3 (a partir de los indicadores de campo por banda) | In situ con ruido de fondo, o una máquina entre muchas |
 | Sala anecoica | **ISO 3745** | Presión sonora sobre un conjunto fijo de micrófonos | Sala anecoica o semianecoica cualificada | Grado 1 (precisión) | Emisión de grado de referencia en un laboratorio de campo libre |
@@ -52,7 +52,7 @@ primera coincidencia nombra la norma.
    (grado 2, el grado preferido para las declaraciones de ruido); una fuente
    de referencia, una clasificación de productos o un litigio piden precisión
    (grado 1); un primer reconocimiento de una nave ruidosa tolera el grado de
-   control (grado 3). El grado 1 solo existe en una sala de laboratorio
+   inspección (grado 3). El grado 1 solo existe en una sala de laboratorio
    cualificada (ISO 3741, ISO 3745) o mediante los métodos de intensidad de
    precisión (ISO 9614-1 en puntos discretos, ISO 9614-3 por barrido).
 2. **¿Puede la fuente viajar al laboratorio?** ISO 3741 quiere la fuente
@@ -66,7 +66,7 @@ primera coincidencia nombra la norma.
    el fondo al menos 6 dB por debajo de la fuente (preferiblemente más de
    15 dB) y `K2 ≤ 4 dB`. Si solo se alcanza un margen de 3 dB o `K2 ≤ 7 dB`, los
    mismos micrófonos y fórmulas pasan sin más a ISO 3746 en grado de
-   control.
+   inspección.
 4. **¿Es el fondo el problema?** Cuando las máquinas vecinas no se pueden
    apagar, o el margen es directamente negativo, los métodos de presión
    quedan descartados. El barrido de intensidad (ISO 9614-2, o ISO 9614-3
@@ -130,7 +130,7 @@ El área de la superficie es una forma cerrada de la geometría: una semiesfera
 es `S = 2πr²` sobre un plano reflectante (dividida entre dos y entre cuatro
 para dos y tres planos), y una caja de un plano es `S = 4(ab + bc + ca)` con
 `a = 0.5·l1 + d`, `b = 0.5·l2 + d`, `c = l3 + d` para la distancia de medición
-`d`. ISO 3746 (control) comparte todas las fórmulas pero es más burda: menos
+`d`. ISO 3746 (inspección) comparte todas las fórmulas pero es más burda: menos
 posiciones de micrófono, un criterio de fondo de 3 dB en lugar de 6 dB, y
 validez hasta `K2 ≤ 7 dB` en lugar de 4 dB.
 
@@ -218,19 +218,19 @@ por eso la mayoría de las disputas sobre un resultado de superficie
 envolvente se remontan a uno de estos hábitos:
 
 - **K1 tiene un precipicio, no una pendiente.** Con 15 dB de margen la
-  corrección es un despreciable 0,14 dB; en el criterio de ingeniería de
-  6 dB ya es 1,26 dB, el mayor valor que acepta el grado. Por debajo del
-  criterio la norma no deja correr la fórmula: `K1` se acota y el resultado
-  se declara cota superior. Nunca extrapoles la resta a un margen menor;
-  aumenta el margen (emplazamiento más silencioso, superficie más cercana) o
+  corrección es de tan solo 0,14 dB (despreciable); en el criterio de
+  ingeniería de 6 dB ya es 1,26 dB, el mayor valor que acepta el grado. Por
+  debajo del criterio la norma no permite aplicar la fórmula: `K1` se acota
+  y el resultado se declara cota superior. Nunca extrapoles la resta a un
+  margen menor; aumenta el margen (emplazamiento más silencioso, superficie más cercana) o
   pásate al método de intensidad.
 - **K1 supone un fondo estacionario.** La lectura con la fuente apagada debe
   tomarse en las mismas posiciones y con la sala en el mismo estado, y la
   energía de fondo debe ser la misma durante ambas lecturas. Un sistema de
   ventilación que cicla o un vehículo que pasa durante cualquiera de las dos
-  invalida la pareja; la resta energética supone además fuente y fondo
-  incoherentes, lo que vale para el ruido ajeno pero no para las reflexiones
-  de la propia fuente.
+  invalida la pareja; la resta energética supone además que la fuente y el
+  fondo son incoherentes, lo que vale para el ruido ajeno pero no para las
+  reflexiones de la propia fuente.
 - **K2 elimina la acumulación media de la sala, no las reflexiones
   discretas.** Una pared cercana, un carro u otra máquina justo fuera de la
   superficie añaden una contribución especular concentrada en unos pocos
@@ -239,8 +239,9 @@ envolvente se remontan a uno de estos hábitos:
   la superficie, retira el reflector o trátalo con absorción.
 - **K2 vale lo que valga `A`.** Con `A` de Sabine (`0.16·V/T`), los errores
   en el tiempo de reverberación o en el volumen se propagan directamente. En
-  el límite de validez `K2 = 4 dB` cerca del 60 % de la energía medida es
-  sala, no fuente, y un error del 20 % en `A` aún mueve `LW` unos 0,5 dB.
+  el límite de validez `K2 = 4 dB` cerca del 60 % de la energía medida
+  proviene de la sala, no de la fuente, y un error del 20 % en `A` aún
+  modifica `LW` en unos 0,5 dB.
   Prefiere un `T60` medido a un coeficiente de absorción estimado, y mantén
   la distancia de medición lo bastante pequeña para que `K2` quede
   holgadamente por debajo del límite.
@@ -445,7 +446,7 @@ residual de presión menos el factor de sesgo `K`, 10 dB para el grado 2 y 7 dB
 para el grado 3) debe superar `FpI` (criterio 1); `F+/- ≤ 3 dB` es el criterio
 2 (obligatorio para el grado 2); y los dos barridos repetidos deben coincidir
 dentro del límite `s` de la Tabla 2 por segmento (criterio 3). Una banda es de
-grado **ingeniería** cuando se cumplen los criterios 1, 2 y 3, de **control**
+grado **ingeniería** cuando se cumplen los criterios 1, 2 y 3, de **inspección**
 cuando se cumplen 1 y 3, y en caso contrario `none`.
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_pp_probe_es.svg" alt="Una sonda de intensidad sonora p-p de dos micrófonos: dos micrófonos de presión separados por un separador, a partir de los cuales se estima el gradiente de presión y, por tanto, la intensidad normal" style="width:70%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_pp_probe_es_dark.svg" alt="Una sonda de intensidad sonora p-p de dos micrófonos: dos micrófonos de presión separados por un separador, a partir de los cuales se estima el gradiente de presión y, por tanto, la intensidad normal" style="width:70%">

--- a/site/src/content/docs/es/reference/bibliography.md
+++ b/site/src/content/docs/es/reference/bibliography.md
@@ -33,7 +33,8 @@ que las guías incorporan sus secciones de Referencias.
   [doi:10.1016/C2011-0-05897-0](https://doi.org/10.1016/C2011-0-05897-0).
   Campos sonoros, radiación y transductores electroacústicos; sustenta el
   material de electroacústica y potencia sonora.
-  Citado por [Electroacústica](/phonometry/es/guides/electroacoustics/).
+  Citado por [Electroacústica](/phonometry/es/guides/electroacoustics/) y
+  [Potencia sonora](/phonometry/es/guides/sound-power/).
 
 ## Procesado de señal
 
@@ -48,6 +49,59 @@ que las guías incorporan sus secciones de Referencias.
   [ccrma.stanford.edu/~jos/filters](https://ccrma.stanford.edu/~jos/filters/).
   Tratamiento gratuito y complementario del diseño y análisis de filtros
   digitales, el paso natural tras las guías de bancos de filtros.
+
+## Potencia sonora e intensidad
+
+- Fahy, F. J. (1995). *Sound intensity* (2.ª ed.). E&FN Spon.
+  ISBN 978-0-419-19810-9.
+  [doi:10.4324/9780203475386](https://doi.org/10.4324/9780203475386).
+  La monografía sobre el flujo de energía sonora: intensidad activa y
+  reactiva, el estimador p-p y su presupuesto de error por desfase.
+  Citado por [Potencia sonora](/phonometry/es/guides/sound-power/) e
+  [Intensidad sonora (p-p)](/phonometry/es/guides/intensity/).
+- International Organization for Standardization. (2019). *Acoustics —
+  Determination of sound power levels of noise sources — Guidelines for the
+  use of basic standards* (ISO 3740:2019).
+  [Catálogo iso.org](https://www.iso.org/standard/45107.html).
+  La guía de selección de la familia de potencia sonora: grados, entornos y
+  criterios de tamaño de fuente y de ruido de fondo.
+  Citado por [Potencia sonora](/phonometry/es/guides/sound-power/).
+- International Organization for Standardization. (2010). *Acoustics —
+  Determination of sound power levels and sound energy levels of noise
+  sources using sound pressure — Precision methods for reverberation test
+  rooms* (ISO 3741:2010).
+  [Catálogo iso.org](https://www.iso.org/standard/52053.html).
+  El método de precisión en sala reverberante.
+  Citado por [Potencia sonora](/phonometry/es/guides/sound-power/).
+- International Organization for Standardization. (2010). *Acoustics —
+  Determination of sound power levels and sound energy levels of noise
+  sources using sound pressure — Engineering methods for an essentially free
+  field over a reflecting plane* (ISO 3744:2010).
+  [Catálogo iso.org](https://www.iso.org/standard/52055.html).
+  El método de ingeniería por superficie envolvente.
+  Citado por [Potencia sonora](/phonometry/es/guides/sound-power/).
+- International Organization for Standardization. (2012). *Acoustics —
+  Determination of sound power levels and sound energy levels of noise
+  sources using sound pressure — Precision methods for anechoic rooms and
+  hemi-anechoic rooms* (ISO 3745:2012).
+  [Catálogo iso.org](https://www.iso.org/standard/45362.html).
+  El método de precisión en sala anecoica.
+  Citado por [Potencia sonora](/phonometry/es/guides/sound-power/).
+- International Organization for Standardization. (1993). *Acoustics —
+  Determination of sound power levels of noise sources using sound
+  intensity — Part 1: Measurement at discrete points* (ISO 9614-1:1993).
+  [Catálogo iso.org](https://www.iso.org/standard/17427.html).
+  Los indicadores de campo y el criterio de capacidad dinámica de la medida
+  de intensidad.
+  Citado por [Intensidad sonora (p-p)](/phonometry/es/guides/intensity/).
+- International Electrotechnical Commission. (1993). *Electroacoustics —
+  Instruments for the measurement of sound intensity — Measurements with
+  pairs of pressure sensing microphones* (IEC 61043:1993; adoptada en Europa
+  como EN 61043:1994).
+  [Tienda IEC](https://webstore.iec.ch/en/publication/4353).
+  La norma de instrumentación p-p: el estimador por espectro cruzado y el
+  índice presión-intensidad residual.
+  Citado por [Intensidad sonora (p-p)](/phonometry/es/guides/intensity/).
 
 ## Acústica de edificios
 

--- a/site/src/content/docs/guides/intensity.md
+++ b/site/src/content/docs/guides/intensity.md
@@ -133,6 +133,73 @@ print(ld, ld > fi.f2)                                      # 8.0 True (criterion
 
 <video class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_intensity_scan_power.webm" preload="none" poster="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_intensity_scan_power_poster.jpg" width="2400" height="1350" loop muted controls playsinline title="Animation: a p-p probe traces the serpentine scan over the top face of the measurement box while the normal-intensity arrows appear behind it, and the partial powers of the five faces accumulate into the sound power level L_W" style="width:88%"></video><video class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_intensity_scan_power_dark.webm" preload="none" poster="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_intensity_scan_power_dark_poster.jpg" width="2400" height="1350" loop muted controls playsinline title="Animation: a p-p probe traces the serpentine scan over the top face of the measurement box while the normal-intensity arrows appear behind it, and the partial powers of the five faces accumulate into the sound power level L_W" style="width:88%"></video>
 
+### The margin over the residual index
+
+The two channels of any real probe and analyzer are never perfectly phase
+matched. Feed both channels the *same* signal (the residual-intensity test
+of IEC 61043): the true intensity is exactly zero, yet the mismatch reports
+a small false intensity. The gap between the pressure level and that false
+intensity level is the **residual pressure-intensity index** `δpI0`, the
+instrument's phase-error floor expressed as an index; IEC 61043 grades
+probes and processors (class 1 / class 2) chiefly by it.
+
+In the field, the measured index `δpI = Lp − LI` says how far the pressure
+level stands above the level of the net flow, and the systematic error of
+the intensity estimate is bounded by the margin between the two indices:
+
+$$
+\varepsilon = 10 \log_{10}\!\left( 1 \pm 10^{(\delta_{pI} - \delta_{pI0})/10} \right)
+$$
+
+A 10 dB margin keeps the bias within about 0.5 dB and a 7 dB margin within
+about 1 dB; these are precisely the bias factors `K` of ISO 9614, and the
+**dynamic capability** `Ld = δpI0 − K` is the largest field index the
+instrument can afford at a given grade. Read it as a budget: every decibel
+the field's `δpI` rises spends a decibel of margin, and when `δpI` reaches
+`δpI0` the reading is pure phase error, of either sign. This is why the
+pressure-intensity index, not the microphone quality, gates the achievable
+accuracy of every intensity measurement.
+
+### Reactive fields near sources
+
+Close to a source the field turns **reactive**: pressure and particle
+velocity drift toward quadrature, so a large pressure carries little net
+flow. For a small source the quadrature component grows as `1/(kr)`; at
+100 Hz and 0.25 m from the source it is already about twice the active one,
+and `δpI` climbs just as it does in the standing wave of the figure above.
+The same happens between a machine and a hard reflecting surface, and in
+reverberant rooms where the diffuse field raises pressure without
+transporting energy outward. This is why ISO 9614-1 keeps the measurement
+surface on average more than 0.5 m away from the source, and why, when a
+scan fails the dynamic-capability criterion, moving the surface outward or
+adding absorption to the room usually lowers `F2` below `Ld` more cheaply
+than better hardware.
+
+### Choosing the spacer
+
+The spacer sets both ends of the usable band, in opposite directions:
+
+- **The top end is geometry.** The finite difference underestimates the
+  gradient by `sin(kΔr)/(kΔr)`, so the ceiling scales as `1/Δr`:
+  `max_valid_frequency ≈ 0.1·c/Δr` keeps the bias within about 0.3 dB,
+  giving roughly 5.7 kHz for a 6 mm spacer, 2.9 kHz for 12 mm and 690 Hz
+  for 50 mm (`bias_correct=True` undoes the known bias somewhat beyond
+  that).
+- **The bottom end is phase.** A progressive wave puts only
+  `360·f·Δr/c` degrees of true phase across the spacer, 0.8° at 63 Hz over
+  12 mm, while the channel mismatch stays fixed. Lowering the frequency
+  shrinks the signal, not the error, so the margin over `δpI0` collapses at
+  low frequency. A larger spacer buys back that margin: the IEC 61043
+  residual-index requirements scale as `10·lg(Δr/25 mm)`, so doubling the
+  spacer is worth 3 dB of low-frequency margin.
+
+No single spacer covers the full audio range: 6 mm suits high-frequency
+work, 50 mm low-frequency work, and the common 12 mm covers the mid band.
+Wide-band surveys are measured twice with two spacers and the band results
+merged; whichever spacer is fitted, verify `δpI0` with that spacer in
+place, since the index belongs to the probe-spacer-analyzer chain, not to
+the microphones alone.
+
 ### `sound_intensity()` parameters
 
 | Parameter | Type | Units | Range / default | Notes |
@@ -149,12 +216,35 @@ print(ld, ld > fi.f2)                                      # 8.0 True (criterion
 See [Theory](/phonometry/reference/theory/signal-analysis/) for the derivations and [Calibration](/phonometry/guides/calibration/)
 for absolute scaling of the two channels.
 
+## References
+
+- Fahy, F. J. (1995). *Sound intensity* (2nd ed.). E&FN Spon.
+  ISBN 978-0-419-19810-9.
+  [doi:10.4324/9780203475386](https://doi.org/10.4324/9780203475386).
+  The monograph on the subject: active and reactive intensity, the p-p
+  estimator and the phase-mismatch error budget behind this page.
+- International Electrotechnical Commission. (1993). *Electroacoustics —
+  Instruments for the measurement of sound intensity — Measurements with
+  pairs of pressure sensing microphones* (IEC 61043:1993; adopted in Europe
+  as EN 61043:1994).
+  [IEC webstore](https://webstore.iec.ch/en/publication/4353).
+  The instrument standard: the cross-spectral estimator, the
+  residual-intensity test behind `δpI0` and the class 1 / class 2
+  requirements.
+- International Organization for Standardization. (1993). *Acoustics —
+  Determination of sound power levels of noise sources using sound
+  intensity — Part 1: Measurement at discrete points* (ISO 9614-1:1993).
+  [iso.org catalogue](https://www.iso.org/standard/17427.html).
+  The field indicators F2 to F4, the dynamic-capability criterion and the
+  0.5 m surface-distance rule.
+
 ---
 
-**Standards.** IEC 61043:1994, *Electroacoustics — Instruments for the
-measurement of sound intensity — Measurements with pairs of pressure sensing
-microphones* — the two-microphone cross-spectral intensity estimator, the
-finite-difference bias correction and the usable-bandwidth bound (clause 7.3,
+**Standards.** IEC 61043:1993 (EN 61043:1994), *Electroacoustics —
+Instruments for the measurement of sound intensity — Measurements with pairs
+of pressure sensing microphones* — the two-microphone cross-spectral
+intensity estimator, the finite-difference bias correction and the
+usable-bandwidth bound (clause 7.3,
 Table 3). ISO 9614-1:1993, *Acoustics — Determination of sound power levels
 of noise sources using sound intensity — Part 1: Measurement at discrete
 points* — the pressure-intensity index, the Annex A field indicators F2, F3

--- a/site/src/content/docs/guides/sound-power.md
+++ b/site/src/content/docs/guides/sound-power.md
@@ -39,6 +39,59 @@ of the page walks each in turn.
 
 <video class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_power_two_rooms.webm" preload="none" poster="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_power_two_rooms_poster.jpg" width="2400" height="1350" loop muted controls playsinline title="Animation: the same source in an anechoic room and in a reverberation room produces different microphone pressures, and the free-field and diffuse-field formulas converge to the same sound power level L_W" style="width:88%"></video><video class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_power_two_rooms_dark.webm" preload="none" poster="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_power_two_rooms_dark_poster.jpg" width="2400" height="1350" loop muted controls playsinline title="Animation: the same source in an anechoic room and in a reverberation room produces different microphone pressures, and the free-field and diffuse-field formulas converge to the same sound power level L_W" style="width:88%"></video>
 
+### A decision path
+
+The table compresses into a short sequence of questions (ISO 3740 dedicates
+its Table 3 and Annex D to exactly this decision). Work through them in
+order; the first match names the standard.
+
+1. **What is the number for?** A datasheet declaration or a limit check
+   normally asks for engineering grade (grade 2, the preferred grade for
+   noise declarations); a reference source, a product ranking or a dispute
+   calls for precision (grade 1); a first walk-through of a noisy plant
+   tolerates survey grade (grade 3). Grade 1 exists only in a qualified
+   laboratory room (ISO 3741, ISO 3745) or via the precision intensity
+   methods (ISO 9614-1 at discrete points, ISO 9614-3 by scanning).
+2. **Can the source travel to a laboratory?** ISO 3741 wants the source
+   small next to the room (volume no more than about 2 % of the room volume)
+   and its noise steady; ISO 3745 wants it inside a qualified anechoic or
+   hemi-anechoic room with a characteristic dimension below half the
+   measurement radius, and it is the route that also yields directivity. A
+   machine bolted to its foundation rules both out and leaves the in-situ
+   methods.
+3. **How quiet and how dry is the site?** ISO 3744 needs the background at
+   least 6 dB below the source (preferably more than 15 dB) and
+   `K2 ≤ 4 dB`. If only a
+   3 dB margin or `K2 ≤ 7 dB` can be met, the same microphones and formulae
+   degrade gracefully to ISO 3746 at survey grade.
+4. **Is the background the problem?** When neighbouring machines cannot be
+   switched off, or the margin is outright negative, the pressure methods
+   are out. Intensity scanning (ISO 9614-2, or ISO 9614-3 for grade 1)
+   tolerates steady extraneous noise even some 10 dB *above* the source,
+   because only the net energy flux through the surface counts; the
+   per-band field indicators then decide the grade actually achieved.
+
+### What the accuracy grades mean
+
+The grade is a claim about **reproducibility**: `σR0` is the standard
+deviation you would see if different laboratories measured the same source,
+each following the standard correctly. Typical A-weighted values are
+`σR0 ≈ 0.5 dB` for grade 1 (ISO 3741), `1.5 dB` for grade 2 (ISO 3744,
+ISO 9614-2) and `3 dB` or more for grade 3 (larger still when `K2` is
+large or the spectrum is tonal). Per-band values are larger at the
+spectrum edges. The `uncertainty` field of the pressure-method results
+(enveloping surface and anechoic) is the expanded uncertainty
+`U = 2·σtot` (95 % coverage), where
+`σtot = √(σR0² + σomc²)` also folds in the operating/mounting instability
+`σomc` that you estimate and pass in; the grade only bounds the method's
+share of the budget.
+
+In practice: a grade-2 `LWA` of 92.4 dB carries `U ≈ 3 dB`, so two grade-2
+results 2 dB apart are statistically indistinguishable, and checking that
+same source against a 93 dB limit is a coin flip. Choose the grade from the
+decision the number has to support, not from the facility that happens to
+be free.
+
 ## 1. Enveloping surface, sound pressure (ISO 3744 / ISO 3746)
 
 Place the source on a reflecting plane and imagine a **measurement surface**
@@ -150,6 +203,40 @@ data (`reverberation_time` + `volume`, or `absorption_area`, or
 field is treated as free (`K2 = 0`). If the background margin drops below the
 grade criterion or `K2` exceeds the validity limit, a `SoundPowerWarning`
 flags that the levels are upper bounds — the determination still returns.
+
+### K1 and K2 pitfalls
+
+Both corrections subtract energy from the surface level, so overestimating
+either one understates the emission. That is why the standards cap them, and
+why most disputes over an enveloping-surface result trace back to one of
+these habits:
+
+- **K1 has a cliff, not a slope.** At a 15 dB margin the correction is a
+  negligible 0.14 dB; at the 6 dB engineering criterion it is already
+  1.26 dB, the largest value the grade accepts. Below the criterion the
+  standard does not let the formula run on: `K1` is capped and the result is
+  reported as an upper bound. Never extrapolate the subtraction into a
+  smaller margin; raise the margin (quieter site, closer surface) or switch
+  to the intensity method.
+- **K1 assumes a stationary background.** The source-off reading must be
+  taken at the same positions with the room in the same state, and the
+  background energy must be the same during both readings. A ventilation
+  system that cycles or a vehicle passing during either reading invalidates
+  the pair; the energy subtraction also assumes source and background are
+  incoherent, which holds for unrelated noise but not for the source's own
+  reflections.
+- **K2 removes the average room build-up, not discrete reflections.** A
+  nearby wall, a trolley or another machine just outside the surface adds a
+  specular contribution concentrated at a few microphones. That imbalance
+  shows up in the apparent directivity index `DIi*`, and no room-average
+  correction can remove it: move the surface, remove the reflector or treat
+  it with absorption.
+- **K2 is only as good as `A`.** With `A` from Sabine (`0.16·V/T`), errors
+  in the reverberation time or the volume propagate directly. At the
+  `K2 = 4 dB` validity limit about 60 % of the measured energy is room, not
+  source, and a 20 % error in `A` still moves `LW` by about 0.5 dB. Prefer a
+  measured `T60` over a guessed absorption coefficient, and keep the
+  measurement distance small enough that `K2` stays well under the limit.
 
 ### `sound_power_pressure()` parameters
 
@@ -665,6 +752,45 @@ plt.show()
 - [Levels](/phonometry/guides/levels/) — energy averaging and the A-weighting behind `LWA`.
 - [Theory](/phonometry/reference/theory/environment-transport/) — the Waterhouse, K1/K2 and C1/C2 derivations.
 - API reference: [`emission.sound_power`](/phonometry/reference/api/power/sound-power/), [`emission.sound_power_reverberation`](/phonometry/reference/api/power/sound-power-reverberation/) and [`emission.sound_power_intensity`](/phonometry/reference/api/power/sound-power-intensity/).
+
+## References
+
+- Fahy, F. J. (1995). *Sound intensity* (2nd ed.). E&FN Spon.
+  ISBN 978-0-419-19810-9.
+  [doi:10.4324/9780203475386](https://doi.org/10.4324/9780203475386).
+  The monograph on sound energy flux: why intensity separates the energy
+  leaving the source from steady energy passing through, behind the
+  scanning methods of sections 3 and 5.
+- Beranek, L. L., & Mellow, T. J. (2012). *Acoustics: Sound fields and
+  transducers*. Academic Press. ISBN 978-0-12-391421-7.
+  [doi:10.1016/C2011-0-05897-0](https://doi.org/10.1016/C2011-0-05897-0).
+  Radiation and sound fields: the free-field and diffuse-field relations
+  between pressure and power that the enveloping-surface and
+  reverberation-room methods rest on.
+- International Organization for Standardization. (2019). *Acoustics —
+  Determination of sound power levels of noise sources — Guidelines for the
+  use of basic standards* (ISO 3740:2019).
+  [iso.org catalogue](https://www.iso.org/standard/45107.html).
+  The selection guide behind "Choosing a method": grades, environments,
+  source-size and background criteria for the whole family.
+- International Organization for Standardization. (2010). *Acoustics —
+  Determination of sound power levels and sound energy levels of noise
+  sources using sound pressure — Precision methods for reverberation test
+  rooms* (ISO 3741:2010).
+  [iso.org catalogue](https://www.iso.org/standard/52053.html).
+  The reverberation-room method of section 2.
+- International Organization for Standardization. (2010). *Acoustics —
+  Determination of sound power levels and sound energy levels of noise
+  sources using sound pressure — Engineering methods for an essentially free
+  field over a reflecting plane* (ISO 3744:2010).
+  [iso.org catalogue](https://www.iso.org/standard/52055.html).
+  The enveloping-surface method of section 1.
+- International Organization for Standardization. (2012). *Acoustics —
+  Determination of sound power levels and sound energy levels of noise
+  sources using sound pressure — Precision methods for anechoic rooms and
+  hemi-anechoic rooms* (ISO 3745:2012).
+  [iso.org catalogue](https://www.iso.org/standard/45362.html).
+  The precision anechoic-room method of section 4.
 
 ---
 

--- a/site/src/content/docs/reference/bibliography.md
+++ b/site/src/content/docs/reference/bibliography.md
@@ -31,7 +31,8 @@ list grows as guides gain their References sections.
   [doi:10.1016/C2011-0-05897-0](https://doi.org/10.1016/C2011-0-05897-0).
   Sound fields, radiation and electroacoustic transducers; supports the
   electroacoustics and sound-power material.
-  Cited by [Electroacoustics](/phonometry/guides/electroacoustics/).
+  Cited by [Electroacoustics](/phonometry/guides/electroacoustics/) and
+  [Sound Power](/phonometry/guides/sound-power/).
 
 ## Signal processing
 
@@ -46,6 +47,59 @@ list grows as guides gain their References sections.
   [ccrma.stanford.edu/~jos/filters](https://ccrma.stanford.edu/~jos/filters/).
   Free companion treatment of digital-filter design and analysis, a good next
   step after the filter-bank guides.
+
+## Sound power and intensity
+
+- Fahy, F. J. (1995). *Sound intensity* (2nd ed.). E&FN Spon.
+  ISBN 978-0-419-19810-9.
+  [doi:10.4324/9780203475386](https://doi.org/10.4324/9780203475386).
+  The monograph on sound energy flux: active and reactive intensity, the
+  p-p estimator and its phase-mismatch error budget.
+  Cited by [Sound Power](/phonometry/guides/sound-power/) and
+  [Sound Intensity (p-p)](/phonometry/guides/intensity/).
+- International Organization for Standardization. (2019). *Acoustics —
+  Determination of sound power levels of noise sources — Guidelines for the
+  use of basic standards* (ISO 3740:2019).
+  [iso.org catalogue](https://www.iso.org/standard/45107.html).
+  The selection guide for the sound-power family: grades, environments,
+  source-size and background criteria.
+  Cited by [Sound Power](/phonometry/guides/sound-power/).
+- International Organization for Standardization. (2010). *Acoustics —
+  Determination of sound power levels and sound energy levels of noise
+  sources using sound pressure — Precision methods for reverberation test
+  rooms* (ISO 3741:2010).
+  [iso.org catalogue](https://www.iso.org/standard/52053.html).
+  The precision reverberation-room method.
+  Cited by [Sound Power](/phonometry/guides/sound-power/).
+- International Organization for Standardization. (2010). *Acoustics —
+  Determination of sound power levels and sound energy levels of noise
+  sources using sound pressure — Engineering methods for an essentially free
+  field over a reflecting plane* (ISO 3744:2010).
+  [iso.org catalogue](https://www.iso.org/standard/52055.html).
+  The enveloping-surface engineering method.
+  Cited by [Sound Power](/phonometry/guides/sound-power/).
+- International Organization for Standardization. (2012). *Acoustics —
+  Determination of sound power levels and sound energy levels of noise
+  sources using sound pressure — Precision methods for anechoic rooms and
+  hemi-anechoic rooms* (ISO 3745:2012).
+  [iso.org catalogue](https://www.iso.org/standard/45362.html).
+  The precision anechoic-room method.
+  Cited by [Sound Power](/phonometry/guides/sound-power/).
+- International Organization for Standardization. (1993). *Acoustics —
+  Determination of sound power levels of noise sources using sound
+  intensity — Part 1: Measurement at discrete points* (ISO 9614-1:1993).
+  [iso.org catalogue](https://www.iso.org/standard/17427.html).
+  The field indicators and the dynamic-capability criterion of intensity
+  measurement.
+  Cited by [Sound Intensity (p-p)](/phonometry/guides/intensity/).
+- International Electrotechnical Commission. (1993). *Electroacoustics —
+  Instruments for the measurement of sound intensity — Measurements with
+  pairs of pressure sensing microphones* (IEC 61043:1993; adopted in Europe
+  as EN 61043:1994).
+  [IEC webstore](https://webstore.iec.ch/en/publication/4353).
+  The p-p instrument standard: the cross-spectral estimator and the
+  residual pressure-intensity index.
+  Cited by [Sound Intensity (p-p)](/phonometry/guides/intensity/).
 
 ## Building acoustics
 


### PR DESCRIPTION
## Summary

Didactic depth and verified references for the sound power and intensity guides, in the three content trees.

- Sound power: a four-question decision path through the ISO 3740 family (purpose and grade, source transportability and size limits such as the ISO 3741 two-percent volume rule, the background and environment criteria, and when the intensity route is the only option); what the accuracy grades mean for the reported uncertainty (why a grade-2 result cannot arbitrate a 0.6 dB limit margin); and the K1/K2 correction pitfalls, from the 1.26 dB background cliff to the sensitivity of K2 to the absorption area.
- Intensity: the margin over the residual pressure-intensity index and the error bound it buys (the 10 and 7 dB dynamic-capability rules), reactive fields near sources and the 0.5 m rule, and spacer choice with the finite-difference ceiling and phase-mismatch floor worked out for the common spacers. Every numeric claim cross-checked against the standards.
- References verified at authoring time, including Fahy's Sound Intensity with its real DOI; a designation finding along the way: IEC 61043 is the 1993 publication and the 1994 date belongs to the EN adoption, now stated precisely on the page.
- The bibliography gains a Sound power and intensity group with back-links.

## Test plan

ruff, mypy, conformance byte-identical, i18n parity (56 pairs), site build with links validator at 0 errors, html-validate. A review pass produced 12 findings (technical precision and Spanish idiom), all resolved.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

