### PR TITLE
perf: parallel test suite with shared heavy fixtures

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -188,8 +188,18 @@ jobs:
         pip install -r requirements-dev.txt
         pip install -e .
     - name: Run tests
+      # -n auto fans the suite out across the runner's cores via pytest-xdist;
+      # pytest-cov combines the per-worker coverage into a single coverage.xml.
+      # Pin the numerical thread pools to one thread each so the per-core xdist
+      # workers do not oversubscribe the CPU with nested BLAS/OpenMP pools.
+      env:
+        OMP_NUM_THREADS: "1"
+        MKL_NUM_THREADS: "1"
+        OPENBLAS_NUM_THREADS: "1"
+        NUMEXPR_NUM_THREADS: "1"
+        VECLIB_MAXIMUM_THREADS: "1"
       run: |
-        pytest --junitxml=test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml --cov=src --cov-report=xml
+        pytest -n auto --junitxml=test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml --cov=src --cov-report=xml
     - name: Upload Test Results
       uses: actions/upload-artifact@v7
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -358,6 +358,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   identical (guarded by the golden baseline and a scalar-equivalence test)
   and ~45x faster on small grids, several hundred times on production-size
   grids (30 000 points in ~0.2 s).
+- The test suite now runs in parallel: `make test`, `make coverage` and the CI
+  test job invoke `pytest -n auto` (pytest-xdist, added to the dev
+  requirements) so the 3241 tests fan out across every CPU core. Each worker
+  pins its numerical thread pools to a single thread
+  (`OMP_NUM_THREADS=1` and the MKL/OpenBLAS/NumExpr/Accelerate equivalents) so
+  the per-core workers do not oversubscribe the machine with nested BLAS
+  pools. On a 12-core host the full suite drops from 508 s to 138 s wall-clock
+  (about 3.7x); pytest-cov combines the per-worker coverage so the Codecov
+  upload is unchanged (identical 96% line coverage, same 13914 statements).
+  Two supporting test changes: the Annex C.1 Moore-Glasberg time-varying
+  loudness checks share one memoised result per distinct tone (the phon and
+  sone suites analysed the same signals independently), and the ECMA-418-2
+  roughness peak/depth checks reuse the module calibration result instead of
+  recomputing it - no oracle, tolerance or covered line changes. The pink-noise
+  flatness test no longer writes a throwaway debug PNG to a fixed path (it
+  raced under parallel workers and left an untracked file); its numerical
+  assertion is untouched.
 
 ### Fixed
 

--- a/Makefile
+++ b/Makefile
@@ -105,11 +105,22 @@ install-hooks:
 	@chmod +x .git/hooks/pre-commit
 	@echo "Installed .git/hooks/pre-commit (regenerates docs/CONFORMANCE.md when src/scripts change)."
 
+# Pin every numerical thread pool to one thread so the pytest-xdist workers
+# (one per core) do not each spawn a nested BLAS/OpenMP pool and oversubscribe
+# the CPU. With one worker per core already saturating the machine, nested
+# threads only add contention: measured ~25% faster wall-clock and ~40% less
+# total CPU on this suite. (PYTHONHASHSEED is deliberately left unset here so
+# the tests still exercise randomised hash/set ordering.)
+TEST_ENV = OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 \
+	NUMEXPR_NUM_THREADS=1 VECLIB_MAXIMUM_THREADS=1
+
+# -n auto fans the suite out across all CPU cores via pytest-xdist (workers are
+# separate processes; pytest-cov combines their coverage data automatically).
 test:
-	$(PYTHON) -m pytest tests/
+	$(TEST_ENV) $(PYTHON) -m pytest -n auto tests/
 
 coverage:
-	$(PYTHON) -m pytest --cov=src/phonometry --cov-report=term-missing tests/
+	$(TEST_ENV) $(PYTHON) -m pytest -n auto --cov=src/phonometry --cov-report=term-missing tests/
 
 check: lint security test
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,5 +4,6 @@ bandit>=1.9.4
 types-setuptools>=82.0.0.20260518
 pytest>=9.1.1
 pytest-cov>=7.1.0
