### PR TITLE
fix: per-model absorption-coefficient domains in reverberation prediction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -361,6 +361,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Reverberation-time prediction no longer rejects absorption coefficients
+  at or above 1 for every model with a blanket `[0, 1)` validator; each
+  model now enforces its own mathematical domain. Sabine accepts measured
+  ISO 354 coefficients at or above 1 (its linear absorption area stays
+  finite), including the exact 1.0 of the ISO 11654 practical-coefficient
+  cap, up to a unit-error guard at 2 that catches percentages passed
+  where fractions are expected. Eyring accepts individual coefficients at
+  or above 1 as long as the mean absorption entering `ln(1 - mean)` stays
+  below 1, and Millington-Sette keeps the strict per-surface requirement
+  (every coefficient below 1) that its per-surface logarithm demands;
+  Fitzroy and Arau-Puchades keep requiring each wall-pair mean below 1,
+  since their inputs enter the axial logarithm directly. NaN inputs, which
+  the old range comparisons silently let through both as coefficients and
+  as `air_attenuation`, are now rejected with explicit finiteness checks.
 - Documentation site rendering on phones: wide parameter tables (4+
   columns with a long-text notes column) no longer crush every column to a
   few characters per line with enormously tall cells; on narrow screens

--- a/docs/materials.md
+++ b/docs/materials.md
@@ -449,13 +449,15 @@ geometric one. Such values are not errors, but they are not portable either:
 they depend on the sample size and perimeter, which is precisely why ISO 354
 fixes both. The ISO 11654 rating simply truncates: practical coefficients
 above $1.00$ are set to $1.00$ (section 1). Prediction inputs get no such
-silent clipping in this library: the
-[reverberation-time estimators](reverberation-prediction.md) reject
-coefficients outside $[0, 1)$ (the Eyring and Millington logarithms diverge
-at one), so ISO 354 values at or above one must be brought back below one by
-the caller, while the equivalent-absorption-area budget of
-[EN 12354-6](enclosed-space-absorption.md) accepts the coefficients as
-supplied.
+silent clipping in this library: each
+[reverberation-time estimator](reverberation-prediction.md) enforces its own
+mathematical domain, so Sabine and Eyring accept ISO 354 values at or above
+one as supplied (Eyring as long as the mean absorption stays below one),
+while Millington-Sette rejects them (its per-surface logarithm diverges at
+one) and any adjustment below one is left to the caller. The
+equivalent-absorption-area budget of
+[EN 12354-6](enclosed-space-absorption.md) likewise accepts the coefficients
+as supplied.
 
 **Which to use.** They answer different questions. The reverberation-room
 value is the one that feeds diffuse-field prediction: Sabine reverberation

--- a/docs/reverberation-prediction.md
+++ b/docs/reverberation-prediction.md
@@ -180,9 +180,14 @@ domain of validity:
   prediction to zero. Reverberation-room coefficients at or above 1.0 (a
   documented ISO 354 outcome, see the absorption section of
   [Room Acoustics](room-acoustics.md)) lie outside the domain of the
-  logarithmic models, whose $\ln(1-\alpha)$ is undefined there, and
-  phonometry rejects them for every formula in this module. Bringing such
-  a coefficient into $[0, 1)$ is a modelling decision the formulas do not
+  logarithmic term, so phonometry enforces each formula's own domain:
+  Sabine accepts such coefficients as supplied (its linear
+  $A = \sum_i S_i\alpha_i$ stays finite); Eyring accepts them as long as
+  the mean entering $\ln(1-\bar\alpha)$ stays below 1 (Fitzroy and
+  Arau-Puchades take the wall-pair means themselves as inputs, so each
+  must already be below 1); Millington-Sette rejects any coefficient at
+  or above 1. To use Millington anyway, bringing such a
+  coefficient into $[0, 1)$ is a modelling decision the formula does not
   prescribe: whatever adjustment you choose (limiting just below 1 is
   common), record it alongside the prediction.
 - **Fitzroy** and **Arau-Puchades** target shoebox rooms whose absorption

--- a/site/src/content/docs/es/guides/materials.md
+++ b/site/src/content/docs/es/guides/materials.md
@@ -461,14 +461,16 @@ perímetro de la muestra, que es exactamente la razón por la que ISO 354 fija
 ambos. La valoración de ISO 11654 simplemente trunca: los coeficientes
 prácticos por encima de $1{,}00$ se fijan en $1{,}00$ (sección 1). Las
 entradas de predicción no reciben ese recorte silencioso en esta biblioteca:
-los
-[estimadores del tiempo de reverberación](/phonometry/es/guides/reverberation-prediction/)
-rechazan coeficientes fuera de $[0, 1)$ (los logaritmos de Eyring y
-Millington divergen en uno), de modo que los valores de ISO 354 iguales o
-superiores a uno deben devolverse por debajo de uno antes de la llamada,
-mientras que el presupuesto de área de absorción equivalente de
-[EN 12354-6](/phonometry/es/guides/enclosed-space-absorption/) acepta los
-coeficientes tal cual se suministran.
+cada
+[estimador del tiempo de reverberación](/phonometry/es/guides/reverberation-prediction/)
+aplica su propio dominio matemático, de modo que Sabine y Eyring aceptan los
+valores de ISO 354 iguales o superiores a uno tal cual (Eyring siempre que la
+absorción media quede por debajo de uno), mientras que Millington-Sette los
+rechaza (su logaritmo por superficie diverge en uno) y cualquier ajuste por
+debajo de uno queda en manos de quien llama. El presupuesto de área de
+absorción equivalente de
+[EN 12354-6](/phonometry/es/guides/enclosed-space-absorption/) también acepta
+los coeficientes tal cual se suministran.
 
 **Cuál usar.** Responden a preguntas distintas. El valor de cámara
 reverberante es el que alimenta la predicción en campo difuso: las

