### PR TITLE
docs: keep the untranslated survey-method term for ISO/TS 7849-1

### DIFF
--- a/site/src/content/docs/es/guides/vibration-sound-power.md
+++ b/site/src/content/docs/es/guides/vibration-sound-power.md
@@ -32,7 +32,8 @@ en edificación (ISO 9611, EN 15657, EN 12354-5).
 
 ## 1. Las dos partes
 
-Las dos partes difieren solo en el factor de radiación. La **Parte 1 (control)**
+Las dos partes difieren solo en el factor de radiación. La **Parte 1** (*survey
+method*, sin versión en español)
 asume `ε = 1` y da el *límite superior* `L_W,max`, necesitando solo el nivel de
 velocidad y el área. La **Parte 2 (ingeniería)** aplica un factor de radiación
 por banda `εⱼ` determinado (según ISO 9614) como `εⱼ = Pⱼ/(Z_{c,n}·⟨vⱼ²⟩·S)`.


### PR DESCRIPTION
ISO/TS 7849-1 has no Spanish adoption, so the Spanish guide no longer invents a term for its survey method: the sentence keeps the standard's own English term with a note, referencing the part correctly. The rest of the page already cited the English method names verbatim.

## Summary by Sourcery

Documentation:
- Update the Spanish vibration sound power guide to reference ISO/TS 7849-1 Part 1 using its original English survey-method term instead of a Spanish translation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the introduction to Part 1 of the vibration, sound, and power guide.
  * Identified Part 1 as the “survey method” and noted that no Spanish translation is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

