### PR TITLE
build: pin numba threads in the test environment too

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ install-hooks:
 # total CPU on this suite. (PYTHONHASHSEED is deliberately left unset here so
 # the tests still exercise randomised hash/set ordering.)
 TEST_ENV = OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 \
-	NUMEXPR_NUM_THREADS=1 VECLIB_MAXIMUM_THREADS=1
+	NUMEXPR_NUM_THREADS=1 VECLIB_MAXIMUM_THREADS=1 NUMBA_NUM_THREADS=1
 
 # -n auto fans the suite out across all CPU cores via pytest-xdist (workers are
 # separate processes; pytest-cov combines their coverage data automatically).


### PR DESCRIPTION
Completes the review suggestion on the parallel test suite: the numba thread pool joins the per-worker pins in TEST_ENV. The commit raced the squash merge of the previous pull request and was left out; this lands it. Inert in environments without numba (the CI matrix) and protective for local make test runs with numba installed; the CI numba job calls pytest directly and keeps its own environment.

## Summary by Sourcery

Build:
- Extend TEST_ENV in the Makefile to include NUMBA_NUM_THREADS=1 so numba respects the per-worker thread pinning during make-based test runs.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