--- a/site/src/content/docs/es/guides/reverberation-prediction.md
+++ b/site/src/content/docs/es/guides/reverberation-prediction.md
@@ -186,10 +186,15 @@ su dominio de validez:
   iguales o superiores a 1,0 (un resultado documentado de ISO 354, ver la
   sección de absorción de
   [Acústica de salas](/phonometry/es/guides/room-acoustics/)) quedan fuera
-  del dominio de los modelos logarítmicos, cuyo $\ln(1-\alpha)$ no está
-  definido ahí, y phonometry los rechaza en todas las fórmulas de este
-  módulo. Llevar un coeficiente así a $[0, 1)$ es una decisión de modelado
-  que las fórmulas no prescriben: el ajuste que elijas (es habitual
+  del dominio del término logarítmico, así que phonometry aplica a cada
+  fórmula su propio dominio: Sabine acepta esos coeficientes tal cual (su
+  $A = \sum_i S_i\alpha_i$ lineal sigue siendo finita); Eyring los acepta
+  siempre que la media que entra en $\ln(1-\bar\alpha)$ quede por debajo
+  de 1 (Fitzroy y Arau-Puchades toman como entrada las propias medias de
+  cada par de paredes, así que cada una debe estar ya por debajo de 1);
+  Millington-Sette rechaza cualquier coeficiente igual o superior a 1. Para usar Millington de
+  todos modos, llevar un coeficiente así a $[0, 1)$ es una decisión de
+  modelado que la fórmula no prescribe: el ajuste que elijas (es habitual
   limitarlo justo por debajo de 1) debe registrarse junto a la predicción.
 - **Fitzroy** y **Arau-Puchades** apuntan a salas rectangulares con la
   absorción concentrada en un eje, la oficina o vivienda típica con suelo y

--- a/site/src/content/docs/guides/materials.md
+++ b/site/src/content/docs/guides/materials.md
@@ -448,13 +448,15 @@ geometric one. Such values are not errors, but they are not portable either:
 they depend on the sample size and perimeter, which is precisely why ISO 354
 fixes both. The ISO 11654 rating simply truncates: practical coefficients
 above $1.00$ are set to $1.00$ (section 1). Prediction inputs get no such
-silent clipping in this library: the
-[reverberation-time estimators](/phonometry/guides/reverberation-prediction/)
-reject coefficients outside $[0, 1)$ (the Eyring and Millington logarithms
-diverge at one), so ISO 354 values at or above one must be brought back below
-one by the caller, while the equivalent-absorption-area budget of
-[EN 12354-6](/phonometry/guides/enclosed-space-absorption/) accepts the
-coefficients as supplied.
+silent clipping in this library: each
+[reverberation-time estimator](/phonometry/guides/reverberation-prediction/)
+enforces its own mathematical domain, so Sabine and Eyring accept ISO 354
+values at or above one as supplied (Eyring as long as the mean absorption
+stays below one), while Millington-Sette rejects them (its per-surface
+logarithm diverges at one) and any adjustment below one is left to the
+caller. The equivalent-absorption-area budget of
+[EN 12354-6](/phonometry/guides/enclosed-space-absorption/) likewise accepts
+the coefficients as supplied.
 
 **Which to use.** They answer different questions. The reverberation-room
 value is the one that feeds diffuse-field prediction: Sabine reverberation

--- a/site/src/content/docs/guides/reverberation-prediction.md
+++ b/site/src/content/docs/guides/reverberation-prediction.md
@@ -180,11 +180,16 @@ domain of validity:
   prediction to zero. Reverberation-room coefficients at or above 1.0 (a
   documented ISO 354 outcome, see the absorption section of
   [Room Acoustics](/phonometry/guides/room-acoustics/)) lie outside the
-  domain of the logarithmic models, whose $\ln(1-\alpha)$ is undefined
-  there, and phonometry rejects them for every formula in this module.
-  Bringing such a coefficient into $[0, 1)$ is a modelling decision the
-  formulas do not prescribe: whatever adjustment you choose (limiting just
-  below 1 is common), record it alongside the prediction.
+  domain of the logarithmic term, so phonometry enforces each formula's
+  own domain: Sabine accepts such coefficients as supplied (its linear
+  $A = \sum_i S_i\alpha_i$ stays finite); Eyring accepts them as long as
+  the mean entering $\ln(1-\bar\alpha)$ stays below 1 (Fitzroy and
+  Arau-Puchades take the wall-pair means themselves as inputs, so each
+  must already be below 1); Millington-Sette rejects any coefficient at
+  or above 1. To use Millington anyway, bringing such a
+  coefficient into $[0, 1)$ is a modelling decision the formula does not
+  prescribe: whatever adjustment you choose (limiting just below 1 is
+  common), record it alongside the prediction.
 - **Fitzroy** and **Arau-Puchades** target shoebox rooms whose absorption
   is concentrated on one axis, the typical office or dwelling with a soft
   floor and ceiling between hard walls. Arau's geometric mean tempers

--- a/site/src/content/docs/reference/api/rooms/reverberation-prediction.md
+++ b/site/src/content/docs/reference/api/rooms/reverberation-prediction.md
@@ -107,7 +107,8 @@ and its area-weighted mean absorption `alpha_bar`.
 
 The formula constrains only the *mean*: `ln(1 - alpha_bar)` requires
 `alpha_bar < 1`, while individual coefficients at or above 1 (a measured
-ISO 354 outcome) are accepted as long as the mean stays below 1.
+ISO 354 outcome) are accepted as long as the mean stays below 1 and each
+coefficient stays within the shared unit-error ceiling of 2.
 
 **Parameters**
 

