### PR TITLE
docs: materials and surface-scattering didactics with verified references

### DIFF
--- a/docs/materials.md
+++ b/docs/materials.md
@@ -221,6 +221,41 @@ their helpers separate and never mixes them.
 
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_impedance_tube_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_impedance_tube.svg" alt="ISO 10534-2 two-microphone impedance tube: a loudspeaker radiating a plane wave down the tube, two microphones flush in the wall at spacing s and distance x1 from the specimen face, the test specimen against a rigid backing, and the incident and reflected waves" width="92%"></picture>
 
+**Working frequency range (ISO 10534-2, Clause 4).** Everything the tube
+reports assumes the field inside is a single plane wave, and the geometry sets
+both ends of the usable band. Above the cut-on of the first cross-sectional
+mode the field stops being planar: a circular tube of diameter $d$ needs
+$f\,d < 0.58\,c_0$ (Eq. (2); $f\,d < 0.50\,c_0$ for a rectangular tube,
+Eq. (3)). The microphone spacing $s$ must also stay clear of the
+half-wavelength singularity of the transfer-function method,
+$f\,s < 0.45\,c_0$ (Eq. (4)). At the low end the opposite problem appears: a
+spacing much shorter than the wavelength leaves almost no phase difference
+between the microphones to measure, so the Clause 4.2 guideline keeps the
+spacing above 5 % of the wavelength:
+
+$$
+\frac{c_0}{20\,s} \;<\; f \;<\;
+\min\!\left(0.58\,\frac{c_0}{d},\ 0.45\,\frac{c_0}{s}\right).
+$$
+
+No single tube covers the building-acoustics range. A 100 mm tube with a
+100 mm spacing works from roughly 170 Hz to 1.5 kHz; reaching the 5 kHz bands
+takes a small tube (29 mm) with a close spacing, which in turn cannot see the
+low bands. Laboratories therefore pair a large and a small tube (or one tube
+with two spacings) and splice the spectra; the two must agree in the overlap
+bands, and a mismatch there points at the sample cut or mounting, not at the
+physics.
+
+```python
+from phonometry import plane_wave_frequency_range
+
+# A 100 mm tube with 100 mm spacing, and a 29 mm tube with 20 mm spacing.
+f_l, f_u = plane_wave_frequency_range(0.100, 343.2, diameter=0.100)
+print(round(f_l, 1), round(f_u, 1))     # 171.6 1544.4
+f_l, f_u = plane_wave_frequency_range(0.020, 343.2, diameter=0.029)
+print(round(f_l, 1), round(f_u, 1))     # 858.0 6864.0
+```
+
 **Standing-wave-ratio method (ISO 10534-1).** A probe traverses the standing wave
 and reads the level difference $\Delta L = L_\text{max} - L_\text{min}$ between a
 pressure maximum and the adjacent minimum. The standing-wave ratio, reflection
@@ -348,6 +383,87 @@ print(np.round(tm.transmission_loss(rho_c), 6))   # [0. 0. 0.]
 `characteristic_impedance_material`, `material_wavenumber`) then read off the
 ASTM E2611 quantities.
 
+**Mounting pitfalls.** Most bad tube data are made at the sample holder, long
+before the signal processing. The recurring failures:
+
+- **Perimeter gaps.** A specimen cut slightly undersize leaves an air sliver
+  along the tube wall. Sound short-circuits around and behind the sample, and
+  the gap itself resonates, so the measured absorption grows a spurious
+  low-to-mid-frequency hump. Cut for a snug slide fit and seal the rim (a thin
+  film of petroleum jelly is the classic remedy) without loading the front
+  face.
+- **Compression.** A specimen cut oversize and forced in is denser than the
+  product it is supposed to represent: the flow resistivity rises, a limp
+  frame is stiffened, and the absorption curve shifts and flattens. The result
+  is repeatable and wrong.
+- **Hidden back cavity.** If the specimen does not sit flush on the rigid
+  backing, the unintended air layer acts as a quarter-wavelength cavity and
+  moves the absorption peak down in frequency, flattering the material.
+  Backing air gaps are perfectly legitimate mountings, but only when they are
+  deliberate, dimensioned and reported with the result.
+- **Face not plane.** A bulging, tilted or torn front face scatters into
+  cross-sectional modes below the nominal cut-on and breaks the
+  normal-incidence assumption the equations rest on. Cut with a sharp tool;
+  do not tear fibrous materials to size.
+- **One specimen is not the material.** Porous products are inhomogeneous at
+  the scale of a tube sample. Measure several cuts and average; a spread
+  between specimens is product variance worth reporting, not measurement noise
+  to hide.
+
+## Tube or reverberation room?
+
+The tube and the reverberation room both deliver a number called the
+"absorption coefficient", and the two are routinely confused. They are
+different physical quantities, measured under different sound fields, and they
+do not match, sometimes not even closely.
+
+The tube measures a **normal-incidence** coefficient: one plane wave, one
+angle, a specimen a few centimetres across, and a complex reflection factor
+that keeps magnitude and phase. ISO 354 measures the **random-incidence**
+coefficient $\alpha_s$: a diffuse field striking a sample of 10 m² to 12 m²
+from every direction at once, recovered from the change in the room's decay
+time through Sabine's formula, an energy average with no phase left in it.
+Because the diffuse field finds more ways into an absorber than the single
+normal-incidence wave (oblique waves travel a longer path inside the layer),
+$\alpha_s$ usually comes out higher. For a locally reacting surface the two
+are linked by Paris' angular average,
+
+$$
+\alpha_{st} = \int_0^{\pi/2} \alpha(\theta)\,\sin 2\theta\,\mathrm{d}\theta,
+$$
+
+which weights the oblique angles most heavily; evaluating it needs the
+angle-dependent $\alpha(\theta)$ from the measured surface impedance, not just
+the normal-incidence coefficient itself.
+
+**Why ISO 354 values exceed 1.** A ratio of absorbed to incident energy cannot
+exceed one, yet reverberation-room reports of $\alpha_s = 1.05$ to $1.20$ for
+thick porous absorbers are routine and correct by the method. Sabine's formula
+converts the decay-time change into an equivalent absorption area $A$, and
+$\alpha_s = A/S$ divides by the *geometric* sample area $S$. Diffraction at
+the sample edges lets the specimen drain energy from a sound field wider than
+its footprint (the edge effect), so the equivalent area can exceed the
+geometric one. Such values are not errors, but they are not portable either:
+they depend on the sample size and perimeter, which is exactly why ISO 354
+fixes both. The ISO 11654 rating simply truncates: practical coefficients
+above $1.00$ are set to $1.00$ (section 1), and prediction software clips at
+one before summing absorption areas.
+
+**Which to use.** They answer different questions. The reverberation-room
+value is the one that feeds diffuse-field prediction: Sabine reverberation
+estimates, the equivalent absorption areas of
+[EN 12354-6](enclosed-space-absorption.md) and the $\alpha_w$ rating and
+class, all of which expect random incidence over a mounted, finite sample
+(ISO 354's Annex B mounting types exist because the mounting is part of the
+result). The tube value is the laboratory and development tool: it needs only
+a few square centimetres of material, resolves magnitude *and* phase, and its
+surface impedance pins down the parameters of porous-material models in the
+Allard and Atalla tradition, with the airflow resistivity of section 2 as the
+first input; the fitted model then predicts the layer at any angle, thickness
+or backing. What the tube number is *not* is a drop-in substitute for
+$\alpha_s$: feeding normal-incidence coefficients into a Sabine or EN 12354-6
+budget systematically underpredicts the installed absorption.
+
 ## 4. Sound-absorption measurement uncertainty (ISO 12999-2)
 
 A rated absorption coefficient means little without its uncertainty. ISO
