### PR TITLE
docs: room acoustics didactics with verified references

### DIFF
--- a/docs/enclosed-space-absorption.md
+++ b/docs/enclosed-space-absorption.md
@@ -117,6 +117,60 @@ reverberation time in [Room Acoustics](room-acoustics.md)
 (ISO 3382) and of the reverberation-room absorption of
 [Acoustic Materials](materials.md) (ISO 354).
 
+## 3. Where the input data comes from
+
+**Surface coefficients.** The standard expects the $\alpha_{s,i}$ to come
+from laboratory measurements to EN ISO 354, the reverberation-room method
+of [Acoustic Materials](materials.md); theoretical, empirical or field
+values are admitted as long as the data source is stated. ISO 354 delivers
+one-third-octave data, and an octave-band calculation takes the arithmetic
+mean of the three thirds as its input. A reverberation-room coefficient can
+exceed 1.0 (edge diffraction scatters more energy into the sample than its
+flat area intercepts); it enters Formula 1 as measured, without clamping,
+because the same diffuse-field convention that produced it is the one the
+model assumes.
+
+**Furniture and occupants.** Objects contribute through three routes:
+a measured equivalent absorption area $A_{obj}$ when one exists (persons
+and seating have tabulated values in the informative Annex C), the
+Formula 4 estimate $V_{obj}^{2/3}$ for hard, irregular, unmeasured objects
+(furniture, machinery), and object *arrays* rated as an absorbing surface
+$\alpha_s S_k$ when many similar objects cover a zone (an audience, a
+storage rack). Objects also displace air: their summed volume enters the
+object fraction $\psi$ that shortens $T$ in Formula 5 beyond what their
+absorption alone would.
+
+**Air.** The air term $A_{air} = 4mV(1-\psi)$ uses the power attenuation
+coefficient $m$ from the standard's Table 1, resolved by the
+`air_condition` strings (temperature and relative-humidity class, derived
+from ISO 9613-1); it only matters above 1 kHz and grows with the volume.
+
+**Validity limits (clause 4.6).** The model assumes an ordinary,
+reasonably diffuse room: no dimension more than 5 times another, opposite
+surface pairs whose coefficients differ by less than a factor of 3 (unless
+scattering objects are present) and an object fraction below 0.2. Outside
+those limits the field is not diffuse and the model errs on the optimistic
+side: the standard's own accuracy clause records measured reverberation
+times up to twice the prediction in low-diffusivity rooms. The classical
+alternatives for those cases live in
+[Reverberation-time prediction](reverberation-prediction.md).
+
+## References
+
+- European Committee for Standardization. (2003). *Building acoustics —
+  Estimation of acoustic performance of buildings from the performance of
+  elements — Part 6: Sound absorption in enclosed spaces*
+  (EN 12354-6:2003).
+  [BSI Knowledge record (BS EN 12354-6:2003)](https://knowledge.bsigroup.com/products/building-acoustics-estimation-of-acoustic-performance-of-buildings-from-the-performance-of-elements-sound-absorption-in-enclosed-spaces).
+  The Clause 4 model, its input-data rules and its validity limits.
+- International Organization for Standardization. (2003). *Acoustics —
+  Measurement of sound absorption in a reverberation room* (ISO 354:2003).
+  [iso.org catalogue](https://www.iso.org/standard/34545.html).
+  The laboratory measurement the surface and array coefficients come from.
+- Kuttruff, H. (2016). *Room acoustics* (6th ed.). CRC Press.
+  [doi:10.1201/9781315372150](https://doi.org/10.1201/9781315372150).
+  The statistical reverberation theory the standard's formulae specialise.
+
 ---
 
 **Standards.** EN 12354-6:2003, *Building acoustics — Estimation of acoustic

--- a/docs/enclosed-space-absorption.md
+++ b/docs/enclosed-space-absorption.md
@@ -144,6 +144,12 @@ absorption alone would.
 coefficient $m$ from the standard's Table 1, resolved by the
 `air_condition` strings (temperature and relative-humidity class, derived
 from ISO 9613-1); it only matters above 1 kHz and grows with the volume.
+The six built-in profiles, `"10C_30-50"` through `"20C_70-90"` (clause 4.3
+recommends `"20C_50-70"` when no conditions are specified), cover the
+standard 125 Hz to 8 kHz octave bands only and cannot be combined with a
+custom frequency axis; `air_condition=None` (the default) omits the air
+term, and for other frequencies or conditions compute $m$ per ISO 9613-1
+and chain `air_absorption_area` into `equivalent_absorption_area`.
 
 **Validity limits (clause 4.6).** The model assumes an ordinary,
 reasonably diffuse room: no dimension more than 5 times another, opposite

--- a/docs/references.md
+++ b/docs/references.md
@@ -198,6 +198,12 @@ it; the list grows as guides gain their References sections.
   [doi:10.1121/1.2369239](https://doi.org/10.1121/1.2369239).
   The original NC curves and their speech-interference rationale.
   Cited by [Room-noise criteria](room-noise.md).
+- Kosten, C. W., & van Os, G. J. (1962). Community reaction criteria for
+  external noises. In *The Control of Noise* (National Physical Laboratory
+  Symposium No. 12, pp. 373-387). Her Majesty's Stationery Office.
+  [Open Library record](https://openlibrary.org/books/OL58781133M).
+  The NR curve family contrasted with NC.
+  Cited by [Room-noise criteria](room-noise.md).
 - Blazier, W. E. (1997). RC Mark II: A refined procedure for rating the
   noise of heating, ventilating, and air-conditioning (HVAC) systems in
   buildings. *Noise Control Engineering Journal*, 45(6), 243-250.
@@ -245,7 +251,8 @@ it; the list grows as guides gain their References sections.
 - Acoustical Society of America. (2019). *Criteria for evaluating room
   noise* (ANSI/ASA S12.2-2019).
   [ANSI webstore](https://webstore.ansi.org/standards/asa/ansiasas122019).
-  The NC tangency method and the RC Mark II rating with its spectral tag.
+  The normative NC tangency method and the RC Mark II rating of its
+  informative Annex D, with its spectral tag.
   Cited by [Room-noise criteria](room-noise.md).
 
 ## Building acoustics

--- a/docs/references.md
+++ b/docs/references.md
@@ -134,6 +134,120 @@ it; the list grows as guides gain their References sections.
   residual pressure-intensity index.
   Cited by [Sound Intensity (p-p)](intensity.md).
 
+## Room acoustics
+
+- Kuttruff, H. (2016). *Room acoustics* (6th ed.). CRC Press.
+  [doi:10.1201/9781315372150](https://doi.org/10.1201/9781315372150).
+  The reference monograph on sound fields in rooms: statistical decay
+  theory, the Schroeder frequency, absorption and the perceptual room
+  parameters.
+  Cited by [Room Acoustics](room-acoustics.md),
+  [Reverberation-time prediction](reverberation-prediction.md) and
+  [Sound absorption in enclosed spaces](enclosed-space-absorption.md).
+- Sabine, W. C. (1922). *Collected papers on acoustics*. Harvard University
+  Press.
+  [Free scan at the Internet Archive](https://archive.org/details/collectedpaperso00sabi).
+  The founding reverberation experiments and the Sabine law.
+  Cited by [Reverberation-time prediction](reverberation-prediction.md).
+- Eyring, C. F. (1930). Reverberation time in "dead" rooms. *The Journal of
+  the Acoustical Society of America*, 1(2A), 217-241.
+  [doi:10.1121/1.1915175](https://doi.org/10.1121/1.1915175).
+  The mean-free-path reverberation formula for strongly absorbing rooms.
+  Cited by [Reverberation-time prediction](reverberation-prediction.md).
+- Millington, G. (1932). A modified formula for reverberation. *The Journal
+  of the Acoustical Society of America*, 4(1), 69-82.
+  [doi:10.1121/1.1915588](https://doi.org/10.1121/1.1915588).
+  The per-surface logarithmic reverberation formula.
+  Cited by [Reverberation-time prediction](reverberation-prediction.md).
+- Fitzroy, D. (1959). Reverberation formula which seems to be more accurate
+  with nonuniform distribution of absorption. *The Journal of the
+  Acoustical Society of America*, 31(7), 893-897.
+  [doi:10.1121/1.1907814](https://doi.org/10.1121/1.1907814).
+  The axial reverberation formula for anisotropic absorption.
+  Cited by [Reverberation-time prediction](reverberation-prediction.md).
+- Arau-Puchades, H. (1988). An improved reverberation formula. *Acustica*,
+  65(4), 163-180.
+  [Publisher record at Ingenta](https://www.ingentaconnect.com/content/dav/aaua/1988/00000065/00000004/art00003).
+  The geometric-mean refinement of the axial reverberation formula.
+  Cited by [Reverberation-time prediction](reverberation-prediction.md).
+- Schroeder, M. R. (1965). New method of measuring reverberation time.
+  *The Journal of the Acoustical Society of America*, 37(3), 409-412.
+  [doi:10.1121/1.1909343](https://doi.org/10.1121/1.1909343).
+  The backward integration of the squared impulse response into a decay
+  curve.
+  Cited by [Room Acoustics](room-acoustics.md).
+- Hak, C. C. J. M., Wenmaekers, R. H. C., & van Luxemburg, L. C. J. (2012).
+  Measuring room impulse responses: Impact of the decay range on derived
+  room acoustic parameters. *Acta Acustica united with Acustica*, 98(6),
+  907-915. [doi:10.3813/aaa.918574](https://doi.org/10.3813/aaa.918574).
+  The impulse-to-noise-ratio (INR) analysis of decay-range requirements.
+  Cited by [Room Acoustics](room-acoustics.md).
+- Everest, F. A. (2001). *Master handbook of acoustics* (4th ed.).
+  McGraw-Hill. ISBN 978-0-07-136097-5.
+  [Open Library record](https://openlibrary.org/isbn/9780071360975).
+  A practical room-acoustics handbook; its Fig. 7-22 worked example anchors
+  the reverberation-prediction conformance suite.
+  Cited by [Reverberation-time prediction](reverberation-prediction.md).
+- Carrión Isbert, A. (1998). *Diseño acústico de espacios arquitectónicos*.
+  Edicions UPC. ISBN 978-84-8301-252-9.
+  [Open Library record](https://openlibrary.org/books/OL23159935M).
+  A Spanish-language textbook on acoustic room design.
+  Cited by [Reverberation-time prediction](reverberation-prediction.md).
+- Beranek, L. L. (1957). Revised criteria for noise in buildings. *Noise
+  Control*, 3(1), 19-27.
+  [doi:10.1121/1.2369239](https://doi.org/10.1121/1.2369239).
+  The original NC curves and their speech-interference rationale.
+  Cited by [Room-noise criteria](room-noise.md).
+- Blazier, W. E. (1997). RC Mark II: A refined procedure for rating the
+  noise of heating, ventilating, and air-conditioning (HVAC) systems in
+  buildings. *Noise Control Engineering Journal*, 45(6), 243-250.
+  [doi:10.3397/1.2828446](https://doi.org/10.3397/1.2828446).
+  The RC Mark II procedure later codified by ANSI/ASA S12.2 Annex D.
+  Cited by [Room-noise criteria](room-noise.md).
+- International Organization for Standardization. (2009). *Acoustics —
+  Measurement of room acoustic parameters — Part 1: Performance spaces*
+  (ISO 3382-1:2009).
+  [iso.org catalogue](https://www.iso.org/standard/40979.html).
+  Room-parameter definitions, position requirements and just-noticeable
+  differences.
+  Cited by [Room Acoustics](room-acoustics.md).
+- International Organization for Standardization. (2008). *Acoustics —
+  Measurement of room acoustic parameters — Part 2: Reverberation time in
+  ordinary rooms* (ISO 3382-2:2008).
+  [iso.org catalogue](https://www.iso.org/standard/36201.html).
+  The accuracy grades and position counts of reverberation measurement.
+  Cited by [Room Acoustics](room-acoustics.md).
+- International Organization for Standardization. (2012). *Acoustics —
+  Measurement of room acoustic parameters — Part 3: Open plan offices*
+  (ISO 3382-3:2012).
+  [iso.org catalogue](https://www.iso.org/standard/46520.html).
+  The open-plan speech-privacy quantities.
+  Cited by [Room Acoustics](room-acoustics.md).
+- International Organization for Standardization. (2006). *Acoustics —
+  Application of new measurement methods in building and room acoustics*
+  (ISO 18233:2006).
+  [iso.org catalogue](https://www.iso.org/standard/40408.html).
+  The swept-sine and MLS acquisition of impulse responses.
+  Cited by [Room Acoustics](room-acoustics.md).
+- International Organization for Standardization. (2003). *Acoustics —
+  Measurement of sound absorption in a reverberation room* (ISO 354:2003).
+  [iso.org catalogue](https://www.iso.org/standard/34545.html).
+  The reverberation-room absorption measurement behind the surface data.
+  Cited by [Room Acoustics](room-acoustics.md) and
+  [Sound absorption in enclosed spaces](enclosed-space-absorption.md).
+- European Committee for Standardization. (2003). *Building acoustics —
+  Estimation of acoustic performance of buildings from the performance of
+  elements — Part 6: Sound absorption in enclosed spaces*
+  (EN 12354-6:2003).
+  [BSI Knowledge record (BS EN 12354-6:2003)](https://knowledge.bsigroup.com/products/building-acoustics-estimation-of-acoustic-performance-of-buildings-from-the-performance-of-elements-sound-absorption-in-enclosed-spaces).
+  The absorption member of the EN 12354 prediction family.
+  Cited by [Sound absorption in enclosed spaces](enclosed-space-absorption.md).
+- Acoustical Society of America. (2019). *Criteria for evaluating room
+  noise* (ANSI/ASA S12.2-2019).
+  [ANSI webstore](https://webstore.ansi.org/standards/asa/ansiasas122019).
+  The NC tangency method and the RC Mark II rating with its spectral tag.
+  Cited by [Room-noise criteria](room-noise.md).
+
 ## Building acoustics
 
 - Hopkins, C. (2007). *Sound insulation*. Butterworth-Heinemann.

--- a/docs/reverberation-prediction.md
+++ b/docs/reverberation-prediction.md
@@ -57,8 +57,8 @@ For a **uniform** distribution Eyring and Millington-Sette coincide, and both
 fall below Sabine — Sabine's over-estimate at high absorption is the reason
 Eyring exists. As $\alpha \to 0$, $-S\ln(1-\bar\alpha) \to \sum_i S_i\alpha_i$
 and Eyring reduces to Sabine. Air absorption enters every model through the
-power-attenuation coefficient $m$ (in neper per metre, from
-[atmospheric absorption](room-acoustics.md)):
+power-attenuation coefficient $m$ (in neper per metre, from the ISO 9613-1
+[atmospheric absorption](outdoor-propagation.md)):
 
 ```python
 import phonometry as ph
@@ -157,21 +157,115 @@ plt.show()
 
 </details>
 
+## 4. Choosing a model, and when every model fails
+
+The five formulae are not rivals on a single axis of accuracy; each has a
+domain of validity:
+
+- **Sabine** is the tool for live rooms with low, reasonably even
+  absorption (mean $\bar\alpha$ up to roughly 0.2): classrooms, halls,
+  reverberation chambers. It is also the convention wired into measurement
+  practice, because the ISO 354 absorption coefficient is *defined* through
+  Sabine's formula, so feeding reverberation-room data back into Sabine is
+  self-consistent even where the formula is strained. Its structural defect
+  shows at high absorption: with $\alpha = 1$ on every surface (an opening
+  in every direction) it still predicts a finite reverberation time.
+- **Eyring** is the choice for evenly treated rooms with substantial
+  absorption: studios, treated offices, listening rooms. It reaches
+  $T = 0$ for total absorption, and its correction over Sabine grows with
+  $\bar\alpha$ (about 10 % shorter at $\bar\alpha = 0.2$, 30 % at 0.5).
+- **Millington-Sette** handles a mix of very absorptive and hard surfaces
+  better than a single mean, but it is meant for measured, sub-unity
+  coefficients: a single surface with $\alpha_i = 1$ drives the whole
+  prediction to zero. Reverberation-room coefficients above 1.0 (a
+  documented ISO 354 outcome, see the absorption section of
+  [Room Acoustics](room-acoustics.md)) must be capped below 1 before any of
+  the logarithmic models can even be evaluated.
+- **Fitzroy** and **Arau-Puchades** target shoebox rooms whose absorption
+  is concentrated on one axis, the typical office or dwelling with a soft
+  floor and ceiling between hard walls. Arau's geometric mean tempers
+  Fitzroy's known over-prediction when one wall pair is very reflective.
+
+**When every formula fails.** All five inherit the same assumption: a
+diffuse field, with sound arriving equally from all directions at every
+point, that stays diffuse while it decays. The common breakages:
+
+- **Below the Schroeder frequency** the band holds a handful of discrete
+  modes (the animation in §1) and a statistical reverberation time is not
+  defined at all; each mode decays at its own rate set by the wall
+  impedances it actually touches.
+- **Coupled volumes** (a hall with an open stage house, two rooms through a
+  doorway) produce double-slope decays; no single $T$ exists, and the
+  measured T20 and T30 disagree (the curvature diagnostic of
+  [Room Acoustics](room-acoustics.md)).
+- **Disproportionate rooms** (corridors, low flat halls) with the
+  absorption on one surface pair keep a grazing sound field parallel to the
+  hard surfaces that the absorber barely touches; the measured time can be
+  up to twice any statistical prediction, the practical experience recorded
+  in EN 12354-6 (see
+  [Sound absorption in enclosed spaces](enclosed-space-absorption.md)).
+- **Focusing geometries** (domes, curved rear walls) concentrate late
+  energy instead of mixing it, producing position-dependent decays no
+  single-number formula can represent.
+
+Scattering objects restore the mixing the models assume: a furnished room
+follows the statistical prediction distinctly better than the same room
+bare, beyond what the furniture's own absorption area accounts for. In
+practice, quote a *band* of predictions (Sabine and Eyring, or Fitzroy and
+Arau-Puchades for axial cases) rather than a single value; where the models
+spread, the room is telling you its field is not diffuse.
+
+## References
+
+- Sabine, W. C. (1922). *Collected papers on acoustics*. Harvard University
+  Press. [Free scan at the Internet Archive](https://archive.org/details/collectedpaperso00sabi).
+  The original reverberation experiments and the $T = 0.161\,V/A$ law of §1.
+- Eyring, C. F. (1930). Reverberation time in "dead" rooms. *The Journal of
+  the Acoustical Society of America*, 1(2A), 217-241.
+  [doi:10.1121/1.1915175](https://doi.org/10.1121/1.1915175).
+  The mean-free-path derivation behind the $-S\ln(1-\bar\alpha)$ term of §1.
+- Millington, G. (1932). A modified formula for reverberation. *The Journal
+  of the Acoustical Society of America*, 4(1), 69-82.
+  [doi:10.1121/1.1915588](https://doi.org/10.1121/1.1915588).
+  The per-surface logarithmic absorption term of §1.
+- Fitzroy, D. (1959). Reverberation formula which seems to be more accurate
+  with nonuniform distribution of absorption. *The Journal of the
+  Acoustical Society of America*, 31(7), 893-897.
+  [doi:10.1121/1.1907814](https://doi.org/10.1121/1.1907814).
+  The axial split into three wall-pair decays of §2.
+- Arau-Puchades, H. (1988). An improved reverberation formula. *Acustica*,
+  65(4), 163-180.
+  [Publisher record at Ingenta](https://www.ingentaconnect.com/content/dav/aaua/1988/00000065/00000004/art00003).
+  The geometric-mean combination of §2 (its Formula 18).
+- Kuttruff, H. (2016). *Room acoustics* (6th ed.). CRC Press.
+  [doi:10.1201/9781315372150](https://doi.org/10.1201/9781315372150).
+  The diffuse-field theory, its limits and the modern assessment of the
+  classical formulae behind §4.
+- Everest, F. A. (2001). *Master handbook of acoustics* (4th ed.).
+  McGraw-Hill. ISBN 978-0-07-136097-5.
+  [Open Library record](https://openlibrary.org/isbn/9780071360975).
+  The Fig. 7-22 worked example the conformance suite reproduces.
+- Carrión Isbert, A. (1998). *Diseño acústico de espacios arquitectónicos*.
+  Edicions UPC. ISBN 978-84-8301-252-9.
+  [Open Library record](https://openlibrary.org/books/OL23159935M).
+  A Spanish-language textbook treatment of the reverberation models and
+  their use in room design.
+
 ---
 
-**References.** W. C. Sabine, *Collected Papers on Acoustics* (1922); C. F.
-Eyring, "Reverberation time in 'dead' rooms", *J. Acoust. Soc. Am.* **1** (1930)
-217; G. Millington, "A modified formula for reverberation", *J. Acoust. Soc.
-Am.* **4** (1932) 69; D. Fitzroy, "Reverberation formula which seems to be more
-accurate with nonuniform distribution of absorption", *J. Acoust. Soc. Am.*
-**31** (1959) 893; H. Arau-Puchades, "An improved reverberation formula",
-*Acustica* **65** (1988) 163 (Formula 18). Textbook treatments: A. Carrión
-Isbert, *Diseño acústico de espacios arquitectónicos* (1998); F. A. Everest &
-K. C. Pohlmann, *Master Handbook of Acoustics*, 4th ed. Air absorption follows
-ISO 9613-1:1993 (see [Room Acoustics](room-acoustics.md)). The conformance suite
-is anchored on a **real worked example** — Everest's Fig. 7-22 Example 1
-(an untreated 23.3 × 16 × 10 ft room), whose six printed Sabine reverberation
-times the SI implementation reproduces to ≤ 0.02 s — reinforced by hand-computed
-closed-form values and the model identities (every model collapses to Eyring for
-uniform absorption; Eyring collapses to Sabine as $\alpha \to 0$), which
-transitively carry that real-data anchor to the whole family.
+**Standards.** The classical reverberation formulae predate the normative
+world; they enter it through EN 12354-6:2003, whose Clause 4 model is a
+Sabine calculation with object and air terms (see
+[Sound absorption in enclosed spaces](enclosed-space-absorption.md)), and
+through ISO 354:2003, which defines the measured absorption coefficient via
+Sabine's formula. Air absorption follows ISO 9613-1:1993, *Acoustics —
+Attenuation of sound during propagation outdoors — Part 1: Calculation of
+the absorption of sound by the atmosphere* (see
+[Outdoor propagation](outdoor-propagation.md)). The conformance suite is
+anchored on a real worked example, Everest's Fig. 7-22 Example 1 (an
+untreated 23.3 × 16 × 10 ft room), whose six printed Sabine reverberation
+times the SI implementation reproduces to ≤ 0.02 s, reinforced by
+hand-computed closed-form values and the model identities (every model
+collapses to Eyring for uniform absorption; Eyring collapses to Sabine as
+$\alpha \to 0$), which transitively carry that real-data anchor to the
+whole family.

--- a/docs/reverberation-prediction.md
+++ b/docs/reverberation-prediction.md
@@ -177,10 +177,14 @@ domain of validity:
 - **Millington-Sette** handles a mix of very absorptive and hard surfaces
   better than a single mean, but it is meant for measured, sub-unity
   coefficients: a single surface with $\alpha_i = 1$ drives the whole
-  prediction to zero. Reverberation-room coefficients above 1.0 (a
+  prediction to zero. Reverberation-room coefficients at or above 1.0 (a
   documented ISO 354 outcome, see the absorption section of
-  [Room Acoustics](room-acoustics.md)) must be capped below 1 before any of
-  the logarithmic models can even be evaluated.
+  [Room Acoustics](room-acoustics.md)) lie outside the domain of the
+  logarithmic models, whose $\ln(1-\alpha)$ is undefined there, and
+  phonometry rejects them for every formula in this module. Bringing such
+  a coefficient into $[0, 1)$ is a modelling decision the formulas do not
+  prescribe: whatever adjustment you choose (limiting just below 1 is
+  common), record it alongside the prediction.
 - **Fitzroy** and **Arau-Puchades** target shoebox rooms whose absorption
   is concentrated on one axis, the typical office or dwelling with a soft
   floor and ceiling between hard walls. Arau's geometric mean tempers

--- a/docs/room-acoustics.md
+++ b/docs/room-acoustics.md
@@ -169,15 +169,43 @@ plt.xlabel("Time [s]"); plt.ylabel("Level re peak [dB]")
 reported room parameter is the spatial average over several. ISO 3382-1
 (performance spaces) asks for at least two source positions and microphones
 spaced $\geq 2$ m apart, $\geq 1$ m from any surface, at $1.2$ m
-(seated-ear) height, avoiding symmetric placements; ISO 3382-2 fixes the
-minimum number of source, microphone and source–microphone combinations per
-accuracy grade (survey / engineering / precision).
+(seated-ear) height; ISO 3382-2 fixes the minimum number of source,
+microphone and source–microphone combinations per accuracy grade
+(survey / engineering / precision) and asks for microphone positions that
+avoid symmetric placements.
 
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_room_measurement_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_room_measurement.svg" alt="Room-acoustics measurement setup: a top-view room plan with two loudspeaker source positions and six microphone positions with the ISO 3382-1 spacing rules, and the ISO 3382-2 table of minimum positions for the survey, engineering and precision grades" width="94%"></picture>
 
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_comb_filtering_dark.gif"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_comb_filtering.gif" alt="Animation: as the microphone height changes, the delay between the direct sound and the floor reflection shifts and the comb filter in the frequency response moves with it, which is why measurement position matters near reflecting surfaces" width="640" height="360" loading="lazy"></picture>
 
 [Watch the high-resolution video (WebM)](https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_comb_filtering.webm)
+
+**Averaging across positions.** The reported per-band parameter is the
+arithmetic mean over all source-microphone combinations, and the spread
+across positions is part of the answer, not noise: quote it alongside the
+mean whenever it exceeds the parameter's JND (§2), because a room can meet a
+target on average while individual seats sit far outside it. Four placement
+mistakes bias the mean itself:
+
+- **Correlated positions.** Microphones closer than 2 m to each other
+  sample nearly the same sound field twice, so the average looks more
+  stable than it is. The 1 m minimum from any surface likewise avoids the
+  pressure build-up near a boundary (and the comb filter of the animation
+  above) that colours everything a too-close microphone records.
+- **Symmetric placements.** In a geometrically symmetric room, mirror-image
+  positions receive mirror-image reflection patterns; averaging them adds
+  no new information. This is why ISO 3382-2 asks for positions that do not
+  sit on symmetry lines.
+- **Too close to the source.** Inside the direct field EDT collapses and
+  C80 saturates upward no matter what the room does. ISO 3382-2 therefore
+  keeps every microphone at least $d_{min} = 2\sqrt{V/(c\,\hat T)}$ from
+  the source, with $\hat T$ an estimate of the expected reverberation time
+  (about 2.2 m for a 200 m³ classroom with an expected 0.5 s).
+- **Low-frequency luck.** Below the Schroeder frequency (§2) each band
+  holds only a handful of room modes, and a microphone on a node of one of
+  them sees a different decay than a microphone on an antinode. The spread
+  of the 63-125 Hz bands across positions is structurally larger; the cure
+  is more positions, not a longer excitation.
 
 ### `sweep_signal()` / `inverse_filter()` parameters
 
@@ -305,6 +333,47 @@ plt.show()
 For this single-slope decay EDT, T20 and T30 all return ≈ 1.0 s, and the
 energy parameters match their closed forms (C80 = 3.05 dB, D50 = 0.499,
 Ts = 72 ms). A real room has a steeper early slope, so EDT < T30.
+
+**Reading EDT, T20 and T30 against each other.** The three times
+extrapolate the same 60 dB decay from different windows, so their
+disagreement carries information:
+
+- **T20 ≈ T30** (curvature below 10 %): the decay is a single straight
+  slope, the diffuse-field picture holds, and either time can stand for
+  "the" reverberation time of the band.
+- **T30 > T20** (curvature above 10 %): the decay sags, with late energy
+  decaying more slowly than early energy. The usual causes are coupled
+  volumes (an open door to a corridor or stairwell, a deep balcony or a
+  stage house feeding energy back) and strongly uneven absorption that
+  leaves one room axis reverberant. No single number describes such a
+  decay: report both windows together with the curvature, and treat the
+  [statistical predictions](reverberation-prediction.md) with suspicion,
+  because their diffuse-field assumption has visibly failed.
+- **EDT far from T20/T30**: EDT is fitted where the direct sound and the
+  first reflections still dominate, so it varies from seat to seat while
+  T30 barely moves. EDT below T30 means the position receives strong early
+  energy (close to the source, under a reflector): the room sounds drier
+  there than its T30 suggests, because perceived reverberance follows EDT.
+  EDT above T30 at one seat points to an echo or a focusing surface
+  concentrating late energy there.
+
+**How much decay the noise floor allows.** A fit window is only as good as
+the decay range underneath it. The **impulse-to-noise ratio** (INR) is the
+level distance between the peak of the band-filtered IR and its noise
+floor; the fit window plus a safety margin must fit inside it, which is the
+ISO 3382 requirement of at least 35 dB of usable decay range for T20 and
+45 dB for T30. An undersized range biases the fitted time upward, toward
+the flat tail the noise floor imposes on the decay curve, and the bias
+grows quietly before the fit visibly fails (Hak, Wenmaekers, & van
+Luxemburg, 2012). `room_parameters` reports the per-band `dynamic_range`
+and tightens the acceptance limits to 46 dB (T20) and 54 dB (T30) before
+flagging a value valid, so the residual truncation-and-compensation bias of
+a flagged-valid time stays inside the 5 % JND. When a band fails its flag,
+the order of remedies is: use T20 instead of T30 (its window needs 10 dB
+less range under the ISO minima, 8 dB under the tightened flags); raise the
+INR at acquisition, since doubling the sweep length or
+the number of synchronous averages buys 3 dB each time; and only then fall
+back to EDT, never to a fit stretched into the noise.
 
 Below the **Schroeder frequency** $f_s \approx 2000\sqrt{T/V}$ these
 decay statistics stop telling the whole story: the field is ruled by
@@ -516,6 +585,51 @@ shape of `t60`; `absorption_coefficient()` returns `alpha_s`;
 - [Theory](theory-rooms-buildings.md) — Schroeder integration, regression windows and the
   reference-curve derivation.
 - API reference: [`room.room_acoustics`](https://jmrplens.github.io/phonometry/reference/api/rooms/room-acoustics/), [`room.room_ir`](https://jmrplens.github.io/phonometry/reference/api/rooms/room-ir/) and [`room.open_plan`](https://jmrplens.github.io/phonometry/reference/api/rooms/open-plan/).
+
+## References
+
+- Kuttruff, H. (2016). *Room acoustics* (6th ed.). CRC Press.
+  [doi:10.1201/9781315372150](https://doi.org/10.1201/9781315372150).
+  The reference monograph behind this page: the statistical theory of
+  decaying sound fields, the Schroeder frequency and the perceptual room
+  parameters of §2.
+- Schroeder, M. R. (1965). New method of measuring reverberation time.
+  *The Journal of the Acoustical Society of America*, 37(3), 409-412.
+  [doi:10.1121/1.1909343](https://doi.org/10.1121/1.1909343).
+  The backward-integration method that turns the squared impulse response
+  into the smooth decay curve of §2.
+- Hak, C. C. J. M., Wenmaekers, R. H. C., & van Luxemburg, L. C. J. (2012).
+  Measuring room impulse responses: Impact of the decay range on derived
+  room acoustic parameters. *Acta Acustica united with Acustica*, 98(6),
+  907-915. [doi:10.3813/aaa.918574](https://doi.org/10.3813/aaa.918574).
+  The INR analysis behind the dynamic-range discussion and the tightened
+  validity flags of §2.
+- International Organization for Standardization. (2009). *Acoustics —
+  Measurement of room acoustic parameters — Part 1: Performance spaces*
+  (ISO 3382-1:2009).
+  [iso.org catalogue](https://www.iso.org/standard/40979.html).
+  The parameter definitions, position requirements and just-noticeable
+  differences of §2.
+- International Organization for Standardization. (2008). *Acoustics —
+  Measurement of room acoustic parameters — Part 2: Reverberation time in
+  ordinary rooms* (ISO 3382-2:2008).
+  [iso.org catalogue](https://www.iso.org/standard/36201.html).
+  The accuracy grades, position counts and the minimum source distance of
+  the position-averaging discussion in §1.
+- International Organization for Standardization. (2012). *Acoustics —
+  Measurement of room acoustic parameters — Part 3: Open plan offices*
+  (ISO 3382-3:2012).
+  [iso.org catalogue](https://www.iso.org/standard/46520.html).
+  The open-plan speech-privacy quantities of §3.
+- International Organization for Standardization. (2006). *Acoustics —
+  Application of new measurement methods in building and room acoustics*
+  (ISO 18233:2006).
+  [iso.org catalogue](https://www.iso.org/standard/40408.html).
+  The swept-sine and MLS acquisition of §1.
+- International Organization for Standardization. (2003). *Acoustics —
+  Measurement of sound absorption in a reverberation room* (ISO 354:2003).
+  [iso.org catalogue](https://www.iso.org/standard/34545.html).
+  The reverberation-room absorption measurement of §4.
 
 ---
 

--- a/docs/room-acoustics.md
+++ b/docs/room-acoustics.md
@@ -338,8 +338,9 @@ Ts = 72 ms). A real room has a steeper early slope, so EDT < T30.
 extrapolate the same 60 dB decay from different windows, so their
 disagreement carries information:
 
-- **T20 ≈ T30** (curvature below 10 %): the decay is a single straight
-  slope, the diffuse-field picture holds, and either time can stand for
+- **T20 ≈ T30** (curvature below 10 %): the decay is close to a single
+  straight slope over both evaluation windows, which is consistent with
+  (though not proof of) a diffuse field, and either time can stand for
   "the" reverberation time of the band.
 - **T30 > T20** (curvature above 10 %): the decay sags, with late energy
   decaying more slowly than early energy. The usual causes are coupled

--- a/docs/room-noise.md
+++ b/docs/room-noise.md
@@ -126,6 +126,64 @@ low-frequency noise (RNC, which needs a time series rather than a single
 spectrum) and the numeric quality-assessment index (QAI, which the standard
 defers to external references) are not part of this module.
 
+## 3. Choosing a criterion: NC, RC Mark II or NR
+
+The two ratings answer different questions, and a third family exists that
+this module deliberately does not implement:
+
+- **NC** answers *"does the room meet its limit, and which band breaks
+  it?"*. It is the compliance rating of North-American practice
+  (specifications, codes, equipment schedules), and the tangency method is
+  driven entirely by the single governing band. That is also its blind
+  spot: two NC-40 rooms can sound completely different, one rumbly and one
+  hissy, because tangency says nothing about spectral balance. Use NC when
+  a specification cites it, and always report the governing band with the
+  rating, since it names the octave any fix must attack first.
+- **RC Mark II** answers *"how does the room sound, and what should be
+  fixed?"*. Its rating tracks speech interference through the
+  mid-frequency average, and its reference slope of −5 dB per octave is
+  the spectrum occupants describe as neutral, a bland ventilation
+  background that is neither boomy nor sharp. The spectral tag then points
+  at the offending frequency range. Reach for RC Mark II at HVAC design
+  time, or to diagnose an installation that fails its NC limit.
+- **NR (Noise Rating)** is the European counterpart of NC: the same
+  tangency logic over a slightly different curve family (more permissive
+  at low frequency, stricter at high), common in European and
+  international equipment and building specifications. phonometry does not
+  implement NR; when a specification cites NR, rate against the NR curves
+  themselves rather than substituting NC, because the two families diverge
+  by several decibels away from the mid frequencies.
+
+**Reading the tag.** The RC Mark II tag is a repair hint, not just a label.
+A rumble tag (`R`, more than 5 dB over the reference at or below 500 Hz)
+points at the air-handling plant: an oversized or starved fan, duct
+rumble, or structure-borne vibration re-radiated by walls, and it is the
+low-frequency energy that rattles lightweight construction and fatigues
+occupants. A hiss tag (`H`, more than 3 dB over at or above 1000 Hz)
+points at the terminal end: diffuser and grille face velocities or a
+throttled damper close to the outlet, and it is the range that masks
+speech. A neutral tag (`N`) means the level can still be wrong, but the
+character is right: reduce the whole spectrum rather than reshape it.
+
+## References
+
+- Beranek, L. L. (1957). Revised criteria for noise in buildings. *Noise
+  Control*, 3(1), 19-27.
+  [doi:10.1121/1.2369239](https://doi.org/10.1121/1.2369239).
+  The paper that introduced the NC curves and the speech-interference
+  reasoning behind them.
+- Blazier, W. E. (1997). RC Mark II: A refined procedure for rating the
+  noise of heating, ventilating, and air-conditioning (HVAC) systems in
+  buildings. *Noise Control Engineering Journal*, 45(6), 243-250.
+  [doi:10.3397/1.2828446](https://doi.org/10.3397/1.2828446).
+  The refined RC procedure, with its neutral-spectrum rationale and the
+  rumble/hiss regions, that ANSI/ASA S12.2 Annex D codifies.
+- Acoustical Society of America. (2019). *Criteria for evaluating room
+  noise* (ANSI/ASA S12.2-2019).
+  [ANSI webstore](https://webstore.ansi.org/standards/asa/ansiasas122019).
+  The normative NC curves, tangency method and RC Mark II procedure this
+  module implements.
+
 ---
 
 **Standards.** ANSI/ASA S12.2-2019, *Criteria for Evaluating Room Noise* — the

--- a/docs/room-noise.md
+++ b/docs/room-noise.md
@@ -146,8 +146,9 @@ this module deliberately does not implement:
   background that is neither boomy nor sharp. The spectral tag then points
   at the offending frequency range. Reach for RC Mark II at HVAC design
   time, or to diagnose an installation that fails its NC limit.
-- **NR (Noise Rating)** is the European counterpart of NC: the same
-  tangency logic over a slightly different curve family (more permissive
+- **NR (Noise Rating)**, the curve family of Kosten & van Os (1962), is
+  the European counterpart of NC: the same tangency logic over a
+  slightly different curve family (more permissive
   at low frequency, stricter at high), common in European and
   international equipment and building specifications. phonometry does not
   implement NR; when a specification cites NR, rate against the NR curves
@@ -172,6 +173,12 @@ character is right: reduce the whole spectrum rather than reshape it.
   [doi:10.1121/1.2369239](https://doi.org/10.1121/1.2369239).
   The paper that introduced the NC curves and the speech-interference
   reasoning behind them.
+- Kosten, C. W., & van Os, G. J. (1962). Community reaction criteria for
+  external noises. In *The Control of Noise* (National Physical Laboratory
+  Symposium No. 12, pp. 373-387). Her Majesty's Stationery Office.
+  [Open Library record](https://openlibrary.org/books/OL58781133M).
+  The paper that introduced the NR curve family the text contrasts
+  with NC.
 - Blazier, W. E. (1997). RC Mark II: A refined procedure for rating the
   noise of heating, ventilating, and air-conditioning (HVAC) systems in
   buildings. *Noise Control Engineering Journal*, 45(6), 243-250.
@@ -181,12 +188,12 @@ character is right: reduce the whole spectrum rather than reshape it.
 - Acoustical Society of America. (2019). *Criteria for evaluating room
   noise* (ANSI/ASA S12.2-2019).
   [ANSI webstore](https://webstore.ansi.org/standards/asa/ansiasas122019).
-  The normative NC curves, tangency method and RC Mark II procedure this
-  module implements.
+  The normative NC curves and tangency method, plus the RC Mark II
+  procedure of its informative Annex D, that this module implements.
 
 ---
 
 **Standards.** ANSI/ASA S12.2-2019, *Criteria for Evaluating Room Noise* — the
-NC curves and the tangency method (Table 1), and the RC Mark II curves
-(Annex D, Table D.1), the mid-frequency-average rating (clause D.4) and the
-neutral/rumble/hiss spectral tag (clause D.3).
+normative NC curves and tangency method (Table 1), and, from the informative
+Annex D, the RC Mark II curves (Table D.1), the mid-frequency-average rating
+(clause D.4) and the neutral/rumble/hiss spectral tag (clause D.3).

--- a/site/src/content/docs/es/guides/enclosed-space-absorption.md
+++ b/site/src/content/docs/es/guides/enclosed-space-absorption.md
@@ -119,6 +119,66 @@ reverberación medido en
 (ISO 3382) y de la absorción en cámara reverberante de
 [Materiales acústicos](/phonometry/es/guides/materials/) (ISO 354).
 
+## 3. De dónde salen los datos de entrada
+
+**Coeficientes de superficie.** La norma espera que los $\alpha_{s,i}$
+procedan de mediciones de laboratorio según EN ISO 354, el método de sala
+reverberante de
+[Materiales acústicos](/phonometry/es/guides/materials/); se admiten
+valores teóricos, empíricos o de campo siempre que se declare la fuente de
+los datos. ISO 354 entrega datos en tercios de octava, y un cálculo en
+bandas de octava toma como entrada la media aritmética de los tres tercios.
+Un coeficiente de sala reverberante puede superar 1,0 (la difracción de
+borde dispersa hacia la muestra más energía de la que intercepta su área
+plana); entra en la Fórmula 1 tal como se midió, sin recorte, porque la
+misma convención de campo difuso que lo produjo es la que asume el modelo.
+
+**Mobiliario y ocupantes.** Los objetos contribuyen por tres vías: un área
+de absorción equivalente medida $A_{obj}$ cuando existe (personas y
+asientos tienen valores tabulados en el Anexo C informativo), la estimación
+de la Fórmula 4 $V_{obj}^{2/3}$ para objetos duros, irregulares y sin
+medir (mobiliario, maquinaria), y los *conjuntos* de objetos valorados como
+una superficie absorbente $\alpha_s S_k$ cuando muchos objetos similares
+cubren una zona (un público sentado, una estantería de almacén). Los objetos
+también desplazan aire: su volumen sumado entra en la fracción de objetos
+$\psi$ que acorta $T$ en la Fórmula 5 más allá de lo que haría su absorción
+sola.
+
+**Aire.** El término de aire $A_{air} = 4mV(1-\psi)$ usa el coeficiente de
+atenuación de potencia $m$ de la Tabla 1 de la norma, resuelto por las
+cadenas `air_condition` (clase de temperatura y humedad relativa, derivada
+de ISO 9613-1); solo importa por encima de 1 kHz y crece con el volumen.
+
+**Límites de validez (cláusula 4.6).** El modelo supone una sala corriente
+y razonablemente difusa: ninguna dimensión más de 5 veces otra, pares de
+superficies opuestas cuyos coeficientes difieran en menos de un factor 3
+(salvo que haya objetos difusores) y una fracción de objetos por debajo de
+0,2. Fuera de esos límites el campo no es difuso y el modelo yerra por el
+lado optimista: la propia cláusula de precisión de la norma registra
+tiempos de reverberación medidos de hasta el doble de la predicción en
+salas de baja difusividad. Las alternativas clásicas para esos casos viven
+en
+[Predicción del tiempo de reverberación](/phonometry/es/guides/reverberation-prediction/).
+
+## Referencias
+
+- European Committee for Standardization. (2003). *Building acoustics —
+  Estimation of acoustic performance of buildings from the performance of
+  elements — Part 6: Sound absorption in enclosed spaces*
+  (EN 12354-6:2003).
+  [Ficha en BSI Knowledge (BS EN 12354-6:2003)](https://knowledge.bsigroup.com/products/building-acoustics-estimation-of-acoustic-performance-of-buildings-from-the-performance-of-elements-sound-absorption-in-enclosed-spaces).
+  El modelo de la cláusula 4, sus reglas de datos de entrada y sus límites
+  de validez.
+- International Organization for Standardization. (2003). *Acoustics —
+  Measurement of sound absorption in a reverberation room* (ISO 354:2003).
+  [Catálogo iso.org](https://www.iso.org/standard/34545.html).
+  La medición de laboratorio de la que salen los coeficientes de
+  superficies y conjuntos.
+- Kuttruff, H. (2016). *Room acoustics* (6.ª ed.). CRC Press.
+  [doi:10.1201/9781315372150](https://doi.org/10.1201/9781315372150).
+  La teoría estadística de la reverberación que las fórmulas de la norma
+  especializan.
+
 ---
 
 **Normas.** EN 12354-6:2003, *Building acoustics — Estimation of acoustic

--- a/site/src/content/docs/es/guides/enclosed-space-absorption.md
+++ b/site/src/content/docs/es/guides/enclosed-space-absorption.md
@@ -122,16 +122,16 @@ reverberación medido en
 ## 3. De dónde salen los datos de entrada
 
 **Coeficientes de superficie.** La norma espera que los $\alpha_{s,i}$
-procedan de mediciones de laboratorio según EN ISO 354, el método de sala
+procedan de mediciones de laboratorio según EN ISO 354, el método de cámara
 reverberante de
 [Materiales acústicos](/phonometry/es/guides/materials/); se admiten
 valores teóricos, empíricos o de campo siempre que se declare la fuente de
 los datos. ISO 354 entrega datos en tercios de octava, y un cálculo en
 bandas de octava toma como entrada la media aritmética de los tres tercios.
-Un coeficiente de sala reverberante puede superar 1,0 (la difracción de
+Un coeficiente de cámara reverberante puede superar 1,0 (la difracción de
 borde dispersa hacia la muestra más energía de la que intercepta su área
 plana); entra en la Fórmula 1 tal como se midió, sin recorte, porque la
-misma convención de campo difuso que lo produjo es la que asume el modelo.
+misma convención de campo difuso que lo produjo es la que supone el modelo.
 
 **Mobiliario y ocupantes.** Los objetos contribuyen por tres vías: un área
 de absorción equivalente medida $A_{obj}$ cuando existe (personas y
@@ -148,6 +148,13 @@ sola.
 atenuación de potencia $m$ de la Tabla 1 de la norma, resuelto por las
 cadenas `air_condition` (clase de temperatura y humedad relativa, derivada
 de ISO 9613-1); solo importa por encima de 1 kHz y crece con el volumen.
+Los seis perfiles integrados, de `"10C_30-50"` a `"20C_70-90"` (la
+cláusula 4.3 recomienda `"20C_50-70"` cuando no se especifican
+condiciones), cubren solo las bandas de octava estándar de 125 Hz a 8 kHz
+y no pueden combinarse con un eje de frecuencias propio;
+`air_condition=None` (el valor por defecto) omite el término de aire, y
+para otras frecuencias o condiciones, calcula $m$ según ISO 9613-1 y
+encadena `air_absorption_area` con `equivalent_absorption_area`.
 
 **Límites de validez (cláusula 4.6).** El modelo supone una sala corriente
 y razonablemente difusa: ninguna dimensión más de 5 veces otra, pares de

--- a/site/src/content/docs/es/guides/reverberation-prediction.md
+++ b/site/src/content/docs/es/guides/reverberation-prediction.md
@@ -60,7 +60,8 @@ quedan por debajo de Sabine — la sobrestimación de Sabine con absorción alta
 la razón de ser de Eyring. Cuando $\alpha \to 0$, Eyring se reduce a Sabine. La
 absorción del aire entra en todos los modelos a través del coeficiente de
 atenuación de potencia $m$ (en neper por metro, de la
-[absorción atmosférica](/phonometry/es/guides/room-acoustics/)):
+[absorción atmosférica](/phonometry/es/guides/outdoor-propagation/) de
+ISO 9613-1):
 
 ```python
 import phonometry as ph
@@ -159,18 +160,130 @@ plt.show()
 
 </details>
 
+## 4. Elegir un modelo, y cuándo fallan todos
+
+Las cinco fórmulas no compiten en un único eje de precisión; cada una tiene
+su dominio de validez:
+
+- **Sabine** es la herramienta para salas vivas con absorción baja y
+  razonablemente repartida ($\bar\alpha$ media hasta aproximadamente 0,2):
+  aulas, salas de actos, salas reverberantes. Es además la convención
+  integrada en la práctica de medida, porque el coeficiente de absorción de
+  ISO 354 se *define* mediante la fórmula de Sabine, así que devolver datos
+  de sala reverberante a Sabine es autoconsistente incluso donde la fórmula
+  se tensa. Su defecto estructural aparece con absorción alta: con
+  $\alpha = 1$ en todas las superficies (una abertura en todas las
+  direcciones) sigue prediciendo un tiempo de reverberación finito.
+- **Eyring** es la elección para salas tratadas de forma uniforme con
+  absorción considerable: estudios, oficinas tratadas, salas de escucha.
+  Alcanza $T = 0$ con absorción total, y su corrección sobre Sabine crece
+  con $\bar\alpha$ (en torno a un 10 % más corto con $\bar\alpha = 0{,}2$,
+  un 30 % con 0,5).
+- **Millington-Sette** maneja una mezcla de superficies muy absorbentes y
+  duras mejor que una única media, pero está pensado para coeficientes
+  medidos por debajo de la unidad: una sola superficie con $\alpha_i = 1$
+  lleva toda la predicción a cero. Los coeficientes de sala reverberante
+  por encima de 1,0 (un resultado documentado de ISO 354, ver la sección de
+  absorción de [Acústica de salas](/phonometry/es/guides/room-acoustics/))
+  deben acotarse por debajo de 1 antes de poder siquiera evaluar los
+  modelos logarítmicos.
+- **Fitzroy** y **Arau-Puchades** apuntan a salas rectangulares con la
+  absorción concentrada en un eje, la oficina o vivienda típica con suelo y
+  techo blandos entre paredes duras. La media geométrica de Arau templa la
+  conocida sobrepredicción de Fitzroy cuando un par de paredes es muy
+  reflectante.
+
+**Cuándo fallan todas las fórmulas.** Las cinco heredan la misma hipótesis:
+un campo difuso, con sonido llegando por igual desde todas las direcciones
+en todos los puntos, que permanece difuso mientras decae. Las rupturas
+habituales:
+
+- **Por debajo de la frecuencia de Schroeder** la banda contiene un puñado
+  de modos discretos (la animación del §1) y un tiempo de reverberación
+  estadístico ni siquiera está definido; cada modo decae a su propio ritmo,
+  fijado por las impedancias de las paredes que realmente toca.
+- **Los volúmenes acoplados** (una sala con la caja escénica abierta, dos
+  recintos a través de una puerta) producen decaimientos de doble
+  pendiente; no existe un único $T$, y los T20 y T30 medidos discrepan (el
+  diagnóstico de curvatura de
+  [Acústica de salas](/phonometry/es/guides/room-acoustics/)).
+- **Las salas desproporcionadas** (pasillos, salas bajas y extensas) con la
+  absorción en un solo par de superficies mantienen un campo rasante
+  paralelo a las superficies duras que el absorbente apenas toca; el tiempo
+  medido puede llegar a duplicar cualquier predicción estadística, la
+  experiencia práctica recogida en EN 12354-6 (ver
+  [Absorción sonora en recintos](/phonometry/es/guides/enclosed-space-absorption/)).
+- **Las geometrías focalizantes** (cúpulas, paredes traseras curvas)
+  concentran la energía tardía en lugar de mezclarla, produciendo
+  decaimientos dependientes de la posición que ninguna fórmula de un solo
+  número puede representar.
+
+Los objetos difusores restauran la mezcla que los modelos suponen: una sala
+amueblada sigue la predicción estadística claramente mejor que la misma
+sala vacía, más allá de lo que explica el área de absorción propia del
+mobiliario. En la práctica, indica una *banda* de predicciones (Sabine y
+Eyring, o Fitzroy y Arau-Puchades en los casos axiales) en lugar de un
+único valor; donde los modelos se separan, la sala está diciendo que su
+campo no es difuso.
+
+## Referencias
+
+- Sabine, W. C. (1922). *Collected papers on acoustics*. Harvard University
+  Press. [Escaneo libre en Internet Archive](https://archive.org/details/collectedpaperso00sabi).
+  Los experimentos originales de reverberación y la ley $T = 0{,}161\,V/A$
+  del §1.
+- Eyring, C. F. (1930). Reverberation time in "dead" rooms. *The Journal of
+  the Acoustical Society of America*, 1(2A), 217-241.
+  [doi:10.1121/1.1915175](https://doi.org/10.1121/1.1915175).
+  La derivación por recorrido libre medio tras el término
+  $-S\ln(1-\bar\alpha)$ del §1.
+- Millington, G. (1932). A modified formula for reverberation. *The Journal
+  of the Acoustical Society of America*, 4(1), 69-82.
+  [doi:10.1121/1.1915588](https://doi.org/10.1121/1.1915588).
+  El término logarítmico de absorción por superficie del §1.
+- Fitzroy, D. (1959). Reverberation formula which seems to be more accurate
+  with nonuniform distribution of absorption. *The Journal of the
+  Acoustical Society of America*, 31(7), 893-897.
+  [doi:10.1121/1.1907814](https://doi.org/10.1121/1.1907814).
+  La división axial en tres decaimientos por pares de paredes del §2.
+- Arau-Puchades, H. (1988). An improved reverberation formula. *Acustica*,
+  65(4), 163-180.
+  [Ficha del editor en Ingenta](https://www.ingentaconnect.com/content/dav/aaua/1988/00000065/00000004/art00003).
+  La combinación por media geométrica del §2 (su Fórmula 18).
+- Kuttruff, H. (2016). *Room acoustics* (6.ª ed.). CRC Press.
+  [doi:10.1201/9781315372150](https://doi.org/10.1201/9781315372150).
+  La teoría del campo difuso, sus límites y la valoración moderna de las
+  fórmulas clásicas tras el §4.
+- Everest, F. A. (2001). *Master handbook of acoustics* (4.ª ed.).
+  McGraw-Hill. ISBN 978-0-07-136097-5.
+  [Ficha en Open Library](https://openlibrary.org/isbn/9780071360975).
+  El ejemplo resuelto de la Fig. 7-22 que reproduce la batería de
+  conformidad.
+- Carrión Isbert, A. (1998). *Diseño acústico de espacios arquitectónicos*.
+  Edicions UPC. ISBN 978-84-8301-252-9.
+  [Ficha en Open Library](https://openlibrary.org/books/OL23159935M).
+  Un tratamiento en español de los modelos de reverberación y su uso en el
+  diseño de salas.
+
 ---
 
-**Referencias.** W. C. Sabine, *Collected Papers on Acoustics* (1922); C. F.
-Eyring (1930); G. Millington (1932); D. Fitzroy, *J. Acoust. Soc. Am.* **31**
-(1959) 893; H. Arau-Puchades, «An improved reverberation formula», *Acustica*
-**65** (1988) 163 (Fórmula 18). Libros de texto: A. Carrión Isbert, *Diseño
-acústico de espacios arquitectónicos*; F. A. Everest y K. C. Pohlmann, *Master
-Handbook of Acoustics*, 4.ª ed. La absorción del aire sigue ISO 9613-1:1993. La
-batería de conformidad se ancla en un **ejemplo resuelto real** — el Ejemplo 1
-de la Fig. 7-22 de Everest, cuyos seis tiempos de reverberación de Sabine
-impresos reproduce la implementación SI con ≤ 0,02 s — reforzado por valores en
-forma cerrada calculados a mano y las identidades entre modelos.
+**Normas.** Las fórmulas clásicas de reverberación son anteriores al mundo
+normativo; entran en él a través de EN 12354-6:2003, cuyo modelo de la
+cláusula 4 es un cálculo de Sabine con términos de objetos y de aire (ver
+[Absorción sonora en recintos](/phonometry/es/guides/enclosed-space-absorption/)),
+y a través de ISO 354:2003, que define el coeficiente de absorción medido
+mediante la fórmula de Sabine. La absorción del aire sigue ISO 9613-1:1993,
+*Acoustics — Attenuation of sound during propagation outdoors — Part 1:
+Calculation of the absorption of sound by the atmosphere* (ver
+[Propagación en exteriores](/phonometry/es/guides/outdoor-propagation/)).
+La batería de conformidad se ancla en un ejemplo resuelto real, el
+Ejemplo 1 de la Fig. 7-22 de Everest (una sala sin tratar de
+23,3 × 16 × 10 ft), cuyos seis tiempos de reverberación de Sabine impresos
+reproduce la implementación SI con ≤ 0,02 s, reforzado por valores en forma
+cerrada calculados a mano y las identidades entre modelos (todo modelo
+colapsa a Eyring con absorción uniforme; Eyring colapsa a Sabine cuando
+$\alpha \to 0$), que trasladan transitivamente ese anclaje de datos reales
+a toda la familia.
 
 ## Véase también
 

--- a/site/src/content/docs/es/guides/reverberation-prediction.md
+++ b/site/src/content/docs/es/guides/reverberation-prediction.md
@@ -167,11 +167,11 @@ su dominio de validez:
 
 - **Sabine** es la herramienta para salas vivas con absorción baja y
   razonablemente repartida ($\bar\alpha$ media hasta aproximadamente 0,2):
-  aulas, salas de actos, salas reverberantes. Es además la convención
+  aulas, salas de actos, cámaras reverberantes. Es además la convención
   integrada en la práctica de medida, porque el coeficiente de absorción de
   ISO 354 se *define* mediante la fórmula de Sabine, así que devolver datos
-  de sala reverberante a Sabine es autoconsistente incluso donde la fórmula
-  se tensa. Su defecto estructural aparece con absorción alta: con
+  de cámara reverberante a Sabine es autoconsistente incluso donde la
+  fórmula se tensa. Su defecto estructural aparece con absorción alta: con
   $\alpha = 1$ en todas las superficies (una abertura en todas las
   direcciones) sigue prediciendo un tiempo de reverberación finito.
 - **Eyring** es la elección para salas tratadas de forma uniforme con
@@ -182,11 +182,15 @@ su dominio de validez:
 - **Millington-Sette** maneja una mezcla de superficies muy absorbentes y
   duras mejor que una única media, pero está pensado para coeficientes
   medidos por debajo de la unidad: una sola superficie con $\alpha_i = 1$
-  lleva toda la predicción a cero. Los coeficientes de sala reverberante
-  por encima de 1,0 (un resultado documentado de ISO 354, ver la sección de
-  absorción de [Acústica de salas](/phonometry/es/guides/room-acoustics/))
-  deben acotarse por debajo de 1 antes de poder siquiera evaluar los
-  modelos logarítmicos.
+  lleva toda la predicción a cero. Los coeficientes de cámara reverberante
+  iguales o superiores a 1,0 (un resultado documentado de ISO 354, ver la
+  sección de absorción de
+  [Acústica de salas](/phonometry/es/guides/room-acoustics/)) quedan fuera
+  del dominio de los modelos logarítmicos, cuyo $\ln(1-\alpha)$ no está
+  definido ahí, y phonometry los rechaza en todas las fórmulas de este
+  módulo. Llevar un coeficiente así a $[0, 1)$ es una decisión de modelado
+  que las fórmulas no prescriben: el ajuste que elijas (es habitual
+  limitarlo justo por debajo de 1) debe registrarse junto a la predicción.
 - **Fitzroy** y **Arau-Puchades** apuntan a salas rectangulares con la
   absorción concentrada en un eje, la oficina o vivienda típica con suelo y
   techo blandos entre paredes duras. La media geométrica de Arau templa la

--- a/site/src/content/docs/es/guides/room-acoustics.md
+++ b/site/src/content/docs/es/guides/room-acoustics.md
@@ -175,14 +175,46 @@ plt.xlabel("Tiempo [s]"); plt.ylabel("Nivel re pico [dB]")
 de sala se obtiene promediando sobre varios. ISO 3382-1 (espacios para
 interpretación) pide al menos dos posiciones de fuente y micrófonos separados
 $\geq 2$ m entre sí, $\geq 1$ m de cualquier superficie, a $1{,}2$ m
-(altura de oído sentado), evitando colocaciones simétricas; ISO 3382-2 fija el
-número mínimo de posiciones de fuente, de micrófono y de combinaciones
-fuente–micrófono según el grado de exactitud (control / ingeniería /
-precisión).
+(altura de oído sentado); ISO 3382-2 fija el número mínimo de posiciones de
+fuente, de micrófono y de combinaciones fuente–micrófono según el grado de
+exactitud (control / ingeniería / precisión) y pide posiciones de micrófono
+que eviten las colocaciones simétricas.
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_room_measurement_es.svg" alt="Configuración de medición de acústica de salas: una planta de la sala en vista superior con dos posiciones de fuente (altavoz) y seis posiciones de micrófono con las reglas de separación de ISO 3382-1, y la tabla de ISO 3382-2 con el número mínimo de posiciones para los grados de control, ingeniería y precisión" style="width:94%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_room_measurement_es_dark.svg" alt="Configuración de medición de acústica de salas: una planta de la sala en vista superior con dos posiciones de fuente (altavoz) y seis posiciones de micrófono con las reglas de separación de ISO 3382-1, y la tabla de ISO 3382-2 con el número mínimo de posiciones para los grados de control, ingeniería y precisión" style="width:94%">
 
 <video class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_comb_filtering_es.webm" preload="none" poster="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_comb_filtering_es_poster.jpg" width="2400" height="1350" loop muted controls playsinline title="Animación: al cambiar la altura del micrófono varía el retardo entre el sonido directo y la reflexión del suelo y el filtro en peine de la respuesta en frecuencia se mueve con él; por eso importa la posición de medición cerca de superficies reflectantes" style="width:88%"></video><video class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_comb_filtering_es_dark.webm" preload="none" poster="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_comb_filtering_es_dark_poster.jpg" width="2400" height="1350" loop muted controls playsinline title="Animación: al cambiar la altura del micrófono varía el retardo entre el sonido directo y la reflexión del suelo y el filtro en peine de la respuesta en frecuencia se mueve con él; por eso importa la posición de medición cerca de superficies reflectantes" style="width:88%"></video>
+
+**Promediar entre posiciones.** El parámetro por banda que se informa es la
+media aritmética sobre todas las combinaciones fuente-micrófono, y la
+dispersión entre posiciones es parte de la respuesta, no ruido: indícala
+junto a la media siempre que supere la diferencia apenas perceptible (DAP)
+del parámetro (§2), porque una
+sala puede cumplir un objetivo en promedio mientras butacas concretas
+quedan muy fuera de él. Cuatro errores de colocación sesgan la propia
+media:
+
+- **Posiciones correlacionadas.** Micrófonos a menos de 2 m entre sí muestrean
+  casi el mismo campo sonoro dos veces, así que el promedio parece más
+  estable de lo que es. El mínimo de 1 m a cualquier superficie evita, a
+  su vez, el refuerzo de presión junto a un contorno (y el filtro en peine
+  de la animación anterior) que colorea todo lo que graba un micrófono
+  demasiado cercano.
+- **Colocaciones simétricas.** En una sala geométricamente simétrica, las
+  posiciones especulares reciben patrones de reflexión especulares;
+  promediarlas no añade información nueva. Por eso la ISO 3382-2 pide
+  posiciones que no caigan sobre líneas de simetría.
+- **Demasiado cerca de la fuente.** Dentro del campo directo el EDT se
+  desploma y el C80 se satura hacia arriba haga lo que haga la sala. La
+  ISO 3382-2 mantiene por ello cada micrófono al menos a
+  $d_{min} = 2\sqrt{V/(c\,\hat T)}$ de la fuente, con $\hat T$ una
+  estimación del tiempo de reverberación esperado (unos 2,2 m para un aula
+  de 200 m³ con 0,5 s esperados).
+- **La lotería de baja frecuencia.** Por debajo de la frecuencia de
+  Schroeder (§2) cada banda contiene solo un puñado de modos propios, y un
+  micrófono sobre un nodo de uno de ellos ve un decaimiento distinto que
+  otro sobre un antinodo. La dispersión de las bandas de 63-125 Hz entre
+  posiciones es estructuralmente mayor; el remedio son más posiciones, no
+  una excitación más larga.
 
 ### Parámetros de `sweep_signal()` / `inverse_filter()`
 
@@ -311,6 +343,52 @@ Para este decaimiento de pendiente única, EDT, T20 y T30 devuelven todos
 ≈ 1,0 s, y los parámetros de energía coinciden con sus formas cerradas
 (C80 = 3,05 dB, D50 = 0,499, Ts = 72 ms). Una sala real tiene una pendiente
 inicial más pronunciada, así que EDT < T30.
+
+**Leer EDT, T20 y T30 unos contra otros.** Los tres tiempos extrapolan el
+mismo decaimiento de 60 dB desde ventanas distintas, así que su desacuerdo
+lleva información:
+
+- **T20 ≈ T30** (curvatura por debajo del 10 %): el decaimiento es una
+  única pendiente recta, la imagen de campo difuso se sostiene y cualquiera
+  de los dos tiempos puede representar "el" tiempo de reverberación de la
+  banda.
+- **T30 > T20** (curvatura por encima del 10 %): el decaimiento se comba,
+  con la energía tardía decayendo más despacio que la temprana. Las causas
+  habituales son volúmenes acoplados (una puerta abierta a un pasillo o a
+  una escalera, un anfiteatro profundo o una caja escénica devolviendo
+  energía) y una absorción muy desigual que deja reverberante un eje de la
+  sala. Ningún número único describe ese decaimiento: informa de ambas
+  ventanas junto con la curvatura, y trata con recelo las
+  [predicciones estadísticas](/phonometry/es/guides/reverberation-prediction/),
+  porque su hipótesis de campo difuso ha fallado a la vista.
+- **EDT lejos de T20/T30**: el EDT se ajusta donde aún dominan el sonido
+  directo y las primeras reflexiones, así que varía de butaca en butaca
+  mientras el T30 apenas se mueve. Un EDT por debajo del T30 dice que la
+  posición recibe mucha energía temprana (cerca de la fuente, bajo un
+  reflector): la sala suena allí más seca de lo que sugiere su T30, porque
+  la reverberación percibida sigue al EDT. Un EDT por encima del T30 en
+  una butaca apunta a un eco o a una superficie focalizante que concentra
+  allí energía tardía.
+
+**Cuánto decaimiento permite el suelo de ruido.** Una ventana de ajuste
+vale lo que el rango de decaimiento que tiene debajo. La **relación
+impulso-ruido** (INR) es la distancia de nivel entre el pico de la RI
+filtrada en banda y su suelo de ruido; la ventana de ajuste más un margen
+de seguridad debe caber dentro de ella, que es el requisito ISO 3382 de al
+menos 35 dB de rango útil de decaimiento para T20 y 45 dB para T30. Un
+rango escaso sesga el tiempo ajustado hacia arriba, hacia la cola plana que
+el suelo de ruido impone a la curva de decaimiento, y el sesgo crece en
+silencio antes de que el ajuste falle a la vista (Hak, Wenmaekers y van
+Luxemburg, 2012). `room_parameters` informa del `dynamic_range` por banda y
+endurece los límites de aceptación a 46 dB (T20) y 54 dB (T30) antes de
+marcar un valor como válido, de modo que el sesgo residual de truncado y
+compensación de un tiempo marcado válido quede dentro de la DAP del 5 %.
+Cuando una banda no supera su indicador, el orden de remedios es: usa T20
+en lugar de T30 (su ventana necesita 10 dB menos de rango según los mínimos
+ISO, 8 dB con los límites endurecidos); sube la INR en la
+adquisición, porque duplicar la longitud del barrido o el número de
+promedios síncronos gana 3 dB cada vez; y solo entonces recurre al EDT,
+nunca a un ajuste estirado dentro del ruido.
 
 Por debajo de la **frecuencia de Schroeder** $f_s \approx 2000\sqrt{T/V}$
 estas estadísticas de caída dejan de contar toda la historia: el campo lo
@@ -527,6 +605,51 @@ con la forma de `t60`; `absorption_coefficient()` devuelve `alpha_s`;
 - [Teoría](/phonometry/es/reference/theory/rooms-buildings/) — la integración de Schroeder, las ventanas de
   regresión y la derivación de la curva de referencia.
 - Referencia de la API: [`room.room_acoustics`](/phonometry/es/reference/api/rooms/room-acoustics/), [`room.room_ir`](/phonometry/es/reference/api/rooms/room-ir/) y [`room.open_plan`](/phonometry/es/reference/api/rooms/open-plan/).
+
+## Referencias
+
+- Kuttruff, H. (2016). *Room acoustics* (6.ª ed.). CRC Press.
+  [doi:10.1201/9781315372150](https://doi.org/10.1201/9781315372150).
+  La monografía de referencia tras esta página: la teoría estadística de
+  los campos sonoros en decaimiento, la frecuencia de Schroeder y los
+  parámetros perceptivos de sala del §2.
+- Schroeder, M. R. (1965). New method of measuring reverberation time.
+  *The Journal of the Acoustical Society of America*, 37(3), 409-412.
+  [doi:10.1121/1.1909343](https://doi.org/10.1121/1.1909343).
+  El método de integración hacia atrás que convierte la respuesta al
+  impulso al cuadrado en la curva suave de decaimiento del §2.
+- Hak, C. C. J. M., Wenmaekers, R. H. C., & van Luxemburg, L. C. J. (2012).
+  Measuring room impulse responses: Impact of the decay range on derived
+  room acoustic parameters. *Acta Acustica united with Acustica*, 98(6),
+  907-915. [doi:10.3813/aaa.918574](https://doi.org/10.3813/aaa.918574).
+  El análisis de la INR tras la discusión del rango dinámico y los
+  indicadores de validez endurecidos del §2.
+- International Organization for Standardization. (2009). *Acoustics —
+  Measurement of room acoustic parameters — Part 1: Performance spaces*
+  (ISO 3382-1:2009).
+  [Catálogo iso.org](https://www.iso.org/standard/40979.html).
+  Las definiciones de parámetros, los requisitos de posiciones y las
+  diferencias apenas perceptibles del §2.
+- International Organization for Standardization. (2008). *Acoustics —
+  Measurement of room acoustic parameters — Part 2: Reverberation time in
+  ordinary rooms* (ISO 3382-2:2008).
+  [Catálogo iso.org](https://www.iso.org/standard/36201.html).
+  Los grados de precisión, los recuentos de posiciones y la distancia
+  mínima a la fuente de la discusión sobre promediado del §1.
+- International Organization for Standardization. (2012). *Acoustics —
+  Measurement of room acoustic parameters — Part 3: Open plan offices*
+  (ISO 3382-3:2012).
+  [Catálogo iso.org](https://www.iso.org/standard/46520.html).
+  Las magnitudes de privacidad del habla en oficinas diáfanas del §3.
+- International Organization for Standardization. (2006). *Acoustics —
+  Application of new measurement methods in building and room acoustics*
+  (ISO 18233:2006).
+  [Catálogo iso.org](https://www.iso.org/standard/40408.html).
+  La adquisición por barrido sinusoidal y MLS del §1.
+- International Organization for Standardization. (2003). *Acoustics —
+  Measurement of sound absorption in a reverberation room* (ISO 354:2003).
+  [Catálogo iso.org](https://www.iso.org/standard/34545.html).
+  La medición de absorción en sala reverberante del §4.
 
 ---
 

--- a/site/src/content/docs/es/guides/room-acoustics.md
+++ b/site/src/content/docs/es/guides/room-acoustics.md
@@ -1,6 +1,6 @@
 ---
 title: "Acústica de salas"
-description: "Adquisición de la respuesta al impulso (ISO 18233), parámetros de sala EDT/T20/T30/C50/C80/Ts (ISO 3382-1/2), métricas de habla en oficinas diáfanas (ISO 3382-3) y absorción sonora en sala reverberante (ISO 354)."
+description: "Adquisición de la respuesta al impulso (ISO 18233), parámetros de sala EDT/T20/T30/C50/C80/Ts (ISO 3382-1/2), métricas de habla en oficinas diáfanas (ISO 3382-3) y absorción sonora en cámara reverberante (ISO 354)."
 ---
 
 La acústica de salas parte de una única medición: la **respuesta al impulso**
@@ -10,7 +10,7 @@ sobre el campo sonoro dentro de un único recinto. Esta página sigue esa cadena
 en orden de medición: adquirir la RI (ISO 18233), convertirla en parámetros de
 sala (ISO 3382-1/2), métricas espaciales del habla para oficinas diáfanas
 (ISO 3382-3) y, cerrando el ciclo, la absorción sonora de un material en una
-sala reverberante (ISO 354). Para el aislamiento acústico *entre* recintos —la
+cámara reverberante (ISO 354). Para el aislamiento acústico *entre* recintos —la
 misma RI medida a ambos lados de un cerramiento— consulta la guía complementaria
 [Medición del aislamiento en campo e índices](/phonometry/es/guides/insulation-field/).
 
@@ -348,8 +348,9 @@ inicial más pronunciada, así que EDT < T30.
 mismo decaimiento de 60 dB desde ventanas distintas, así que su desacuerdo
 lleva información:
 
-- **T20 ≈ T30** (curvatura por debajo del 10 %): el decaimiento es una
-  única pendiente recta, la imagen de campo difuso se sostiene y cualquiera
+- **T20 ≈ T30** (curvatura por debajo del 10 %): el decaimiento se acerca
+  a una única pendiente recta en ambas ventanas de evaluación, algo
+  compatible con un campo difuso (aunque no lo demuestra), y cualquiera
   de los dos tiempos puede representar "el" tiempo de reverberación de la
   banda.
 - **T30 > T20** (curvatura por encima del 10 %): el decaimiento se comba,
@@ -527,7 +528,7 @@ posición puede medirse a su vez con las herramientas STIPA de la
 
 El área de absorción sonora equivalente `A` que gobierna `R'`, `L'n`, la
 corrección ambiental `K2` de ISO 3744 y el término de absorción de ISO 3741 se
-mide a su vez en una sala reverberante
+mide a su vez en una cámara reverberante
 (ISO 354). Mide el tiempo de reverberación de la sala **vacía** ($T_1$) y de
 nuevo **con la muestra de ensayo instalada** ($T_2$); la absorción de la muestra
 es la diferencia de las dos áreas de Sabine, y dividiendo por el área cubierta
@@ -649,7 +650,7 @@ con la forma de `t60`; `absorption_coefficient()` devuelve `alpha_s`;
 - International Organization for Standardization. (2003). *Acoustics —
   Measurement of sound absorption in a reverberation room* (ISO 354:2003).
   [Catálogo iso.org](https://www.iso.org/standard/34545.html).
-  La medición de absorción en sala reverberante del §4.
+  La medición de absorción en cámara reverberante del §4.
 
 ---
 

--- a/site/src/content/docs/es/guides/room-noise.md
+++ b/site/src/content/docs/es/guides/room-noise.md
@@ -151,7 +151,8 @@ tercera familia que este módulo deliberadamente no implementa:
   etiqueta espectral señala después el rango de frecuencias problemático.
   Recurre a RC Mark II en la fase de diseño del sistema de climatización, o
   para diagnosticar una instalación que no cumple su límite NC.
-- **NR (Noise Rating)** es la contraparte europea de NC: la misma lógica de
+- **NR (Noise Rating)**, la familia de curvas de Kosten y van Os (1962),
+  es la contraparte europea de NC: la misma lógica de
   tangencia sobre una familia de curvas algo distinta (más permisiva en
   baja frecuencia, más estricta en alta), habitual en especificaciones
   europeas e internacionales de equipos y edificación. phonometry no
@@ -179,6 +180,12 @@ en lugar de remodelarlo.
   [doi:10.1121/1.2369239](https://doi.org/10.1121/1.2369239).
   El artículo que introdujo las curvas NC y el razonamiento de
   interferencia con el habla que hay detrás.
+- Kosten, C. W., & van Os, G. J. (1962). Community reaction criteria for
+  external noises. In *The Control of Noise* (National Physical Laboratory
+  Symposium No. 12, pp. 373-387). Her Majesty's Stationery Office.
+  [Ficha en Open Library](https://openlibrary.org/books/OL58781133M).
+  El artículo que introdujo la familia de curvas NR con la que el texto
+  contrasta NC.
 - Blazier, W. E. (1997). RC Mark II: A refined procedure for rating the
   noise of heating, ventilating, and air-conditioning (HVAC) systems in
   buildings. *Noise Control Engineering Journal*, 45(6), 243-250.
@@ -189,15 +196,16 @@ en lugar de remodelarlo.
 - Acoustical Society of America. (2019). *Criteria for evaluating room
   noise* (ANSI/ASA S12.2-2019).
   [Tienda ANSI](https://webstore.ansi.org/standards/asa/ansiasas122019).
-  Las curvas NC normativas, el método de tangencia y el procedimiento
-  RC Mark II que implementa este módulo.
+  Las curvas NC normativas y el método de tangencia, más el procedimiento
+  RC Mark II de su Anexo D informativo, que implementa este módulo.
 
 ---
 
 **Normas.** ANSI/ASA S12.2-2019, *Criteria for Evaluating Room Noise* — las
-curvas NC y el método de tangencia (Tabla 1), y las curvas RC Mark II (Anexo D,
-Tabla D.1), la calificación por media de frecuencias medias (cláusula D.4) y la
-etiqueta espectral neutro/retumbo/siseo (cláusula D.3).
+curvas NC normativas y el método de tangencia (Tabla 1), y, del Anexo D
+informativo, las curvas RC Mark II (Tabla D.1), la calificación por media de
+frecuencias medias (cláusula D.4) y la etiqueta espectral neutro/retumbo/siseo
+(cláusula D.3).
 
 ## Véase también
 

--- a/site/src/content/docs/es/guides/room-noise.md
+++ b/site/src/content/docs/es/guides/room-noise.md
@@ -129,6 +129,69 @@ ruido de baja frecuencia fluctuante (RNC, que necesita una serie temporal en
 lugar de un único espectro) y el índice numérico de evaluación de calidad (QAI,
 que la norma remite a referencias externas) no forman parte de este módulo.
 
+## 3. Elegir un criterio: NC, RC Mark II o NR
+
+Las dos calificaciones responden a preguntas distintas, y existe una
+tercera familia que este módulo deliberadamente no implementa:
+
+- **NC** responde a *"¿cumple la sala su límite, y qué banda lo rompe?"*.
+  Es la calificación de conformidad de la práctica norteamericana
+  (especificaciones, códigos, fichas de equipos), y el método de tangencia
+  lo gobierna por completo la única banda determinante. Ese es también su
+  punto ciego: dos salas NC-40 pueden sonar completamente distintas, una
+  retumbante y otra siseante, porque la tangencia no dice nada del
+  equilibrio espectral. Usa NC cuando una especificación lo cite, e informa
+  siempre de la banda determinante junto a la calificación, porque nombra
+  la octava que cualquier corrección debe atacar primero.
+- **RC Mark II** responde a *"¿cómo suena la sala, y qué hay que
+  corregir?"*. Su calificación sigue la interferencia con el habla a través
+  de la media de frecuencias medias, y su pendiente de referencia de
+  −5 dB por octava es el espectro que los ocupantes describen como neutro,
+  un fondo de ventilación anodino que no es ni retumbante ni agudo. La
+  etiqueta espectral señala después el rango de frecuencias problemático.
+  Recurre a RC Mark II en la fase de diseño del sistema de climatización, o
+  para diagnosticar una instalación que no cumple su límite NC.
+- **NR (Noise Rating)** es la contraparte europea de NC: la misma lógica de
+  tangencia sobre una familia de curvas algo distinta (más permisiva en
+  baja frecuencia, más estricta en alta), habitual en especificaciones
+  europeas e internacionales de equipos y edificación. phonometry no
+  implementa NR; cuando una especificación cite NR, califica contra las
+  propias curvas NR en lugar de sustituirlas por NC, porque las dos
+  familias divergen varios decibelios lejos de las frecuencias medias.
+
+**Leer la etiqueta.** La etiqueta de RC Mark II es una pista de reparación,
+no solo un rótulo. Una etiqueta de retumbo (`R`, más de 5 dB sobre la
+referencia a 500 Hz o por debajo) apunta a la planta de climatización: un
+ventilador sobredimensionado o estrangulado, retumbo de conductos o
+vibración estructural rerradiada por las paredes, y es la energía de baja
+frecuencia la que hace vibrar la construcción ligera y fatiga a los
+ocupantes. Una etiqueta de siseo (`H`, más de 3 dB por encima a 1000 Hz o
+más) apunta al extremo terminal: velocidades de paso excesivas en difusores
+y rejillas o una compuerta estrangulada cerca de la salida, y es el rango
+que enmascara el habla. Una etiqueta neutra (`N`) significa que el nivel
+aún puede estar mal, pero el carácter es correcto: reduce todo el espectro
+en lugar de remodelarlo.
+
+## Referencias
+
+- Beranek, L. L. (1957). Revised criteria for noise in buildings. *Noise
+  Control*, 3(1), 19-27.
+  [doi:10.1121/1.2369239](https://doi.org/10.1121/1.2369239).
+  El artículo que introdujo las curvas NC y el razonamiento de
+  interferencia con el habla que hay detrás.
+- Blazier, W. E. (1997). RC Mark II: A refined procedure for rating the
+  noise of heating, ventilating, and air-conditioning (HVAC) systems in
+  buildings. *Noise Control Engineering Journal*, 45(6), 243-250.
+  [doi:10.3397/1.2828446](https://doi.org/10.3397/1.2828446).
+  El procedimiento RC refinado, con su razonamiento de espectro neutro y
+  las regiones de retumbo y siseo, que el Anexo D de ANSI/ASA S12.2
+  codifica.
+- Acoustical Society of America. (2019). *Criteria for evaluating room
+  noise* (ANSI/ASA S12.2-2019).
+  [Tienda ANSI](https://webstore.ansi.org/standards/asa/ansiasas122019).
+  Las curvas NC normativas, el método de tangencia y el procedimiento
+  RC Mark II que implementa este módulo.
+
 ---
 
 **Normas.** ANSI/ASA S12.2-2019, *Criteria for Evaluating Room Noise* — las

--- a/site/src/content/docs/es/reference/bibliography.md
+++ b/site/src/content/docs/es/reference/bibliography.md
@@ -137,6 +137,128 @@ que las guías incorporan sus secciones de Referencias.
   índice presión-intensidad residual.
   Citado por [Intensidad sonora (p-p)](/phonometry/es/guides/intensity/).
 
+## Acústica de salas
+
+- Kuttruff, H. (2016). *Room acoustics* (6.ª ed.). CRC Press.
+  [doi:10.1201/9781315372150](https://doi.org/10.1201/9781315372150).
+  La monografía de referencia sobre el campo sonoro en salas: la teoría
+  estadística del decaimiento, la frecuencia de Schroeder, la absorción y
+  los parámetros perceptivos de sala.
+  Citado por [Acústica de salas](/phonometry/es/guides/room-acoustics/),
+  [Predicción del tiempo de reverberación](/phonometry/es/guides/reverberation-prediction/) y
+  [Absorción sonora en recintos](/phonometry/es/guides/enclosed-space-absorption/).
+- Sabine, W. C. (1922). *Collected papers on acoustics*. Harvard University
+  Press.
+  [Escaneo libre en Internet Archive](https://archive.org/details/collectedpaperso00sabi).
+  Los experimentos fundacionales de la reverberación y la ley de Sabine.
+  Citado por [Predicción del tiempo de reverberación](/phonometry/es/guides/reverberation-prediction/).
+- Eyring, C. F. (1930). Reverberation time in "dead" rooms. *The Journal of
+  the Acoustical Society of America*, 1(2A), 217-241.
+  [doi:10.1121/1.1915175](https://doi.org/10.1121/1.1915175).
+  La fórmula de reverberación por recorrido libre medio para salas muy
+  absorbentes.
+  Citado por [Predicción del tiempo de reverberación](/phonometry/es/guides/reverberation-prediction/).
+- Millington, G. (1932). A modified formula for reverberation. *The Journal
+  of the Acoustical Society of America*, 4(1), 69-82.
+  [doi:10.1121/1.1915588](https://doi.org/10.1121/1.1915588).
+  La fórmula de reverberación logarítmica por superficie.
+  Citado por [Predicción del tiempo de reverberación](/phonometry/es/guides/reverberation-prediction/).
+- Fitzroy, D. (1959). Reverberation formula which seems to be more accurate
+  with nonuniform distribution of absorption. *The Journal of the
+  Acoustical Society of America*, 31(7), 893-897.
+  [doi:10.1121/1.1907814](https://doi.org/10.1121/1.1907814).
+  La fórmula de reverberación axial para absorción anisótropa.
+  Citado por [Predicción del tiempo de reverberación](/phonometry/es/guides/reverberation-prediction/).
+- Arau-Puchades, H. (1988). An improved reverberation formula. *Acustica*,
+  65(4), 163-180.
+  [Ficha del editor en Ingenta](https://www.ingentaconnect.com/content/dav/aaua/1988/00000065/00000004/art00003).
+  El refinamiento por media geométrica de la fórmula de reverberación
+  axial.
+  Citado por [Predicción del tiempo de reverberación](/phonometry/es/guides/reverberation-prediction/).
+- Schroeder, M. R. (1965). New method of measuring reverberation time.
+  *The Journal of the Acoustical Society of America*, 37(3), 409-412.
+  [doi:10.1121/1.1909343](https://doi.org/10.1121/1.1909343).
+  La integración hacia atrás de la respuesta al impulso al cuadrado en una
+  curva de decaimiento.
+  Citado por [Acústica de salas](/phonometry/es/guides/room-acoustics/).
+- Hak, C. C. J. M., Wenmaekers, R. H. C., & van Luxemburg, L. C. J. (2012).
+  Measuring room impulse responses: Impact of the decay range on derived
+  room acoustic parameters. *Acta Acustica united with Acustica*, 98(6),
+  907-915. [doi:10.3813/aaa.918574](https://doi.org/10.3813/aaa.918574).
+  El análisis de la relación impulso-ruido (INR) sobre los requisitos de
+  rango de decaimiento.
+  Citado por [Acústica de salas](/phonometry/es/guides/room-acoustics/).
+- Everest, F. A. (2001). *Master handbook of acoustics* (4.ª ed.).
+  McGraw-Hill. ISBN 978-0-07-136097-5.
+  [Ficha en Open Library](https://openlibrary.org/isbn/9780071360975).
+  Un manual práctico de acústica de salas; su ejemplo resuelto de la
+  Fig. 7-22 ancla la batería de conformidad de la predicción de
+  reverberación.
+  Citado por [Predicción del tiempo de reverberación](/phonometry/es/guides/reverberation-prediction/).
+- Carrión Isbert, A. (1998). *Diseño acústico de espacios arquitectónicos*.
+  Edicions UPC. ISBN 978-84-8301-252-9.
+  [Ficha en Open Library](https://openlibrary.org/books/OL23159935M).
+  Un manual en español sobre el diseño acústico de salas.
+  Citado por [Predicción del tiempo de reverberación](/phonometry/es/guides/reverberation-prediction/).
+- Beranek, L. L. (1957). Revised criteria for noise in buildings. *Noise
+  Control*, 3(1), 19-27.
+  [doi:10.1121/1.2369239](https://doi.org/10.1121/1.2369239).
+  Las curvas NC originales y su razonamiento de interferencia con el habla.
+  Citado por [Criterios de ruido de salas](/phonometry/es/guides/room-noise/).
+- Blazier, W. E. (1997). RC Mark II: A refined procedure for rating the
+  noise of heating, ventilating, and air-conditioning (HVAC) systems in
+  buildings. *Noise Control Engineering Journal*, 45(6), 243-250.
+  [doi:10.3397/1.2828446](https://doi.org/10.3397/1.2828446).
+  El procedimiento RC Mark II codificado después por el Anexo D de
+  ANSI/ASA S12.2.
+  Citado por [Criterios de ruido de salas](/phonometry/es/guides/room-noise/).
+- International Organization for Standardization. (2009). *Acoustics —
+  Measurement of room acoustic parameters — Part 1: Performance spaces*
+  (ISO 3382-1:2009).
+  [Catálogo iso.org](https://www.iso.org/standard/40979.html).
+  Las definiciones de parámetros de sala, los requisitos de posiciones y
+  las diferencias apenas perceptibles.
+  Citado por [Acústica de salas](/phonometry/es/guides/room-acoustics/).
+- International Organization for Standardization. (2008). *Acoustics —
+  Measurement of room acoustic parameters — Part 2: Reverberation time in
+  ordinary rooms* (ISO 3382-2:2008).
+  [Catálogo iso.org](https://www.iso.org/standard/36201.html).
+  Los grados de precisión y los recuentos de posiciones de la medición de
+  la reverberación.
+  Citado por [Acústica de salas](/phonometry/es/guides/room-acoustics/).
+- International Organization for Standardization. (2012). *Acoustics —
+  Measurement of room acoustic parameters — Part 3: Open plan offices*
+  (ISO 3382-3:2012).
+  [Catálogo iso.org](https://www.iso.org/standard/46520.html).
+  Las magnitudes de privacidad del habla en oficinas diáfanas.
+  Citado por [Acústica de salas](/phonometry/es/guides/room-acoustics/).
+- International Organization for Standardization. (2006). *Acoustics —
+  Application of new measurement methods in building and room acoustics*
+  (ISO 18233:2006).
+  [Catálogo iso.org](https://www.iso.org/standard/40408.html).
+  La adquisición de respuestas al impulso por barrido sinusoidal y MLS.
+  Citado por [Acústica de salas](/phonometry/es/guides/room-acoustics/).
+- International Organization for Standardization. (2003). *Acoustics —
+  Measurement of sound absorption in a reverberation room* (ISO 354:2003).
+  [Catálogo iso.org](https://www.iso.org/standard/34545.html).
+  La medición de absorción en sala reverberante tras los datos de
+  superficie.
+  Citado por [Acústica de salas](/phonometry/es/guides/room-acoustics/) y
+  [Absorción sonora en recintos](/phonometry/es/guides/enclosed-space-absorption/).
+- European Committee for Standardization. (2003). *Building acoustics —
+  Estimation of acoustic performance of buildings from the performance of
+  elements — Part 6: Sound absorption in enclosed spaces*
+  (EN 12354-6:2003).
+  [Ficha en BSI Knowledge (BS EN 12354-6:2003)](https://knowledge.bsigroup.com/products/building-acoustics-estimation-of-acoustic-performance-of-buildings-from-the-performance-of-elements-sound-absorption-in-enclosed-spaces).
+  El miembro de absorción de la familia de predicción EN 12354.
+  Citado por [Absorción sonora en recintos](/phonometry/es/guides/enclosed-space-absorption/).
+- Acoustical Society of America. (2019). *Criteria for evaluating room
+  noise* (ANSI/ASA S12.2-2019).
+  [Tienda ANSI](https://webstore.ansi.org/standards/asa/ansiasas122019).
+  El método de tangencia NC y la calificación RC Mark II con su etiqueta
+  espectral.
+  Citado por [Criterios de ruido de salas](/phonometry/es/guides/room-noise/).
+
 ## Acústica de edificios
 
 - Hopkins, C. (2007). *Sound insulation*. Butterworth-Heinemann.

--- a/site/src/content/docs/es/reference/bibliography.md
+++ b/site/src/content/docs/es/reference/bibliography.md
@@ -205,6 +205,12 @@ que las guías incorporan sus secciones de Referencias.
   [doi:10.1121/1.2369239](https://doi.org/10.1121/1.2369239).
   Las curvas NC originales y su razonamiento de interferencia con el habla.
   Citado por [Criterios de ruido de salas](/phonometry/es/guides/room-noise/).
+- Kosten, C. W., & van Os, G. J. (1962). Community reaction criteria for
+  external noises. In *The Control of Noise* (National Physical Laboratory
+  Symposium No. 12, pp. 373-387). Her Majesty's Stationery Office.
+  [Ficha en Open Library](https://openlibrary.org/books/OL58781133M).
+  La familia de curvas NR que se contrasta con NC.
+  Citado por [Criterios de ruido de salas](/phonometry/es/guides/room-noise/).
 - Blazier, W. E. (1997). RC Mark II: A refined procedure for rating the
   noise of heating, ventilating, and air-conditioning (HVAC) systems in
   buildings. *Noise Control Engineering Journal*, 45(6), 243-250.
@@ -223,7 +229,7 @@ que las guías incorporan sus secciones de Referencias.
   Measurement of room acoustic parameters — Part 2: Reverberation time in
   ordinary rooms* (ISO 3382-2:2008).
   [Catálogo iso.org](https://www.iso.org/standard/36201.html).
-  Los grados de precisión y los recuentos de posiciones de la medición de
+  Los grados de exactitud y los recuentos de posiciones de la medición de
   la reverberación.
   Citado por [Acústica de salas](/phonometry/es/guides/room-acoustics/).
 - International Organization for Standardization. (2012). *Acoustics —
@@ -241,7 +247,7 @@ que las guías incorporan sus secciones de Referencias.
 - International Organization for Standardization. (2003). *Acoustics —
   Measurement of sound absorption in a reverberation room* (ISO 354:2003).
   [Catálogo iso.org](https://www.iso.org/standard/34545.html).
-  La medición de absorción en sala reverberante tras los datos de
+  La medición de absorción en cámara reverberante tras los datos de
   superficie.
   Citado por [Acústica de salas](/phonometry/es/guides/room-acoustics/) y
   [Absorción sonora en recintos](/phonometry/es/guides/enclosed-space-absorption/).
@@ -255,8 +261,8 @@ que las guías incorporan sus secciones de Referencias.
 - Acoustical Society of America. (2019). *Criteria for evaluating room
   noise* (ANSI/ASA S12.2-2019).
   [Tienda ANSI](https://webstore.ansi.org/standards/asa/ansiasas122019).
-  El método de tangencia NC y la calificación RC Mark II con su etiqueta
-  espectral.
+  El método de tangencia NC normativo y la calificación RC Mark II de su
+  Anexo D informativo, con su etiqueta espectral.
   Citado por [Criterios de ruido de salas](/phonometry/es/guides/room-noise/).
 
 ## Acústica de edificios

--- a/site/src/content/docs/guides/enclosed-space-absorption.md
+++ b/site/src/content/docs/guides/enclosed-space-absorption.md
@@ -146,6 +146,12 @@ absorption alone would.
 coefficient $m$ from the standard's Table 1, resolved by the
 `air_condition` strings (temperature and relative-humidity class, derived
 from ISO 9613-1); it only matters above 1 kHz and grows with the volume.
+The six built-in profiles, `"10C_30-50"` through `"20C_70-90"` (clause 4.3
+recommends `"20C_50-70"` when no conditions are specified), cover the
+standard 125 Hz to 8 kHz octave bands only and cannot be combined with a
+custom frequency axis; `air_condition=None` (the default) omits the air
+term, and for other frequencies or conditions compute $m$ per ISO 9613-1
+and chain `air_absorption_area` into `equivalent_absorption_area`.
 
 **Validity limits (clause 4.6).** The model assumes an ordinary,
 reasonably diffuse room: no dimension more than 5 times another, opposite

--- a/site/src/content/docs/guides/enclosed-space-absorption.md
+++ b/site/src/content/docs/guides/enclosed-space-absorption.md
@@ -119,6 +119,60 @@ reverberation time in
 of the reverberation-room absorption of
 [Acoustic Materials](/phonometry/guides/materials/) (ISO 354).
 
+## 3. Where the input data comes from
+
+**Surface coefficients.** The standard expects the $\alpha_{s,i}$ to come
+from laboratory measurements to EN ISO 354, the reverberation-room method
+of [Acoustic Materials](/phonometry/guides/materials/); theoretical,
+empirical or field values are admitted as long as the data source is
+stated. ISO 354 delivers one-third-octave data, and an octave-band
+calculation takes the arithmetic mean of the three thirds as its input. A
+reverberation-room coefficient can exceed 1.0 (edge diffraction scatters
+more energy into the sample than its flat area intercepts); it enters
+Formula 1 as measured, without clamping, because the same diffuse-field
+convention that produced it is the one the model assumes.
+
+**Furniture and occupants.** Objects contribute through three routes:
+a measured equivalent absorption area $A_{obj}$ when one exists (persons
+and seating have tabulated values in the informative Annex C), the
+Formula 4 estimate $V_{obj}^{2/3}$ for hard, irregular, unmeasured objects
+(furniture, machinery), and object *arrays* rated as an absorbing surface
+$\alpha_s S_k$ when many similar objects cover a zone (an audience, a
+storage rack). Objects also displace air: their summed volume enters the
+object fraction $\psi$ that shortens $T$ in Formula 5 beyond what their
+absorption alone would.
+
+**Air.** The air term $A_{air} = 4mV(1-\psi)$ uses the power attenuation
+coefficient $m$ from the standard's Table 1, resolved by the
+`air_condition` strings (temperature and relative-humidity class, derived
+from ISO 9613-1); it only matters above 1 kHz and grows with the volume.
+
+**Validity limits (clause 4.6).** The model assumes an ordinary,
+reasonably diffuse room: no dimension more than 5 times another, opposite
+surface pairs whose coefficients differ by less than a factor of 3 (unless
+scattering objects are present) and an object fraction below 0.2. Outside
+those limits the field is not diffuse and the model errs on the optimistic
+side: the standard's own accuracy clause records measured reverberation
+times up to twice the prediction in low-diffusivity rooms. The classical
+alternatives for those cases live in
+[Reverberation-time prediction](/phonometry/guides/reverberation-prediction/).
+
+## References
+
+- European Committee for Standardization. (2003). *Building acoustics —
+  Estimation of acoustic performance of buildings from the performance of
+  elements — Part 6: Sound absorption in enclosed spaces*
+  (EN 12354-6:2003).
+  [BSI Knowledge record (BS EN 12354-6:2003)](https://knowledge.bsigroup.com/products/building-acoustics-estimation-of-acoustic-performance-of-buildings-from-the-performance-of-elements-sound-absorption-in-enclosed-spaces).
+  The Clause 4 model, its input-data rules and its validity limits.
+- International Organization for Standardization. (2003). *Acoustics —
+  Measurement of sound absorption in a reverberation room* (ISO 354:2003).
+  [iso.org catalogue](https://www.iso.org/standard/34545.html).
+  The laboratory measurement the surface and array coefficients come from.
+- Kuttruff, H. (2016). *Room acoustics* (6th ed.). CRC Press.
+  [doi:10.1201/9781315372150](https://doi.org/10.1201/9781315372150).
+  The statistical reverberation theory the standard's formulae specialise.
+
 ---
 
 **Standards.** EN 12354-6:2003, *Building acoustics — Estimation of acoustic

--- a/site/src/content/docs/guides/reverberation-prediction.md
+++ b/site/src/content/docs/guides/reverberation-prediction.md
@@ -177,10 +177,14 @@ domain of validity:
 - **Millington-Sette** handles a mix of very absorptive and hard surfaces
   better than a single mean, but it is meant for measured, sub-unity
   coefficients: a single surface with $\alpha_i = 1$ drives the whole
-  prediction to zero. Reverberation-room coefficients above 1.0 (a
+  prediction to zero. Reverberation-room coefficients at or above 1.0 (a
   documented ISO 354 outcome, see the absorption section of
-  [Room Acoustics](/phonometry/guides/room-acoustics/)) must be capped
-  below 1 before any of the logarithmic models can even be evaluated.
+  [Room Acoustics](/phonometry/guides/room-acoustics/)) lie outside the
+  domain of the logarithmic models, whose $\ln(1-\alpha)$ is undefined
+  there, and phonometry rejects them for every formula in this module.
+  Bringing such a coefficient into $[0, 1)$ is a modelling decision the
+  formulas do not prescribe: whatever adjustment you choose (limiting just
+  below 1 is common), record it alongside the prediction.
 - **Fitzroy** and **Arau-Puchades** target shoebox rooms whose absorption
   is concentrated on one axis, the typical office or dwelling with a soft
   floor and ceiling between hard walls. Arau's geometric mean tempers

--- a/site/src/content/docs/guides/reverberation-prediction.md
+++ b/site/src/content/docs/guides/reverberation-prediction.md
@@ -59,7 +59,8 @@ For a **uniform** distribution Eyring and Millington-Sette coincide, and both
 fall below Sabine — Sabine's over-estimate at high absorption is the reason
 Eyring exists. As $\alpha \to 0$, Eyring reduces to Sabine. Air absorption
 enters every model through the power-attenuation coefficient $m$ (in neper per
-metre, from [atmospheric absorption](/phonometry/guides/room-acoustics/)):
+metre, from the ISO 9613-1
+[atmospheric absorption](/phonometry/guides/outdoor-propagation/)):
 
 ```python
 import phonometry as ph
@@ -156,18 +157,118 @@ plt.show()
 
 </details>
 
+## 4. Choosing a model, and when every model fails
+
+The five formulae are not rivals on a single axis of accuracy; each has a
+domain of validity:
+
+- **Sabine** is the tool for live rooms with low, reasonably even
+  absorption (mean $\bar\alpha$ up to roughly 0.2): classrooms, halls,
+  reverberation chambers. It is also the convention wired into measurement
+  practice, because the ISO 354 absorption coefficient is *defined* through
+  Sabine's formula, so feeding reverberation-room data back into Sabine is
+  self-consistent even where the formula is strained. Its structural defect
+  shows at high absorption: with $\alpha = 1$ on every surface (an opening
+  in every direction) it still predicts a finite reverberation time.
+- **Eyring** is the choice for evenly treated rooms with substantial
+  absorption: studios, treated offices, listening rooms. It reaches
+  $T = 0$ for total absorption, and its correction over Sabine grows with
+  $\bar\alpha$ (about 10 % shorter at $\bar\alpha = 0.2$, 30 % at 0.5).
+- **Millington-Sette** handles a mix of very absorptive and hard surfaces
+  better than a single mean, but it is meant for measured, sub-unity
+  coefficients: a single surface with $\alpha_i = 1$ drives the whole
+  prediction to zero. Reverberation-room coefficients above 1.0 (a
+  documented ISO 354 outcome, see the absorption section of
+  [Room Acoustics](/phonometry/guides/room-acoustics/)) must be capped
+  below 1 before any of the logarithmic models can even be evaluated.
+- **Fitzroy** and **Arau-Puchades** target shoebox rooms whose absorption
+  is concentrated on one axis, the typical office or dwelling with a soft
+  floor and ceiling between hard walls. Arau's geometric mean tempers
+  Fitzroy's known over-prediction when one wall pair is very reflective.
+
+**When every formula fails.** All five inherit the same assumption: a
+diffuse field, with sound arriving equally from all directions at every
+point, that stays diffuse while it decays. The common breakages:
+
+- **Below the Schroeder frequency** the band holds a handful of discrete
+  modes (the animation in §1) and a statistical reverberation time is not
+  defined at all; each mode decays at its own rate set by the wall
+  impedances it actually touches.
+- **Coupled volumes** (a hall with an open stage house, two rooms through a
+  doorway) produce double-slope decays; no single $T$ exists, and the
+  measured T20 and T30 disagree (the curvature diagnostic of
+  [Room Acoustics](/phonometry/guides/room-acoustics/)).
+- **Disproportionate rooms** (corridors, low flat halls) with the
+  absorption on one surface pair keep a grazing sound field parallel to the
+  hard surfaces that the absorber barely touches; the measured time can be
+  up to twice any statistical prediction, the practical experience recorded
+  in EN 12354-6 (see
+  [Sound absorption in enclosed spaces](/phonometry/guides/enclosed-space-absorption/)).
+- **Focusing geometries** (domes, curved rear walls) concentrate late
+  energy instead of mixing it, producing position-dependent decays no
+  single-number formula can represent.
+
+Scattering objects restore the mixing the models assume: a furnished room
+follows the statistical prediction distinctly better than the same room
+bare, beyond what the furniture's own absorption area accounts for. In
+practice, quote a *band* of predictions (Sabine and Eyring, or Fitzroy and
+Arau-Puchades for axial cases) rather than a single value; where the models
+spread, the room is telling you its field is not diffuse.
+
+## References
+
+- Sabine, W. C. (1922). *Collected papers on acoustics*. Harvard University
+  Press. [Free scan at the Internet Archive](https://archive.org/details/collectedpaperso00sabi).
+  The original reverberation experiments and the $T = 0.161\,V/A$ law of §1.
+- Eyring, C. F. (1930). Reverberation time in "dead" rooms. *The Journal of
+  the Acoustical Society of America*, 1(2A), 217-241.
+  [doi:10.1121/1.1915175](https://doi.org/10.1121/1.1915175).
+  The mean-free-path derivation behind the $-S\ln(1-\bar\alpha)$ term of §1.
+- Millington, G. (1932). A modified formula for reverberation. *The Journal
+  of the Acoustical Society of America*, 4(1), 69-82.
+  [doi:10.1121/1.1915588](https://doi.org/10.1121/1.1915588).
+  The per-surface logarithmic absorption term of §1.
+- Fitzroy, D. (1959). Reverberation formula which seems to be more accurate
+  with nonuniform distribution of absorption. *The Journal of the
+  Acoustical Society of America*, 31(7), 893-897.
+  [doi:10.1121/1.1907814](https://doi.org/10.1121/1.1907814).
+  The axial split into three wall-pair decays of §2.
+- Arau-Puchades, H. (1988). An improved reverberation formula. *Acustica*,
+  65(4), 163-180.
+  [Publisher record at Ingenta](https://www.ingentaconnect.com/content/dav/aaua/1988/00000065/00000004/art00003).
+  The geometric-mean combination of §2 (its Formula 18).
+- Kuttruff, H. (2016). *Room acoustics* (6th ed.). CRC Press.
+  [doi:10.1201/9781315372150](https://doi.org/10.1201/9781315372150).
+  The diffuse-field theory, its limits and the modern assessment of the
+  classical formulae behind §4.
+- Everest, F. A. (2001). *Master handbook of acoustics* (4th ed.).
+  McGraw-Hill. ISBN 978-0-07-136097-5.
+  [Open Library record](https://openlibrary.org/isbn/9780071360975).
+  The Fig. 7-22 worked example the conformance suite reproduces.
+- Carrión Isbert, A. (1998). *Diseño acústico de espacios arquitectónicos*.
+  Edicions UPC. ISBN 978-84-8301-252-9.
+  [Open Library record](https://openlibrary.org/books/OL23159935M).
+  A Spanish-language textbook treatment of the reverberation models and
+  their use in room design.
+
 ---
 
-**References.** W. C. Sabine, *Collected Papers on Acoustics* (1922); C. F.
-Eyring (1930); G. Millington (1932); D. Fitzroy, *J. Acoust. Soc. Am.* **31**
-(1959) 893; H. Arau-Puchades, "An improved reverberation formula", *Acustica*
-**65** (1988) 163 (Formula 18). Textbooks: A. Carrión Isbert, *Diseño acústico
-de espacios arquitectónicos*; F. A. Everest & K. C. Pohlmann, *Master Handbook
-of Acoustics*, 4th ed. Air absorption follows ISO 9613-1:1993. The conformance
-suite is anchored on a **real worked example** — Everest's Fig. 7-22 Example 1,
-whose six printed Sabine reverberation times the SI implementation reproduces to
-≤ 0.02 s — reinforced by hand-computed closed-form values and the model
-identities.
+**Standards.** The classical reverberation formulae predate the normative
+world; they enter it through EN 12354-6:2003, whose Clause 4 model is a
+Sabine calculation with object and air terms (see
+[Sound absorption in enclosed spaces](/phonometry/guides/enclosed-space-absorption/)),
+and through ISO 354:2003, which defines the measured absorption coefficient
+via Sabine's formula. Air absorption follows ISO 9613-1:1993, *Acoustics —
+Attenuation of sound during propagation outdoors — Part 1: Calculation of
+the absorption of sound by the atmosphere* (see
+[Outdoor propagation](/phonometry/guides/outdoor-propagation/)). The
+conformance suite is anchored on a real worked example, Everest's Fig. 7-22
+Example 1 (an untreated 23.3 × 16 × 10 ft room), whose six printed Sabine
+reverberation times the SI implementation reproduces to ≤ 0.02 s,
+reinforced by hand-computed closed-form values and the model identities
+(every model collapses to Eyring for uniform absorption; Eyring collapses
+to Sabine as $\alpha \to 0$), which transitively carry that real-data
+anchor to the whole family.
 
 ## See also
 

--- a/site/src/content/docs/guides/room-acoustics.md
+++ b/site/src/content/docs/guides/room-acoustics.md
@@ -333,8 +333,9 @@ Ts = 72 ms). A real room has a steeper early slope, so EDT < T30.
 extrapolate the same 60 dB decay from different windows, so their
 disagreement carries information:
 
-- **T20 ≈ T30** (curvature below 10 %): the decay is a single straight
-  slope, the diffuse-field picture holds, and either time can stand for
+- **T20 ≈ T30** (curvature below 10 %): the decay is close to a single
+  straight slope over both evaluation windows, which is consistent with
+  (though not proof of) a diffuse field, and either time can stand for
   "the" reverberation time of the band.
 - **T30 > T20** (curvature above 10 %): the decay sags, with late energy
   decaying more slowly than early energy. The usual causes are coupled

--- a/site/src/content/docs/guides/room-acoustics.md
+++ b/site/src/content/docs/guides/room-acoustics.md
@@ -168,13 +168,41 @@ plt.xlabel("Time [s]"); plt.ylabel("Level re peak [dB]")
 reported room parameter is the spatial average over several. ISO 3382-1
 (performance spaces) asks for at least two source positions and microphones
 spaced $\geq 2$ m apart, $\geq 1$ m from any surface, at $1.2$ m
-(seated-ear) height, avoiding symmetric placements; ISO 3382-2 fixes the
-minimum number of source, microphone and source–microphone combinations per
-accuracy grade (survey / engineering / precision).
+(seated-ear) height; ISO 3382-2 fixes the minimum number of source,
+microphone and source–microphone combinations per accuracy grade
+(survey / engineering / precision) and asks for microphone positions that
+avoid symmetric placements.
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_room_measurement.svg" alt="Room-acoustics measurement setup: a top-view room plan with two loudspeaker source positions and six microphone positions with the ISO 3382-1 spacing rules, and the ISO 3382-2 table of minimum positions for the survey, engineering and precision grades" style="width:94%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_room_measurement_dark.svg" alt="Room-acoustics measurement setup: a top-view room plan with two loudspeaker source positions and six microphone positions with the ISO 3382-1 spacing rules, and the ISO 3382-2 table of minimum positions for the survey, engineering and precision grades" style="width:94%">
 
 <video class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_comb_filtering.webm" preload="none" poster="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_comb_filtering_poster.jpg" width="2400" height="1350" loop muted controls playsinline title="Animation: as the microphone height changes, the delay between the direct sound and the floor reflection shifts and the comb filter in the frequency response moves with it, which is why measurement position matters near reflecting surfaces" style="width:88%"></video><video class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_comb_filtering_dark.webm" preload="none" poster="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_comb_filtering_dark_poster.jpg" width="2400" height="1350" loop muted controls playsinline title="Animation: as the microphone height changes, the delay between the direct sound and the floor reflection shifts and the comb filter in the frequency response moves with it, which is why measurement position matters near reflecting surfaces" style="width:88%"></video>
+
+**Averaging across positions.** The reported per-band parameter is the
+arithmetic mean over all source-microphone combinations, and the spread
+across positions is part of the answer, not noise: quote it alongside the
+mean whenever it exceeds the parameter's JND (§2), because a room can meet a
+target on average while individual seats sit far outside it. Four placement
+mistakes bias the mean itself:
+
+- **Correlated positions.** Microphones closer than 2 m to each other
+  sample nearly the same sound field twice, so the average looks more
+  stable than it is. The 1 m minimum from any surface likewise avoids the
+  pressure build-up near a boundary (and the comb filter of the animation
+  above) that colours everything a too-close microphone records.
+- **Symmetric placements.** In a geometrically symmetric room, mirror-image
+  positions receive mirror-image reflection patterns; averaging them adds
+  no new information. This is why ISO 3382-2 asks for positions that do not
+  sit on symmetry lines.
+- **Too close to the source.** Inside the direct field EDT collapses and
+  C80 saturates upward no matter what the room does. ISO 3382-2 therefore
+  keeps every microphone at least $d_{min} = 2\sqrt{V/(c\,\hat T)}$ from
+  the source, with $\hat T$ an estimate of the expected reverberation time
+  (about 2.2 m for a 200 m³ classroom with an expected 0.5 s).
+- **Low-frequency luck.** Below the Schroeder frequency (§2) each band
+  holds only a handful of room modes, and a microphone on a node of one of
+  them sees a different decay than a microphone on an antinode. The spread
+  of the 63-125 Hz bands across positions is structurally larger; the cure
+  is more positions, not a longer excitation.
 
 ### `sweep_signal()` / `inverse_filter()` parameters
 
@@ -300,6 +328,48 @@ plt.show()
 For this single-slope decay EDT, T20 and T30 all return ≈ 1.0 s, and the
 energy parameters match their closed forms (C80 = 3.05 dB, D50 = 0.499,
 Ts = 72 ms). A real room has a steeper early slope, so EDT < T30.
+
+**Reading EDT, T20 and T30 against each other.** The three times
+extrapolate the same 60 dB decay from different windows, so their
+disagreement carries information:
+
+- **T20 ≈ T30** (curvature below 10 %): the decay is a single straight
+  slope, the diffuse-field picture holds, and either time can stand for
+  "the" reverberation time of the band.
+- **T30 > T20** (curvature above 10 %): the decay sags, with late energy
+  decaying more slowly than early energy. The usual causes are coupled
+  volumes (an open door to a corridor or stairwell, a deep balcony or a
+  stage house feeding energy back) and strongly uneven absorption that
+  leaves one room axis reverberant. No single number describes such a
+  decay: report both windows together with the curvature, and treat the
+  [statistical predictions](/phonometry/guides/reverberation-prediction/)
+  with suspicion, because their diffuse-field assumption has visibly
+  failed.
+- **EDT far from T20/T30**: EDT is fitted where the direct sound and the
+  first reflections still dominate, so it varies from seat to seat while
+  T30 barely moves. EDT below T30 means the position receives strong early
+  energy (close to the source, under a reflector): the room sounds drier
+  there than its T30 suggests, because perceived reverberance follows EDT.
+  EDT above T30 at one seat points to an echo or a focusing surface
+  concentrating late energy there.
+
+**How much decay the noise floor allows.** A fit window is only as good as
+the decay range underneath it. The **impulse-to-noise ratio** (INR) is the
+level distance between the peak of the band-filtered IR and its noise
+floor; the fit window plus a safety margin must fit inside it, which is the
+ISO 3382 requirement of at least 35 dB of usable decay range for T20 and
+45 dB for T30. An undersized range biases the fitted time upward, toward
+the flat tail the noise floor imposes on the decay curve, and the bias
+grows quietly before the fit visibly fails (Hak, Wenmaekers, & van
+Luxemburg, 2012). `room_parameters` reports the per-band `dynamic_range`
+and tightens the acceptance limits to 46 dB (T20) and 54 dB (T30) before
+flagging a value valid, so the residual truncation-and-compensation bias of
+a flagged-valid time stays inside the 5 % JND. When a band fails its flag,
+the order of remedies is: use T20 instead of T30 (its window needs 10 dB
+less range under the ISO minima, 8 dB under the tightened flags); raise the
+INR at acquisition, since doubling the sweep length or
+the number of synchronous averages buys 3 dB each time; and only then fall
+back to EDT, never to a fit stretched into the noise.
 
 Below the **Schroeder frequency** $f_s \approx 2000\sqrt{T/V}$ these
 decay statistics stop telling the whole story: the field is ruled by
@@ -511,6 +581,51 @@ shape of `t60`; `absorption_coefficient()` returns `alpha_s`;
 - [Theory](/phonometry/reference/theory/rooms-buildings/) — Schroeder integration, regression windows and the
   reference-curve derivation.
 - API reference: [`room.room_acoustics`](/phonometry/reference/api/rooms/room-acoustics/), [`room.room_ir`](/phonometry/reference/api/rooms/room-ir/) and [`room.open_plan`](/phonometry/reference/api/rooms/open-plan/).
+
+## References
+
+- Kuttruff, H. (2016). *Room acoustics* (6th ed.). CRC Press.
+  [doi:10.1201/9781315372150](https://doi.org/10.1201/9781315372150).
+  The reference monograph behind this page: the statistical theory of
+  decaying sound fields, the Schroeder frequency and the perceptual room
+  parameters of §2.
+- Schroeder, M. R. (1965). New method of measuring reverberation time.
+  *The Journal of the Acoustical Society of America*, 37(3), 409-412.
+  [doi:10.1121/1.1909343](https://doi.org/10.1121/1.1909343).
+  The backward-integration method that turns the squared impulse response
+  into the smooth decay curve of §2.
+- Hak, C. C. J. M., Wenmaekers, R. H. C., & van Luxemburg, L. C. J. (2012).
+  Measuring room impulse responses: Impact of the decay range on derived
+  room acoustic parameters. *Acta Acustica united with Acustica*, 98(6),
+  907-915. [doi:10.3813/aaa.918574](https://doi.org/10.3813/aaa.918574).
+  The INR analysis behind the dynamic-range discussion and the tightened
+  validity flags of §2.
+- International Organization for Standardization. (2009). *Acoustics —
+  Measurement of room acoustic parameters — Part 1: Performance spaces*
+  (ISO 3382-1:2009).
+  [iso.org catalogue](https://www.iso.org/standard/40979.html).
+  The parameter definitions, position requirements and just-noticeable
+  differences of §2.
+- International Organization for Standardization. (2008). *Acoustics —
+  Measurement of room acoustic parameters — Part 2: Reverberation time in
+  ordinary rooms* (ISO 3382-2:2008).
+  [iso.org catalogue](https://www.iso.org/standard/36201.html).
+  The accuracy grades, position counts and the minimum source distance of
+  the position-averaging discussion in §1.
+- International Organization for Standardization. (2012). *Acoustics —
+  Measurement of room acoustic parameters — Part 3: Open plan offices*
+  (ISO 3382-3:2012).
+  [iso.org catalogue](https://www.iso.org/standard/46520.html).
+  The open-plan speech-privacy quantities of §3.
+- International Organization for Standardization. (2006). *Acoustics —
+  Application of new measurement methods in building and room acoustics*
+  (ISO 18233:2006).
+  [iso.org catalogue](https://www.iso.org/standard/40408.html).
+  The swept-sine and MLS acquisition of §1.
+- International Organization for Standardization. (2003). *Acoustics —
+  Measurement of sound absorption in a reverberation room* (ISO 354:2003).
+  [iso.org catalogue](https://www.iso.org/standard/34545.html).
+  The reverberation-room absorption measurement of §4.
 
 ---
 

--- a/site/src/content/docs/guides/room-noise.md
+++ b/site/src/content/docs/guides/room-noise.md
@@ -127,6 +127,64 @@ low-frequency noise (RNC, which needs a time series rather than a single
 spectrum) and the numeric quality-assessment index (QAI, which the standard
 defers to external references) are not part of this module.
 
+## 3. Choosing a criterion: NC, RC Mark II or NR
+
+The two ratings answer different questions, and a third family exists that
+this module deliberately does not implement:
+
+- **NC** answers *"does the room meet its limit, and which band breaks
+  it?"*. It is the compliance rating of North-American practice
+  (specifications, codes, equipment schedules), and the tangency method is
+  driven entirely by the single governing band. That is also its blind
+  spot: two NC-40 rooms can sound completely different, one rumbly and one
+  hissy, because tangency says nothing about spectral balance. Use NC when
+  a specification cites it, and always report the governing band with the
+  rating, since it names the octave any fix must attack first.
+- **RC Mark II** answers *"how does the room sound, and what should be
+  fixed?"*. Its rating tracks speech interference through the
+  mid-frequency average, and its reference slope of −5 dB per octave is
+  the spectrum occupants describe as neutral, a bland ventilation
+  background that is neither boomy nor sharp. The spectral tag then points
+  at the offending frequency range. Reach for RC Mark II at HVAC design
+  time, or to diagnose an installation that fails its NC limit.
+- **NR (Noise Rating)** is the European counterpart of NC: the same
+  tangency logic over a slightly different curve family (more permissive
+  at low frequency, stricter at high), common in European and
+  international equipment and building specifications. phonometry does not
+  implement NR; when a specification cites NR, rate against the NR curves
+  themselves rather than substituting NC, because the two families diverge
+  by several decibels away from the mid frequencies.
+
+**Reading the tag.** The RC Mark II tag is a repair hint, not just a label.
+A rumble tag (`R`, more than 5 dB over the reference at or below 500 Hz)
+points at the air-handling plant: an oversized or starved fan, duct
+rumble, or structure-borne vibration re-radiated by walls, and it is the
+low-frequency energy that rattles lightweight construction and fatigues
+occupants. A hiss tag (`H`, more than 3 dB over at or above 1000 Hz)
+points at the terminal end: diffuser and grille face velocities or a
+throttled damper close to the outlet, and it is the range that masks
+speech. A neutral tag (`N`) means the level can still be wrong, but the
+character is right: reduce the whole spectrum rather than reshape it.
+
+## References
+
+- Beranek, L. L. (1957). Revised criteria for noise in buildings. *Noise
+  Control*, 3(1), 19-27.
+  [doi:10.1121/1.2369239](https://doi.org/10.1121/1.2369239).
+  The paper that introduced the NC curves and the speech-interference
+  reasoning behind them.
+- Blazier, W. E. (1997). RC Mark II: A refined procedure for rating the
+  noise of heating, ventilating, and air-conditioning (HVAC) systems in
+  buildings. *Noise Control Engineering Journal*, 45(6), 243-250.
+  [doi:10.3397/1.2828446](https://doi.org/10.3397/1.2828446).
+  The refined RC procedure, with its neutral-spectrum rationale and the
+  rumble/hiss regions, that ANSI/ASA S12.2 Annex D codifies.
+- Acoustical Society of America. (2019). *Criteria for evaluating room
+  noise* (ANSI/ASA S12.2-2019).
+  [ANSI webstore](https://webstore.ansi.org/standards/asa/ansiasas122019).
+  The normative NC curves, tangency method and RC Mark II procedure this
+  module implements.
+
 ---
 
 **Standards.** ANSI/ASA S12.2-2019, *Criteria for Evaluating Room Noise* — the

--- a/site/src/content/docs/guides/room-noise.md
+++ b/site/src/content/docs/guides/room-noise.md
@@ -147,8 +147,9 @@ this module deliberately does not implement:
   background that is neither boomy nor sharp. The spectral tag then points
   at the offending frequency range. Reach for RC Mark II at HVAC design
   time, or to diagnose an installation that fails its NC limit.
-- **NR (Noise Rating)** is the European counterpart of NC: the same
-  tangency logic over a slightly different curve family (more permissive
+- **NR (Noise Rating)**, the curve family of Kosten & van Os (1962), is
+  the European counterpart of NC: the same tangency logic over a
+  slightly different curve family (more permissive
   at low frequency, stricter at high), common in European and
   international equipment and building specifications. phonometry does not
   implement NR; when a specification cites NR, rate against the NR curves
@@ -173,6 +174,12 @@ character is right: reduce the whole spectrum rather than reshape it.
   [doi:10.1121/1.2369239](https://doi.org/10.1121/1.2369239).
   The paper that introduced the NC curves and the speech-interference
   reasoning behind them.
+- Kosten, C. W., & van Os, G. J. (1962). Community reaction criteria for
+  external noises. In *The Control of Noise* (National Physical Laboratory
+  Symposium No. 12, pp. 373-387). Her Majesty's Stationery Office.
+  [Open Library record](https://openlibrary.org/books/OL58781133M).
+  The paper that introduced the NR curve family the text contrasts
+  with NC.
 - Blazier, W. E. (1997). RC Mark II: A refined procedure for rating the
   noise of heating, ventilating, and air-conditioning (HVAC) systems in
   buildings. *Noise Control Engineering Journal*, 45(6), 243-250.
@@ -182,15 +189,15 @@ character is right: reduce the whole spectrum rather than reshape it.
 - Acoustical Society of America. (2019). *Criteria for evaluating room
   noise* (ANSI/ASA S12.2-2019).
   [ANSI webstore](https://webstore.ansi.org/standards/asa/ansiasas122019).
-  The normative NC curves, tangency method and RC Mark II procedure this
-  module implements.
+  The normative NC curves and tangency method, plus the RC Mark II
+  procedure of its informative Annex D, that this module implements.
 
 ---
 
 **Standards.** ANSI/ASA S12.2-2019, *Criteria for Evaluating Room Noise* — the
-NC curves and the tangency method (Table 1), and the RC Mark II curves
-(Annex D, Table D.1), the mid-frequency-average rating (clause D.4) and the
-neutral/rumble/hiss spectral tag (clause D.3).
+normative NC curves and tangency method (Table 1), and, from the informative
+Annex D, the RC Mark II curves (Table D.1), the mid-frequency-average rating
+(clause D.4) and the neutral/rumble/hiss spectral tag (clause D.3).
 
 ## See also
 

--- a/site/src/content/docs/reference/bibliography.md
+++ b/site/src/content/docs/reference/bibliography.md
@@ -135,6 +135,120 @@ list grows as guides gain their References sections.
   residual pressure-intensity index.
   Cited by [Sound Intensity (p-p)](/phonometry/guides/intensity/).
 
+## Room acoustics
+
+- Kuttruff, H. (2016). *Room acoustics* (6th ed.). CRC Press.
+  [doi:10.1201/9781315372150](https://doi.org/10.1201/9781315372150).
+  The reference monograph on sound fields in rooms: statistical decay
+  theory, the Schroeder frequency, absorption and the perceptual room
+  parameters.
+  Cited by [Room Acoustics](/phonometry/guides/room-acoustics/),
+  [Reverberation-time prediction](/phonometry/guides/reverberation-prediction/) and
+  [Sound absorption in enclosed spaces](/phonometry/guides/enclosed-space-absorption/).
+- Sabine, W. C. (1922). *Collected papers on acoustics*. Harvard University
+  Press.
+  [Free scan at the Internet Archive](https://archive.org/details/collectedpaperso00sabi).
+  The founding reverberation experiments and the Sabine law.
+  Cited by [Reverberation-time prediction](/phonometry/guides/reverberation-prediction/).
+- Eyring, C. F. (1930). Reverberation time in "dead" rooms. *The Journal of
+  the Acoustical Society of America*, 1(2A), 217-241.
+  [doi:10.1121/1.1915175](https://doi.org/10.1121/1.1915175).
+  The mean-free-path reverberation formula for strongly absorbing rooms.
+  Cited by [Reverberation-time prediction](/phonometry/guides/reverberation-prediction/).
+- Millington, G. (1932). A modified formula for reverberation. *The Journal
+  of the Acoustical Society of America*, 4(1), 69-82.
+  [doi:10.1121/1.1915588](https://doi.org/10.1121/1.1915588).
+  The per-surface logarithmic reverberation formula.
+  Cited by [Reverberation-time prediction](/phonometry/guides/reverberation-prediction/).
+- Fitzroy, D. (1959). Reverberation formula which seems to be more accurate
+  with nonuniform distribution of absorption. *The Journal of the
+  Acoustical Society of America*, 31(7), 893-897.
+  [doi:10.1121/1.1907814](https://doi.org/10.1121/1.1907814).
+  The axial reverberation formula for anisotropic absorption.
+  Cited by [Reverberation-time prediction](/phonometry/guides/reverberation-prediction/).
+- Arau-Puchades, H. (1988). An improved reverberation formula. *Acustica*,
+  65(4), 163-180.
+  [Publisher record at Ingenta](https://www.ingentaconnect.com/content/dav/aaua/1988/00000065/00000004/art00003).
+  The geometric-mean refinement of the axial reverberation formula.
+  Cited by [Reverberation-time prediction](/phonometry/guides/reverberation-prediction/).
+- Schroeder, M. R. (1965). New method of measuring reverberation time.
+  *The Journal of the Acoustical Society of America*, 37(3), 409-412.
+  [doi:10.1121/1.1909343](https://doi.org/10.1121/1.1909343).
+  The backward integration of the squared impulse response into a decay
+  curve.
+  Cited by [Room Acoustics](/phonometry/guides/room-acoustics/).
+- Hak, C. C. J. M., Wenmaekers, R. H. C., & van Luxemburg, L. C. J. (2012).
+  Measuring room impulse responses: Impact of the decay range on derived
+  room acoustic parameters. *Acta Acustica united with Acustica*, 98(6),
+  907-915. [doi:10.3813/aaa.918574](https://doi.org/10.3813/aaa.918574).
+  The impulse-to-noise-ratio (INR) analysis of decay-range requirements.
+  Cited by [Room Acoustics](/phonometry/guides/room-acoustics/).
+- Everest, F. A. (2001). *Master handbook of acoustics* (4th ed.).
+  McGraw-Hill. ISBN 978-0-07-136097-5.
+  [Open Library record](https://openlibrary.org/isbn/9780071360975).
+  A practical room-acoustics handbook; its Fig. 7-22 worked example anchors
+  the reverberation-prediction conformance suite.
+  Cited by [Reverberation-time prediction](/phonometry/guides/reverberation-prediction/).
+- Carrión Isbert, A. (1998). *Diseño acústico de espacios arquitectónicos*.
+  Edicions UPC. ISBN 978-84-8301-252-9.
+  [Open Library record](https://openlibrary.org/books/OL23159935M).
+  A Spanish-language textbook on acoustic room design.
+  Cited by [Reverberation-time prediction](/phonometry/guides/reverberation-prediction/).
+- Beranek, L. L. (1957). Revised criteria for noise in buildings. *Noise
+  Control*, 3(1), 19-27.
+  [doi:10.1121/1.2369239](https://doi.org/10.1121/1.2369239).
+  The original NC curves and their speech-interference rationale.
+  Cited by [Room-noise criteria](/phonometry/guides/room-noise/).
+- Blazier, W. E. (1997). RC Mark II: A refined procedure for rating the
+  noise of heating, ventilating, and air-conditioning (HVAC) systems in
+  buildings. *Noise Control Engineering Journal*, 45(6), 243-250.
+  [doi:10.3397/1.2828446](https://doi.org/10.3397/1.2828446).
+  The RC Mark II procedure later codified by ANSI/ASA S12.2 Annex D.
+  Cited by [Room-noise criteria](/phonometry/guides/room-noise/).
+- International Organization for Standardization. (2009). *Acoustics —
+  Measurement of room acoustic parameters — Part 1: Performance spaces*
+  (ISO 3382-1:2009).
+  [iso.org catalogue](https://www.iso.org/standard/40979.html).
+  Room-parameter definitions, position requirements and just-noticeable
+  differences.
+  Cited by [Room Acoustics](/phonometry/guides/room-acoustics/).
+- International Organization for Standardization. (2008). *Acoustics —
+  Measurement of room acoustic parameters — Part 2: Reverberation time in
+  ordinary rooms* (ISO 3382-2:2008).
+  [iso.org catalogue](https://www.iso.org/standard/36201.html).
+  The accuracy grades and position counts of reverberation measurement.
+  Cited by [Room Acoustics](/phonometry/guides/room-acoustics/).
+- International Organization for Standardization. (2012). *Acoustics —
+  Measurement of room acoustic parameters — Part 3: Open plan offices*
+  (ISO 3382-3:2012).
+  [iso.org catalogue](https://www.iso.org/standard/46520.html).
+  The open-plan speech-privacy quantities.
+  Cited by [Room Acoustics](/phonometry/guides/room-acoustics/).
+- International Organization for Standardization. (2006). *Acoustics —
+  Application of new measurement methods in building and room acoustics*
+  (ISO 18233:2006).
+  [iso.org catalogue](https://www.iso.org/standard/40408.html).
+  The swept-sine and MLS acquisition of impulse responses.
+  Cited by [Room Acoustics](/phonometry/guides/room-acoustics/).
+- International Organization for Standardization. (2003). *Acoustics —
+  Measurement of sound absorption in a reverberation room* (ISO 354:2003).
+  [iso.org catalogue](https://www.iso.org/standard/34545.html).
+  The reverberation-room absorption measurement behind the surface data.
+  Cited by [Room Acoustics](/phonometry/guides/room-acoustics/) and
+  [Sound absorption in enclosed spaces](/phonometry/guides/enclosed-space-absorption/).
+- European Committee for Standardization. (2003). *Building acoustics —
+  Estimation of acoustic performance of buildings from the performance of
+  elements — Part 6: Sound absorption in enclosed spaces*
+  (EN 12354-6:2003).
+  [BSI Knowledge record (BS EN 12354-6:2003)](https://knowledge.bsigroup.com/products/building-acoustics-estimation-of-acoustic-performance-of-buildings-from-the-performance-of-elements-sound-absorption-in-enclosed-spaces).
+  The absorption member of the EN 12354 prediction family.
+  Cited by [Sound absorption in enclosed spaces](/phonometry/guides/enclosed-space-absorption/).
+- Acoustical Society of America. (2019). *Criteria for evaluating room
+  noise* (ANSI/ASA S12.2-2019).
+  [ANSI webstore](https://webstore.ansi.org/standards/asa/ansiasas122019).
+  The NC tangency method and the RC Mark II rating with its spectral tag.
+  Cited by [Room-noise criteria](/phonometry/guides/room-noise/).
+
 ## Building acoustics
 
 - Hopkins, C. (2007). *Sound insulation*. Butterworth-Heinemann.

--- a/site/src/content/docs/reference/bibliography.md
+++ b/site/src/content/docs/reference/bibliography.md
@@ -199,6 +199,12 @@ list grows as guides gain their References sections.
   [doi:10.1121/1.2369239](https://doi.org/10.1121/1.2369239).
   The original NC curves and their speech-interference rationale.
   Cited by [Room-noise criteria](/phonometry/guides/room-noise/).
+- Kosten, C. W., & van Os, G. J. (1962). Community reaction criteria for
+  external noises. In *The Control of Noise* (National Physical Laboratory
+  Symposium No. 12, pp. 373-387). Her Majesty's Stationery Office.
+  [Open Library record](https://openlibrary.org/books/OL58781133M).
+  The NR curve family contrasted with NC.
+  Cited by [Room-noise criteria](/phonometry/guides/room-noise/).
 - Blazier, W. E. (1997). RC Mark II: A refined procedure for rating the
   noise of heating, ventilating, and air-conditioning (HVAC) systems in
   buildings. *Noise Control Engineering Journal*, 45(6), 243-250.
@@ -246,7 +252,8 @@ list grows as guides gain their References sections.
 - Acoustical Society of America. (2019). *Criteria for evaluating room
   noise* (ANSI/ASA S12.2-2019).
   [ANSI webstore](https://webstore.ansi.org/standards/asa/ansiasas122019).
-  The NC tangency method and the RC Mark II rating with its spectral tag.
+  The normative NC tangency method and the RC Mark II rating of its
+  informative Annex D, with its spectral tag.
   Cited by [Room-noise criteria](/phonometry/guides/room-noise/).
 
 ## Building acoustics


### PR DESCRIPTION
## Summary

Didactic depth and verified references for the four room-acoustics guides, in the three content trees.

- Room acoustics: how to read EDT, T20 and T30 against each other (curvature diagnosis, coupled volumes, the seat-dependent perceptual role of EDT), what the impulse-to-noise ratio allows and the remedy ordering, and four position-averaging pitfalls including the ISO 3382-2 minimum source distance; a pre-existing misattribution of the avoid-symmetric-positions requirement (it belongs to ISO 3382-2, not 3382-1) is corrected.
- Reverberation prediction: a model-selection section (Sabine, Eyring, Millington, Fitzroy, Arau-Puchades domains of validity, the alpha-equals-one Sabine paradox, capping ISO 354 coefficients before the logarithmic models) and the non-diffuse failure modes where every formula degrades; the page's stray closing references paragraph is normalized into the house References-plus-Standards structure, and a mislinked air-absorption reference now points at the page that implements it.
- Enclosed-space absorption: where the EN 12354-6 input data comes from (ISO 354 laboratory data, the thirds-to-octaves arithmetic mean, unclamped coefficients above one, the object routes including persons and seating, the air term classes and the clause 4.6 validity limits), verified against the standard.
- Room noise: choosing between NC, RC Mark II and NR (compliance versus diagnosis versus the European family, with a do-not-substitute warning) and reading the rumble/hiss/neutral tag toward the fix.
- Nineteen verified references (Kuttruff with the publisher-dated record, Schroeder, Eyring, Millington, Fitzroy, Sabine's public-domain collected papers, Beranek 1957, Blazier's RC Mark II, the INR paper, and the standards catalogue pages); the bibliography gains a Room acoustics group. An authorship error in an old footer (the fourth edition of Everest was not co-authored by Pohlmann) is corrected.

## Test plan

ruff, mypy, conformance byte-identical, i18n parity (56 pairs), site build with links validator at 0 errors, html-validate. A review pass produced three must-fix findings (a standards misattribution and two Spanish terminology unifications) and several refinements, all applied.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded room-acoustics guidance on measurement placement, position averaging, EDT/T20/T30 interpretation, and usable decay limits tied to the noise floor.
  * Clarified reverberation-model inputs (including how atmospheric absorption is applied) plus each model’s validity ranges and “when models fail” scenarios.
  * Added/expanded guidance for choosing and interpreting NC, RC Mark II, and NR noise criteria (including the spectral tag).
  * Updated English and Spanish guides and references with new “Room acoustics” bibliography sections, added standards citations, and improved cross-links between related topics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->