### PR TITLE
docs(site): readable wide tables and full-width figures on phones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -361,6 +361,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Documentation site rendering on phones: wide parameter tables (4+
+  columns with a long-text notes column) no longer crush every column to a
+  few characters per line with enormously tall cells; on narrow screens
+  their cells keep a readable minimum width (16rem for the trailing notes
+  column) and the table scrolls horizontally inside Starlight's scroll
+  container instead (new `site/src/styles/theme-tables.css`, desktop
+  rendering unchanged); these wide tables also get `tabindex="0"` and a
+  visible focus outline so the scroll container stays keyboard-reachable
+  on Safari/WebKit, which unlike Chrome and Firefox does not focus
+  scrollable regions by default. Figure widths on phones now cover the whole
+  authored tier inventory with a generic selector: every
+  `<img style="width:NN%">` and video spans the full reading column on
+  screens up to 50rem, where tiers such as 60/70/72/75/78/82/86/90/94/96%
+  previously kept wasted side margins and left axis labels illegible.
 - G-weighting (ISO 7196) digital design is now sample-rate aware: at the low
   sample rates common for infrasound recordings, 315 Hz approaches Nyquist
   and the un-prewarped bilinear design warped the upper response; the design

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -9,10 +9,34 @@ import rehypeKatex from 'rehype-katex';
 import { apiSidebar } from './src/generated/api-sidebar.mjs';
 
 // Converts deprecated HTML align attributes (emitted by markdown table