@@ -412,6 +528,48 @@ print(float(r.reported_expanded_uncertainty[0]))             # 0.08  (U, k=2)
 print(float(weighted_coefficient_uncertainty(0.70).reported_expanded_uncertainty[0]))  # 0.07
 print(float(single_number_rating_uncertainty(8.1).reported_expanded_uncertainty[0]))   # 1.6
 ```
+
+## References
+
+- Allard, J. F., & Atalla, N. (2009). *Propagation of sound in porous media:
+  Modelling sound absorbing materials* (2nd ed.). Wiley.
+  ISBN 978-0-470-74661-5.
+  [doi:10.1002/9780470747339](https://doi.org/10.1002/9780470747339).
+  The porous-material theory behind the measured quantities: airflow
+  resistivity as a model input, and the surface impedance and absorption the
+  tube recovers.
+- Cox, T. J., & D'Antonio, P. (2017). *Acoustic absorbers and diffusers:
+  Theory, design and application* (3rd ed.). CRC Press.
+  ISBN 978-1-4987-4099-9.
+  [doi:10.1201/9781315369211](https://doi.org/10.1201/9781315369211).
+  Absorber measurement and design in practice: the tube and room methods side
+  by side, mountings, and the edge-effect discussion behind the
+  tube-or-reverberation-room section.
+- International Organization for Standardization. (2003). *Acoustics —
+  Measurement of sound absorption in a reverberation room* (ISO 354:2003).
+  [iso.org catalogue](https://www.iso.org/standard/34545.html).
+  The reverberation-room method that produces the $\alpha_s$ spectra rated by
+  ISO 11654, including the Annex B specimen mountings.
+- International Organization for Standardization. (1998). *Acoustics —
+  Determination of sound absorption coefficient and impedance in impedance
+  tubes — Part 2: Transfer-function method* (ISO 10534-2:1998; adopted in
+  Europe as BS EN ISO 10534-2:2001, the edition implemented here; since
+  revised as [ISO 10534-2:2023](https://www.iso.org/standard/81294.html)).
+  [iso.org catalogue](https://www.iso.org/standard/22851.html).
+  The two-microphone transfer-function method and its plane-wave
+  frequency-range limits.
+- ASTM International. (2019). *Standard test method for normal incidence
+  determination of porous material acoustical properties based on the
+  transfer matrix method* (ASTM E2611-19).
+  [ASTM store](https://store.astm.org/e2611-19.html).
+  The four-microphone transfer-matrix method behind the transmission-loss
+  helpers.
+- International Organization for Standardization. (2018). *Acoustics —
+  Determination of airflow resistance — Part 1: Static airflow method*
+  (ISO 9053-1:2018).
+  [iso.org catalogue](https://www.iso.org/standard/69869.html).
+  The static method of section 2, with the through-origin regression and the
+  0.5 mm/s reference velocity.
 
 ---
 

--- a/docs/materials.md
+++ b/docs/materials.md
@@ -446,10 +446,16 @@ $\alpha_s = A/S$ divides by the *geometric* sample area $S$. Diffraction at
 the sample edges lets the specimen drain energy from a sound field wider than
 its footprint (the edge effect), so the equivalent area can exceed the
 geometric one. Such values are not errors, but they are not portable either:
-they depend on the sample size and perimeter, which is exactly why ISO 354
+they depend on the sample size and perimeter, which is precisely why ISO 354
 fixes both. The ISO 11654 rating simply truncates: practical coefficients
-above $1.00$ are set to $1.00$ (section 1), and prediction software clips at
-one before summing absorption areas.
+above $1.00$ are set to $1.00$ (section 1). Prediction inputs get no such
+silent clipping in this library: the
+[reverberation-time estimators](reverberation-prediction.md) reject
+coefficients outside $[0, 1)$ (the Eyring and Millington logarithms diverge
+at one), so ISO 354 values at or above one must be brought back below one by
+the caller, while the equivalent-absorption-area budget of
+[EN 12354-6](enclosed-space-absorption.md) accepts the coefficients as
+supplied.
 
 **Which to use.** They answer different questions. The reverberation-room
 value is the one that feeds diffuse-field prediction: Sabine reverberation
@@ -562,7 +568,8 @@ print(float(single_number_rating_uncertainty(8.1).reported_expanded_uncertainty[
   frequency-range limits.
 - ASTM International. (2019). *Standard test method for normal incidence
   determination of porous material acoustical properties based on the
-  transfer matrix method* (ASTM E2611-19).
+  transfer matrix method* (ASTM E2611-19, the edition implemented here;
+  since revised as [ASTM E2611-24](https://store.astm.org/e2611-24.html)).
   [ASTM store](https://store.astm.org/e2611-19.html).
   The four-microphone transfer-matrix method behind the transmission-loss
   helpers.

--- a/docs/materials.md
+++ b/docs/materials.md
@@ -426,13 +426,15 @@ time through Sabine's formula, an energy average with no phase left in it.
 Because the diffuse field finds more ways into an absorber than the single
 normal-incidence wave (oblique waves travel a longer path inside the layer),
 $\alpha_s$ usually comes out higher. For a locally reacting surface the two
-are linked by Paris' angular average,
+are linked by Paris' angular average, which defines the statistical
+absorption coefficient
 
 $$
 \alpha_{st} = \int_0^{\pi/2} \alpha(\theta)\,\sin 2\theta\,\mathrm{d}\theta,
 $$
 
-which weights the oblique angles most heavily; evaluating it needs the
+an integral that weights the oblique angles most heavily; evaluating it
+needs the
 angle-dependent $\alpha(\theta)$ from the measured surface impedance, not just
 the normal-incidence coefficient itself.
 
@@ -553,7 +555,7 @@ print(float(single_number_rating_uncertainty(8.1).reported_expanded_uncertainty[
 - International Organization for Standardization. (1998). *Acoustics —
   Determination of sound absorption coefficient and impedance in impedance
   tubes — Part 2: Transfer-function method* (ISO 10534-2:1998; adopted in
-  Europe as BS EN ISO 10534-2:2001, the edition implemented here; since
+  Europe as EN ISO 10534-2:2001, the edition implemented here; since
   revised as [ISO 10534-2:2023](https://www.iso.org/standard/81294.html)).
   [iso.org catalogue](https://www.iso.org/standard/22851.html).
   The two-microphone transfer-function method and its plane-wave

--- a/docs/references.md
+++ b/docs/references.md
@@ -166,7 +166,8 @@ it; the list grows as guides gain their References sections.
   Cited by [Acoustic Materials](materials.md).
 - ASTM International. (2019). *Standard test method for normal incidence
   determination of porous material acoustical properties based on the
-  transfer matrix method* (ASTM E2611-19).
+  transfer matrix method* (ASTM E2611-19, the edition implemented here;
+  since revised as [ASTM E2611-24](https://store.astm.org/e2611-24.html)).
   [ASTM store](https://store.astm.org/e2611-19.html).
   The four-microphone transfer-matrix transmission-loss method.
   Cited by [Acoustic Materials](materials.md).
@@ -179,7 +180,7 @@ it; the list grows as guides gain their References sections.
 - International Organization for Standardization. (2004). *Acoustics —
   Sound-scattering properties of surfaces — Part 1: Measurement of the
   random-incidence scattering coefficient in a reverberation room*
-  (ISO 17497-1:2004).
+  (ISO 17497-1:2004+A1:2014, the edition implemented here).
   [iso.org catalogue](https://www.iso.org/standard/31397.html).
   The turntable scattering-coefficient method.
   Cited by [Surface Scattering, Diffusion and In-situ Absorption](surface-scattering.md).

--- a/docs/references.md
+++ b/docs/references.md
@@ -148,7 +148,7 @@ it; the list grows as guides gain their References sections.
   ISBN 978-1-4987-4099-9.
   [doi:10.1201/9781315369211](https://doi.org/10.1201/9781315369211).
   The monograph on absorber and diffuser measurement and design, by the
-  authors behind the ISO 17497 methods.
+  authors behind the ISO 17497-2 diffusion-coefficient method.
   Cited by [Acoustic Materials](materials.md) and
   [Surface Scattering, Diffusion and In-situ Absorption](surface-scattering.md).
 - International Organization for Standardization. (2003). *Acoustics —
@@ -159,7 +159,7 @@ it; the list grows as guides gain their References sections.
 - International Organization for Standardization. (1998). *Acoustics —
   Determination of sound absorption coefficient and impedance in impedance
   tubes — Part 2: Transfer-function method* (ISO 10534-2:1998; adopted in
-  Europe as BS EN ISO 10534-2:2001; since revised as
+  Europe as EN ISO 10534-2:2001; since revised as
   [ISO 10534-2:2023](https://www.iso.org/standard/81294.html)).
   [iso.org catalogue](https://www.iso.org/standard/22851.html).
   The two-microphone transfer-function method and its plane-wave limits.

--- a/docs/references.md
+++ b/docs/references.md
@@ -134,6 +134,62 @@ it; the list grows as guides gain their References sections.
   residual pressure-intensity index.
   Cited by [Sound Intensity (p-p)](intensity.md).
 
+## Materials and surfaces
+
+- Allard, J. F., & Atalla, N. (2009). *Propagation of sound in porous media:
+  Modelling sound absorbing materials* (2nd ed.). Wiley.
+  ISBN 978-0-470-74661-5.
+  [doi:10.1002/9780470747339](https://doi.org/10.1002/9780470747339).
+  The porous-material theory linking airflow resistivity, surface impedance
+  and absorption.
+  Cited by [Acoustic Materials](materials.md).
+- Cox, T. J., & D'Antonio, P. (2017). *Acoustic absorbers and diffusers:
+  Theory, design and application* (3rd ed.). CRC Press.
+  ISBN 978-1-4987-4099-9.
+  [doi:10.1201/9781315369211](https://doi.org/10.1201/9781315369211).
+  The monograph on absorber and diffuser measurement and design, by the
+  authors behind the ISO 17497 methods.
+  Cited by [Acoustic Materials](materials.md) and
+  [Surface Scattering, Diffusion and In-situ Absorption](surface-scattering.md).
+- International Organization for Standardization. (2003). *Acoustics —
+  Measurement of sound absorption in a reverberation room* (ISO 354:2003).
+  [iso.org catalogue](https://www.iso.org/standard/34545.html).
+  The reverberation-room absorption method and its specimen mountings.
+  Cited by [Acoustic Materials](materials.md).
+- International Organization for Standardization. (1998). *Acoustics —
+  Determination of sound absorption coefficient and impedance in impedance
+  tubes — Part 2: Transfer-function method* (ISO 10534-2:1998; adopted in
+  Europe as BS EN ISO 10534-2:2001; since revised as
+  [ISO 10534-2:2023](https://www.iso.org/standard/81294.html)).
+  [iso.org catalogue](https://www.iso.org/standard/22851.html).
+  The two-microphone transfer-function method and its plane-wave limits.
+  Cited by [Acoustic Materials](materials.md).
+- ASTM International. (2019). *Standard test method for normal incidence
+  determination of porous material acoustical properties based on the
+  transfer matrix method* (ASTM E2611-19).
+  [ASTM store](https://store.astm.org/e2611-19.html).
+  The four-microphone transfer-matrix transmission-loss method.
+  Cited by [Acoustic Materials](materials.md).
+- International Organization for Standardization. (2018). *Acoustics —
+  Determination of airflow resistance — Part 1: Static airflow method*
+  (ISO 9053-1:2018).
+  [iso.org catalogue](https://www.iso.org/standard/69869.html).
+  The static airflow-resistance method and its reference velocity.
+  Cited by [Acoustic Materials](materials.md).
+- International Organization for Standardization. (2004). *Acoustics —
+  Sound-scattering properties of surfaces — Part 1: Measurement of the
+  random-incidence scattering coefficient in a reverberation room*
+  (ISO 17497-1:2004).
+  [iso.org catalogue](https://www.iso.org/standard/31397.html).
+  The turntable scattering-coefficient method.
+  Cited by [Surface Scattering, Diffusion and In-situ Absorption](surface-scattering.md).
+- International Organization for Standardization. (2012). *Acoustics —
+  Sound-scattering properties of surfaces — Part 2: Measurement of the
+  directional diffusion coefficient in a free field* (ISO 17497-2:2012).
+  [iso.org catalogue](https://www.iso.org/standard/55293.html).
+  The goniometer diffusion-coefficient method.
+  Cited by [Surface Scattering, Diffusion and In-situ Absorption](surface-scattering.md).
+
 ## Building acoustics
 
 - Hopkins, C. (2007). *Sound insulation*. Butterworth-Heinemann.

--- a/docs/surface-scattering.md
+++ b/docs/surface-scattering.md
@@ -259,11 +259,11 @@ A pair of counterexamples keeps them apart. A curved or tilted element that
 *redirects* the reflection concentrates nearly all the reflected energy into
 one strong lobe away from the specular direction: almost everything is
 non-specular, so $s$ is high, yet the beam is as collimated as a mirror's, so
-$d$ stays low. Conversely, a lightly textured surface may scatter only a small
-fraction of the energy while spreading that little bit perfectly evenly: $d$
-of the scattered field looks respectable while $s$ stays near zero. High $s$
-does not mean uniform; decent $d$ does not mean much energy was scattered at
-all.
+$d$ stays low. Conversely, a small flat panel measured at low frequency sends
+nearly all the reflected energy toward the specular direction, so $s$ stays
+near zero, yet edge diffraction spreads that reflection so broadly over the
+receiver arc that the measured $d$ comes out surprisingly high. High $s$ does
+not mean uniform; decent $d$ does not mean much energy was scattered at all.
 
 **Which one for design.** The two numbers serve different consumers:
 
@@ -461,8 +461,9 @@ print(round(s_min, 3), round(s_max, 3))    # 0.078 0.086  (metres)
   Theory, design and application* (3rd ed.). CRC Press.
   ISBN 978-1-4987-4099-9.
   [doi:10.1201/9781315369211](https://doi.org/10.1201/9781315369211).
-  The monograph on diffuser theory and design by the authors behind both
-  ISO 17497 methods: the scattering-versus-diffusion distinction, the
+  The reference monograph on diffuser theory and design, by the authors
+  behind the ISO 17497-2 diffusion-coefficient method: the
+  scattering-versus-diffusion distinction, the
   measurement rigs and the design guidance this page condenses.
 - International Organization for Standardization. (2004). *Acoustics —
   Sound-scattering properties of surfaces — Part 1: Measurement of the

--- a/docs/surface-scattering.md
+++ b/docs/surface-scattering.md
@@ -468,19 +468,20 @@ print(round(s_min, 3), round(s_max, 3))    # 0.078 0.086  (metres)
 - International Organization for Standardization. (2004). *Acoustics —
   Sound-scattering properties of surfaces — Part 1: Measurement of the
   random-incidence scattering coefficient in a reverberation room*
-  (ISO 17497-1:2004).
+  (ISO 17497-1:2004+A1:2014, the edition implemented here).
   [iso.org catalogue](https://www.iso.org/standard/31397.html).
-  The turntable method of section 1 and the base-plate limits of Table 1.
+  The turntable method implemented in section 1 of this page and the
+  base-plate limits of the standard's Table 1.
 - International Organization for Standardization. (2012). *Acoustics —
   Sound-scattering properties of surfaces — Part 2: Measurement of the
   directional diffusion coefficient in a free field* (ISO 17497-2:2012).
   [iso.org catalogue](https://www.iso.org/standard/55293.html).
-  The goniometer autocorrelation coefficient of section 2, its area
-  weighting and the normalised $d_n$.
+  The goniometer autocorrelation coefficient behind section 2 of this page,
+  its area weighting and the normalised $d_n$.
 
 ---
 
-**Standards.** ISO 17497-1:2004 (scattering
+**Standards.** ISO 17497-1:2004+A1:2014 (scattering
 coefficient), ISO 17497-2:2012 (diffusion coefficient), ISO 13472-1:2002 (in-situ
 absorption, extended surface), ISO 13472-2:2010 (in-situ absorption, spot
 method), and ISO 9613-1:1993 — only the pure-tone attenuation coefficient

--- a/docs/surface-scattering.md
+++ b/docs/surface-scattering.md
@@ -243,6 +243,51 @@ plt.show()
 
 </details>
 
+## Scattering or diffusion? Two coefficients, two jobs
+
+The two coefficients above are routinely treated as interchangeable, in
+product data sheets and occasionally in simulation manuals. They are not, and
+neither can be computed from the other. The scattering coefficient $s$
+(ISO 17497-1) does **energy bookkeeping**: what fraction of the reflected
+energy leaves the specular direction. It says nothing about where that energy
+goes. The diffusion coefficient $d$ (ISO 17497-2) grades **spatial quality**:
+how evenly the reflected energy covers the receiver arc, one source direction
+at a time. It says nothing about how the energy divides between the specular
+lobe and the rest.
+
+A pair of counterexamples keeps them apart. A curved or tilted element that
+*redirects* the reflection concentrates nearly all the reflected energy into
+one strong lobe away from the specular direction: almost everything is
+non-specular, so $s$ is high, yet the beam is as collimated as a mirror's, so
+$d$ stays low. Conversely, a lightly textured surface may scatter only a small
+fraction of the energy while spreading that little bit perfectly evenly: $d$
+of the scattered field looks respectable while $s$ stays near zero. High $s$
+does not mean uniform; decent $d$ does not mean much energy was scattered at
+all.
+
+**Which one for design.** The two numbers serve different consumers:
+
+- **The scattering coefficient feeds room-acoustics simulation.**
+  Geometrical-acoustics engines decide at every wall reflection how much
+  energy continues specularly and how much is redistributed; the per-band
+  random-incidence $s$ of each surface is precisely that split, which is what
+  ISO 17497-1 was written to supply. Getting it wrong shows up as the wrong
+  reverberation-time and clarity predictions in non-mixing rooms.
+- **The diffusion coefficient qualifies diffusers.** When the task is to break
+  up an echo, a flutter or a focusing reflection, what matters is that the
+  reflected energy is spread over angle, and $d$ measures exactly that. The
+  normalised $d_n$ (Formula (7)) additionally subtracts the edge diffraction
+  that every finite panel exhibits, so products of different sizes can be
+  compared fairly.
+
+Swapping them fails in both directions: a diffusion coefficient dropped into a
+simulator's scattering slot biases the energy split, and a scattering
+coefficient quoted as proof of "diffusion" may describe a surface that merely
+redirects the problem reflection somewhere else. Both coefficients are
+one-third-octave-band functions that generally rise once the surface relief is
+no longer small against the wavelength; a frequency-blind single number
+("scatters 90 % of the sound") is neither of them.
+
 ## 3. In-situ road absorption — subtraction technique (ISO 13472-1)
 
 Out in the field there is no reverberation room. ISO 13472-1 measures the sound
@@ -409,6 +454,28 @@ s_min, s_max = ph.spot_microphone_spacing_bounds(
     343.0, f_min=220.0, f_max=1800.0)
 print(round(s_min, 3), round(s_max, 3))    # 0.078 0.086  (metres)
 ```