+pytest-xdist>=3.6.1  # parallel test execution (`pytest -n auto`); coverage is combined across workers by pytest-cov
 matplotlib>=3.10.9  # required by the result-object .plot() tests
 pyoxipng==9.1.1  # deterministic PNG optimizer; pinned so a local `make graphs` emits the same bytes as the figures CI stack

--- a/tests/psychoacoustics/test_loudness_moore_glasberg_time.py
+++ b/tests/psychoacoustics/test_loudness_moore_glasberg_time.py
@@ -43,14 +43,47 @@ def _tone(frequency: float, level_db: float, duration: float = 1.3) -> np.ndarra
     return np.sqrt(2.0) * p_rms * np.sin(2.0 * np.pi * frequency * t)
 
 
+@pytest.fixture(scope="module")
+def mg_tone():
+    """Memoised steady-tone loudness, shared across the Annex C.1 checks.
+
+    Several parametrised suites analyse the *same* (frequency, level, field,
+    presentation) 1.3 s tone but assert different columns of the one result
+    object: ``test_annex_c1_other_tones`` pins the phon value while
+    ``test_annex_c1_sone_values`` pins the sone value of the identical tone,
+    and the 1 kHz / 40 dB anchor is shared by three checks. Each analysis is a
+    full time-varying loudness chain (~2 s), so computing it once per distinct
+    input and reusing the (read-only) result object removes ~8 redundant
+    recomputations without touching any oracle or tolerance. The returned
+    ``MooreGlasbergTimeVaryingLoudness`` is never mutated by callers.
+    """
+    cache: dict[tuple, MooreGlasbergTimeVaryingLoudness] = {}
+
+    def get(
+        frequency: float,
+        level_db: float,
+        *,
+        field: str = "free",
+        presentation: str = "binaural",
+    ) -> MooreGlasbergTimeVaryingLoudness:
+        key = (frequency, level_db, field, presentation)
+        if key not in cache:
+            cache[key] = loudness_moore_glasberg_time(
+                _tone(frequency, level_db), FS, field=field, presentation=presentation
+            )
+        return cache[key]
+
+    return get
+
+
 # --------------------------------------------------------------------------
 # Definitional anchor (clause 7.3 / Annex C.1)
 # --------------------------------------------------------------------------
 
 
-def test_anchor_1khz_40db_is_one_sone() -> None:
+def test_anchor_1khz_40db_is_one_sone(mg_tone) -> None:
     """A 1 kHz tone at 40 dB SPL, binaural, free field -> 1.000 sone / 40 phon."""
-    res = loudness_moore_glasberg_time(_tone(1000.0, 40.0), FS)
+    res = mg_tone(1000.0, 40.0)
     assert res.n_max == pytest.approx(1.0, abs=0.02)
     assert res.loudness_level_max == pytest.approx(40.0, abs=0.3)
 