--- a/site/src/content/docs/reference/api/rooms/reverberation-prediction.md
+++ b/site/src/content/docs/reference/api/rooms/reverberation-prediction.md
@@ -42,6 +42,13 @@ coefficient `m` (in neper per metre) as the additive term `4 m V`; obtain a
 physical `m` from temperature and humidity with
 [`phonometry.air_absorption.air_attenuation_m`](/phonometry/reference/api/environment/air-absorption/#air_attenuation_m).
 
+Each model enforces its own mathematical domain on the absorption
+coefficients. Sabine's linear sum is finite for any non-negative coefficient,
+so it accepts measured ISO 354 values at or above 1 (up to a unit-error guard
+at 2). The logarithmic models are stricter exactly where the maths requires
+it: Millington-Sette needs *every* coefficient below 1, while Eyring, Fitzroy
+and Arau-Puchades need each *mean* entering `ln(1 - alpha)` below 1.
+
 The Fitzroy and Arau-Puchades models require a rectangular (shoebox) room and
 take the room `dimensions` together with the mean absorption of each of the
 three wall pairs. All five reduce to Eyring for a uniform absorption
@@ -67,7 +74,8 @@ Arau-Puchades reverberation time -- area-weighted geometric mean of axial times.
 pair perpendicular to axis `i` (Arau-Puchades, *Acustica* 65 (1988) 163,
 Formula 18). Preferred by its author over Fitzroy for rooms with an
 anisotropic absorption distribution. Reduces to Eyring for a uniform
-distribution.
+distribution. Each input is itself a mean entering `ln(1 - alpha_i)`,
+so each must be below 1.
 
 **Parameters**
 
@@ -97,6 +105,10 @@ Eyring (Norris-Eyring) reverberation time.
 `T = k V / (-S ln(1 - alpha_bar) + 4 m V)` with the total surface `S`
 and its area-weighted mean absorption `alpha_bar`.
 
+The formula constrains only the *mean*: `ln(1 - alpha_bar)` requires
+`alpha_bar < 1`, while individual coefficients at or above 1 (a measured
+ISO 354 outcome) are accepted as long as the mean stays below 1.
+
 **Parameters**
 
 | Name | Description |
@@ -125,7 +137,8 @@ Fitzroy reverberation time -- area-weighted arithmetic mean of axial times.
 `T = sum_i (S_i / S) T_i` with `T_i` the Eyring time of the wall pair
 perpendicular to axis `i` (Fitzroy, *J. Acoust. Soc. Am.* 31 (1959) 893).
 Equivalent to `T = k V / S**2 * sum_i S_i / (-ln(1 - alpha_i))` without
-air. Reduces to Eyring for a uniform absorption distribution.
+air. Reduces to Eyring for a uniform absorption distribution. Each input
+is itself a mean entering `ln(1 - alpha_i)`, so each must be below 1.
 
 **Parameters**
 
@@ -171,6 +184,9 @@ Millington-Sette reverberation time.
 `T = k V / (-sum_i S_i ln(1 - alpha_i) + 4 m V)`: the Eyring absorption
 term summed surface by surface rather than through a single mean. A surface
 approaching total absorption (`alpha_i -> 1`) drives `T` to zero.
+Because the logarithm applies per surface, *every* coefficient must be
+strictly below 1; measured ISO 354 coefficients at or above 1 are outside
+this model's domain (use Sabine, or Eyring while the mean stays below 1).
 
 **Parameters**
 
@@ -202,7 +218,9 @@ A convenience front-end that builds the six boundary surfaces of the room
 from `dimensions` and the three wall-pair mean absorptions, then evaluates
 [`sabine_reverberation_time`](/phonometry/reference/api/rooms/reverberation-prediction/#sabine_reverberation_time), [`eyring_reverberation_time`](/phonometry/reference/api/rooms/reverberation-prediction/#eyring_reverberation_time),
 [`millington_sette_reverberation_time`](/phonometry/reference/api/rooms/reverberation-prediction/#millington_sette_reverberation_time), [`fitzroy_reverberation_time`](/phonometry/reference/api/rooms/reverberation-prediction/#fitzroy_reverberation_time)
-and [`arau_puchades_reverberation_time`](/phonometry/reference/api/rooms/reverberation-prediction/#arau_puchades_reverberation_time) on a common footing.
+and [`arau_puchades_reverberation_time`](/phonometry/reference/api/rooms/reverberation-prediction/#arau_puchades_reverberation_time) on a common footing. Because
+the bundle evaluates the logarithmic models too, the inputs must satisfy
+the strictest of the five domains: every absorption below 1.
 
 **Parameters**
 
@@ -277,12 +295,19 @@ sabine_reverberation_time(
 
 Sabine reverberation time `T = k V / (A + 4 m V)`.
 
+`A = sum_i S_i alpha_i` is finite for any non-negative coefficient, so
+unlike the logarithmic models Sabine accepts coefficients at or above 1:
+measured ISO 354 reverberation-room values of 1.05 to 1.20 (the edge
+effect) and the exact 1.0 that the ISO 11654 practical rating caps at are
+legitimate inputs. Coefficients above 2 are rejected as a probable unit
+error (a percentage passed instead of a fraction).
+
 **Parameters**
 
 | Name | Description |
 | :--- | :--- |
 | `volume` | Room volume `V`, m3. |
-| `surfaces` | Sequence of `(area, absorption_coefficient)` pairs; each coefficient a scalar or a per-band array. |
+| `surfaces` | Sequence of `(area, absorption_coefficient)` pairs; each coefficient a scalar or a per-band array in `[0, 2]`. |
 | `air_attenuation` | Air power-attenuation coefficient `m`, in neper per metre (scalar or per-band); see [`phonometry.air_absorption.air_attenuation_m`](/phonometry/reference/api/environment/air-absorption/#air_attenuation_m). Default `0` (air absorption neglected). |
 | `speed_of_sound` | Speed of sound `c0`, m/s (default [`DEFAULT_SPEED_OF_SOUND`](/phonometry/reference/api/materials/road-absorption/#default_speed_of_sound), giving the factor `0.161`). |
 

--- a/src/phonometry/room/reverberation_prediction.py
+++ b/src/phonometry/room/reverberation_prediction.py
@@ -214,8 +214,9 @@ def _eyring_absorption(total_area: float, mean_absorption: NDArray[np.float64]) 
         raise ValueError(
             "the mean absorption coefficient must be below 1 for the "
             "Eyring-family models: ln(1 - mean) diverges at a mean of 1. "
-            "Individual coefficients at or above 1 are accepted as long as "
-            "the mean stays below 1; Sabine does not constrain the mean."
+            "Individual coefficients at or above 1 are accepted (up to the "
+            "shared unit-error ceiling of 2) as long as the mean stays "
+            "below 1; Sabine does not constrain the mean."
         )
     return np.asarray(-total_area * np.log1p(-mean_absorption), dtype=np.float64)
 
@@ -299,7 +300,8 @@ def eyring_reverberation_time(
 
     The formula constrains only the *mean*: ``ln(1 - alpha_bar)`` requires
     ``alpha_bar < 1``, while individual coefficients at or above 1 (a measured
-    ISO 354 outcome) are accepted as long as the mean stays below 1.
+    ISO 354 outcome) are accepted as long as the mean stays below 1 and each
+    coefficient stays within the shared unit-error ceiling of 2.
 
     :param volume: Room volume ``V``, m3.
     :param surfaces: Sequence of ``(area, absorption_coefficient)`` pairs.

--- a/src/phonometry/room/reverberation_prediction.py
+++ b/src/phonometry/room/reverberation_prediction.py
@@ -35,6 +35,13 @@ coefficient ``m`` (in neper per metre) as the additive term ``4 m V``; obtain a
 physical ``m`` from temperature and humidity with
 :func:`phonometry.air_absorption.air_attenuation_m`.
 
+Each model enforces its own mathematical domain on the absorption
+coefficients. Sabine's linear sum is finite for any non-negative coefficient,
+so it accepts measured ISO 354 values at or above 1 (up to a unit-error guard
+at 2). The logarithmic models are stricter exactly where the maths requires
+it: Millington-Sette needs *every* coefficient below 1, while Eyring, Fitzroy
+and Arau-Puchades need each *mean* entering ``ln(1 - alpha)`` below 1.
+
 The Fitzroy and Arau-Puchades models require a rectangular (shoebox) room and
 take the room ``dimensions`` together with the mean absorption of each of the
 three wall pairs. All five reduce to Eyring for a uniform absorption
@@ -77,6 +84,15 @@ DEFAULT_SPEED_OF_SOUND = 343.0
 #: no finite Eyring reverberation time.
 _MAX_MEAN_ABSORPTION = 1.0
 
+#: Sanity ceiling for any individual absorption coefficient. Measured ISO 354
+#: reverberation-room coefficients legitimately exceed 1 (edge diffraction
+#: makes 1.05 to 1.20 routine for thick porous absorbers), so Sabine accepts
+#: them as supplied; a value above this bound is almost certainly a unit error
+#: (a percentage passed where a fraction is expected) and is rejected by the
+#: shared surface validator. The axial models (Fitzroy, Arau-Puchades) never
+#: reach it: their stricter below-1 wall-pair-mean check fires first.
+_MAX_ABSORPTION = 2.0
+
 
 Surface = tuple[float, ArrayLike]
 
@@ -106,16 +122,23 @@ def _broadcast_or_raise(
 
 def _accumulate_surfaces(
     surfaces: Sequence[Surface],
-) -> tuple[float, NDArray[np.float64], NDArray[np.float64]]:
-    """Total area ``S``, total absorption area ``A`` and Millington sum.
+) -> tuple[float, NDArray[np.float64], list[tuple[float, NDArray[np.float64]]]]:
+    """Total area ``S``, total absorption area ``A`` and the validated surfaces.
 
-    Returns ``(S, A, M)`` where ``A = sum_i S_i alpha_i`` and
-    ``M = -sum_i S_i ln(1 - alpha_i)``; ``A`` and ``M`` are per-band arrays
-    (0-d for scalar coefficients).
+    Returns ``(S, A, pairs)`` where ``A = sum_i S_i alpha_i`` is a per-band
+    array (0-d for scalar coefficients) and ``pairs`` is the list of validated
+    ``(area, alpha)`` items for model-specific processing.
+
+    Validation here is the domain shared by *all* models: coefficients must be
+    finite, non-negative and at most :data:`_MAX_ABSORPTION` (the unit-error
+    guard). The stricter logarithmic domains are enforced where the maths
+    requires them: per surface in :func:`_millington_absorption`, on the mean
+    in :func:`_eyring_absorption`.
 
     :raises ValueError: for an empty surface list, a negative area, a
-        coefficient outside ``[0, 1)`` (``1`` gives a divergent Millington sum),
-        or per-band coefficients whose band counts do not broadcast together.
+        non-finite or negative coefficient, a coefficient above
+        :data:`_MAX_ABSORPTION`, or per-band coefficients whose band counts do
+        not broadcast together.
     """
     if not surfaces:
         raise ValueError("at least one surface is required.")
@@ -124,8 +147,16 @@ def _accumulate_surfaces(
     for area, alpha in surfaces:
         areas.append(require_non_negative(area, "surface area"))
         alpha_arr = np.asarray(alpha, dtype=np.float64)
-        if np.any(alpha_arr < 0.0) or np.any(alpha_arr >= 1.0):
-            raise ValueError("absorption coefficients must be in the range [0, 1).")
+        if not np.all(np.isfinite(alpha_arr)):
+            raise ValueError("absorption coefficients must be finite.")
+        if np.any(alpha_arr < 0.0):
+            raise ValueError("absorption coefficients must be non-negative.")
+        if np.any(alpha_arr > _MAX_ABSORPTION):
+            raise ValueError(
+                f"absorption coefficients above {_MAX_ABSORPTION} look like a "
+                "unit error (a percentage passed instead of a fraction); "
+                "measured ISO 354 coefficients do not exceed about 1.2."
+            )
         alphas.append(alpha_arr)
     shape = _broadcast_or_raise(
         [a.shape for a in alphas], "surface absorption coefficients"
@@ -134,18 +165,16 @@ def _accumulate_surfaces(
     if total_area <= 0.0:
         raise ValueError("the total surface area must be positive.")
     absorption_area = np.zeros(shape, dtype=np.float64)
-    millington = np.zeros(shape, dtype=np.float64)
     for area, alpha_arr in zip(areas, alphas):
         absorption_area = absorption_area + area * alpha_arr
-        millington = millington - area * np.log1p(-alpha_arr)
-    return total_area, absorption_area, millington
+    return total_area, absorption_area, list(zip(areas, alphas))
 
 
 def _air_term(air_attenuation: ArrayLike, volume: float) -> NDArray[np.float64]:
-    """Air absorption area ``4 m V`` (m2), validated non-negative."""
+    """Air absorption area ``4 m V`` (m2), validated finite and non-negative."""
     m = np.asarray(air_attenuation, dtype=np.float64)
-    if np.any(m < 0.0):
-        raise ValueError("'air_attenuation' must be non-negative.")
+    if not np.all(np.isfinite(m)) or np.any(m < 0.0):
+        raise ValueError("'air_attenuation' must be finite and non-negative.")
     return np.asarray(4.0 * m * volume, dtype=np.float64)
 
 
@@ -160,12 +189,36 @@ def _add_air(
     return np.asarray(absorption_term + air, dtype=np.float64)
 
 
+def _millington_absorption(
+    pairs: Sequence[tuple[float, NDArray[np.float64]]],
+) -> NDArray[np.float64]:
+    """Millington equivalent absorption ``-sum_i S_i ln(1 - alpha_i)`` (per band).
+
+    :raises ValueError: for any coefficient at or above 1; the per-surface
+        ``ln(1 - alpha_i)`` diverges there, so Millington-Sette (alone among
+        the five models) requires every individual coefficient below 1.
+    """
+    total = np.asarray(0.0, dtype=np.float64)
+    for area, alpha_arr in pairs:
+        if np.any(alpha_arr >= 1.0):
+            raise ValueError(
+                "Millington-Sette requires every absorption coefficient below "
+                "1: its per-surface ln(1 - alpha) diverges at alpha = 1. For "
+                "measured ISO 354 coefficients at or above 1 use Sabine, or "
+                "Eyring if the mean absorption stays below 1."
+            )
+        total = total - area * np.log1p(-alpha_arr)
+    return np.asarray(total, dtype=np.float64)
+
+
 def _eyring_absorption(total_area: float, mean_absorption: NDArray[np.float64]) -> NDArray[np.float64]:
     """Eyring equivalent absorption ``-S ln(1 - alpha_bar)`` (per band)."""
     if np.any(mean_absorption >= _MAX_MEAN_ABSORPTION):
         raise ValueError(
-            "the mean absorption coefficient must be below 1; a fully absorbing "
-            "room has no finite Eyring reverberation time."
+            "the mean absorption coefficient must be below 1 for the "
+            "Eyring-family models: ln(1 - mean) diverges at a mean of 1. "
+            "Individual coefficients at or above 1 are accepted as long as "
+            "the mean stays below 1; Sabine does not constrain the mean."
         )
     return np.asarray(-total_area * np.log1p(-mean_absorption), dtype=np.float64)
 
@@ -209,9 +262,16 @@ def sabine_reverberation_time(
 ) -> np.ndarray | float:
     """Sabine reverberation time ``T = k V / (A + 4 m V)``.
 
+    ``A = sum_i S_i alpha_i`` is finite for any non-negative coefficient, so
+    unlike the logarithmic models Sabine accepts coefficients at or above 1:
+    measured ISO 354 reverberation-room values of 1.05 to 1.20 (the edge
+    effect) and the exact 1.0 that the ISO 11654 practical rating caps at are
+    legitimate inputs. Coefficients above 2 are rejected as a probable unit
+    error (a percentage passed instead of a fraction).
+
     :param volume: Room volume ``V``, m3.
     :param surfaces: Sequence of ``(area, absorption_coefficient)`` pairs; each
-        coefficient a scalar or a per-band array.
+        coefficient a scalar or a per-band array in ``[0, 2]``.
     :param air_attenuation: Air power-attenuation coefficient ``m``, in neper
         per metre (scalar or per-band); see
         :func:`phonometry.air_absorption.air_attenuation_m`. Default ``0``
@@ -240,6 +300,10 @@ def eyring_reverberation_time(
     ``T = k V / (-S ln(1 - alpha_bar) + 4 m V)`` with the total surface ``S``
     and its area-weighted mean absorption ``alpha_bar``.
 
+    The formula constrains only the *mean*: ``ln(1 - alpha_bar)`` requires
+    ``alpha_bar < 1``, while individual coefficients at or above 1 (a measured
+    ISO 354 outcome) are accepted as long as the mean stays below 1.
+
     :param volume: Room volume ``V``, m3.
     :param surfaces: Sequence of ``(area, absorption_coefficient)`` pairs.
     :param air_attenuation: Air power-attenuation coefficient ``m`` (1/m).
@@ -266,6 +330,9 @@ def millington_sette_reverberation_time(
     ``T = k V / (-sum_i S_i ln(1 - alpha_i) + 4 m V)``: the Eyring absorption
     term summed surface by surface rather than through a single mean. A surface
     approaching total absorption (``alpha_i -> 1``) drives ``T`` to zero.
+    Because the logarithm applies per surface, *every* coefficient must be
+    strictly below 1; measured ISO 354 coefficients at or above 1 are outside
+    this model's domain (use Sabine, or Eyring while the mean stays below 1).
 
     :param volume: Room volume ``V``, m3.
     :param surfaces: Sequence of ``(area, absorption_coefficient)`` pairs.
@@ -275,8 +342,8 @@ def millington_sette_reverberation_time(
     """
     volume = require_positive(volume, "volume")
     speed_of_sound = require_positive(speed_of_sound, "speed_of_sound")
-    _, _, millington = _accumulate_surfaces(surfaces)
-    absorption = _add_air(millington, air_attenuation, volume)
+    _, _, pairs = _accumulate_surfaces(surfaces)
+    absorption = _add_air(_millington_absorption(pairs), air_attenuation, volume)
     return _reverberation_time(volume, absorption, speed_of_sound)
 
 
@@ -323,8 +390,17 @@ def _axial_eyring_times(
     means: list[NDArray[np.float64]] = []
     for alpha in absorptions:
         mean = np.asarray(alpha, dtype=np.float64)
-        if np.any(mean < 0.0) or np.any(mean >= 1.0):
-            raise ValueError("absorption coefficients must be in the range [0, 1).")
+        if not np.all(np.isfinite(mean)):
+            raise ValueError("absorption coefficients must be finite.")
+        if np.any(mean < 0.0):
+            raise ValueError("absorption coefficients must be non-negative.")
+        if np.any(mean >= 1.0):
+            raise ValueError(
+                "each wall-pair mean absorption must be below 1: the axial "
+                "Eyring term ln(1 - alpha_i) diverges at alpha_i = 1. The "
+                "inputs of the Fitzroy and Arau-Puchades models are "
+                "themselves the means entering the logarithm."
+            )
         means.append(mean)
     # The three axial times are combined (arithmetic/geometric mean), so their
     # band counts -- and the shared air term -- must broadcast together.
@@ -351,7 +427,8 @@ def fitzroy_reverberation_time(
     ``T = sum_i (S_i / S) T_i`` with ``T_i`` the Eyring time of the wall pair
     perpendicular to axis ``i`` (Fitzroy, *J. Acoust. Soc. Am.* 31 (1959) 893).
     Equivalent to ``T = k V / S**2 * sum_i S_i / (-ln(1 - alpha_i))`` without
-    air. Reduces to Eyring for a uniform absorption distribution.
+    air. Reduces to Eyring for a uniform absorption distribution. Each input
+    is itself a mean entering ``ln(1 - alpha_i)``, so each must be below 1.
 
     :param dimensions: Room lengths ``(Lx, Ly, Lz)``, m.
     :param absorptions: Mean absorption ``(alpha_x, alpha_y, alpha_z)`` of the
@@ -381,7 +458,8 @@ def arau_puchades_reverberation_time(
     pair perpendicular to axis ``i`` (Arau-Puchades, *Acustica* 65 (1988) 163,
     Formula 18). Preferred by its author over Fitzroy for rooms with an
     anisotropic absorption distribution. Reduces to Eyring for a uniform
-    distribution.
+    distribution. Each input is itself a mean entering ``ln(1 - alpha_i)``,
+    so each must be below 1.
 
     :param dimensions: Room lengths ``(Lx, Ly, Lz)``, m.
     :param absorptions: Mean absorption ``(alpha_x, alpha_y, alpha_z)`` of the
@@ -462,7 +540,9 @@ def reverberation_time_models(
     from ``dimensions`` and the three wall-pair mean absorptions, then evaluates
     :func:`sabine_reverberation_time`, :func:`eyring_reverberation_time`,
     :func:`millington_sette_reverberation_time`, :func:`fitzroy_reverberation_time`
-    and :func:`arau_puchades_reverberation_time` on a common footing.
+    and :func:`arau_puchades_reverberation_time` on a common footing. Because
+    the bundle evaluates the logarithmic models too, the inputs must satisfy
+    the strictest of the five domains: every absorption below 1.
 
     :param dimensions: Room lengths ``(Lx, Ly, Lz)``, m.
     :param absorptions: Mean absorption ``(alpha_x, alpha_y, alpha_z)`` of the

--- a/src/phonometry/room/reverberation_prediction.py
+++ b/src/phonometry/room/reverberation_prediction.py
@@ -79,11 +79,6 @@ _SABINE_NUMERATOR = 24.0 * log(10.0)
 DEFAULT_SPEED_OF_SOUND = 343.0
 
 #: Absorption-coefficient ceiling for the Eyring-family logarithm ``ln(1 -
-#: alpha)``; a mean absorption at or above this triggers a clear error rather
-#: than a silent ``-inf``/``nan``. A fully absorbing surface (``alpha = 1``) has
-#: no finite Eyring reverberation time.
-_MAX_MEAN_ABSORPTION = 1.0
-
 #: Sanity ceiling for any individual absorption coefficient. Measured ISO 354
 #: reverberation-room coefficients legitimately exceed 1 (edge diffraction
 #: makes 1.05 to 1.20 routine for thick porous absorbers), so Sabine accepts
@@ -213,7 +208,9 @@ def _millington_absorption(
 
 def _eyring_absorption(total_area: float, mean_absorption: NDArray[np.float64]) -> NDArray[np.float64]:
     """Eyring equivalent absorption ``-S ln(1 - alpha_bar)`` (per band)."""
-    if np.any(mean_absorption >= _MAX_MEAN_ABSORPTION):
+    # A mean of exactly 1 (fully absorbing on average) has no finite Eyring
+    # time: ln(1 - mean) diverges, so fail with a clear message instead.
+    if np.any(mean_absorption >= 1.0):
         raise ValueError(
             "the mean absorption coefficient must be below 1 for the "
             "Eyring-family models: ln(1 - mean) diverges at a mean of 1. "

--- a/tests/room/test_reverberation_prediction.py
+++ b/tests/room/test_reverberation_prediction.py
@@ -220,11 +220,122 @@ def test_empty_surfaces_raise() -> None:
         sabine_reverberation_time(VOLUME, [])
 
 
-def test_absorption_out_of_range_raises() -> None:
-    with pytest.raises(ValueError, match=r"\[0, 1\)"):
-        sabine_reverberation_time(VOLUME, [(10.0, 1.0)])
-    with pytest.raises(ValueError, match=r"\[0, 1\)"):
-        eyring_reverberation_time(VOLUME, [(10.0, -0.1)])
+# The old blanket [0, 1) validator rejected alpha >= 1 for every model; that
+# was over-strict for Sabine (whose A = sum S_i alpha_i is finite there) and
+# for Eyring (which only needs the mean below 1). The tests below encode the
+# per-model domains that replaced it.
+@pytest.mark.parametrize(
+    "model",
+    [
+        sabine_reverberation_time,
+        eyring_reverberation_time,
+        millington_sette_reverberation_time,
+    ],
+)
+@pytest.mark.parametrize("bad", [-0.1, math.nan, math.inf])
+def test_negative_and_non_finite_alpha_rejected_by_surface_models(
+    model, bad: float
+) -> None:
+    """Negative and non-finite coefficients are rejected by every model."""
+    with pytest.raises(ValueError, match="absorption coefficients must be"):
+        model(VOLUME, [(10.0, bad)])
+
+
+@pytest.mark.parametrize(
+    "model",
+    [fitzroy_reverberation_time, arau_puchades_reverberation_time],
+)
+@pytest.mark.parametrize("bad", [-0.1, math.nan, math.inf])
+def test_negative_and_non_finite_alpha_rejected_by_axial_models(
+    model, bad: float
+) -> None:
+    with pytest.raises(ValueError, match="absorption coefficients must be"):
+        model(DIMS, (bad, 0.2, 0.2))
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        sabine_reverberation_time,
+        eyring_reverberation_time,
+        millington_sette_reverberation_time,
+    ],
+)
+def test_alpha_above_unit_error_bound_rejected_by_surface_models(model) -> None:
+    """A coefficient above 2 is flagged as a probable percent-vs-fraction slip.
+
+    (The axial models reject 20.0 too, but through their stricter below-1
+    wall-pair-mean check, exercised in the axial rejection test below.)
+    """
+    with pytest.raises(ValueError, match="unit error"):
+        model(VOLUME, [(10.0, 20.0)])
+
+
+def test_sabine_accepts_the_documented_upper_bound() -> None:
+    """The bound is inclusive: alpha exactly 2.0 computes, 2.0 + eps raises."""
+    t = sabine_reverberation_time(VOLUME, [(SURFACE, 2.0)])
+    assert t == pytest.approx(_K * VOLUME / (SURFACE * 2.0), abs=1e-9)
+    with pytest.raises(ValueError, match="unit error"):
+        sabine_reverberation_time(VOLUME, [(SURFACE, 2.0000001)])
+
+
+def test_sabine_accepts_iso354_alphas_at_and_above_one() -> None:
+    """Sabine: A = S alpha stays finite for alpha in {0.2, 1.0, 1.15}.
+
+    Hand check per band: A = 158 alpha, T = k 120 / A, i.e. 0.611825 s,
+    0.122365 s and 0.106404 s. The exact 1.0 is the ISO 11654 practical-
+    coefficient cap; 1.15 is a routine measured ISO 354 value (edge effect).
+    """
+    alpha = np.array([0.2, 1.0, 1.15])
+    surfaces = [(area, alpha) for area, _ in UNIFORM_SURFACES]
+    t = sabine_reverberation_time(VOLUME, surfaces)
+    np.testing.assert_allclose(t, _K * VOLUME / (SURFACE * alpha), atol=1e-9)
+    np.testing.assert_allclose(t, [0.6118246547, 0.1223649309, 0.1064042878],
+                               atol=1e-6)
+
+
+def test_millington_rejects_any_alpha_at_or_above_one() -> None:
+    """The per-surface ln(1 - alpha) diverges at 1, so Millington rejects it."""
+    for alpha in (1.0, 1.15):
+        with pytest.raises(ValueError, match="Millington-Sette requires every"):
+            millington_sette_reverberation_time(
+                100.0, [(60.0, 0.3), (40.0, alpha)]
+            )
+
+
+def test_eyring_accepts_alpha_above_one_when_mean_stays_below_one() -> None:
+    """Eyring constrains only the mean: 10 m2 at 1.2 in a 158 m2 room is fine."""
+    surfaces = [(10.0, 1.2), (148.0, 0.1)]
+    mean = (10.0 * 1.2 + 148.0 * 0.1) / 158.0
+    t = eyring_reverberation_time(VOLUME, surfaces)
+    assert t == pytest.approx(_K * VOLUME / (-158.0 * math.log(1.0 - mean)),
+                              abs=1e-9)
+
+
+def test_eyring_rejects_mean_at_or_above_one() -> None:
+    """A mean of exactly 1 or above has no finite Eyring time."""
+    for high in (1.1, 1.2):  # means 1.0 and 1.05 with the 0.9 partner below
+        with pytest.raises(ValueError, match="mean absorption coefficient"):
+            eyring_reverberation_time(VOLUME, [(79.0, high), (79.0, 0.9)])
+
+
+def test_axial_models_reject_wall_pair_mean_at_or_above_one() -> None:
+    """Fitzroy/Arau inputs are the means entering ln(1 - alpha_i) directly."""
+    for model in (fitzroy_reverberation_time, arau_puchades_reverberation_time):
+        for bad in (1.0, 20.0):
+            with pytest.raises(ValueError, match="wall-pair mean absorption"):
+                model(DIMS, (bad, 0.2, 0.2))
+
+
+def test_models_bundle_inherits_the_strictest_domain() -> None:
+    """The bundle evaluates Millington too, so alpha >= 1 raises its error."""
+    with pytest.raises(ValueError, match="Millington-Sette requires every"):
+        reverberation_time_models(DIMS, (1.0, 0.2, 0.2))
+
+
+def test_mean_absorption_accepts_iso354_alphas_above_one() -> None:
+    """The mean of measured coefficients above 1 is meaningful: 0.21 here."""
+    assert mean_absorption([(10.0, 1.2), (90.0, 0.1)]) == pytest.approx(0.21)
 
 
 def test_perfectly_reflecting_room_raises() -> None:
@@ -240,6 +351,13 @@ def test_non_positive_volume_raises() -> None:
 def test_negative_air_attenuation_raises() -> None:
     with pytest.raises(ValueError, match="air_attenuation"):
         sabine_reverberation_time(VOLUME, UNIFORM_SURFACES, air_attenuation=-1.0)
+
+
+@pytest.mark.parametrize("bad", [math.nan, math.inf])
+def test_non_finite_air_attenuation_raises(bad: float) -> None:
+    """NaN used to slip through the old m < 0 comparison and return NaN."""
+    with pytest.raises(ValueError, match="air_attenuation"):
+        sabine_reverberation_time(VOLUME, UNIFORM_SURFACES, air_attenuation=bad)
 
 
 def test_bad_dimensions_raise() -> None:


### PR DESCRIPTION
## Summary

Reverberation-prediction absorption coefficients are now validated per model instead of with a blanket rejection of everything outside [0, 1).

- Sabine accepts the full physically meaningful range: its equivalent area is a finite sum for any non-negative coefficient, so legitimate ISO 354 values of 1.05 to 1.20 and the exact 1.0 of the ISO 11654 practical-coefficient convention now work; values above 2 are rejected as a percent-versus-fraction unit error with a message saying so.
- Eyring validates the mean (the only quantity its logarithm uses): individual coefficients at or above 1 are fine while the surface-weighted mean stays below 1, and the error message for a mean at or above 1 says exactly that.
- Millington keeps the strict per-surface domain its logarithm requires, with a message naming the model and pointing to Sabine or Eyring; Fitzroy and Arau keep strict inputs because their inputs are themselves the means entering the logarithm.
- NaN previously slipped through the range comparisons (including the air-attenuation term); every path now rejects non-finite values.
- The guide prose that documented the old blanket behavior is updated to the per-model domains in the three content trees.

## Test plan

Seven new parametrized test groups (53 tests in the module): Sabine hand-checked at 0.2/1.0/1.15 and at the exact 2.0 boundary, Millington and the axial models rejecting at 1.0, Eyring accepting an individual 1.2 with mean 0.17 and rejecting means at 1.0, the bundle inheriting the strictest domain, and negatives/NaN/inf rejected everywhere. Full suite 3241 passed; ruff, mypy, conformance byte-identical (257/257); goldens untouched; site parity and build green. A review pass added the boundary and NaN cases and tightened the messages.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reverberation-time estimators now enforce model-specific absorption-coefficient validity domains.
  * Sabine and Eyring accept coefficients at/above 1 when their domain conditions are met; Millington–Sette continues to reject coefficients at/above 1.
  * Negative, non-finite, and out-of-range values (including unit-error/upper bound handling) are rejected consistently.
  * Non-finite air-attenuation inputs are now rejected.

* **Documentation**
  * Updated materials and API docs to clarify per-model coefficient domains and any mean-based acceptance rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->