+
+## References
+
+- Cox, T. J., & D'Antonio, P. (2017). *Acoustic absorbers and diffusers:
+  Theory, design and application* (3rd ed.). CRC Press.
+  ISBN 978-1-4987-4099-9.
+  [doi:10.1201/9781315369211](https://doi.org/10.1201/9781315369211).
+  The monograph on diffuser theory and design by the authors behind both
+  ISO 17497 methods: the scattering-versus-diffusion distinction, the
+  measurement rigs and the design guidance this page condenses.
+- International Organization for Standardization. (2004). *Acoustics —
+  Sound-scattering properties of surfaces — Part 1: Measurement of the
+  random-incidence scattering coefficient in a reverberation room*
+  (ISO 17497-1:2004).
+  [iso.org catalogue](https://www.iso.org/standard/31397.html).
+  The turntable method of section 1 and the base-plate limits of Table 1.
+- International Organization for Standardization. (2012). *Acoustics —
+  Sound-scattering properties of surfaces — Part 2: Measurement of the
+  directional diffusion coefficient in a free field* (ISO 17497-2:2012).
+  [iso.org catalogue](https://www.iso.org/standard/55293.html).
+  The goniometer autocorrelation coefficient of section 2, its area
+  weighting and the normalised $d_n$.
 
 ---
 

--- a/site/src/content/docs/es/guides/materials.md
+++ b/site/src/content/docs/es/guides/materials.md
@@ -228,6 +228,42 @@ que la biblioteca mantiene sus ayudantes separados y nunca los mezcla.
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_impedance_tube_es.svg" alt="Tubo de impedancia de dos micrófonos de ISO 10534-2: un altavoz radiando una onda plana por el tubo, dos micrófonos enrasados en la pared a la separación s y a la distancia x1 de la cara de la probeta, la probeta de ensayo contra un respaldo rígido, y las ondas incidente y reflejada" style="width:92%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_impedance_tube_es_dark.svg" alt="Tubo de impedancia de dos micrófonos de ISO 10534-2: un altavoz radiando una onda plana por el tubo, dos micrófonos enrasados en la pared a la separación s y a la distancia x1 de la cara de la probeta, la probeta de ensayo contra un respaldo rígido, y las ondas incidente y reflejada" style="width:92%">
 
+**Rango de frecuencia de trabajo (ISO 10534-2, cláusula 4).** Todo lo que
+informa el tubo asume que el campo interior es una única onda plana, y la
+geometría fija los dos extremos de la banda útil. Por encima del corte del
+primer modo transversal el campo deja de ser plano: un tubo circular de
+diámetro $d$ exige $f\,d < 0{,}58\,c_0$ (Ec. (2); $f\,d < 0{,}50\,c_0$ para un
+tubo rectangular, Ec. (3)). La separación de micrófonos $s$ debe además
+mantenerse lejos de la singularidad de media longitud de onda del método de la
+función de transferencia, $f\,s < 0{,}45\,c_0$ (Ec. (4)). En el extremo bajo
+aparece el problema opuesto: una separación mucho menor que la longitud de
+onda apenas deja diferencia de fase entre micrófonos que medir, así que la
+pauta de la cláusula 4.2 mantiene la separación por encima del 5 % de la
+longitud de onda:
+
+$$
+\frac{c_0}{20\,s} \;<\; f \;<\;
+\min\!\left(0{,}58\,\frac{c_0}{d},\ 0{,}45\,\frac{c_0}{s}\right).
+$$
+
+Ningún tubo cubre por sí solo el rango de la acústica de edificios. Un tubo de
+100 mm con separación de 100 mm trabaja aproximadamente de 170 Hz a 1,5 kHz;
+llegar a las bandas de 5 kHz exige un tubo pequeño (29 mm) con separación
+corta, que a su vez no ve las bandas bajas. Los laboratorios emparejan por eso
+un tubo grande y uno pequeño (o un tubo con dos separaciones) y empalman los
+espectros; ambos deben coincidir en las bandas de solape, y una discrepancia
+ahí apunta al corte o al montaje de la muestra, no a la física.
+
+```python
+from phonometry import plane_wave_frequency_range
+
+# Un tubo de 100 mm con separación de 100 mm y uno de 29 mm con 20 mm.
+f_l, f_u = plane_wave_frequency_range(0.100, 343.2, diameter=0.100)
+print(round(f_l, 1), round(f_u, 1))     # 171.6 1544.4
+f_l, f_u = plane_wave_frequency_range(0.020, 343.2, diameter=0.029)
+print(round(f_l, 1), round(f_u, 1))     # 858.0 6864.0
+```
+
 **Método de la razón de onda estacionaria (ISO 10534-1).** Una sonda recorre la
 onda estacionaria y lee la diferencia de nivel $\Delta L = L_\text{max} -
 L_\text{min}$ entre un máximo de presión y el mínimo adyacente. La razón de onda
@@ -356,6 +392,92 @@ micrófonos `(H1, H2, H3, H4)` medidas en cada carga; sus métodos
 `absorption_hard_backed`, `characteristic_impedance_material`,
 `material_wavenumber`) leen entonces las magnitudes de ASTM E2611.
 
+**Errores de montaje.** La mayoría de los malos datos de tubo se fabrican en
+el portamuestras, mucho antes del procesado de señal. Los fallos recurrentes:
+
+- **Holguras perimetrales.** Una probeta cortada ligeramente pequeña deja una
+  lámina de aire junto a la pared del tubo. El sonido se cortocircuita
+  alrededor y por detrás de la muestra, y la propia holgura resuena, de modo
+  que la absorción medida gana una joroba espuria de baja a media frecuencia.
+  Corte con ajuste deslizante ceñido y selle el borde (una película fina de
+  vaselina es el remedio clásico) sin cargar la cara frontal.
+- **Compresión.** Una probeta cortada grande y embutida a la fuerza es más
+  densa que el producto que debe representar: la resistividad al flujo sube,
+  un esqueleto flexible se rigidiza, y la curva de absorción se desplaza y se
+  aplana. El resultado es repetible y erróneo.
+- **Cavidad trasera oculta.** Si la probeta no asienta a ras del respaldo
+  rígido, la capa de aire involuntaria actúa como cavidad de cuarto de
+  longitud de onda y desplaza el pico de absorción hacia abajo en frecuencia,
+  favoreciendo al material. Las cámaras de aire traseras son montajes
+  perfectamente legítimos, pero solo cuando son deliberadas, dimensionadas y
+  declaradas con el resultado.
+- **Cara no plana.** Una cara frontal abombada, inclinada o desgarrada
+  dispersa hacia modos transversales por debajo del corte nominal y rompe la
+  hipótesis de incidencia normal sobre la que descansan las ecuaciones. Corte
+  con herramienta afilada; no rasgue los materiales fibrosos a medida.
+- **Una probeta no es el material.** Los productos porosos son inhomogéneos a
+  la escala de una muestra de tubo. Mida varios cortes y promedie; la
+  dispersión entre probetas es varianza del producto que merece declararse,
+  no ruido de medida que esconder.
+
+## ¿Tubo o cámara reverberante?
+
+El tubo y la cámara reverberante entregan ambos un número llamado "coeficiente
+de absorción", y los dos se confunden de forma rutinaria. Son magnitudes
+físicas distintas, medidas bajo campos sonoros distintos, y no coinciden, a
+veces ni de lejos.
+
+El tubo mide un coeficiente a **incidencia normal**: una onda plana, un
+ángulo, una probeta de unos centímetros y un factor de reflexión complejo que
+conserva módulo y fase. ISO 354 mide el coeficiente de **incidencia
+aleatoria** $\alpha_s$: un campo difuso que golpea una muestra de 10 a 12 m²
+desde todas las direcciones a la vez, recuperado del cambio del tiempo de
+caída de la sala mediante la fórmula de Sabine, un promedio de energía sin
+fase alguna. Como el campo difuso encuentra más caminos hacia el interior del
+absorbente que la única onda a incidencia normal (las ondas oblicuas recorren
+más camino dentro de la capa), $\alpha_s$ suele salir más alto. Para una
+superficie de reacción local ambos se conectan mediante el promedio angular de
+Paris,
+
+$$
+\alpha_{st} = \int_0^{\pi/2} \alpha(\theta)\,\sin 2\theta\,\mathrm{d}\theta,
+$$
+
+que pondera sobre todo los ángulos oblicuos; evaluarlo exige el
+$\alpha(\theta)$ dependiente del ángulo a partir de la impedancia superficial
+medida, no solo el propio coeficiente a incidencia normal.
+
+**Por qué los valores de ISO 354 superan 1.** Un cociente de energía absorbida
+sobre incidente no puede superar la unidad y, sin embargo, los informes de
+cámara reverberante con $\alpha_s = 1{,}05$ a $1{,}20$ para absorbentes
+porosos gruesos son rutinarios y correctos según el método. La fórmula de
+Sabine convierte el cambio del tiempo de caída en un área de absorción
+equivalente $A$, y $\alpha_s = A/S$ divide por el área *geométrica* de la
+muestra $S$. La difracción en los bordes de la muestra permite a la probeta
+drenar energía de un campo sonoro más ancho que su huella (el efecto de
+borde), de modo que el área equivalente puede superar la geométrica. Esos
+valores no son errores, pero tampoco son portables: dependen del tamaño y del
+perímetro de la muestra, que es exactamente la razón por la que ISO 354 fija
+ambos. La valoración de ISO 11654 simplemente trunca: los coeficientes
+prácticos por encima de $1{,}00$ se fijan en $1{,}00$ (sección 1), y el
+software de predicción recorta a uno antes de sumar áreas de absorción.
+
+**Cuál usar.** Responden a preguntas distintas. El valor de cámara
+reverberante es el que alimenta la predicción en campo difuso: las
+estimaciones de reverberación de Sabine, las áreas de absorción equivalentes
+de [EN 12354-6](/phonometry/es/guides/enclosed-space-absorption/) y la
+valoración $\alpha_w$ con su clase, todas las cuales esperan incidencia
+aleatoria sobre una muestra finita y montada (los tipos de montaje del Anexo B
+de ISO 354 existen porque el montaje es parte del resultado). El valor de tubo
+es la herramienta de laboratorio y desarrollo: necesita solo unos centímetros
+cuadrados de material, resuelve módulo *y* fase, y su impedancia superficial
+fija los parámetros de los modelos de material poroso de la tradición de
+Allard y Atalla, con la resistividad al flujo de la sección 2 como primera
+entrada; el modelo ajustado predice después la capa a cualquier ángulo,
+espesor o respaldo. Lo que el número del tubo *no* es, es un sustituto directo
+de $\alpha_s$: alimentar coeficientes a incidencia normal en un presupuesto de
+Sabine o de EN 12354-6 infrapredice sistemáticamente la absorción instalada.
+
 ## 4. Incertidumbre de medida de la absorción (ISO 12999-2)
 
 Un coeficiente de absorción valorado significa poco sin su incertidumbre. La
@@ -422,6 +544,48 @@ print(float(r.reported_expanded_uncertainty[0]))             # 0.08  (U, k=2)
 print(float(weighted_coefficient_uncertainty(0.70).reported_expanded_uncertainty[0]))  # 0.07
 print(float(single_number_rating_uncertainty(8.1).reported_expanded_uncertainty[0]))   # 1.6
 ```
+
+## Referencias
+
+- Allard, J. F., & Atalla, N. (2009). *Propagation of sound in porous media:
+  Modelling sound absorbing materials* (2.ª ed.). Wiley.
+  ISBN 978-0-470-74661-5.
+  [doi:10.1002/9780470747339](https://doi.org/10.1002/9780470747339).
+  La teoría del material poroso tras las magnitudes medidas: la resistividad
+  al flujo como entrada de modelo, y la impedancia superficial y la absorción
+  que recupera el tubo.
+- Cox, T. J., & D'Antonio, P. (2017). *Acoustic absorbers and diffusers:
+  Theory, design and application* (3.ª ed.). CRC Press.
+  ISBN 978-1-4987-4099-9.
+  [doi:10.1201/9781315369211](https://doi.org/10.1201/9781315369211).
+  La medida y el diseño de absorbentes en la práctica: los métodos de tubo y
+  de sala lado a lado, los montajes y la discusión del efecto de borde tras
+  la sección de tubo o cámara reverberante.
+- International Organization for Standardization. (2003). *Acoustics —
+  Measurement of sound absorption in a reverberation room* (ISO 354:2003).
+  [Catálogo iso.org](https://www.iso.org/standard/34545.html).
+  El método de cámara reverberante que produce los espectros de $\alpha_s$
+  valorados por ISO 11654, incluidos los montajes de probeta del Anexo B.
+- International Organization for Standardization. (1998). *Acoustics —
+  Determination of sound absorption coefficient and impedance in impedance
+  tubes — Part 2: Transfer-function method* (ISO 10534-2:1998; adoptada en
+  Europa como BS EN ISO 10534-2:2001, la edición implementada aquí; revisada
+  después como [ISO 10534-2:2023](https://www.iso.org/standard/81294.html)).
+  [Catálogo iso.org](https://www.iso.org/standard/22851.html).
+  El método de la función de transferencia con dos micrófonos y sus límites
+  de rango de onda plana.
+- ASTM International. (2019). *Standard test method for normal incidence
+  determination of porous material acoustical properties based on the
+  transfer matrix method* (ASTM E2611-19).
+  [Tienda ASTM](https://store.astm.org/e2611-19.html).
+  El método de matriz de transferencia con cuatro micrófonos tras los
+  ayudantes de pérdida por transmisión.
+- International Organization for Standardization. (2018). *Acoustics —
+  Determination of airflow resistance — Part 1: Static airflow method*
+  (ISO 9053-1:2018).
+  [Catálogo iso.org](https://www.iso.org/standard/69869.html).
+  El método estático de la sección 2, con la regresión por el origen y la
+  velocidad de referencia de 0,5 mm/s.
 
 ---
 

--- a/site/src/content/docs/es/guides/materials.md
+++ b/site/src/content/docs/es/guides/materials.md
@@ -4,7 +4,7 @@ description: "Caracterización de absorbentes y particiones en laboratorio: la v
 ---
 
 Caracterizar un absorbente o una partición es un ejercicio de laboratorio con
-tres instrumentos distintos detrás. La **sala reverberante** entrega un espectro
+tres instrumentos distintos detrás. La **cámara reverberante** entrega un espectro
 de coeficientes de absorción sonora que ISO 11654 condensa en un único número
 valorado $\alpha_w$ con una clase por letra. El **banco de flujo** —estacionario
 u oscilante— mide cuánto cuesta empujar aire a través de una muestra porosa, la
@@ -17,7 +17,7 @@ de una muestra pequeña, y —con cuatro micrófonos— su pérdida por transmis
 ## 1. Valoración de la absorción sonora (ISO 11654)
 
 ISO 354 mide el coeficiente de absorción sonora $\alpha_s$ de un material en
-bandas de tercio de octava en una sala reverberante. ISO 11654:1997 convierte
+bandas de tercio de octava en una cámara reverberante. ISO 11654:1997 convierte
 ese espectro en una valoración de número único comparable entre productos.
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_iso11654_es.svg" alt="Flujo de valoración ISO 11654: el alpha_s medido pasa a alpha_p práctico por banda de octava, la curva de referencia se desplaza hasta el mejor ajuste, alpha_w se lee a 500 Hz con indicadores de forma, dando la clase de absorción A a E" style="width:82%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_iso11654_es_dark.svg" alt="Flujo de valoración ISO 11654: el alpha_s medido pasa a alpha_p práctico por banda de octava, la curva de referencia se desplaza hasta el mejor ajuste, alpha_w se lee a 500 Hz con indicadores de forma, dando la clase de absorción A a E" style="width:82%">
@@ -229,7 +229,7 @@ que la biblioteca mantiene sus ayudantes separados y nunca los mezcla.
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_impedance_tube_es.svg" alt="Tubo de impedancia de dos micrófonos de ISO 10534-2: un altavoz radiando una onda plana por el tubo, dos micrófonos enrasados en la pared a la separación s y a la distancia x1 de la cara de la probeta, la probeta de ensayo contra un respaldo rígido, y las ondas incidente y reflejada" style="width:92%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_impedance_tube_es_dark.svg" alt="Tubo de impedancia de dos micrófonos de ISO 10534-2: un altavoz radiando una onda plana por el tubo, dos micrófonos enrasados en la pared a la separación s y a la distancia x1 de la cara de la probeta, la probeta de ensayo contra un respaldo rígido, y las ondas incidente y reflejada" style="width:92%">
 
 **Rango de frecuencia de trabajo (ISO 10534-2, cláusula 4).** Todo lo que
-informa el tubo asume que el campo interior es una única onda plana, y la
+informa el tubo supone que el campo interior es una única onda plana, y la
 geometría fija los dos extremos de la banda útil. Por encima del corte del
 primer modo transversal el campo deja de ser plano: un tubo circular de
 diámetro $d$ exige $f\,d < 0{,}58\,c_0$ (Ec. (2); $f\,d < 0{,}50\,c_0$ para un
@@ -420,9 +420,9 @@ el portamuestras, mucho antes del procesado de señal. Los fallos recurrentes:
   dispersión entre probetas es varianza del producto que merece declararse,
   no ruido de medida que esconder.
 
-## ¿Tubo o sala reverberante?
+## ¿Tubo o cámara reverberante?
 
-El tubo y la sala reverberante entregan ambos un número llamado "coeficiente
+El tubo y la cámara reverberante entregan ambos un número llamado "coeficiente
 de absorción", y los dos se confunden de forma rutinaria. Son magnitudes
 físicas distintas, medidas bajo campos sonoros distintos, y no coinciden, a
 veces ni de lejos.
@@ -432,7 +432,7 @@ El tubo mide un coeficiente a **incidencia normal**: una onda plana, un
 conserva módulo y fase. ISO 354 mide el coeficiente de **incidencia
 aleatoria** $\alpha_s$: un campo difuso que golpea una muestra de 10 a 12 m²
 desde todas las direcciones a la vez, recuperado del cambio del tiempo de
-caída de la sala mediante la fórmula de Sabine, un promedio de energía sin
+caída de la cámara mediante la fórmula de Sabine, un promedio de energía sin
 fase alguna. Como el campo difuso encuentra más caminos hacia el interior del
 absorbente que la única onda a incidencia normal (las ondas oblicuas recorren
 más camino dentro de la capa), $\alpha_s$ suele salir más alto. Para una
@@ -449,7 +449,7 @@ medida, no solo el propio coeficiente a incidencia normal.
 
 **Por qué los valores de ISO 354 superan 1.** Un cociente de energía absorbida
 sobre incidente no puede superar la unidad y, sin embargo, los informes de
-sala reverberante con $\alpha_s = 1{,}05$ a $1{,}20$ para absorbentes
+cámara reverberante con $\alpha_s = 1{,}05$ a $1{,}20$ para absorbentes
 porosos gruesos son rutinarios y correctos según el método. La fórmula de
 Sabine convierte el cambio del tiempo de caída en un área de absorción
 equivalente $A$, y $\alpha_s = A/S$ divide por el área *geométrica* de la
@@ -459,10 +459,18 @@ borde), de modo que el área equivalente puede superar la geométrica. Esos
 valores no son errores, pero tampoco son portables: dependen del tamaño y del
 perímetro de la muestra, que es exactamente la razón por la que ISO 354 fija
 ambos. La valoración de ISO 11654 simplemente trunca: los coeficientes
-prácticos por encima de $1{,}00$ se fijan en $1{,}00$ (sección 1), y el
-software de predicción recorta a uno antes de sumar áreas de absorción.
+prácticos por encima de $1{,}00$ se fijan en $1{,}00$ (sección 1). Las
+entradas de predicción no reciben ese recorte silencioso en esta biblioteca:
+los
+[estimadores del tiempo de reverberación](/phonometry/es/guides/reverberation-prediction/)
+rechazan coeficientes fuera de $[0, 1)$ (los logaritmos de Eyring y
+Millington divergen en uno), de modo que los valores de ISO 354 iguales o
+superiores a uno deben devolverse por debajo de uno antes de la llamada,
+mientras que el presupuesto de área de absorción equivalente de
+[EN 12354-6](/phonometry/es/guides/enclosed-space-absorption/) acepta los
+coeficientes tal cual se suministran.
 
-**Cuál usar.** Responden a preguntas distintas. El valor de sala
+**Cuál usar.** Responden a preguntas distintas. El valor de cámara
 reverberante es el que alimenta la predicción en campo difuso: las
 estimaciones de reverberación de Sabine, las áreas de absorción equivalentes
 de [EN 12354-6](/phonometry/es/guides/enclosed-space-absorption/) y la
@@ -559,12 +567,12 @@ print(float(single_number_rating_uncertainty(8.1).reported_expanded_uncertainty[
   ISBN 978-1-4987-4099-9.
   [doi:10.1201/9781315369211](https://doi.org/10.1201/9781315369211).
   La medida y el diseño de absorbentes en la práctica: los métodos de tubo y
-  de sala lado a lado, los montajes y la discusión del efecto de borde tras
-  la sección de tubo o sala reverberante.
+  de cámara lado a lado, los montajes y la discusión del efecto de borde tras
+  la sección de tubo o cámara reverberante.
 - International Organization for Standardization. (2003). *Acoustics —
   Measurement of sound absorption in a reverberation room* (ISO 354:2003).
   [Catálogo iso.org](https://www.iso.org/standard/34545.html).
-  El método de sala reverberante que produce los espectros de $\alpha_s$
+  El método de cámara reverberante que produce los espectros de $\alpha_s$
   valorados por ISO 11654, incluidos los montajes de probeta del Anexo B.
 - International Organization for Standardization. (1998). *Acoustics —
   Determination of sound absorption coefficient and impedance in impedance
@@ -576,7 +584,8 @@ print(float(single_number_rating_uncertainty(8.1).reported_expanded_uncertainty[
   de rango de onda plana.
 - ASTM International. (2019). *Standard test method for normal incidence
   determination of porous material acoustical properties based on the
-  transfer matrix method* (ASTM E2611-19).
+  transfer matrix method* (ASTM E2611-19, la edición implementada aquí;
+  revisada después como [ASTM E2611-24](https://store.astm.org/e2611-24.html)).
   [Tienda ASTM](https://store.astm.org/e2611-19.html).
   El método de matriz de transferencia con cuatro micrófonos tras los
   ayudantes de pérdida por transmisión.

--- a/site/src/content/docs/es/guides/materials.md
+++ b/site/src/content/docs/es/guides/materials.md
@@ -420,9 +420,9 @@ el portamuestras, mucho antes del procesado de señal. Los fallos recurrentes:
   dispersión entre probetas es varianza del producto que merece declararse,
   no ruido de medida que esconder.
 
-## ¿Tubo o cámara reverberante?
+## ¿Tubo o sala reverberante?
 
-El tubo y la cámara reverberante entregan ambos un número llamado "coeficiente
+El tubo y la sala reverberante entregan ambos un número llamado "coeficiente
 de absorción", y los dos se confunden de forma rutinaria. Son magnitudes
 físicas distintas, medidas bajo campos sonoros distintos, y no coinciden, a
 veces ni de lejos.
@@ -436,20 +436,20 @@ caída de la sala mediante la fórmula de Sabine, un promedio de energía sin
 fase alguna. Como el campo difuso encuentra más caminos hacia el interior del
 absorbente que la única onda a incidencia normal (las ondas oblicuas recorren
 más camino dentro de la capa), $\alpha_s$ suele salir más alto. Para una
-superficie de reacción local ambos se conectan mediante el promedio angular de
-Paris,
+superficie de reacción local ambos se conectan mediante el promedio angular
+de Paris, que define el coeficiente de absorción estadístico
 
 $$
 \alpha_{st} = \int_0^{\pi/2} \alpha(\theta)\,\sin 2\theta\,\mathrm{d}\theta,
 $$
 
-que pondera sobre todo los ángulos oblicuos; evaluarlo exige el
+una integral que pondera sobre todo los ángulos oblicuos; evaluarla exige el
 $\alpha(\theta)$ dependiente del ángulo a partir de la impedancia superficial
 medida, no solo el propio coeficiente a incidencia normal.
 
 **Por qué los valores de ISO 354 superan 1.** Un cociente de energía absorbida
 sobre incidente no puede superar la unidad y, sin embargo, los informes de
-cámara reverberante con $\alpha_s = 1{,}05$ a $1{,}20$ para absorbentes
+sala reverberante con $\alpha_s = 1{,}05$ a $1{,}20$ para absorbentes
 porosos gruesos son rutinarios y correctos según el método. La fórmula de
 Sabine convierte el cambio del tiempo de caída en un área de absorción
 equivalente $A$, y $\alpha_s = A/S$ divide por el área *geométrica* de la
@@ -462,7 +462,7 @@ ambos. La valoración de ISO 11654 simplemente trunca: los coeficientes
 prácticos por encima de $1{,}00$ se fijan en $1{,}00$ (sección 1), y el
 software de predicción recorta a uno antes de sumar áreas de absorción.
 
-**Cuál usar.** Responden a preguntas distintas. El valor de cámara
+**Cuál usar.** Responden a preguntas distintas. El valor de sala
 reverberante es el que alimenta la predicción en campo difuso: las
 estimaciones de reverberación de Sabine, las áreas de absorción equivalentes
 de [EN 12354-6](/phonometry/es/guides/enclosed-space-absorption/) y la
@@ -476,7 +476,7 @@ Allard y Atalla, con la resistividad al flujo de la sección 2 como primera
 entrada; el modelo ajustado predice después la capa a cualquier ángulo,
 espesor o respaldo. Lo que el número del tubo *no* es, es un sustituto directo
 de $\alpha_s$: alimentar coeficientes a incidencia normal en un presupuesto de
-Sabine o de EN 12354-6 infrapredice sistemáticamente la absorción instalada.
+Sabine o de EN 12354-6 subestima sistemáticamente la absorción instalada.
 
 ## 4. Incertidumbre de medida de la absorción (ISO 12999-2)
 
@@ -560,16 +560,16 @@ print(float(single_number_rating_uncertainty(8.1).reported_expanded_uncertainty[
   [doi:10.1201/9781315369211](https://doi.org/10.1201/9781315369211).
   La medida y el diseño de absorbentes en la práctica: los métodos de tubo y
   de sala lado a lado, los montajes y la discusión del efecto de borde tras
-  la sección de tubo o cámara reverberante.
+  la sección de tubo o sala reverberante.
 - International Organization for Standardization. (2003). *Acoustics —
   Measurement of sound absorption in a reverberation room* (ISO 354:2003).
   [Catálogo iso.org](https://www.iso.org/standard/34545.html).
-  El método de cámara reverberante que produce los espectros de $\alpha_s$
+  El método de sala reverberante que produce los espectros de $\alpha_s$
   valorados por ISO 11654, incluidos los montajes de probeta del Anexo B.
 - International Organization for Standardization. (1998). *Acoustics —
   Determination of sound absorption coefficient and impedance in impedance
   tubes — Part 2: Transfer-function method* (ISO 10534-2:1998; adoptada en
-  Europa como BS EN ISO 10534-2:2001, la edición implementada aquí; revisada
+  Europa como EN ISO 10534-2:2001, la edición implementada aquí; revisada
   después como [ISO 10534-2:2023](https://www.iso.org/standard/81294.html)).
   [Catálogo iso.org](https://www.iso.org/standard/22851.html).
   El método de la función de transferencia con dos micrófonos y sus límites

--- a/site/src/content/docs/es/guides/surface-scattering.md
+++ b/site/src/content/docs/es/guides/surface-scattering.md
@@ -249,6 +249,53 @@ plt.show()
 
 </details>
 
+## ¿Dispersión o difusión? Dos coeficientes, dos trabajos
+
+Los dos coeficientes anteriores se tratan de forma rutinaria como
+intercambiables, en fichas de producto y a veces en manuales de simulación. No
+lo son, y ninguno puede calcularse a partir del otro. El coeficiente de
+dispersión $s$ (ISO 17497-1) hace **contabilidad de energía**: qué fracción de
+la energía reflejada abandona la dirección especular. No dice nada sobre a
+dónde va esa energía. El coeficiente de difusión $d$ (ISO 17497-2) califica la
+**calidad espacial**: cuán uniformemente cubre la energía reflejada el arco de
+receptores, para una dirección de fuente cada vez. No dice nada sobre cómo se
+reparte la energía entre el lóbulo especular y el resto.
+
+Un par de contraejemplos los mantiene separados. Un elemento curvo o inclinado
+que *redirige* la reflexión concentra casi toda la energía reflejada en un
+lóbulo intenso alejado de la dirección especular: casi todo es no especular,
+así que $s$ es alto, pero el haz queda tan colimado como el de un espejo, así
+que $d$ se mantiene bajo. A la inversa, una superficie con textura ligera
+puede dispersar solo una fracción pequeña de la energía repartiendo ese poco
+de manera perfectamente uniforme: el $d$ del campo dispersado parece
+respetable mientras $s$ se queda cerca de cero. Un $s$ alto no significa
+uniforme; un $d$ decente no significa que se dispersara mucha energía.
+
+**Cuál usar en diseño.** Los dos números sirven a consumidores distintos:
+
+- **El coeficiente de dispersión alimenta la simulación de salas.** Los
+  motores de acústica geométrica deciden en cada reflexión de pared cuánta
+  energía continúa especularmente y cuánta se redistribuye; el $s$ de
+  incidencia aleatoria por banda de cada superficie es precisamente ese
+  reparto, que es lo que ISO 17497-1 se redactó para suministrar. Equivocarlo
+  aparece como predicciones erróneas de tiempo de reverberación y claridad en
+  salas poco mezcladoras.
+- **El coeficiente de difusión califica difusores.** Cuando la tarea es
+  deshacer un eco, un flutter o una reflexión focalizada, lo que importa es
+  que la energía reflejada se reparta en ángulo, y $d$ mide exactamente eso.
+  El $d_n$ normalizado (fórmula (7)) resta además la difracción de borde que
+  exhibe todo panel finito, de modo que productos de tamaños distintos puedan
+  compararse con justicia.
+
+Intercambiarlos falla en ambos sentidos: un coeficiente de difusión metido en
+la casilla de dispersión de un simulador sesga el reparto de energía, y un
+coeficiente de dispersión citado como prueba de "difusión" puede describir una
+superficie que simplemente redirige la reflexión problemática a otro sitio.
+Ambos coeficientes son funciones por banda de tercio de octava que en general
+crecen cuando el relieve de la superficie deja de ser pequeño frente a la
+longitud de onda; un número único ciego a la frecuencia ("dispersa el 90 % del
+sonido") no es ninguno de los dos.
+
 ## 3. Absorción in situ de pavimentos — técnica de sustracción (ISO 13472-1)
 
 En campo no hay sala reverberante. ISO 13472-1 mide la absorción sonora de un
@@ -419,6 +466,29 @@ s_min, s_max = ph.spot_microphone_spacing_bounds(
     343.0, f_min=220.0, f_max=1800.0)
 print(round(s_min, 3), round(s_max, 3))    # 0.078 0.086  (metros)
 ```
+
+## Referencias
+
+- Cox, T. J., & D'Antonio, P. (2017). *Acoustic absorbers and diffusers:
+  Theory, design and application* (3.ª ed.). CRC Press.
+  ISBN 978-1-4987-4099-9.
+  [doi:10.1201/9781315369211](https://doi.org/10.1201/9781315369211).
+  La monografía sobre teoría y diseño de difusores, de los autores tras los
+  dos métodos ISO 17497: la distinción dispersión-difusión, los montajes de
+  medida y la guía de diseño que esta página condensa.
+- International Organization for Standardization. (2004). *Acoustics —
+  Sound-scattering properties of surfaces — Part 1: Measurement of the
+  random-incidence scattering coefficient in a reverberation room*
+  (ISO 17497-1:2004).
+  [Catálogo iso.org](https://www.iso.org/standard/31397.html).
+  El método de mesa giratoria de la sección 1 y los límites de placa base de
+  la Tabla 1.
+- International Organization for Standardization. (2012). *Acoustics —
+  Sound-scattering properties of surfaces — Part 2: Measurement of the
+  directional diffusion coefficient in a free field* (ISO 17497-2:2012).
+  [Catálogo iso.org](https://www.iso.org/standard/55293.html).
+  El coeficiente de autocorrelación del goniómetro de la sección 2, su
+  ponderación por área y el $d_n$ normalizado.
 
 ---
 

--- a/site/src/content/docs/es/guides/surface-scattering.md
+++ b/site/src/content/docs/es/guides/surface-scattering.md
@@ -265,11 +265,12 @@ Un par de contraejemplos los mantiene separados. Un elemento curvo o inclinado
 que *redirige* la reflexión concentra casi toda la energía reflejada en un
 lóbulo intenso alejado de la dirección especular: casi todo es no especular,
 así que $s$ es alto, pero el haz queda tan colimado como el de un espejo, así
-que $d$ se mantiene bajo. A la inversa, una superficie con textura ligera
-puede dispersar solo una fracción pequeña de la energía repartiendo ese poco
-de manera perfectamente uniforme: el $d$ del campo dispersado parece
-respetable mientras $s$ se queda cerca de cero. Un $s$ alto no significa
-uniforme; un $d$ decente no significa que se dispersara mucha energía.
+que $d$ se mantiene bajo. A la inversa, un panel plano pequeño medido a baja
+frecuencia envía casi toda la energía reflejada hacia la dirección especular,
+así que $s$ se queda cerca de cero, y sin embargo la difracción de borde
+reparte esa reflexión tan ampliamente sobre el arco de receptores que el $d$
+medido sale sorprendentemente alto. Un $s$ alto no significa uniforme; un $d$
+decente no significa que se dispersara mucha energía.
 
 **Cuál usar en diseño.** Los dos números sirven a consumidores distintos:
 
@@ -278,8 +279,8 @@ uniforme; un $d$ decente no significa que se dispersara mucha energía.
   energía continúa especularmente y cuánta se redistribuye; el $s$ de
   incidencia aleatoria por banda de cada superficie es precisamente ese
   reparto, que es lo que ISO 17497-1 se redactó para suministrar. Equivocarlo
-  aparece como predicciones erróneas de tiempo de reverberación y claridad en
-  salas poco mezcladoras.
+  se traduce en predicciones erróneas de tiempo de reverberación y claridad
+  en salas no mezcladoras.
 - **El coeficiente de difusión califica difusores.** Cuando la tarea es
   deshacer un eco, un flutter o una reflexión focalizada, lo que importa es
   que la energía reflejada se reparta en ángulo, y $d$ mide exactamente eso.
@@ -473,8 +474,9 @@ print(round(s_min, 3), round(s_max, 3))    # 0.078 0.086  (metros)
   Theory, design and application* (3.ª ed.). CRC Press.
   ISBN 978-1-4987-4099-9.
   [doi:10.1201/9781315369211](https://doi.org/10.1201/9781315369211).
-  La monografía sobre teoría y diseño de difusores, de los autores tras los
-  dos métodos ISO 17497: la distinción dispersión-difusión, los montajes de
+  La monografía de referencia sobre teoría y diseño de difusores, de los
+  autores tras el método del coeficiente de difusión de ISO 17497-2: la
+  distinción dispersión-difusión, los montajes de
   medida y la guía de diseño que esta página condensa.
 - International Organization for Standardization. (2004). *Acoustics —
   Sound-scattering properties of surfaces — Part 1: Measurement of the

--- a/site/src/content/docs/es/guides/surface-scattering.md
+++ b/site/src/content/docs/es/guides/surface-scattering.md
@@ -481,20 +481,20 @@ print(round(s_min, 3), round(s_max, 3))    # 0.078 0.086  (metros)
 - International Organization for Standardization. (2004). *Acoustics —
   Sound-scattering properties of surfaces — Part 1: Measurement of the
   random-incidence scattering coefficient in a reverberation room*
-  (ISO 17497-1:2004).
+  (ISO 17497-1:2004+A1:2014, la edición implementada aquí).
   [Catálogo iso.org](https://www.iso.org/standard/31397.html).
-  El método de mesa giratoria de la sección 1 y los límites de placa base de
-  la Tabla 1.
+  El método de mesa giratoria implementado en la sección 1 de esta página y
+  los límites de placa base de la Tabla 1 de la norma.
 - International Organization for Standardization. (2012). *Acoustics —
   Sound-scattering properties of surfaces — Part 2: Measurement of the
   directional diffusion coefficient in a free field* (ISO 17497-2:2012).
   [Catálogo iso.org](https://www.iso.org/standard/55293.html).
-  El coeficiente de autocorrelación del goniómetro de la sección 2, su
-  ponderación por área y el $d_n$ normalizado.
+  El coeficiente de autocorrelación del goniómetro que hay tras la sección 2
+  de esta página, su ponderación por área y el $d_n$ normalizado.
 
 ---
 
-**Normas.** ISO 17497-1:2004 (coeficiente de
+**Normas.** ISO 17497-1:2004+A1:2014 (coeficiente de
 dispersión), ISO 17497-2:2012 (coeficiente de difusión), ISO 13472-1:2002
 (absorción in situ, superficie extensa), ISO 13472-2:2010 (absorción in situ,
 método puntual), e ISO 9613-1:1993 — solo el coeficiente de atenuación de

--- a/site/src/content/docs/es/reference/bibliography.md
+++ b/site/src/content/docs/es/reference/bibliography.md
@@ -137,6 +137,65 @@ que las guías incorporan sus secciones de Referencias.
   índice presión-intensidad residual.
   Citado por [Intensidad sonora (p-p)](/phonometry/es/guides/intensity/).
 
+## Materiales y superficies
+
+- Allard, J. F., & Atalla, N. (2009). *Propagation of sound in porous media:
+  Modelling sound absorbing materials* (2.ª ed.). Wiley.
+  ISBN 978-0-470-74661-5.
+  [doi:10.1002/9780470747339](https://doi.org/10.1002/9780470747339).
+  La teoría del material poroso que enlaza resistividad al flujo, impedancia
+  superficial y absorción.
+  Citado por [Materiales acústicos](/phonometry/es/guides/materials/).
+- Cox, T. J., & D'Antonio, P. (2017). *Acoustic absorbers and diffusers:
+  Theory, design and application* (3.ª ed.). CRC Press.
+  ISBN 978-1-4987-4099-9.
+  [doi:10.1201/9781315369211](https://doi.org/10.1201/9781315369211).
+  La monografía sobre medida y diseño de absorbentes y difusores, de los
+  autores tras los métodos ISO 17497.
+  Citado por [Materiales acústicos](/phonometry/es/guides/materials/) y
+  [Dispersión superficial, difusión y absorción in situ](/phonometry/es/guides/surface-scattering/).
+- International Organization for Standardization. (2003). *Acoustics —
+  Measurement of sound absorption in a reverberation room* (ISO 354:2003).
+  [Catálogo iso.org](https://www.iso.org/standard/34545.html).
+  El método de absorción en cámara reverberante y sus montajes de probeta.
+  Citado por [Materiales acústicos](/phonometry/es/guides/materials/).
+- International Organization for Standardization. (1998). *Acoustics —
+  Determination of sound absorption coefficient and impedance in impedance
+  tubes — Part 2: Transfer-function method* (ISO 10534-2:1998; adoptada en
+  Europa como BS EN ISO 10534-2:2001; revisada después como
+  [ISO 10534-2:2023](https://www.iso.org/standard/81294.html)).
+  [Catálogo iso.org](https://www.iso.org/standard/22851.html).
+  El método de la función de transferencia con dos micrófonos y sus límites
+  de onda plana.
+  Citado por [Materiales acústicos](/phonometry/es/guides/materials/).
+- ASTM International. (2019). *Standard test method for normal incidence
+  determination of porous material acoustical properties based on the
+  transfer matrix method* (ASTM E2611-19).
+  [Tienda ASTM](https://store.astm.org/e2611-19.html).
+  El método de pérdida por transmisión por matriz de transferencia con
+  cuatro micrófonos.
+  Citado por [Materiales acústicos](/phonometry/es/guides/materials/).
+- International Organization for Standardization. (2018). *Acoustics —
+  Determination of airflow resistance — Part 1: Static airflow method*
+  (ISO 9053-1:2018).
+  [Catálogo iso.org](https://www.iso.org/standard/69869.html).
+  El método estático de resistencia al flujo de aire y su velocidad de
+  referencia.
+  Citado por [Materiales acústicos](/phonometry/es/guides/materials/).
+- International Organization for Standardization. (2004). *Acoustics —
+  Sound-scattering properties of surfaces — Part 1: Measurement of the
+  random-incidence scattering coefficient in a reverberation room*
+  (ISO 17497-1:2004).
+  [Catálogo iso.org](https://www.iso.org/standard/31397.html).
+  El método del coeficiente de dispersión con mesa giratoria.
+  Citado por [Dispersión superficial, difusión y absorción in situ](/phonometry/es/guides/surface-scattering/).
+- International Organization for Standardization. (2012). *Acoustics —
+  Sound-scattering properties of surfaces — Part 2: Measurement of the
+  directional diffusion coefficient in a free field* (ISO 17497-2:2012).
+  [Catálogo iso.org](https://www.iso.org/standard/55293.html).
+  El método del coeficiente de difusión con goniómetro.
+  Citado por [Dispersión superficial, difusión y absorción in situ](/phonometry/es/guides/surface-scattering/).
+
 ## Acústica de edificios
 
 - Hopkins, C. (2007). *Sound insulation*. Butterworth-Heinemann.

--- a/site/src/content/docs/es/reference/bibliography.md
+++ b/site/src/content/docs/es/reference/bibliography.md
@@ -157,7 +157,7 @@ que las guías incorporan sus secciones de Referencias.
 - International Organization for Standardization. (2003). *Acoustics —
   Measurement of sound absorption in a reverberation room* (ISO 354:2003).
   [Catálogo iso.org](https://www.iso.org/standard/34545.html).
-  El método de absorción en sala reverberante y sus montajes de probeta.
+  El método de absorción en cámara reverberante y sus montajes de probeta.
   Citado por [Materiales acústicos](/phonometry/es/guides/materials/).
 - International Organization for Standardization. (1998). *Acoustics —
   Determination of sound absorption coefficient and impedance in impedance
@@ -170,7 +170,8 @@ que las guías incorporan sus secciones de Referencias.
   Citado por [Materiales acústicos](/phonometry/es/guides/materials/).
 - ASTM International. (2019). *Standard test method for normal incidence
   determination of porous material acoustical properties based on the
-  transfer matrix method* (ASTM E2611-19).
+  transfer matrix method* (ASTM E2611-19, la edición implementada aquí;
+  revisada después como [ASTM E2611-24](https://store.astm.org/e2611-24.html)).
   [Tienda ASTM](https://store.astm.org/e2611-19.html).
   El método de pérdida por transmisión por matriz de transferencia con
   cuatro micrófonos.
@@ -185,7 +186,7 @@ que las guías incorporan sus secciones de Referencias.
 - International Organization for Standardization. (2004). *Acoustics —
   Sound-scattering properties of surfaces — Part 1: Measurement of the
   random-incidence scattering coefficient in a reverberation room*
-  (ISO 17497-1:2004).
+  (ISO 17497-1:2004+A1:2014, la edición implementada aquí).
   [Catálogo iso.org](https://www.iso.org/standard/31397.html).
   El método del coeficiente de dispersión con mesa giratoria.
   Citado por [Dispersión superficial, difusión y absorción in situ](/phonometry/es/guides/surface-scattering/).

--- a/site/src/content/docs/es/reference/bibliography.md
+++ b/site/src/content/docs/es/reference/bibliography.md
@@ -151,18 +151,18 @@ que las guías incorporan sus secciones de Referencias.
   ISBN 978-1-4987-4099-9.
   [doi:10.1201/9781315369211](https://doi.org/10.1201/9781315369211).
   La monografía sobre medida y diseño de absorbentes y difusores, de los
-  autores tras los métodos ISO 17497.
+  autores tras el método del coeficiente de difusión de ISO 17497-2.
   Citado por [Materiales acústicos](/phonometry/es/guides/materials/) y
   [Dispersión superficial, difusión y absorción in situ](/phonometry/es/guides/surface-scattering/).
 - International Organization for Standardization. (2003). *Acoustics —
   Measurement of sound absorption in a reverberation room* (ISO 354:2003).
   [Catálogo iso.org](https://www.iso.org/standard/34545.html).
-  El método de absorción en cámara reverberante y sus montajes de probeta.
+  El método de absorción en sala reverberante y sus montajes de probeta.
   Citado por [Materiales acústicos](/phonometry/es/guides/materials/).
 - International Organization for Standardization. (1998). *Acoustics —
   Determination of sound absorption coefficient and impedance in impedance
   tubes — Part 2: Transfer-function method* (ISO 10534-2:1998; adoptada en
-  Europa como BS EN ISO 10534-2:2001; revisada después como
+  Europa como EN ISO 10534-2:2001; revisada después como
   [ISO 10534-2:2023](https://www.iso.org/standard/81294.html)).
   [Catálogo iso.org](https://www.iso.org/standard/22851.html).
   El método de la función de transferencia con dos micrófonos y sus límites

--- a/site/src/content/docs/guides/materials.md
+++ b/site/src/content/docs/guides/materials.md
@@ -425,13 +425,15 @@ time through Sabine's formula, an energy average with no phase left in it.
 Because the diffuse field finds more ways into an absorber than the single
 normal-incidence wave (oblique waves travel a longer path inside the layer),
 $\alpha_s$ usually comes out higher. For a locally reacting surface the two
-are linked by Paris' angular average,
+are linked by Paris' angular average, which defines the statistical
+absorption coefficient
 
 $$
 \alpha_{st} = \int_0^{\pi/2} \alpha(\theta)\,\sin 2\theta\,\mathrm{d}\theta,
 $$
 
-which weights the oblique angles most heavily; evaluating it needs the
+an integral that weights the oblique angles most heavily; evaluating it
+needs the
 angle-dependent $\alpha(\theta)$ from the measured surface impedance, not just
 the normal-incidence coefficient itself.
 
@@ -554,7 +556,7 @@ print(float(single_number_rating_uncertainty(8.1).reported_expanded_uncertainty[
 - International Organization for Standardization. (1998). *Acoustics —
   Determination of sound absorption coefficient and impedance in impedance
   tubes — Part 2: Transfer-function method* (ISO 10534-2:1998; adopted in
-  Europe as BS EN ISO 10534-2:2001, the edition implemented here; since
+  Europe as EN ISO 10534-2:2001, the edition implemented here; since
   revised as [ISO 10534-2:2023](https://www.iso.org/standard/81294.html)).
   [iso.org catalogue](https://www.iso.org/standard/22851.html).
   The two-microphone transfer-function method and its plane-wave

--- a/site/src/content/docs/guides/materials.md
+++ b/site/src/content/docs/guides/materials.md
@@ -445,10 +445,16 @@ $\alpha_s = A/S$ divides by the *geometric* sample area $S$. Diffraction at
 the sample edges lets the specimen drain energy from a sound field wider than
 its footprint (the edge effect), so the equivalent area can exceed the
 geometric one. Such values are not errors, but they are not portable either:
-they depend on the sample size and perimeter, which is exactly why ISO 354
+they depend on the sample size and perimeter, which is precisely why ISO 354
 fixes both. The ISO 11654 rating simply truncates: practical coefficients
-above $1.00$ are set to $1.00$ (section 1), and prediction software clips at
-one before summing absorption areas.
+above $1.00$ are set to $1.00$ (section 1). Prediction inputs get no such
+silent clipping in this library: the
+[reverberation-time estimators](/phonometry/guides/reverberation-prediction/)
+reject coefficients outside $[0, 1)$ (the Eyring and Millington logarithms
+diverge at one), so ISO 354 values at or above one must be brought back below
+one by the caller, while the equivalent-absorption-area budget of
+[EN 12354-6](/phonometry/guides/enclosed-space-absorption/) accepts the
+coefficients as supplied.
 
 **Which to use.** They answer different questions. The reverberation-room
 value is the one that feeds diffuse-field prediction: Sabine reverberation
@@ -563,7 +569,8 @@ print(float(single_number_rating_uncertainty(8.1).reported_expanded_uncertainty[
   frequency-range limits.
 - ASTM International. (2019). *Standard test method for normal incidence
   determination of porous material acoustical properties based on the
-  transfer matrix method* (ASTM E2611-19).
+  transfer matrix method* (ASTM E2611-19, the edition implemented here;
+  since revised as [ASTM E2611-24](https://store.astm.org/e2611-24.html)).
   [ASTM store](https://store.astm.org/e2611-19.html).
   The four-microphone transfer-matrix method behind the transmission-loss
   helpers.

--- a/site/src/content/docs/guides/materials.md
+++ b/site/src/content/docs/guides/materials.md
@@ -222,6 +222,41 @@ their helpers separate and never mixes them.
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_impedance_tube.svg" alt="ISO 10534-2 two-microphone impedance tube: a loudspeaker radiating a plane wave down the tube, two microphones flush in the wall at spacing s and distance x1 from the specimen face, the test specimen against a rigid backing, and the incident and reflected waves" style="width:92%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_impedance_tube_dark.svg" alt="ISO 10534-2 two-microphone impedance tube: a loudspeaker radiating a plane wave down the tube, two microphones flush in the wall at spacing s and distance x1 from the specimen face, the test specimen against a rigid backing, and the incident and reflected waves" style="width:92%">
 
+**Working frequency range (ISO 10534-2, Clause 4).** Everything the tube
+reports assumes the field inside is a single plane wave, and the geometry sets
+both ends of the usable band. Above the cut-on of the first cross-sectional
+mode the field stops being planar: a circular tube of diameter $d$ needs
+$f\,d < 0.58\,c_0$ (Eq. (2); $f\,d < 0.50\,c_0$ for a rectangular tube,
+Eq. (3)). The microphone spacing $s$ must also stay clear of the
+half-wavelength singularity of the transfer-function method,
+$f\,s < 0.45\,c_0$ (Eq. (4)). At the low end the opposite problem appears: a
+spacing much shorter than the wavelength leaves almost no phase difference
+between the microphones to measure, so the Clause 4.2 guideline keeps the
+spacing above 5 % of the wavelength:
+
+$$
+\frac{c_0}{20\,s} \;<\; f \;<\;
+\min\!\left(0.58\,\frac{c_0}{d},\ 0.45\,\frac{c_0}{s}\right).
+$$
+
+No single tube covers the building-acoustics range. A 100 mm tube with a
+100 mm spacing works from roughly 170 Hz to 1.5 kHz; reaching the 5 kHz bands
+takes a small tube (29 mm) with a close spacing, which in turn cannot see the
+low bands. Laboratories therefore pair a large and a small tube (or one tube
+with two spacings) and splice the spectra; the two must agree in the overlap
+bands, and a mismatch there points at the sample cut or mounting, not at the
+physics.
+
+```python
+from phonometry import plane_wave_frequency_range
+
+# A 100 mm tube with 100 mm spacing, and a 29 mm tube with 20 mm spacing.
+f_l, f_u = plane_wave_frequency_range(0.100, 343.2, diameter=0.100)
+print(round(f_l, 1), round(f_u, 1))     # 171.6 1544.4
+f_l, f_u = plane_wave_frequency_range(0.020, 343.2, diameter=0.029)
+print(round(f_l, 1), round(f_u, 1))     # 858.0 6864.0
+```
+
 **Standing-wave-ratio method (ISO 10534-1).** A probe traverses the standing wave
 and reads the level difference $\Delta L = L_\text{max} - L_\text{min}$ between a
 pressure maximum and the adjacent minimum. The standing-wave ratio, reflection
@@ -347,6 +382,87 @@ print(np.round(tm.transmission_loss(rho_c), 6))   # [0. 0. 0.]
 `characteristic_impedance_material`, `material_wavenumber`) then read off the
 ASTM E2611 quantities.
 
+**Mounting pitfalls.** Most bad tube data are made at the sample holder, long
+before the signal processing. The recurring failures:
+
+- **Perimeter gaps.** A specimen cut slightly undersize leaves an air sliver
+  along the tube wall. Sound short-circuits around and behind the sample, and
+  the gap itself resonates, so the measured absorption grows a spurious
+  low-to-mid-frequency hump. Cut for a snug slide fit and seal the rim (a thin
+  film of petroleum jelly is the classic remedy) without loading the front
+  face.
+- **Compression.** A specimen cut oversize and forced in is denser than the
+  product it is supposed to represent: the flow resistivity rises, a limp
+  frame is stiffened, and the absorption curve shifts and flattens. The result
+  is repeatable and wrong.
+- **Hidden back cavity.** If the specimen does not sit flush on the rigid
+  backing, the unintended air layer acts as a quarter-wavelength cavity and
+  moves the absorption peak down in frequency, flattering the material.
+  Backing air gaps are perfectly legitimate mountings, but only when they are
+  deliberate, dimensioned and reported with the result.
+- **Face not plane.** A bulging, tilted or torn front face scatters into
+  cross-sectional modes below the nominal cut-on and breaks the
+  normal-incidence assumption the equations rest on. Cut with a sharp tool;
+  do not tear fibrous materials to size.
+- **One specimen is not the material.** Porous products are inhomogeneous at
+  the scale of a tube sample. Measure several cuts and average; a spread
+  between specimens is product variance worth reporting, not measurement noise
+  to hide.
+
+## Tube or reverberation room?
+
+The tube and the reverberation room both deliver a number called the
+"absorption coefficient", and the two are routinely confused. They are
+different physical quantities, measured under different sound fields, and they
+do not match, sometimes not even closely.
+
+The tube measures a **normal-incidence** coefficient: one plane wave, one
+angle, a specimen a few centimetres across, and a complex reflection factor
+that keeps magnitude and phase. ISO 354 measures the **random-incidence**
+coefficient $\alpha_s$: a diffuse field striking a sample of 10 m² to 12 m²
+from every direction at once, recovered from the change in the room's decay
+time through Sabine's formula, an energy average with no phase left in it.
+Because the diffuse field finds more ways into an absorber than the single
+normal-incidence wave (oblique waves travel a longer path inside the layer),
+$\alpha_s$ usually comes out higher. For a locally reacting surface the two
+are linked by Paris' angular average,
+
+$$
+\alpha_{st} = \int_0^{\pi/2} \alpha(\theta)\,\sin 2\theta\,\mathrm{d}\theta,
+$$
+
+which weights the oblique angles most heavily; evaluating it needs the
+angle-dependent $\alpha(\theta)$ from the measured surface impedance, not just
+the normal-incidence coefficient itself.
+
+**Why ISO 354 values exceed 1.** A ratio of absorbed to incident energy cannot
+exceed one, yet reverberation-room reports of $\alpha_s = 1.05$ to $1.20$ for
+thick porous absorbers are routine and correct by the method. Sabine's formula
+converts the decay-time change into an equivalent absorption area $A$, and
+$\alpha_s = A/S$ divides by the *geometric* sample area $S$. Diffraction at
+the sample edges lets the specimen drain energy from a sound field wider than
+its footprint (the edge effect), so the equivalent area can exceed the
+geometric one. Such values are not errors, but they are not portable either:
+they depend on the sample size and perimeter, which is exactly why ISO 354
+fixes both. The ISO 11654 rating simply truncates: practical coefficients
+above $1.00$ are set to $1.00$ (section 1), and prediction software clips at
+one before summing absorption areas.
+
+**Which to use.** They answer different questions. The reverberation-room
+value is the one that feeds diffuse-field prediction: Sabine reverberation
+estimates, the equivalent absorption areas of
+[EN 12354-6](/phonometry/guides/enclosed-space-absorption/) and the $\alpha_w$
+rating and class, all of which expect random incidence over a mounted, finite
+sample (ISO 354's Annex B mounting types exist because the mounting is part of
+the result). The tube value is the laboratory and development tool: it needs
+only a few square centimetres of material, resolves magnitude *and* phase, and
+its surface impedance pins down the parameters of porous-material models in
+the Allard and Atalla tradition, with the airflow resistivity of section 2 as
+the first input; the fitted model then predicts the layer at any angle,
+thickness or backing. What the tube number is *not* is a drop-in substitute
+for $\alpha_s$: feeding normal-incidence coefficients into a Sabine or
+EN 12354-6 budget systematically underpredicts the installed absorption.
+
 ## 4. Sound-absorption measurement uncertainty (ISO 12999-2)
 
 A rated absorption coefficient means little without its uncertainty. ISO
@@ -413,6 +529,48 @@ print(float(r.reported_expanded_uncertainty[0]))             # 0.08  (U, k=2)
 print(float(weighted_coefficient_uncertainty(0.70).reported_expanded_uncertainty[0]))  # 0.07
 print(float(single_number_rating_uncertainty(8.1).reported_expanded_uncertainty[0]))   # 1.6
 ```
+
+## References
+
+- Allard, J. F., & Atalla, N. (2009). *Propagation of sound in porous media:
+  Modelling sound absorbing materials* (2nd ed.). Wiley.
+  ISBN 978-0-470-74661-5.
+  [doi:10.1002/9780470747339](https://doi.org/10.1002/9780470747339).
+  The porous-material theory behind the measured quantities: airflow
+  resistivity as a model input, and the surface impedance and absorption the
+  tube recovers.
+- Cox, T. J., & D'Antonio, P. (2017). *Acoustic absorbers and diffusers:
+  Theory, design and application* (3rd ed.). CRC Press.
+  ISBN 978-1-4987-4099-9.
+  [doi:10.1201/9781315369211](https://doi.org/10.1201/9781315369211).
+  Absorber measurement and design in practice: the tube and room methods side
+  by side, mountings, and the edge-effect discussion behind the
+  tube-or-reverberation-room section.
+- International Organization for Standardization. (2003). *Acoustics —
+  Measurement of sound absorption in a reverberation room* (ISO 354:2003).
+  [iso.org catalogue](https://www.iso.org/standard/34545.html).
+  The reverberation-room method that produces the $\alpha_s$ spectra rated by
+  ISO 11654, including the Annex B specimen mountings.
+- International Organization for Standardization. (1998). *Acoustics —
+  Determination of sound absorption coefficient and impedance in impedance
+  tubes — Part 2: Transfer-function method* (ISO 10534-2:1998; adopted in
+  Europe as BS EN ISO 10534-2:2001, the edition implemented here; since
+  revised as [ISO 10534-2:2023](https://www.iso.org/standard/81294.html)).
+  [iso.org catalogue](https://www.iso.org/standard/22851.html).
+  The two-microphone transfer-function method and its plane-wave
+  frequency-range limits.
+- ASTM International. (2019). *Standard test method for normal incidence
+  determination of porous material acoustical properties based on the
+  transfer matrix method* (ASTM E2611-19).
+  [ASTM store](https://store.astm.org/e2611-19.html).
+  The four-microphone transfer-matrix method behind the transmission-loss
+  helpers.
+- International Organization for Standardization. (2018). *Acoustics —
+  Determination of airflow resistance — Part 1: Static airflow method*
+  (ISO 9053-1:2018).
+  [iso.org catalogue](https://www.iso.org/standard/69869.html).
+  The static method of section 2, with the through-origin regression and the
+  0.5 mm/s reference velocity.
 
 ---
 

--- a/site/src/content/docs/guides/surface-scattering.md
+++ b/site/src/content/docs/guides/surface-scattering.md
@@ -242,6 +242,51 @@ plt.show()
 
 </details>
 
+## Scattering or diffusion? Two coefficients, two jobs
+
+The two coefficients above are routinely treated as interchangeable, in
+product data sheets and occasionally in simulation manuals. They are not, and
+neither can be computed from the other. The scattering coefficient $s$
+(ISO 17497-1) does **energy bookkeeping**: what fraction of the reflected
+energy leaves the specular direction. It says nothing about where that energy
+goes. The diffusion coefficient $d$ (ISO 17497-2) grades **spatial quality**:
+how evenly the reflected energy covers the receiver arc, one source direction
+at a time. It says nothing about how the energy divides between the specular
+lobe and the rest.
+
+A pair of counterexamples keeps them apart. A curved or tilted element that
+*redirects* the reflection concentrates nearly all the reflected energy into
+one strong lobe away from the specular direction: almost everything is
+non-specular, so $s$ is high, yet the beam is as collimated as a mirror's, so
+$d$ stays low. Conversely, a lightly textured surface may scatter only a small
+fraction of the energy while spreading that little bit perfectly evenly: $d$
+of the scattered field looks respectable while $s$ stays near zero. High $s$
+does not mean uniform; decent $d$ does not mean much energy was scattered at
+all.
+
+**Which one for design.** The two numbers serve different consumers:
+
+- **The scattering coefficient feeds room-acoustics simulation.**
+  Geometrical-acoustics engines decide at every wall reflection how much
+  energy continues specularly and how much is redistributed; the per-band
+  random-incidence $s$ of each surface is precisely that split, which is what
+  ISO 17497-1 was written to supply. Getting it wrong shows up as the wrong
+  reverberation-time and clarity predictions in non-mixing rooms.
+- **The diffusion coefficient qualifies diffusers.** When the task is to break
+  up an echo, a flutter or a focusing reflection, what matters is that the
+  reflected energy is spread over angle, and $d$ measures exactly that. The
+  normalised $d_n$ (Formula (7)) additionally subtracts the edge diffraction
+  that every finite panel exhibits, so products of different sizes can be
+  compared fairly.
+
+Swapping them fails in both directions: a diffusion coefficient dropped into a
+simulator's scattering slot biases the energy split, and a scattering
+coefficient quoted as proof of "diffusion" may describe a surface that merely
+redirects the problem reflection somewhere else. Both coefficients are
+one-third-octave-band functions that generally rise once the surface relief is
+no longer small against the wavelength; a frequency-blind single number
+("scatters 90 % of the sound") is neither of them.
+
 ## 3. In-situ road absorption — subtraction technique (ISO 13472-1)
 
 Out in the field there is no reverberation room. ISO 13472-1 measures the sound
@@ -408,6 +453,28 @@ s_min, s_max = ph.spot_microphone_spacing_bounds(
     343.0, f_min=220.0, f_max=1800.0)
 print(round(s_min, 3), round(s_max, 3))    # 0.078 0.086  (metres)
 ```
+
+## References
+
+- Cox, T. J., & D'Antonio, P. (2017). *Acoustic absorbers and diffusers:
+  Theory, design and application* (3rd ed.). CRC Press.
+  ISBN 978-1-4987-4099-9.
+  [doi:10.1201/9781315369211](https://doi.org/10.1201/9781315369211).
+  The monograph on diffuser theory and design by the authors behind both
+  ISO 17497 methods: the scattering-versus-diffusion distinction, the
+  measurement rigs and the design guidance this page condenses.
+- International Organization for Standardization. (2004). *Acoustics —
+  Sound-scattering properties of surfaces — Part 1: Measurement of the
+  random-incidence scattering coefficient in a reverberation room*
+  (ISO 17497-1:2004).
+  [iso.org catalogue](https://www.iso.org/standard/31397.html).
+  The turntable method of section 1 and the base-plate limits of Table 1.
+- International Organization for Standardization. (2012). *Acoustics —
+  Sound-scattering properties of surfaces — Part 2: Measurement of the
+  directional diffusion coefficient in a free field* (ISO 17497-2:2012).
+  [iso.org catalogue](https://www.iso.org/standard/55293.html).
+  The goniometer autocorrelation coefficient of section 2, its area
+  weighting and the normalised $d_n$.
 
 ---
 

--- a/site/src/content/docs/guides/surface-scattering.md
+++ b/site/src/content/docs/guides/surface-scattering.md
@@ -258,11 +258,11 @@ A pair of counterexamples keeps them apart. A curved or tilted element that
 *redirects* the reflection concentrates nearly all the reflected energy into
 one strong lobe away from the specular direction: almost everything is
 non-specular, so $s$ is high, yet the beam is as collimated as a mirror's, so
-$d$ stays low. Conversely, a lightly textured surface may scatter only a small
-fraction of the energy while spreading that little bit perfectly evenly: $d$
-of the scattered field looks respectable while $s$ stays near zero. High $s$
-does not mean uniform; decent $d$ does not mean much energy was scattered at
-all.
+$d$ stays low. Conversely, a small flat panel measured at low frequency sends
+nearly all the reflected energy toward the specular direction, so $s$ stays
+near zero, yet edge diffraction spreads that reflection so broadly over the
+receiver arc that the measured $d$ comes out surprisingly high. High $s$ does
+not mean uniform; decent $d$ does not mean much energy was scattered at all.
 
 **Which one for design.** The two numbers serve different consumers:
 
@@ -460,8 +460,9 @@ print(round(s_min, 3), round(s_max, 3))    # 0.078 0.086  (metres)
   Theory, design and application* (3rd ed.). CRC Press.
   ISBN 978-1-4987-4099-9.
   [doi:10.1201/9781315369211](https://doi.org/10.1201/9781315369211).
-  The monograph on diffuser theory and design by the authors behind both
-  ISO 17497 methods: the scattering-versus-diffusion distinction, the
+  The reference monograph on diffuser theory and design, by the authors
+  behind the ISO 17497-2 diffusion-coefficient method: the
+  scattering-versus-diffusion distinction, the
   measurement rigs and the design guidance this page condenses.
 - International Organization for Standardization. (2004). *Acoustics —
   Sound-scattering properties of surfaces — Part 1: Measurement of the

--- a/site/src/content/docs/guides/surface-scattering.md
+++ b/site/src/content/docs/guides/surface-scattering.md
@@ -467,19 +467,20 @@ print(round(s_min, 3), round(s_max, 3))    # 0.078 0.086  (metres)
 - International Organization for Standardization. (2004). *Acoustics —
   Sound-scattering properties of surfaces — Part 1: Measurement of the
   random-incidence scattering coefficient in a reverberation room*
-  (ISO 17497-1:2004).
+  (ISO 17497-1:2004+A1:2014, the edition implemented here).
   [iso.org catalogue](https://www.iso.org/standard/31397.html).
-  The turntable method of section 1 and the base-plate limits of Table 1.
+  The turntable method implemented in section 1 of this page and the
+  base-plate limits of the standard's Table 1.
 - International Organization for Standardization. (2012). *Acoustics —
   Sound-scattering properties of surfaces — Part 2: Measurement of the
   directional diffusion coefficient in a free field* (ISO 17497-2:2012).
   [iso.org catalogue](https://www.iso.org/standard/55293.html).
-  The goniometer autocorrelation coefficient of section 2, its area
-  weighting and the normalised $d_n$.
+  The goniometer autocorrelation coefficient behind section 2 of this page,
+  its area weighting and the normalised $d_n$.
 
 ---
 
-**Standards.** ISO 17497-1:2004 (scattering
+**Standards.** ISO 17497-1:2004+A1:2014 (scattering
 coefficient), ISO 17497-2:2012 (diffusion coefficient), ISO 13472-1:2002 (in-situ
 absorption, extended surface), ISO 13472-2:2010 (in-situ absorption, spot
 method), and ISO 9613-1:1993 — only the pure-tone attenuation coefficient

--- a/site/src/content/docs/reference/bibliography.md
+++ b/site/src/content/docs/reference/bibliography.md
@@ -135,6 +135,62 @@ list grows as guides gain their References sections.
   residual pressure-intensity index.
   Cited by [Sound Intensity (p-p)](/phonometry/guides/intensity/).
 
+## Materials and surfaces
+
+- Allard, J. F., & Atalla, N. (2009). *Propagation of sound in porous media:
+  Modelling sound absorbing materials* (2nd ed.). Wiley.
+  ISBN 978-0-470-74661-5.
+  [doi:10.1002/9780470747339](https://doi.org/10.1002/9780470747339).
+  The porous-material theory linking airflow resistivity, surface impedance
+  and absorption.
+  Cited by [Acoustic Materials](/phonometry/guides/materials/).
+- Cox, T. J., & D'Antonio, P. (2017). *Acoustic absorbers and diffusers:
+  Theory, design and application* (3rd ed.). CRC Press.
+  ISBN 978-1-4987-4099-9.
+  [doi:10.1201/9781315369211](https://doi.org/10.1201/9781315369211).
+  The monograph on absorber and diffuser measurement and design, by the
+  authors behind the ISO 17497 methods.
+  Cited by [Acoustic Materials](/phonometry/guides/materials/) and
+  [Surface Scattering, Diffusion and In-situ Absorption](/phonometry/guides/surface-scattering/).
+- International Organization for Standardization. (2003). *Acoustics —
+  Measurement of sound absorption in a reverberation room* (ISO 354:2003).
+  [iso.org catalogue](https://www.iso.org/standard/34545.html).
+  The reverberation-room absorption method and its specimen mountings.
+  Cited by [Acoustic Materials](/phonometry/guides/materials/).
+- International Organization for Standardization. (1998). *Acoustics —
+  Determination of sound absorption coefficient and impedance in impedance
+  tubes — Part 2: Transfer-function method* (ISO 10534-2:1998; adopted in
+  Europe as BS EN ISO 10534-2:2001; since revised as
+  [ISO 10534-2:2023](https://www.iso.org/standard/81294.html)).
+  [iso.org catalogue](https://www.iso.org/standard/22851.html).
+  The two-microphone transfer-function method and its plane-wave limits.
+  Cited by [Acoustic Materials](/phonometry/guides/materials/).
+- ASTM International. (2019). *Standard test method for normal incidence
+  determination of porous material acoustical properties based on the
+  transfer matrix method* (ASTM E2611-19).
+  [ASTM store](https://store.astm.org/e2611-19.html).
+  The four-microphone transfer-matrix transmission-loss method.
+  Cited by [Acoustic Materials](/phonometry/guides/materials/).
+- International Organization for Standardization. (2018). *Acoustics —
+  Determination of airflow resistance — Part 1: Static airflow method*
+  (ISO 9053-1:2018).
+  [iso.org catalogue](https://www.iso.org/standard/69869.html).
+  The static airflow-resistance method and its reference velocity.
+  Cited by [Acoustic Materials](/phonometry/guides/materials/).
+- International Organization for Standardization. (2004). *Acoustics —
+  Sound-scattering properties of surfaces — Part 1: Measurement of the
+  random-incidence scattering coefficient in a reverberation room*
+  (ISO 17497-1:2004).
+  [iso.org catalogue](https://www.iso.org/standard/31397.html).
+  The turntable scattering-coefficient method.
+  Cited by [Surface Scattering, Diffusion and In-situ Absorption](/phonometry/guides/surface-scattering/).
+- International Organization for Standardization. (2012). *Acoustics —
+  Sound-scattering properties of surfaces — Part 2: Measurement of the
+  directional diffusion coefficient in a free field* (ISO 17497-2:2012).
+  [iso.org catalogue](https://www.iso.org/standard/55293.html).
+  The goniometer diffusion-coefficient method.
+  Cited by [Surface Scattering, Diffusion and In-situ Absorption](/phonometry/guides/surface-scattering/).
+
 ## Building acoustics
 
 - Hopkins, C. (2007). *Sound insulation*. Butterworth-Heinemann.

--- a/site/src/content/docs/reference/bibliography.md
+++ b/site/src/content/docs/reference/bibliography.md
@@ -167,7 +167,8 @@ list grows as guides gain their References sections.
   Cited by [Acoustic Materials](/phonometry/guides/materials/).
 - ASTM International. (2019). *Standard test method for normal incidence
   determination of porous material acoustical properties based on the
-  transfer matrix method* (ASTM E2611-19).
+  transfer matrix method* (ASTM E2611-19, the edition implemented here;
+  since revised as [ASTM E2611-24](https://store.astm.org/e2611-24.html)).
   [ASTM store](https://store.astm.org/e2611-19.html).
   The four-microphone transfer-matrix transmission-loss method.
   Cited by [Acoustic Materials](/phonometry/guides/materials/).
@@ -180,7 +181,7 @@ list grows as guides gain their References sections.
 - International Organization for Standardization. (2004). *Acoustics —
   Sound-scattering properties of surfaces — Part 1: Measurement of the
   random-incidence scattering coefficient in a reverberation room*
-  (ISO 17497-1:2004).
+  (ISO 17497-1:2004+A1:2014, the edition implemented here).
   [iso.org catalogue](https://www.iso.org/standard/31397.html).
   The turntable scattering-coefficient method.
   Cited by [Surface Scattering, Diffusion and In-situ Absorption](/phonometry/guides/surface-scattering/).

--- a/site/src/content/docs/reference/bibliography.md
+++ b/site/src/content/docs/reference/bibliography.md
@@ -149,7 +149,7 @@ list grows as guides gain their References sections.
   ISBN 978-1-4987-4099-9.
   [doi:10.1201/9781315369211](https://doi.org/10.1201/9781315369211).
   The monograph on absorber and diffuser measurement and design, by the
-  authors behind the ISO 17497 methods.
+  authors behind the ISO 17497-2 diffusion-coefficient method.
   Cited by [Acoustic Materials](/phonometry/guides/materials/) and
   [Surface Scattering, Diffusion and In-situ Absorption](/phonometry/guides/surface-scattering/).
 - International Organization for Standardization. (2003). *Acoustics —
@@ -160,7 +160,7 @@ list grows as guides gain their References sections.
 - International Organization for Standardization. (1998). *Acoustics —
   Determination of sound absorption coefficient and impedance in impedance
   tubes — Part 2: Transfer-function method* (ISO 10534-2:1998; adopted in
-  Europe as BS EN ISO 10534-2:2001; since revised as
+  Europe as EN ISO 10534-2:2001; since revised as
   [ISO 10534-2:2023](https://www.iso.org/standard/81294.html)).
   [iso.org catalogue](https://www.iso.org/standard/22851.html).
   The two-microphone transfer-function method and its plane-wave limits.


### PR DESCRIPTION
## Summary

Didactic depth and verified references for the materials and surface-scattering guides, in the three content trees.

- Materials: the ISO 10534-2 working frequency range with the cut-on and microphone-spacing bounds and a runnable snippet whose printed limits match the implementation; mounting pitfalls (perimeter gaps, compression, hidden cavities, the single-specimen fallacy); and a new "tube or reverberation room" section explaining normal versus random incidence, the statistical absorption coefficient, why ISO 354 values legitimately exceed 1 and which coefficient feeds prediction versus model fitting.
- Surface scattering: the classic confusion untangled: the scattering coefficient s is energy bookkeeping (the geometrical-acoustics simulation input) while the diffusion coefficient d is spatial uniformity (the diffuser qualification metric), with two physically precise counterexamples and the failure modes of swapping them.
- References verified at authoring time (Allard and Atalla, Cox and D'Antonio with their Crossref records; a plausible publisher slug that resolved to a different book was rejected; seven standards catalogue pages); the bibliography gains a Materials and surfaces group with back-links.

## Test plan

ruff, mypy, conformance byte-identical, i18n parity (56 pairs), site build with links validator at 0 errors, html-validate. A review pass produced seven findings (physics precision on the counterexamples, attribution scope, designation style, Spanish idiom), all applied.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded materials guidance with impedance-tube frequency limits, calculation examples, mounting pitfalls, and tube-versus-reverberation-room comparisons.
  - Clarified the differences between scattering and diffusion coefficients, including appropriate use cases for room simulation and diffuser evaluation.
  - Added references and standards covering acoustic materials, absorption, airflow resistance, scattering, and diffusion.
  - Updated the English and Spanish documentation and bibliographies with the new guidance and citations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->