-// alignment) to CSS text-align, for WCAG2AA compliance (pa11y).
+// alignment) to CSS text-align, for WCAG2AA compliance (pa11y), and makes
+// wide tables keyboard-scrollable: Starlight renders markdown tables as
+// scrollable blocks (display:block + overflow:auto) and theme-tables.css
+// gives 4+ column tables readable minimum cell widths on phones, so they
+// scroll horizontally there. Chrome (127+) and Firefox focus scrollable
+// regions without focusable children by default, but Safari/WebKit does
+// not, so the scroll container needs an explicit tabindex for WCAG 2.1.1
+// (theme-tables.css adds the matching :focus-visible outline).
 function rehypeTableAlign() {
+  const firstRow = (node) => {
+    if (node.type === 'element' && node.tagName === 'tr') return node;
+    for (const child of node.children ?? []) {
+      const found = firstRow(child);
+      if (found) return found;
+    }
+    return null;
+  };
   return (tree) => {
     (function visit(node) {
+      if (node.type === 'element' && node.tagName === 'table') {
+        const row = firstRow(node);
+        const cells = (row?.children ?? []).filter(
+          (c) => c.type === 'element' && (c.tagName === 'th' || c.tagName === 'td'),
+        ).length;
+        if (cells >= 4) {
+          node.properties = { ...node.properties, tabIndex: 0 };
+        }
+      }
       if (
         node.type === 'element' &&
         (node.tagName === 'td' || node.tagName === 'th') &&
@@ -217,6 +241,7 @@ export default defineConfig({
       customCss: [
         './src/styles/katex.css',
         './src/styles/theme-images.css',
+        './src/styles/theme-tables.css',
         './src/styles/splash-menu.css',
       ],
       social: [

--- a/site/src/styles/theme-images.css
+++ b/site/src/styles/theme-images.css
@@ -40,7 +40,7 @@
  *   - Mobile (<=50rem, column tracks the viewport): every sized figure
  *     spans the full reading column. Even the smallest authored tier
  *     (60%, detailed filter-response plots) only becomes legible on a
- *     phone at 100%, and the generic `[style*="width:"]` selector covers
+ *     phone at 100%, and the generic `[style^="width:"]` prefix selector covers
  *     the whole tier inventory (60-96%) so new tiers cannot fall through.
  *   - Desktop (>50rem, column capped at 720px so never full-screen):
  *     gentle boost of detailed plots 80% -> 92% (matches wide diagrams).
@@ -49,8 +49,8 @@
 /* Phones & small tablets (column tracks the viewport): reclaim the
    wasted side margins so every figure fills the reading column. */
 @media (max-width: 50rem) {
-  .sl-markdown-content img[style*="width:"],
-  .sl-markdown-content video[style*="width:"] { width: 100% !important; }
+  .sl-markdown-content img[style^="width:"],
+  .sl-markdown-content video[style^="width:"] { width: 100% !important; }
 }
 
 /* Desktop / wide reading column (capped at 720px, so never full-screen):

--- a/site/src/styles/theme-images.css
+++ b/site/src/styles/theme-images.css
@@ -26,33 +26,31 @@
 }
 
 /* ------------------------------------------------------------------ *
- * Responsive figure sizing — full width on narrow screens, 92% plots on desktop.
+ * Responsive figure sizing: full width on narrow screens, 92% plots on desktop.
  * Figures are authored as <img style="width:NN%"> (inline). NN encodes
  * intent: 60/70 = small schematic diagrams, 80 = detailed plots,
  * 88/92 = wide diagrams, 100 = full-bleed. The width lives in an inline
  * style attribute (the markdown pipeline emits the literal, unspaced
  * string `width:80%`), so it can only be overridden with `!important`
- * and is targeted per-tier via `img[style*="width:NN%"]`. Natural sizes
+ * and is targeted via `img[style*="width:"]`. Natural sizes
  * (plots ~1200-1310px, diagrams 900px) exceed the 720px reading-column
  * cap (Starlight --sl-content-width: 45rem), so 100% never upscales.
  *
  * Two tiers (both maintainer-approved):
- *   - Mobile (<=50rem, column tracks the viewport): reclaim wasted side
- *     margins — 80/88/92% -> 100%, 70% -> 90%, 60% -> 80%.
+ *   - Mobile (<=50rem, column tracks the viewport): every sized figure
+ *     spans the full reading column. Even the smallest authored tier
+ *     (60%, detailed filter-response plots) only becomes legible on a
+ *     phone at 100%, and the generic `[style*="width:"]` selector covers
+ *     the whole tier inventory (60-96%) so new tiers cannot fall through.
  *   - Desktop (>50rem, column capped at 720px so never full-screen):
  *     gentle boost of detailed plots 80% -> 92% (matches wide diagrams).
  * ------------------------------------------------------------------ */
 
 /* Phones & small tablets (column tracks the viewport): reclaim the
-   wasted side margins so detailed figures fill the reading column. */
+   wasted side margins so every figure fills the reading column. */
 @media (max-width: 50rem) {
-  .sl-markdown-content img[style*="width:80%"],
-  .sl-markdown-content img[style*="width:88%"],
-  .sl-markdown-content img[style*="width:92%"],
-  .sl-markdown-content video[style*="width:88%"] { width: 100% !important; }
-  /* keep the small schematics subordinate, but larger than on desktop */
-  .sl-markdown-content img[style*="width:70%"] { width: 90% !important; }
-  .sl-markdown-content img[style*="width:60%"] { width: 80% !important; }
+  .sl-markdown-content img[style*="width:"],
+  .sl-markdown-content video[style*="width:"] { width: 100% !important; }
 }
 
 /* Desktop / wide reading column (capped at 720px, so never full-screen):

--- a/site/src/styles/theme-tables.css
+++ b/site/src/styles/theme-tables.css
@@ -1,0 +1,49 @@
+/* Responsive tables: readable columns plus horizontal swipe on phones.
+   Starlight already renders markdown tables as scrollable blocks
+   (`.sl-markdown-content table { display: block; overflow: auto }`), but
+   the browser's automatic table layout first wraps text columns down to
+   their min-content width. On a phone, a wide parameter table (4+ columns
+   with a long-text "Notes" column) therefore crushes every column to a
+   few characters per line and grows enormously tall cells before any
+   horizontal scrolling kicks in.
+
+   Fix (mobile only; desktop rendering is unchanged): give the cells of
+   wide tables a readable minimum width so the table overflows into
+   Starlight's scroll container instead of crushing. The
+   `:first-child:nth-last-child(n+4)` pair matches rows with 4 or more
+   cells, i.e. only genuinely wide tables; 2-3 column tables keep wrapping
+   naturally inside the reading column. The last column of a wide table is
+   by convention the long-text notes column, so it gets a wider floor
+   (16rem, about 40 characters per line). Keyboard reachability: Chrome
+   (127+) and Firefox focus scrollable regions without focusable children
+   by default, but Safari/WebKit does not, so the rehypeTableAlign
+   transform in astro.config.mjs stamps tabindex="0" on these 4+ column
+   tables; the focus outline below is its visible affordance. */
+.sl-markdown-content table:not(:where(.not-content *)):focus-visible {
+  outline: 2px solid var(--sl-color-accent);
+  outline-offset: 2px;
+}
+
+@media (max-width: 50rem) {
+  .sl-markdown-content table:not(:where(.not-content *)) {
+    -webkit-overflow-scrolling: touch;
+  }
+
+  /* Header cells of wide tables stay on one line: headers are short and
+     define a sensible floor for their column. */
+  .sl-markdown-content table:not(:where(.not-content *)) tr > th:first-child:nth-last-child(n+4),
+  .sl-markdown-content table:not(:where(.not-content *)) tr > th:first-child:nth-last-child(n+4) ~ th {
+    white-space: nowrap;
+  }
+
+  /* Body cells of wide tables never shrink below a readable line. */
+  .sl-markdown-content table:not(:where(.not-content *)) tr > td:first-child:nth-last-child(n+4),
+  .sl-markdown-content table:not(:where(.not-content *)) tr > td:first-child:nth-last-child(n+4) ~ td {
+    min-width: 8rem;
+  }
+
+  /* The trailing notes column carries prose: give it a comfortable measure. */
+  .sl-markdown-content table:not(:where(.not-content *)) tr > td:first-child:nth-last-child(n+4) ~ td:last-child {
+    min-width: 16rem;
+  }
+}


### PR DESCRIPTION
## Summary

Mobile rendering fixes for the documentation site, from a viewport audit at 375 px and 1440 px across representative pages.

- Wide tables no longer crush on phones: 4-plus-column tables (the guide and theory parameter tables; the worst case rendered 2-3 characters per line with 500 px tall rows) now keep readable column widths (8rem minimum, 16rem for the trailing notes column, nowrap headers) and scroll horizontally inside Starlight's existing overflow container. Two- and three-column tables and desktop rendering are untouched; the generated API tables are two-column and were verified fine as-is.
- Scrollable tables stay keyboard-reachable everywhere: the table-align transform now stamps tabindex on wide tables (WebKit does not focus scrollable regions by default) with a matching focus outline.
- Images and videos use the full column width on phones: the mobile rule is now generic over the authored width tiers, closing the gap where 14 tiers existed but only 5 were enumerated (about 300 images in the 72-96 percent tiers kept wasted margins; the 60 percent filter plots had illegible axis labels).

## Test plan

Before/after screenshots at both viewports confirm the maintainer-reported table renders as scrollable readable columns, images fill the column, no page-level horizontal overflow anywhere audited, and identical desktop metrics. pa11y 30/30 URLs (run twice, before and after the tabindex change), html-validate and the site build clean; keyboard scrolling of a focused table verified.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