@@ -94,9 +127,9 @@ _C1_1KHZ = [
 
 
 @pytest.mark.parametrize("level_db, sone, phon", _C1_1KHZ)
-def test_annex_c1_1khz_tone(level_db: float, sone: float, phon: float) -> None:
+def test_annex_c1_1khz_tone(mg_tone, level_db: float, sone: float, phon: float) -> None:
     """1 kHz tone 10-80 dB reaches the Annex C.1 peak long-term loudness."""
-    res = loudness_moore_glasberg_time(_tone(1000.0, level_db), FS)
+    res = mg_tone(1000.0, level_db)
     # Loudness level (phon) is the linear-in-perception comparison; within the
     # standard's expanded uncertainty (2.8 phon, clause 8).
     assert res.loudness_level_max == pytest.approx(phon, abs=1.0)
@@ -122,12 +155,10 @@ _C1_OTHER = [
 
 @pytest.mark.parametrize("frequency, level_db, field, presentation, phon", _C1_OTHER)
 def test_annex_c1_other_tones(
-    frequency: float, level_db: float, field: str, presentation: str, phon: float
+    mg_tone, frequency: float, level_db: float, field: str, presentation: str, phon: float
 ) -> None:
     """3 kHz / 100 Hz / 4 kHz and monaural earphone tones match Annex C.1."""
-    res = loudness_moore_glasberg_time(
-        _tone(frequency, level_db), FS, field=field, presentation=presentation
-    )
+    res = mg_tone(frequency, level_db, field=field, presentation=presentation)
     assert res.loudness_level_max == pytest.approx(phon, abs=1.2)
 
 
@@ -147,16 +178,14 @@ _C1_SONE = [
 
 @pytest.mark.parametrize("frequency, field, presentation, level_db, sone", _C1_SONE)
 def test_annex_c1_sone_values(
-    frequency: float, field: str, presentation: str, level_db: float, sone: float
+    mg_tone, frequency: float, field: str, presentation: str, level_db: float, sone: float
 ) -> None:
     """Annex C.1.2/C.1.3 peak long-term loudness in sone.
 
     Values print to two decimals; the absolute floor covers their rounding
     half-width at the quiet end.
     """
-    res = loudness_moore_glasberg_time(
-        _tone(frequency, level_db), FS, field=field, presentation=presentation
-    )
+    res = mg_tone(frequency, level_db, field=field, presentation=presentation)
     assert res.n_max == pytest.approx(sone, rel=0.02, abs=0.005)
 
 

--- a/tests/psychoacoustics/test_roughness_ecma.py
+++ b/tests/psychoacoustics/test_roughness_ecma.py
@@ -95,18 +95,21 @@ def test_silence_is_zero() -> None:
     assert np.all(result.specific_roughness == 0.0)
 
 
-def test_peaks_near_70hz_modulation() -> None:
+def test_peaks_near_70hz_modulation(ref_calibration: EcmaRoughness) -> None:
     # Roughness is maximal around 70 Hz modulation and falls off toward slow
-    # (< 20 Hz) and fast (> 200 Hz) modulation (Clause 7 intro, Annex C).
-    r70 = roughness_ecma(_am_tone(1000.0, 70.0, 1.0, 60.0), FS).roughness
+    # (< 20 Hz) and fast (> 200 Hz) modulation (Clause 7 intro, Annex C). The
+    # 70 Hz reference is the module calibration signal, so reuse its result
+    # rather than recompute the same chain.
+    r70 = ref_calibration.roughness
     r10 = roughness_ecma(_am_tone(1000.0, 10.0, 1.0, 60.0), FS).roughness
     r300 = roughness_ecma(_am_tone(1000.0, 300.0, 1.0, 60.0), FS).roughness
     assert r70 > r10
     assert r70 > r300
 
 
-def test_grows_with_modulation_depth() -> None:
-    r_full = roughness_ecma(_am_tone(1000.0, 70.0, 1.0, 60.0), FS).roughness
+def test_grows_with_modulation_depth(ref_calibration: EcmaRoughness) -> None:
+    # The full-depth 70 Hz signal is the module calibration signal; reuse it.
+    r_full = ref_calibration.roughness
     r_half = roughness_ecma(_am_tone(1000.0, 70.0, 0.5, 60.0), FS).roughness
     assert r_full > r_half > 0.05
 

--- a/tests/test_audio_processing.py
+++ b/tests/test_audio_processing.py
@@ -5,7 +5,6 @@ Advanced audio processing tests including Pink Noise spectral analysis.
 
 from typing import cast
 
-import matplotlib.pyplot as plt
 import numpy as np
 
 from phonometry import octave_filter
@@ -59,24 +58,10 @@ def test_pink_noise_flatness() -> None:
     samples = int(fs * duration)
     x = generate_pink_noise(samples)
 
-    spl, freq = octave_filter(x, fs=fs, fraction=3, order=6, limits=[20, 20000])
-
-    mean_spl = np.mean(spl)
+    spl, _freq = octave_filter(x, fs=fs, fraction=3, order=6, limits=[20, 20000])
 
     # Check flatness in central bands (ignoring edges)
     valid_spl = np.array(spl)[2:-2]
     deviation = np.max(np.abs(valid_spl - np.mean(valid_spl)))
-
-    # Plot results for visual verification (optional in CI)
-    _, ax = plt.subplots(figsize=(10, 6))
-    ax.semilogx(freq, spl, "b-o", label="Measured SPL", markerfacecolor="white")
-    ax.axhline(float(mean_spl), color="r", linestyle="--", label="Mean SPL", alpha=0.7)
-    ax.set_title("Pink Noise 1/3 Octave Spectrum (Flatness Check)", fontweight="bold")
-    ax.set_xlabel("Frequency [Hz]")
-    ax.set_ylabel("Level [dB]")
-    ax.grid(True, which="both", alpha=0.3)
-    ax.legend()
-    plt.savefig("tests/pink_noise_test.png", dpi=150)
-    plt.close()
 
     assert deviation < 3.0, f"Spectrum deviation too high: {deviation:.2f} dB"


### PR DESCRIPTION
## Summary

Cuts the test-suite wall time from about 8.5 minutes to under 2.5 without touching a single oracle, tolerance or assertion.

- Profiling showed the Moore-Glasberg time-varying module spending 95 seconds analysing identical tones across independent tests; a module-scoped memoising fixture computes each distinct tone once (frozen results, read-only, memo keys verified against the original inline inputs). The roughness calibration result is shared the same way. Sequential run drops 508 to 452 seconds.
- The suite now runs in parallel with pytest-xdist (`-n auto`) in the Makefile and the CI tests job, with BLAS thread pinning per worker (the hidden cost was oversubscription: pinning alone cut 27 percent of wall and 42 percent of CPU on the heavy subset). Full suite: 138 seconds wall on 12 cores, 3.7 to 3.9x.
- One isolation fix surfaced by the xdist review: an assertion-free debug PNG written to a fixed repo path is gone.
- Deliberately NOT taken: signal shortening and parametrization dedup, because the remaining long cases pin published-oracle durations (ISO 532-1 Annex B, ECMA calibration lengths) and distinct oracle rows; weakening them was out of bounds.
- The numba performance job stays serial by design; the local-only STIPA bench parallelizes fine.

## Test plan

Identical test count (3241 passed) sequential and parallel, before and after; coverage identical at 96 percent (13914 statements, 616 missed) with pytest-cov combining xdist workers and the Codecov artifact unchanged in shape; ruff, mypy, conformance byte-identical, goldens untouched. A review pass over the fixture-sharing safety found zero issues.

## Summary by Sourcery

Parallelize the test suite with pytest-xdist while ensuring deterministic coverage and non-oversubscribed numerical backends.

New Features:
- Introduce a module-scoped memoized loudness fixture to share Moore-Glasberg time-varying tone analyses across Annex C.1 tests.
- Reuse the ECMA-418-2 roughness calibration result across multiple modulation tests instead of recomputing it.

Enhancements:
- Run local and CI test and coverage commands with pytest-xdist (`-n auto`) and pin numerical thread pools to a single thread per worker to avoid BLAS/OpenMP oversubscription.
- Remove the debug PNG plotting/output from the pink-noise flatness test to keep tests side-effect free under parallel execution.

CI:
- Update the GitHub Actions test job to run tests in parallel with pytest-xdist and single-threaded numerical libraries.

Documentation:
- Document the new parallel test setup, memoized fixtures, and removal of the debug PNG output in the changelog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Test suites now run in parallel locally and in continuous integration for faster feedback.
  * Numerical libraries are configured to avoid excessive thread usage during parallel tests.
  * Coverage reporting remains available with explicit project instrumentation.
  * Updated loudness and roughness tests reuse calculated results to improve test efficiency.
  * Pink-noise testing no longer creates debug image files, preventing conflicting output during parallel runs.
  * Added support for parallel test execution through the development test tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

