### PR TITLE
docs: verified references for the aircraft and underwater guides

### DIFF
--- a/docs/ERRATA.md
+++ b/docs/ERRATA.md
@@ -287,7 +287,7 @@ to the issuing body, with date and reference).
   in [`distortion.py`](../src/phonometry/electroacoustics/distortion.py).
 - **Status:** unreported.
 
-## NORAH2 rotorcraft guidance SC03.D1.5d (EASA.2020.FC.06) — Eq. (27)
+## NORAH2 rotorcraft guidance SC01.D1.5d (EASA.2020.FC.06) — Eq. (27)
 
 - **Location:** section A.4.2, Eq. (27) (atmospheric absorption coefficient).
 - **The print:** the coefficient 6,6928·10⁻⁶ is paired with the relaxation

--- a/docs/aircraft-noise.md
+++ b/docs/aircraft-noise.md
@@ -278,6 +278,55 @@ geometry behind takeoff roll, the Eq. 4-13b average runway-segment speed and
 the recommended 30 m floor on NPD lookups. Seven branch-covering receptor
 events of the reference workbook are reproduced end-to-end in the test suite.
 
+## References
+
+- International Civil Aviation Organization. (2017). *Annex 16 to the
+  Convention on International Civil Aviation: Environmental protection —
+  Volume I: Aircraft noise* (8th ed.).
+  [ICAO store](https://store.icao.int/en/annex-16-environmental-protection-volume-i-aircraft-noise).
+  The normative Appendix 2 EPNL procedure implemented in sections 1-3.
+- International Civil Aviation Organization. (2018). *Environmental technical
+  manual — Volume I: Procedures for the noise certification of aircraft*
+  (Doc 9501, 3rd ed.).
+  [ICAO store](https://store.icao.int/en/environmental-technical-manual-volume-1-procedures-for-the-noise-certification-of-aircraft-doc-9501-1).
+  The worked examples (Table 3-7 tone correction, Table 4-4 integrated-method
+  EPNL) used as the numeric oracles of sections 2-3.
+- International Electrotechnical Commission. (1995). *Electroacoustics —
+  Instruments for measurement of aircraft noise — Performance requirements for
+  systems to measure one-third-octave-band sound pressure levels in noise
+  certification of transport-category aeroplanes* (IEC 61265:1995; since
+  revised as [IEC 61265:2018](https://webstore.iec.ch/en/publication/32635),
+  the 1995 edition is the implemented one).
+  [IEC webstore](https://webstore.iec.ch/en/publication/5076).
+  The measurement-system tolerances checked by the section 4 verifier.
+- SAE International. (2013). *Application of pure-tone atmospheric absorption
+  losses to one-third octave-band data* (SAE ARP 5534, reaffirmed 2021).
+  [sae.org](https://www.sae.org/standards/content/arp5534/).
+  The SAE-Method band attenuation of section 5.
+- SAE International. (2012). *Standard values of atmospheric absorption as a
+  function of temperature and humidity* (SAE ARP 866B, stabilized 2012).
+  [sae.org](https://www.sae.org/standards/content/arp866b/).
+  The predecessor SAE atmospheric-absorption practice, source of the 50
+  dB-limited Approximate Method that section 5 contrasts with the SAE Method.
+- SAE International. (2006). *Method for predicting lateral attenuation of
+  airplane noise* (SAE AIR 5662).
+  [sae.org](https://www.sae.org/standards/content/air5662/).
+  The soft-ground lateral-attenuation model that Doc 29 §4.5.4 adopts in
+  section 7.
+- European Civil Aviation Conference. (2016). *Report on standard method of
+  computing noise contours around civil airports* (ECAC.CEAC Doc 29, 4th ed.),
+  Volume 2: Technical guide.
+  [ECAC documents page](https://www.ecac-ceac.org/documents/ecac-documents-and-international-agreements),
+  [free PDF](https://www.ecac-ceac.org/images/documents/ECAC-Doc_29_4th_edition_Dec_2016_Volume_2.pdf).
+  The NPD interpolation and the single-event segment chain of sections 6-7.
+- European Civil Aviation Conference. (2026). *Report on standard method of
+  computing noise contours around civil airports* (ECAC.CEAC Doc 29, 5th ed.),
+  Volume 3: Reference cases and verification framework.
+  [ECAC documents page](https://www.ecac-ceac.org/documents/ecac-documents-and-international-agreements),
+  [free PDF](https://www.ecac-ceac.org/images/documents/ECAC-CEAC-DOC_29_5th_Edition-REPORT_ON_STANDARD_METHOD_OF_COMPUTING_NOISE_CONTOURS_AROUND_CIVIL_AIRPORTS-Volume_3-REFERENCE_CASES_AND_VERIFICATION_FRAMEWORK.pdf).
+  The reference workbook the section 7 single-event chain is validated
+  against.
+
 ## Standards
 
 ICAO Annex 16, *Environmental Protection*, Vol. I, *Aircraft

--- a/docs/references.md
+++ b/docs/references.md
@@ -435,8 +435,10 @@ it; the list grows as guides gain their References sections.
   Office of the European Union.
   [doi:10.2788/31776](https://doi.org/10.2788/31776),
   [JRC repository](https://publications.jrc.ec.europa.eu/repository/handle/JRC72550).
-  The common EU noise-mapping framework, contrasted with ISO 9613-2.
-  Cited by [Outdoor Sound Propagation](outdoor-propagation.md).
+  The common EU noise-mapping framework, contrasted with ISO 9613-2; its
+  flow-resistivity ground classes are reused by the rotorcraft ground effect.
+  Cited by [Outdoor Sound Propagation](outdoor-propagation.md) and
+  [Rotorcraft noise](rotorcraft-noise.md).
 - International Organization for Standardization. (1993). *Acoustics —
   Attenuation of sound during propagation outdoors — Part 1: Calculation of
   the absorption of sound by the atmosphere* (ISO 9613-1:1993).
@@ -490,6 +492,200 @@ it; the list grows as guides gain their References sections.
   [IEC webstore](https://webstore.iec.ch/en/publication/5432).
   Declared values and their uncertainty for a batch of turbines.
   Cited by [Wind-turbine noise](wind-turbine-noise.md).
+
+## Aircraft noise
+
+- International Civil Aviation Organization. (2017). *Annex 16 to the
+  Convention on International Civil Aviation: Environmental protection —
+  Volume I: Aircraft noise* (8th ed.).
+  [ICAO store](https://store.icao.int/en/annex-16-environmental-protection-volume-i-aircraft-noise).
+  The aircraft noise-certification standard whose Appendix 2 defines the
+  EPNL procedure.
+  Cited by [Aircraft noise](aircraft-noise.md).
+- International Civil Aviation Organization. (2018). *Environmental technical
+  manual — Volume I: Procedures for the noise certification of aircraft*
+  (Doc 9501, 3rd ed.).
+  [ICAO store](https://store.icao.int/en/environmental-technical-manual-volume-1-procedures-for-the-noise-certification-of-aircraft-doc-9501-1).
+  The certification guidance whose worked examples (tone correction,
+  integrated-method EPNL) serve as numeric oracles.
+  Cited by [Aircraft noise](aircraft-noise.md).
+- International Electrotechnical Commission. (1995). *Electroacoustics —
+  Instruments for measurement of aircraft noise — Performance requirements for
+  systems to measure one-third-octave-band sound pressure levels in noise
+  certification of transport-category aeroplanes* (IEC 61265:1995; since
+  revised as [IEC 61265:2018](https://webstore.iec.ch/en/publication/32635),
+  the 1995 edition is the implemented one).
+  [IEC webstore](https://webstore.iec.ch/en/publication/5076).
+  The aircraft-noise measurement-system performance tolerances.
+  Cited by [Aircraft noise](aircraft-noise.md).
+- SAE International. (2013). *Application of pure-tone atmospheric absorption
+  losses to one-third octave-band data* (SAE ARP 5534, reaffirmed 2021).
+  [sae.org](https://www.sae.org/standards/content/arp5534/).
+  The SAE-Method one-third-octave-band atmospheric absorption for aircraft
+  flyover spectra.
+  Cited by [Aircraft noise](aircraft-noise.md).
+- SAE International. (2012). *Standard values of atmospheric absorption as a
+  function of temperature and humidity* (SAE ARP 866B, stabilized 2012).
+  [sae.org](https://www.sae.org/standards/content/arp866b/).
+  The predecessor SAE atmospheric-absorption practice, source of the older
+  50 dB-limited Approximate Method.
+  Cited by [Aircraft noise](aircraft-noise.md).
+- SAE International. (2006). *Method for predicting lateral attenuation of
+  airplane noise* (SAE AIR 5662).
+  [sae.org](https://www.sae.org/standards/content/air5662/).
+  The soft-ground lateral-attenuation model adopted by ECAC Doc 29.
+  Cited by [Aircraft noise](aircraft-noise.md).
+- European Civil Aviation Conference. (2016). *Report on standard method of
+  computing noise contours around civil airports* (ECAC.CEAC Doc 29, 4th ed.),
+  Volume 2: Technical guide.
+  [ECAC documents page](https://www.ecac-ceac.org/documents/ecac-documents-and-international-agreements),
+  [free PDF](https://www.ecac-ceac.org/images/documents/ECAC-Doc_29_4th_edition_Dec_2016_Volume_2.pdf).
+  The European airport noise-contour method: NPD interpolation and the
+  single-event segment calculation.
+  Cited by [Aircraft noise](aircraft-noise.md).
+- European Civil Aviation Conference. (2026). *Report on standard method of
+  computing noise contours around civil airports* (ECAC.CEAC Doc 29, 5th ed.),
+  Volume 3: Reference cases and verification framework.
+  [ECAC documents page](https://www.ecac-ceac.org/documents/ecac-documents-and-international-agreements),
+  [free PDF](https://www.ecac-ceac.org/images/documents/ECAC-CEAC-DOC_29_5th_Edition-REPORT_ON_STANDARD_METHOD_OF_COMPUTING_NOISE_CONTOURS_AROUND_CIVIL_AIRPORTS-Volume_3-REFERENCE_CASES_AND_VERIFICATION_FRAMEWORK.pdf).
+  The reference cases and workbook used to validate the single-event chain.
+  Cited by [Aircraft noise](aircraft-noise.md).
+- European Civil Aviation Conference. (2026). *Report on standard method of
+  computing rotorcraft noise contours* (ECAC.CEAC Doc 32, 1st ed.).
+  [ECAC documents page](https://www.ecac-ceac.org/documents/ecac-documents-and-international-agreements),
+  [free PDF](https://www.ecac-ceac.org/images/documents/ECAC-CEAC-DOC_32-REPORT_ON_STANDARD_METHOD_OF_COMPUTING_ROTORCRAFT_NOISE_CONTOURS.pdf).
+  The standard rotorcraft contour method built on the noise hemisphere.
+  Cited by [Rotorcraft noise](rotorcraft-noise.md).
+- Olsen, H., Tuinstra, M., & van Oosten, N. (2024). *Rotorcraft noise
+  modelling guidance* (Research Project NOISE SC01, deliverable D1.5d,
+  contract EASA.2020.FC.06). European Union Aviation Safety Agency.
+  [EASA project page](https://www.easa.europa.eu/en/research-projects/environmental-research-rotorcraft-noise),
+  [free PDF](https://www.easa.europa.eu/en/downloads/132005/en).
+  The NORAH2 equation-level modelling guidance, whose tables and reference
+  hemispheres serve as oracles.
+  Cited by [Rotorcraft noise](rotorcraft-noise.md).
+- Chien, C. F., & Soroka, W. W. (1975). Sound propagation along an impedance
+  plane. *Journal of Sound and Vibration*, 43(1), 9-20.
+  [doi:10.1016/0022-460X(75)90200-X](https://doi.org/10.1016/0022-460X(75)90200-X).
+  The two-ray interference solution over an impedance plane behind the
+  rotorcraft ground effect.
+  Cited by [Rotorcraft noise](rotorcraft-noise.md).
+- Delany, M. E., & Bazley, E. N. (1970). Acoustical properties of fibrous
+  absorbent materials. *Applied Acoustics*, 3(2), 105-116.
+  [doi:10.1016/0003-682X(70)90031-9](https://doi.org/10.1016/0003-682X(70)90031-9).
+  The one-parameter flow-resistivity ground-impedance model.
+  Cited by [Rotorcraft noise](rotorcraft-noise.md).
+
+## Underwater sound
+
+- Urick, R. J. (1983). *Principles of underwater sound* (3rd ed.).
+  McGraw-Hill; reprinted 1996 by Peninsula Publishing.
+  ISBN 978-0-932146-62-5.
+  [Open Library record](https://openlibrary.org/books/OL9317725M).
+  The classic monograph on underwater sound: level conventions, ship
+  radiated noise and the sonar-equation framework.
+  Cited by [Underwater acoustics](underwater-acoustics.md) and
+  [Underwater sound propagation](underwater-propagation.md).
+- Ainslie, M. A. (2010). *Principles of sonar performance modelling*.
+  Springer.
+  [doi:10.1007/978-3-540-87662-5](https://doi.org/10.1007/978-3-540-87662-5).
+  The systematic treatment of underwater acoustical quantities in the line
+  that ISO 18405 standardised.
+  Cited by [Underwater acoustics](underwater-acoustics.md).
+- Medwin, H., & Clay, C. S. (1998). *Fundamentals of acoustical oceanography*.
+  Academic Press. ISBN 978-0-12-487570-8.
+  [Publisher page](https://shop.elsevier.com/books/fundamentals-of-acoustical-oceanography/medwin/978-0-12-487570-8).
+  Ocean acoustics from first principles; the fluid-fluid Rayleigh
+  reflection coefficient of the seabed model.
+  Cited by [Underwater sound propagation](underwater-propagation.md).
+- Jensen, F. B., Kuperman, W. A., Porter, M. B., & Schmidt, H. (2011).
+  *Computational ocean acoustics* (2nd ed.). Springer.
+  [doi:10.1007/978-1-4419-8678-8](https://doi.org/10.1007/978-1-4419-8678-8).
+  The reference monograph on numerical propagation: normal modes, ray
+  tracing and the parabolic equation.
+  Cited by [Underwater sound propagation](underwater-propagation.md).
+- Francois, R. E., & Garrison, G. R. (1982). Sound absorption based on ocean
+  measurements: Part I: Pure water and magnesium sulfate contributions.
+  *The Journal of the Acoustical Society of America*, 72(3), 896-907.
+  [doi:10.1121/1.388170](https://doi.org/10.1121/1.388170).
+  The pure-water and magnesium-sulfate halves of the reference seawater
+  absorption model.
+  Cited by [Underwater sound propagation](underwater-propagation.md).
+- Francois, R. E., & Garrison, G. R. (1982). Sound absorption based on ocean
+  measurements. Part II: Boric acid contribution and equation for total
+  absorption. *The Journal of the Acoustical Society of America*, 72(6),
+  1879-1890.
+  [doi:10.1121/1.388673](https://doi.org/10.1121/1.388673).
+  The boric-acid term and the complete total-absorption equation.
+  Cited by [Underwater sound propagation](underwater-propagation.md).
+- Ainslie, M. A., & McColm, J. G. (1998). A simplified formula for viscous and
+  chemical absorption in sea water. *The Journal of the Acoustical Society of
+  America*, 103(3), 1671-1672.
+  [doi:10.1121/1.421258](https://doi.org/10.1121/1.421258).
+  The legible simplified seawater absorption formula.
+  Cited by [Underwater sound propagation](underwater-propagation.md).
+- Thorp, W. H. (1967). Analytic description of the low-frequency attenuation
+  coefficient. *The Journal of the Acoustical Society of America*, 42(1), 270.
+  [doi:10.1121/1.1910566](https://doi.org/10.1121/1.1910566).
+  The frequency-only low-frequency absorption formula.
+  Cited by [Underwater sound propagation](underwater-propagation.md).
+- Chen, C.-T., & Millero, F. J. (1977). Speed of sound in seawater at high
+  pressures. *The Journal of the Acoustical Society of America*, 62(5),
+  1129-1135.
+  [doi:10.1121/1.381646](https://doi.org/10.1121/1.381646).
+  The UNESCO international-standard sound-speed equation.
+  Cited by [Underwater sound propagation](underwater-propagation.md).
+- Wong, G. S. K., & Zhu, S. (1995). Speed of sound in seawater as a function
+  of salinity, temperature, and pressure. *The Journal of the Acoustical
+  Society of America*, 97(3), 1732-1736.
+  [doi:10.1121/1.413048](https://doi.org/10.1121/1.413048).
+  The ITS-90 recast of the UNESCO sound-speed coefficients, the implemented
+  form.
+  Cited by [Underwater sound propagation](underwater-propagation.md).
+- Del Grosso, V. A. (1974). New equation for the speed of sound in natural
+  waters (with comparisons to other equations). *The Journal of the
+  Acoustical Society of America*, 56(4), 1084-1091.
+  [doi:10.1121/1.1903388](https://doi.org/10.1121/1.1903388).
+  The alternative pressure-based sound-speed equation.
+  Cited by [Underwater sound propagation](underwater-propagation.md).
+- Mackenzie, K. V. (1981). Nine-term equation for sound speed in the oceans.
+  *The Journal of the Acoustical Society of America*, 70(3), 807-812.
+  [doi:10.1121/1.386920](https://doi.org/10.1121/1.386920).
+  The depth-based nine-term sound-speed equation.
+  Cited by [Underwater sound propagation](underwater-propagation.md).
+- Leroy, C. C., & Parthiot, F. (1998). Depth-pressure relationships in the
+  oceans and seas. *The Journal of the Acoustical Society of America*, 103(3),
+  1346-1352.
+  [doi:10.1121/1.421275](https://doi.org/10.1121/1.421275).
+  The depth-to-pressure conversion used by the sound-speed equations.
+  Cited by [Underwater sound propagation](underwater-propagation.md).
+- Wenz, G. M. (1962). Acoustic ambient noise in the ocean: Spectra and
+  sources. *The Journal of the Acoustical Society of America*, 34(12),
+  1936-1956.
+  [doi:10.1121/1.1909155](https://doi.org/10.1121/1.1909155).
+  The classic ambient-noise survey behind the wind and thermal spectrum
+  components.
+  Cited by [Underwater sound propagation](underwater-propagation.md).
+- Carey, W. M., & Evans, R. B. (2011). *Ocean ambient noise: Measurement and
+  theory*. Springer.
+  [doi:10.1007/978-1-4419-7832-5](https://doi.org/10.1007/978-1-4419-7832-5).
+  The modern treatment of ocean ambient noise: the wind "rule of fives" and
+  the Mellen thermal-noise derivation.
+  Cited by [Underwater sound propagation](underwater-propagation.md).
+- MacGillivray, A., & de Jong, C. (2021). A reference spectrum model for
+  estimating source levels of marine shipping based on automated
+  identification system data. *Journal of Marine Science and Engineering*,
+  9(4), 369.
+  [doi:10.3390/jmse9040369](https://doi.org/10.3390/jmse9040369).
+  The open-access JOMOPANS-ECHO ship source-level model and its reference
+  calculator.
+  Cited by [Underwater sound propagation](underwater-propagation.md).
+- Wales, S. C., & Heitmeyer, R. M. (2002). An ensemble source spectra model
+  for merchant ship-radiated noise. *The Journal of the Acoustical Society of
+  America*, 111(3), 1211-1231.
+  [doi:10.1121/1.1427355](https://doi.org/10.1121/1.1427355).
+  The ensemble merchant-ship source-spectrum model.
+  Cited by [Underwater sound propagation](underwater-propagation.md).
 
 ## Speech
 

--- a/docs/rotorcraft-noise.md
+++ b/docs/rotorcraft-noise.md
@@ -80,11 +80,44 @@ hemispheres of all eleven rotorcraft types, and end to end against the NORAH2
 prototype: single-hemisphere emissions of its reference single-event histories
 are reproduced to 0.1 dB(A) over hard ground (0.5 dB over soft ground).
 
+## References
+
+- European Civil Aviation Conference. (2026). *Report on standard method of
+  computing rotorcraft noise contours* (ECAC.CEAC Doc 32, 1st ed.).
+  [ECAC documents page](https://www.ecac-ceac.org/documents/ecac-documents-and-international-agreements),
+  [free PDF](https://www.ecac-ceac.org/images/documents/ECAC-CEAC-DOC_32-REPORT_ON_STANDARD_METHOD_OF_COMPUTING_ROTORCRAFT_NOISE_CONTOURS.pdf).
+  The standard rotorcraft contour method whose hemisphere source model and
+  propagation adjustments this page implements.
+- Olsen, H., Tuinstra, M., & van Oosten, N. (2024). *Rotorcraft noise
+  modelling guidance* (Research Project NOISE SC01, deliverable D1.5d,
+  contract EASA.2020.FC.06). European Union Aviation Safety Agency.
+  [EASA project page](https://www.easa.europa.eu/en/research-projects/environmental-research-rotorcraft-noise),
+  [free PDF](https://www.easa.europa.eu/en/downloads/132005/en).
+  The equation-level guidance (Eq. 13-35) behind the implementation, with the
+  Table 4 attenuation values and the reference hemispheres used as oracles.
+- Chien, C. F., & Soroka, W. W. (1975). Sound propagation along an impedance
+  plane. *Journal of Sound and Vibration*, 43(1), 9-20.
+  [doi:10.1016/0022-460X(75)90200-X](https://doi.org/10.1016/0022-460X(75)90200-X).
+  The two-ray interference solution over an impedance plane behind the
+  section 2 ground-effect adjustment.
+- Delany, M. E., & Bazley, E. N. (1970). Acoustical properties of fibrous
+  absorbent materials. *Applied Acoustics*, 3(2), 105-116.
+  [doi:10.1016/0003-682X(70)90031-9](https://doi.org/10.1016/0003-682X(70)90031-9).
+  The one-parameter flow-resistivity impedance model the ground effect
+  evaluates.
+- Kephalopoulos, S., Paviotti, M., & Anfosso-Lédée, F. (2012). *Common noise
+  assessment methods in Europe (CNOSSOS-EU)* (EUR 25379 EN). Publications
+  Office of the European Union.
+  [doi:10.2788/31776](https://doi.org/10.2788/31776),
+  [JRC repository](https://publications.jrc.ec.europa.eu/repository/handle/JRC72550).
+  The flow-resistivity ground classes `"A"`-`"H"` accepted by
+  `ground_effect_adjustment`.
+
 ## Standards
 
 ECAC Doc 32, 1st ed., *Report on Standard Method of Computing
 Rotorcraft Noise Contours*; NORAH2 rotorcraft-noise modelling guidance
-(EASA.2020.FC.06 SC03.D1.5d), §A.3-A.4 — the noise hemisphere (§A.3.2), spherical
+(EASA.2020.FC.06 SC01.D1.5d), §A.3-A.4 — the noise hemisphere (§A.3.2), spherical
 spreading (Eq. 24), atmospheric attenuation (Eq. 26/27, ISO 9613-1 coefficient,
 Table 4) and ground effect (Chien-Soroka, Eq. 28-35, Delany-Bazley impedance,
 CNOSSOS flow resistivity). Flight-path integration (SEL/LAmax/EPNL), ground-grid

--- a/docs/underwater-acoustics.md
+++ b/docs/underwater-acoustics.md
@@ -138,6 +138,21 @@ res.plot()
 
 </details>
 
+## References
+
+- Urick, R. J. (1983). *Principles of underwater sound* (3rd ed.).
+  McGraw-Hill; reprinted 1996 by Peninsula Publishing.
+  ISBN 978-0-932146-62-5.
+  [Open Library record](https://openlibrary.org/books/OL9317725M).
+  The classic treatment of underwater sound levels and of ship radiated
+  noise behind the reference conventions of sections 1-2.
+- Ainslie, M. A. (2010). *Principles of sonar performance modelling*.
+  Springer.
+  [doi:10.1007/978-3-540-87662-5](https://doi.org/10.1007/978-3-540-87662-5).
+  The systematic treatment of underwater acoustical quantities in the line
+  that ISO 18405 standardised; supports the reference levels and the source
+  level of sections 1-2.
+
 ## Standards
 
 ISO 18405:2017, *Underwater acoustics — Terminology*: the 1 µPa

--- a/docs/underwater-propagation.md
+++ b/docs/underwater-propagation.md
@@ -278,6 +278,94 @@ ray); `parabolic_equation` a `ParabolicEquationResult` (the `transmission_loss`
 field). All assume a range-independent water column with a pressure-release
 surface.
 
+## References
+
+- Francois, R. E., & Garrison, G. R. (1982). Sound absorption based on ocean
+  measurements: Part I: Pure water and magnesium sulfate contributions.
+  *The Journal of the Acoustical Society of America*, 72(3), 896-907.
+  [doi:10.1121/1.388170](https://doi.org/10.1121/1.388170).
+  The pure-water and magnesium-sulfate halves of the default absorption
+  model of section 1.
+- Francois, R. E., & Garrison, G. R. (1982). Sound absorption based on ocean
+  measurements. Part II: Boric acid contribution and equation for total
+  absorption. *The Journal of the Acoustical Society of America*, 72(6),
+  1879-1890.
+  [doi:10.1121/1.388673](https://doi.org/10.1121/1.388673).
+  The boric-acid term and the complete Francois-Garrison total-absorption
+  equation, the implemented default.
+- Ainslie, M. A., & McColm, J. G. (1998). A simplified formula for viscous and
+  chemical absorption in sea water. *The Journal of the Acoustical Society of
+  America*, 103(3), 1671-1672.
+  [doi:10.1121/1.421258](https://doi.org/10.1121/1.421258).
+  The legible simplified absorption model (`"ainslie-mccolm"`).
+- Thorp, W. H. (1967). Analytic description of the low-frequency attenuation
+  coefficient. *The Journal of the Acoustical Society of America*, 42(1), 270.
+  [doi:10.1121/1.1910566](https://doi.org/10.1121/1.1910566).
+  The frequency-only low-frequency absorption formula (`"thorp"`).
+- Chen, C.-T., & Millero, F. J. (1977). Speed of sound in seawater at high
+  pressures. *The Journal of the Acoustical Society of America*, 62(5),
+  1129-1135.
+  [doi:10.1121/1.381646](https://doi.org/10.1121/1.381646).
+  The UNESCO international-standard sound-speed equation of section 2.
+- Wong, G. S. K., & Zhu, S. (1995). Speed of sound in seawater as a function
+  of salinity, temperature, and pressure. *The Journal of the Acoustical
+  Society of America*, 97(3), 1732-1736.
+  [doi:10.1121/1.413048](https://doi.org/10.1121/1.413048).
+  The ITS-90 recast of the UNESCO coefficients, the implemented form.
+- Del Grosso, V. A. (1974). New equation for the speed of sound in natural
+  waters (with comparisons to other equations). *The Journal of the
+  Acoustical Society of America*, 56(4), 1084-1091.
+  [doi:10.1121/1.1903388](https://doi.org/10.1121/1.1903388).
+  The alternative pressure-based sound-speed equation (`"del-grosso"`).
+- Mackenzie, K. V. (1981). Nine-term equation for sound speed in the oceans.
+  *The Journal of the Acoustical Society of America*, 70(3), 807-812.
+  [doi:10.1121/1.386920](https://doi.org/10.1121/1.386920).
+  The depth-based nine-term equation and its 1550.744 m/s check value.
+- Leroy, C. C., & Parthiot, F. (1998). Depth-pressure relationships in the
+  oceans and seas. *The Journal of the Acoustical Society of America*, 103(3),
+  1346-1352.
+  [doi:10.1121/1.421275](https://doi.org/10.1121/1.421275).
+  The depth-to-pressure conversion feeding the UNESCO and Del Grosso
+  equations.
+- Urick, R. J. (1983). *Principles of underwater sound* (3rd ed.).
+  McGraw-Hill; reprinted 1996 by Peninsula Publishing.
+  ISBN 978-0-932146-62-5.
+  [Open Library record](https://openlibrary.org/books/OL9317725M).
+  The sonar-equation framework (signal excess, figure of merit) of section 3.
+- Medwin, H., & Clay, C. S. (1998). *Fundamentals of acoustical oceanography*.
+  Academic Press. ISBN 978-0-12-487570-8.
+  [Publisher page](https://shop.elsevier.com/books/fundamentals-of-acoustical-oceanography/medwin/978-0-12-487570-8).
+  The fluid-fluid Rayleigh reflection coefficient and critical grazing angle
+  of section 4.
+- Wenz, G. M. (1962). Acoustic ambient noise in the ocean: Spectra and
+  sources. *The Journal of the Acoustical Society of America*, 34(12),
+  1936-1956.
+  [doi:10.1121/1.1909155](https://doi.org/10.1121/1.1909155).
+  The ambient-noise survey behind the wind and thermal components of
+  section 5.
+- Carey, W. M., & Evans, R. B. (2011). *Ocean ambient noise: Measurement and
+  theory*. Springer.
+  [doi:10.1007/978-1-4419-7832-5](https://doi.org/10.1007/978-1-4419-7832-5).
+  The wind "rule of fives" anchor and the Mellen thermal-noise derivation
+  used by section 5.
+- MacGillivray, A., & de Jong, C. (2021). A reference spectrum model for
+  estimating source levels of marine shipping based on automated
+  identification system data. *Journal of Marine Science and Engineering*,
+  9(4), 369.
+  [doi:10.3390/jmse9040369](https://doi.org/10.3390/jmse9040369).
+  The JOMOPANS-ECHO ship source-level model of section 6 (open access); its
+  File S1 calculator is the validation oracle.
+- Wales, S. C., & Heitmeyer, R. M. (2002). An ensemble source spectra model
+  for merchant ship-radiated noise. *The Journal of the Acoustical Society of
+  America*, 111(3), 1211-1231.
+  [doi:10.1121/1.1427355](https://doi.org/10.1121/1.1427355).
+  The ensemble merchant-ship spectrum model of section 6.
+- Jensen, F. B., Kuperman, W. A., Porter, M. B., & Schmidt, H. (2011).
+  *Computational ocean acoustics* (2nd ed.). Springer.
+  [doi:10.1007/978-1-4419-8678-8](https://doi.org/10.1007/978-1-4419-8678-8).
+  The normal-mode, ray-tracing and split-step Fourier parabolic-equation
+  solvers of section 7.
+
 ## Standards & sources
 
 - Speed of sound: UNESCO / Chen & Millero (1977, Wong & Zhu 1995 ITS-90),

--- a/site/src/content/docs/es/guides/aircraft-noise.md
+++ b/site/src/content/docs/es/guides/aircraft-noise.md
@@ -202,6 +202,58 @@ del rodaje de despegue, la velocidad media Ec. 4-13b en segmentos de pista y el
 suelo recomendado de 30 m en las consultas NPD. Siete eventos de receptor del
 workbook de referencia se reproducen end-to-end en la suite de tests.
 
+## Referencias
+
+- International Civil Aviation Organization. (2017). *Annex 16 to the
+  Convention on International Civil Aviation: Environmental protection —
+  Volume I: Aircraft noise* (8.ª ed.).
+  [Tienda ICAO](https://store.icao.int/en/annex-16-environmental-protection-volume-i-aircraft-noise).
+  El procedimiento normativo EPNL del Apéndice 2 implementado en las
+  secciones de molestia percibida, corrección tonal y EPNL.
+- International Civil Aviation Organization. (2018). *Environmental technical
+  manual — Volume I: Procedures for the noise certification of aircraft*
+  (Doc 9501, 3.ª ed.).
+  [Tienda ICAO](https://store.icao.int/en/environmental-technical-manual-volume-1-procedures-for-the-noise-certification-of-aircraft-doc-9501-1).
+  Los ejemplos trabajados (corrección tonal de la Tabla 3-7, EPNL por el
+  método integrado de la Tabla 4-4) usados como oráculos numéricos.
+- International Electrotechnical Commission. (1995). *Electroacoustics —
+  Instruments for measurement of aircraft noise — Performance requirements for
+  systems to measure one-third-octave-band sound pressure levels in noise
+  certification of transport-category aeroplanes* (IEC 61265:1995; revisada
+  después como [IEC 61265:2018](https://webstore.iec.ch/en/publication/32635),
+  la edición de 1995 es la implementada).
+  [Catálogo IEC](https://webstore.iec.ch/en/publication/5076).
+  Las tolerancias del sistema de medida que comprueba el verificador.
+- SAE International. (2013). *Application of pure-tone atmospheric absorption
+  losses to one-third octave-band data* (SAE ARP 5534, reafirmada en 2021).
+  [sae.org](https://www.sae.org/standards/content/arp5534/).
+  La atenuación de banda por el método SAE de la sección de absorción
+  atmosférica.
+- SAE International. (2012). *Standard values of atmospheric absorption as a
+  function of temperature and humidity* (SAE ARP 866B, estabilizada en 2012).
+  [sae.org](https://www.sae.org/standards/content/arp866b/).
+  La práctica SAE de absorción atmosférica predecesora, origen del método
+  aproximado limitado a 50 dB con el que se contrasta el método SAE.
+- SAE International. (2006). *Method for predicting lateral attenuation of
+  airplane noise* (SAE AIR 5662).
+  [sae.org](https://www.sae.org/standards/content/air5662/).
+  El modelo de atenuación lateral sobre suelo blando que la Doc 29 §4.5.4
+  adopta en la sección de contornos de evento único.
+- European Civil Aviation Conference. (2016). *Report on standard method of
+  computing noise contours around civil airports* (ECAC.CEAC Doc 29, 4.ª ed.),
+  Volumen 2: Guía técnica.
+  [Página de documentos de ECAC](https://www.ecac-ceac.org/documents/ecac-documents-and-international-agreements),
+  [PDF gratuito](https://www.ecac-ceac.org/images/documents/ECAC-Doc_29_4th_edition_Dec_2016_Volume_2.pdf).
+  La interpolación NPD y la cadena de evento único por segmentos de las
+  secciones de ruido de aeropuerto.
+- European Civil Aviation Conference. (2026). *Report on standard method of
+  computing noise contours around civil airports* (ECAC.CEAC Doc 29, 5.ª ed.),
+  Volumen 3: Casos de referencia y marco de verificación.
+  [Página de documentos de ECAC](https://www.ecac-ceac.org/documents/ecac-documents-and-international-agreements),
+  [PDF gratuito](https://www.ecac-ceac.org/images/documents/ECAC-CEAC-DOC_29_5th_Edition-REPORT_ON_STANDARD_METHOD_OF_COMPUTING_NOISE_CONTOURS_AROUND_CIVIL_AIRPORTS-Volume_3-REFERENCE_CASES_AND_VERIFICATION_FRAMEWORK.pdf).
+  El workbook de referencia contra el que se valida la cadena de evento
+  único.
+
 ## Normas
 
 ICAO Anexo 16 Vol. I Apéndice 2 (procedimiento EPNL), ICAO Doc 9501

--- a/site/src/content/docs/es/guides/rotorcraft-noise.md
+++ b/site/src/content/docs/es/guides/rotorcraft-noise.md
@@ -62,10 +62,44 @@ hemisferios de referencia de los once tipos de helicóptero, y de extremo a
 extremo contra los historiales de evento único del prototipo NORAH2 (0.1 dB(A)
 sobre suelo duro, 0.5 dB sobre suelo blando).
 
+## Referencias
+
+- European Civil Aviation Conference. (2026). *Report on standard method of
+  computing rotorcraft noise contours* (ECAC.CEAC Doc 32, 1.ª ed.).
+  [Página de documentos de ECAC](https://www.ecac-ceac.org/documents/ecac-documents-and-international-agreements),
+  [PDF gratuito](https://www.ecac-ceac.org/images/documents/ECAC-CEAC-DOC_32-REPORT_ON_STANDARD_METHOD_OF_COMPUTING_ROTORCRAFT_NOISE_CONTOURS.pdf).
+  El método estándar de contornos de rotorcraft cuyo modelo de fuente por
+  hemisferio y ajustes de propagación implementa esta página.
+- Olsen, H., Tuinstra, M., & van Oosten, N. (2024). *Rotorcraft noise
+  modelling guidance* (Research Project NOISE SC01, entregable D1.5d,
+  contrato EASA.2020.FC.06). European Union Aviation Safety Agency.
+  [Página del proyecto en EASA](https://www.easa.europa.eu/en/research-projects/environmental-research-rotorcraft-noise),
+  [PDF gratuito](https://www.easa.europa.eu/en/downloads/132005/en).
+  La guía a nivel de ecuación (Ec. 13-35) tras la implementación, con los
+  valores de atenuación de la Tabla 4 y los hemisferios de referencia usados
+  como oráculos.
+- Chien, C. F., & Soroka, W. W. (1975). Sound propagation along an impedance
+  plane. *Journal of Sound and Vibration*, 43(1), 9-20.
+  [doi:10.1016/0022-460X(75)90200-X](https://doi.org/10.1016/0022-460X(75)90200-X).
+  La solución de interferencia de dos rayos sobre un plano de impedancia tras
+  el ajuste de efecto de suelo.
+- Delany, M. E., & Bazley, E. N. (1970). Acoustical properties of fibrous
+  absorbent materials. *Applied Acoustics*, 3(2), 105-116.
+  [doi:10.1016/0003-682X(70)90031-9](https://doi.org/10.1016/0003-682X(70)90031-9).
+  El modelo de impedancia de un parámetro (resistividad de flujo) que evalúa
+  el efecto de suelo.
+- Kephalopoulos, S., Paviotti, M., & Anfosso-Lédée, F. (2012). *Common noise
+  assessment methods in Europe (CNOSSOS-EU)* (EUR 25379 EN). Oficina de
+  Publicaciones de la Unión Europea.
+  [doi:10.2788/31776](https://doi.org/10.2788/31776),
+  [repositorio del JRC](https://publications.jrc.ec.europa.eu/repository/handle/JRC72550).
+  Las clases de suelo por resistividad de flujo `"A"`-`"H"` que acepta
+  `ground_effect_adjustment`.
+
 ## Normas
 
 ECAC Doc 32, 1ª ed. (contornos de ruido de rotorcraft); guía de
-modelado NORAH2 (EASA.2020.FC.06 SC03.D1.5d) §A.3-A.4: el hemisferio de ruido, el
+modelado NORAH2 (EASA.2020.FC.06 SC01.D1.5d) §A.3-A.4: el hemisferio de ruido, el
 ensanchamiento esférico, la atenuación atmosférica (ISO 9613-1, Tabla 4) y el
 efecto de suelo de Chien-Soroka (impedancia de Delany-Bazley, resistividad de
 flujo CNOSSOS). La integración sobre la trayectoria (SEL/LAmax/EPNL), los

--- a/site/src/content/docs/es/guides/underwater-acoustics.md
+++ b/site/src/content/docs/es/guides/underwater-acoustics.md
@@ -143,6 +143,22 @@ res.plot()
 
 </details>
 
+## Referencias
+
+- Urick, R. J. (1983). *Principles of underwater sound* (3.ª ed.).
+  McGraw-Hill; reimpreso en 1996 por Peninsula Publishing.
+  ISBN 978-0-932146-62-5.
+  [Ficha en Open Library](https://openlibrary.org/books/OL9317725M).
+  El tratamiento clásico de los niveles de sonido submarino y del ruido
+  radiado por buques tras las convenciones de referencia de las
+  secciones 1-2.
+- Ainslie, M. A. (2010). *Principles of sonar performance modelling*.
+  Springer.
+  [doi:10.1007/978-3-540-87662-5](https://doi.org/10.1007/978-3-540-87662-5).
+  El tratamiento sistemático de las magnitudes acústicas submarinas en la
+  línea que la ISO 18405 normalizó; sustenta los niveles de referencia y el
+  nivel de fuente de las secciones 1-2.
+
 ## Normas
 
 ISO 18405:2017, *Underwater acoustics — Terminology*: las

--- a/site/src/content/docs/es/guides/underwater-propagation.md
+++ b/site/src/content/docs/es/guides/underwater-propagation.md
@@ -204,7 +204,7 @@ de presión-liberada.
   measurements: Part I: Pure water and magnesium sulfate contributions.
   *The Journal of the Acoustical Society of America*, 72(3), 896-907.
   [doi:10.1121/1.388170](https://doi.org/10.1121/1.388170).
-  Las mitades de agua pura y sulfato de magnesio del modelo de absorción por
+  Las componentes de agua pura y sulfato de magnesio del modelo de absorción por
   defecto de la sección de pérdida por transmisión.
 - Francois, R. E., & Garrison, G. R. (1982). Sound absorption based on ocean
   measurements. Part II: Boric acid contribution and equation for total
@@ -221,7 +221,7 @@ de presión-liberada.
 - Thorp, W. H. (1967). Analytic description of the low-frequency attenuation
   coefficient. *The Journal of the Acoustical Society of America*, 42(1), 270.
   [doi:10.1121/1.1910566](https://doi.org/10.1121/1.1910566).
-  La fórmula de absorción de baja frecuencia solo en frecuencia (`"thorp"`).
+  La fórmula de absorción de baja frecuencia dependiente solo de la frecuencia (`"thorp"`).
 - Chen, C.-T., & Millero, F. J. (1977). Speed of sound in seawater at high
   pressures. *The Journal of the Acoustical Society of America*, 62(5),
   1129-1135.
@@ -263,7 +263,7 @@ de presión-liberada.
   sources. *The Journal of the Acoustical Society of America*, 34(12),
   1936-1956.
   [doi:10.1121/1.1909155](https://doi.org/10.1121/1.1909155).
-  El estudio de ruido ambiental tras las componentes de viento y térmica de
+  El estudio de ruido ambiental tras las componentes eólica y térmica de
   la sección de ruido ambiental oceánico.
 - Carey, W. M., & Evans, R. B. (2011). *Ocean ambient noise: Measurement and
   theory*. Springer.

--- a/site/src/content/docs/es/guides/underwater-propagation.md
+++ b/site/src/content/docs/es/guides/underwater-propagation.md
@@ -198,6 +198,97 @@ ph.parabolic_equation(50.0, [0.0, 200.0], [1500.0, 1500.0],
 Los tres asumen una columna de agua independiente de la distancia con superficie
 de presión-liberada.
 
+## Referencias
+
+- Francois, R. E., & Garrison, G. R. (1982). Sound absorption based on ocean
+  measurements: Part I: Pure water and magnesium sulfate contributions.
+  *The Journal of the Acoustical Society of America*, 72(3), 896-907.
+  [doi:10.1121/1.388170](https://doi.org/10.1121/1.388170).
+  Las mitades de agua pura y sulfato de magnesio del modelo de absorción por
+  defecto de la sección de pérdida por transmisión.
+- Francois, R. E., & Garrison, G. R. (1982). Sound absorption based on ocean
+  measurements. Part II: Boric acid contribution and equation for total
+  absorption. *The Journal of the Acoustical Society of America*, 72(6),
+  1879-1890.
+  [doi:10.1121/1.388673](https://doi.org/10.1121/1.388673).
+  El término de ácido bórico y la ecuación completa de absorción total de
+  Francois-Garrison, el modelo por defecto implementado.
+- Ainslie, M. A., & McColm, J. G. (1998). A simplified formula for viscous and
+  chemical absorption in sea water. *The Journal of the Acoustical Society of
+  America*, 103(3), 1671-1672.
+  [doi:10.1121/1.421258](https://doi.org/10.1121/1.421258).
+  El modelo de absorción simplificado y legible (`"ainslie-mccolm"`).
+- Thorp, W. H. (1967). Analytic description of the low-frequency attenuation
+  coefficient. *The Journal of the Acoustical Society of America*, 42(1), 270.
+  [doi:10.1121/1.1910566](https://doi.org/10.1121/1.1910566).
+  La fórmula de absorción de baja frecuencia solo en frecuencia (`"thorp"`).
+- Chen, C.-T., & Millero, F. J. (1977). Speed of sound in seawater at high
+  pressures. *The Journal of the Acoustical Society of America*, 62(5),
+  1129-1135.
+  [doi:10.1121/1.381646](https://doi.org/10.1121/1.381646).
+  La ecuación de velocidad del sonido UNESCO, el estándar internacional.
+- Wong, G. S. K., & Zhu, S. (1995). Speed of sound in seawater as a function
+  of salinity, temperature, and pressure. *The Journal of the Acoustical
+  Society of America*, 97(3), 1732-1736.
+  [doi:10.1121/1.413048](https://doi.org/10.1121/1.413048).
+  La reformulación ITS-90 de los coeficientes UNESCO, la forma implementada.
+- Del Grosso, V. A. (1974). New equation for the speed of sound in natural
+  waters (with comparisons to other equations). *The Journal of the
+  Acoustical Society of America*, 56(4), 1084-1091.
+  [doi:10.1121/1.1903388](https://doi.org/10.1121/1.1903388).
+  La ecuación alternativa de velocidad del sonido basada en presión
+  (`"del-grosso"`).
+- Mackenzie, K. V. (1981). Nine-term equation for sound speed in the oceans.
+  *The Journal of the Acoustical Society of America*, 70(3), 807-812.
+  [doi:10.1121/1.386920](https://doi.org/10.1121/1.386920).
+  La ecuación de nueve términos basada en profundidad y su valor de
+  comprobación de 1550.744 m/s.
+- Leroy, C. C., & Parthiot, F. (1998). Depth-pressure relationships in the
+  oceans and seas. *The Journal of the Acoustical Society of America*, 103(3),
+  1346-1352.
+  [doi:10.1121/1.421275](https://doi.org/10.1121/1.421275).
+  La conversión de profundidad a presión que alimenta las ecuaciones UNESCO
+  y Del Grosso.
+- Urick, R. J. (1983). *Principles of underwater sound* (3.ª ed.).
+  McGraw-Hill; reimpreso en 1996 por Peninsula Publishing.
+  ISBN 978-0-932146-62-5.
+  [Ficha en Open Library](https://openlibrary.org/books/OL9317725M).
+  El marco de la ecuación del sonar (exceso de señal, figura de mérito).
+- Medwin, H., & Clay, C. S. (1998). *Fundamentals of acoustical oceanography*.
+  Academic Press. ISBN 978-0-12-487570-8.
+  [Página del editor](https://shop.elsevier.com/books/fundamentals-of-acoustical-oceanography/medwin/978-0-12-487570-8).
+  El coeficiente de reflexión de Rayleigh fluido-fluido y el ángulo rasante
+  crítico de la sección de reflexión en el fondo.
+- Wenz, G. M. (1962). Acoustic ambient noise in the ocean: Spectra and
+  sources. *The Journal of the Acoustical Society of America*, 34(12),
+  1936-1956.
+  [doi:10.1121/1.1909155](https://doi.org/10.1121/1.1909155).
+  El estudio de ruido ambiental tras las componentes de viento y térmica de
+  la sección de ruido ambiental oceánico.
+- Carey, W. M., & Evans, R. B. (2011). *Ocean ambient noise: Measurement and
+  theory*. Springer.
+  [doi:10.1007/978-1-4419-7832-5](https://doi.org/10.1007/978-1-4419-7832-5).
+  El anclaje de la "regla de los cincos" del viento y la derivación del ruido
+  térmico de Mellen.
+- MacGillivray, A., & de Jong, C. (2021). A reference spectrum model for
+  estimating source levels of marine shipping based on automated
+  identification system data. *Journal of Marine Science and Engineering*,
+  9(4), 369.
+  [doi:10.3390/jmse9040369](https://doi.org/10.3390/jmse9040369).
+  El modelo de nivel de fuente de buques JOMOPANS-ECHO (acceso abierto); su
+  calculadora del archivo S1 es el oráculo de validación.
+- Wales, S. C., & Heitmeyer, R. M. (2002). An ensemble source spectra model
+  for merchant ship-radiated noise. *The Journal of the Acoustical Society of
+  America*, 111(3), 1211-1231.
+  [doi:10.1121/1.1427355](https://doi.org/10.1121/1.1427355).
+  El modelo de espectro de conjunto de buques mercantes de la sección de
+  tráfico marítimo.
+- Jensen, F. B., Kuperman, W. A., Porter, M. B., & Schmidt, H. (2011).
+  *Computational ocean acoustics* (2.ª ed.). Springer.
+  [doi:10.1007/978-1-4419-8678-8](https://doi.org/10.1007/978-1-4419-8678-8).
+  Los solvers de modos normales, trazado de rayos y ecuación parabólica
+  split-step Fourier de la sección de solvers numéricos.
+
 ## Véase también
 
 - Referencia de la API: [`underwater.propagation`](/phonometry/es/reference/api/underwater/propagation/), [`underwater.numerical_propagation`](/phonometry/es/reference/api/underwater/numerical-propagation/) y [`underwater.sound_speed`](/phonometry/es/reference/api/underwater/sound-speed/).

--- a/site/src/content/docs/es/reference/bibliography.md
+++ b/site/src/content/docs/es/reference/bibliography.md
@@ -454,8 +454,10 @@ que las guías incorporan sus secciones de Referencias.
   [doi:10.2788/31776](https://doi.org/10.2788/31776),
   [repositorio del JRC](https://publications.jrc.ec.europa.eu/repository/handle/JRC72550).
   El marco común de la UE para los mapas de ruido, contrastado con la
-  ISO 9613-2.
-  Citado por [Propagación del sonido en exteriores](/phonometry/es/guides/outdoor-propagation/).
+  ISO 9613-2; sus clases de suelo por resistividad de flujo las reutiliza el
+  efecto de suelo de rotorcraft.
+  Citado por [Propagación del sonido en exteriores](/phonometry/es/guides/outdoor-propagation/)
+  y [Ruido de rotorcraft](/phonometry/es/guides/rotorcraft-noise/).
 - International Organization for Standardization. (1993). *Acoustics —
   Attenuation of sound during propagation outdoors — Part 1: Calculation of
   the absorption of sound by the atmosphere* (ISO 9613-1:1993).
@@ -510,6 +512,204 @@ que las guías incorporan sus secciones de Referencias.
   [Tienda IEC](https://webstore.iec.ch/en/publication/5432).
   Los valores declarados y su incertidumbre para un lote de aerogeneradores.
   Citado por [Ruido de aerogeneradores](/phonometry/es/guides/wind-turbine-noise/).
+
+## Ruido de aeronaves
+
+- International Civil Aviation Organization. (2017). *Annex 16 to the
+  Convention on International Civil Aviation: Environmental protection —
+  Volume I: Aircraft noise* (8.ª ed.).
+  [Tienda ICAO](https://store.icao.int/en/annex-16-environmental-protection-volume-i-aircraft-noise).
+  La norma de certificación acústica de aeronaves cuyo Apéndice 2 define el
+  procedimiento EPNL.
+  Citado por [Ruido de aeronaves](/phonometry/es/guides/aircraft-noise/).
+- International Civil Aviation Organization. (2018). *Environmental technical
+  manual — Volume I: Procedures for the noise certification of aircraft*
+  (Doc 9501, 3.ª ed.).
+  [Tienda ICAO](https://store.icao.int/en/environmental-technical-manual-volume-1-procedures-for-the-noise-certification-of-aircraft-doc-9501-1).
+  La guía de certificación cuyos ejemplos trabajados (corrección tonal, EPNL
+  por el método integrado) sirven de oráculos numéricos.
+  Citado por [Ruido de aeronaves](/phonometry/es/guides/aircraft-noise/).
+- International Electrotechnical Commission. (1995). *Electroacoustics —
+  Instruments for measurement of aircraft noise — Performance requirements for
+  systems to measure one-third-octave-band sound pressure levels in noise
+  certification of transport-category aeroplanes* (IEC 61265:1995; revisada
+  después como [IEC 61265:2018](https://webstore.iec.ch/en/publication/32635),
+  la edición de 1995 es la implementada).
+  [Catálogo IEC](https://webstore.iec.ch/en/publication/5076).
+  Las tolerancias de comportamiento del sistema de medida de ruido de
+  aeronaves.
+  Citado por [Ruido de aeronaves](/phonometry/es/guides/aircraft-noise/).
+- SAE International. (2013). *Application of pure-tone atmospheric absorption
+  losses to one-third octave-band data* (SAE ARP 5534, reafirmada en 2021).
+  [sae.org](https://www.sae.org/standards/content/arp5534/).
+  La absorción atmosférica en bandas de tercio de octava por el método SAE
+  para espectros de sobrevuelo.
+  Citado por [Ruido de aeronaves](/phonometry/es/guides/aircraft-noise/).
+- SAE International. (2012). *Standard values of atmospheric absorption as a
+  function of temperature and humidity* (SAE ARP 866B, estabilizada en 2012).
+  [sae.org](https://www.sae.org/standards/content/arp866b/).
+  La práctica SAE de absorción atmosférica predecesora, origen del antiguo
+  método aproximado limitado a 50 dB.
+  Citado por [Ruido de aeronaves](/phonometry/es/guides/aircraft-noise/).
+- SAE International. (2006). *Method for predicting lateral attenuation of
+  airplane noise* (SAE AIR 5662).
+  [sae.org](https://www.sae.org/standards/content/air5662/).
+  El modelo de atenuación lateral sobre suelo blando que adopta la ECAC
+  Doc 29.
+  Citado por [Ruido de aeronaves](/phonometry/es/guides/aircraft-noise/).
+- European Civil Aviation Conference. (2016). *Report on standard method of
+  computing noise contours around civil airports* (ECAC.CEAC Doc 29, 4.ª ed.),
+  Volumen 2: Guía técnica.
+  [Página de documentos de ECAC](https://www.ecac-ceac.org/documents/ecac-documents-and-international-agreements),
+  [PDF gratuito](https://www.ecac-ceac.org/images/documents/ECAC-Doc_29_4th_edition_Dec_2016_Volume_2.pdf).
+  El método europeo de contornos de ruido de aeropuerto: interpolación NPD y
+  cálculo de evento único por segmentos.
+  Citado por [Ruido de aeronaves](/phonometry/es/guides/aircraft-noise/).
+- European Civil Aviation Conference. (2026). *Report on standard method of
+  computing noise contours around civil airports* (ECAC.CEAC Doc 29, 5.ª ed.),
+  Volumen 3: Casos de referencia y marco de verificación.
+  [Página de documentos de ECAC](https://www.ecac-ceac.org/documents/ecac-documents-and-international-agreements),
+  [PDF gratuito](https://www.ecac-ceac.org/images/documents/ECAC-CEAC-DOC_29_5th_Edition-REPORT_ON_STANDARD_METHOD_OF_COMPUTING_NOISE_CONTOURS_AROUND_CIVIL_AIRPORTS-Volume_3-REFERENCE_CASES_AND_VERIFICATION_FRAMEWORK.pdf).
+  Los casos de referencia y el workbook con los que se valida la cadena de
+  evento único.
+  Citado por [Ruido de aeronaves](/phonometry/es/guides/aircraft-noise/).
+- European Civil Aviation Conference. (2026). *Report on standard method of
+  computing rotorcraft noise contours* (ECAC.CEAC Doc 32, 1.ª ed.).
+  [Página de documentos de ECAC](https://www.ecac-ceac.org/documents/ecac-documents-and-international-agreements),
+  [PDF gratuito](https://www.ecac-ceac.org/images/documents/ECAC-CEAC-DOC_32-REPORT_ON_STANDARD_METHOD_OF_COMPUTING_ROTORCRAFT_NOISE_CONTOURS.pdf).
+  El método estándar de contornos de rotorcraft construido sobre el
+  hemisferio de ruido.
+  Citado por [Ruido de rotorcraft](/phonometry/es/guides/rotorcraft-noise/).
+- Olsen, H., Tuinstra, M., & van Oosten, N. (2024). *Rotorcraft noise
+  modelling guidance* (Research Project NOISE SC01, entregable D1.5d,
+  contrato EASA.2020.FC.06). European Union Aviation Safety Agency.
+  [Página del proyecto en EASA](https://www.easa.europa.eu/en/research-projects/environmental-research-rotorcraft-noise),
+  [PDF gratuito](https://www.easa.europa.eu/en/downloads/132005/en).
+  La guía de modelado NORAH2 a nivel de ecuación, cuyas tablas y hemisferios
+  de referencia sirven de oráculos.
+  Citado por [Ruido de rotorcraft](/phonometry/es/guides/rotorcraft-noise/).
+- Chien, C. F., & Soroka, W. W. (1975). Sound propagation along an impedance
+  plane. *Journal of Sound and Vibration*, 43(1), 9-20.
+  [doi:10.1016/0022-460X(75)90200-X](https://doi.org/10.1016/0022-460X(75)90200-X).
+  La solución de interferencia de dos rayos sobre un plano de impedancia tras
+  el efecto de suelo de rotorcraft.
+  Citado por [Ruido de rotorcraft](/phonometry/es/guides/rotorcraft-noise/).
+- Delany, M. E., & Bazley, E. N. (1970). Acoustical properties of fibrous
+  absorbent materials. *Applied Acoustics*, 3(2), 105-116.
+  [doi:10.1016/0003-682X(70)90031-9](https://doi.org/10.1016/0003-682X(70)90031-9).
+  El modelo de impedancia del suelo de un parámetro (resistividad de flujo).
+  Citado por [Ruido de rotorcraft](/phonometry/es/guides/rotorcraft-noise/).
+
+## Sonido submarino
+
+- Urick, R. J. (1983). *Principles of underwater sound* (3.ª ed.).
+  McGraw-Hill; reimpreso en 1996 por Peninsula Publishing.
+  ISBN 978-0-932146-62-5.
+  [Ficha en Open Library](https://openlibrary.org/books/OL9317725M).
+  La monografía clásica del sonido submarino: convenciones de nivel, ruido
+  radiado por buques y el marco de la ecuación del sonar.
+  Citado por [Acústica submarina](/phonometry/es/guides/underwater-acoustics/) y
+  [Propagación submarina del sonido](/phonometry/es/guides/underwater-propagation/).
+- Ainslie, M. A. (2010). *Principles of sonar performance modelling*.
+  Springer.
+  [doi:10.1007/978-3-540-87662-5](https://doi.org/10.1007/978-3-540-87662-5).
+  El tratamiento sistemático de las magnitudes acústicas submarinas en la
+  línea que la ISO 18405 normalizó.
+  Citado por [Acústica submarina](/phonometry/es/guides/underwater-acoustics/).
+- Medwin, H., & Clay, C. S. (1998). *Fundamentals of acoustical oceanography*.
+  Academic Press. ISBN 978-0-12-487570-8.
+  [Página del editor](https://shop.elsevier.com/books/fundamentals-of-acoustical-oceanography/medwin/978-0-12-487570-8).
+  La acústica oceánica desde primeros principios; el coeficiente de reflexión
+  de Rayleigh fluido-fluido del modelo de fondo marino.
+  Citado por [Propagación submarina del sonido](/phonometry/es/guides/underwater-propagation/).
+- Jensen, F. B., Kuperman, W. A., Porter, M. B., & Schmidt, H. (2011).
+  *Computational ocean acoustics* (2.ª ed.). Springer.
+  [doi:10.1007/978-1-4419-8678-8](https://doi.org/10.1007/978-1-4419-8678-8).
+  La monografía de referencia de la propagación numérica: modos normales,
+  trazado de rayos y ecuación parabólica.
+  Citado por [Propagación submarina del sonido](/phonometry/es/guides/underwater-propagation/).
+- Francois, R. E., & Garrison, G. R. (1982). Sound absorption based on ocean
+  measurements: Part I: Pure water and magnesium sulfate contributions.
+  *The Journal of the Acoustical Society of America*, 72(3), 896-907.
+  [doi:10.1121/1.388170](https://doi.org/10.1121/1.388170).
+  Las mitades de agua pura y sulfato de magnesio del modelo de referencia de
+  absorción en agua de mar.
+  Citado por [Propagación submarina del sonido](/phonometry/es/guides/underwater-propagation/).
+- Francois, R. E., & Garrison, G. R. (1982). Sound absorption based on ocean
+  measurements. Part II: Boric acid contribution and equation for total
+  absorption. *The Journal of the Acoustical Society of America*, 72(6),
+  1879-1890.
+  [doi:10.1121/1.388673](https://doi.org/10.1121/1.388673).
+  El término de ácido bórico y la ecuación completa de absorción total.
+  Citado por [Propagación submarina del sonido](/phonometry/es/guides/underwater-propagation/).
+- Ainslie, M. A., & McColm, J. G. (1998). A simplified formula for viscous and
+  chemical absorption in sea water. *The Journal of the Acoustical Society of
+  America*, 103(3), 1671-1672.
+  [doi:10.1121/1.421258](https://doi.org/10.1121/1.421258).
+  La fórmula simplificada y legible de absorción en agua de mar.
+  Citado por [Propagación submarina del sonido](/phonometry/es/guides/underwater-propagation/).
+- Thorp, W. H. (1967). Analytic description of the low-frequency attenuation
+  coefficient. *The Journal of the Acoustical Society of America*, 42(1), 270.
+  [doi:10.1121/1.1910566](https://doi.org/10.1121/1.1910566).
+  La fórmula de absorción de baja frecuencia solo en frecuencia.
+  Citado por [Propagación submarina del sonido](/phonometry/es/guides/underwater-propagation/).
+- Chen, C.-T., & Millero, F. J. (1977). Speed of sound in seawater at high
+  pressures. *The Journal of the Acoustical Society of America*, 62(5),
+  1129-1135.
+  [doi:10.1121/1.381646](https://doi.org/10.1121/1.381646).
+  La ecuación de velocidad del sonido UNESCO, el estándar internacional.
+  Citado por [Propagación submarina del sonido](/phonometry/es/guides/underwater-propagation/).
+- Wong, G. S. K., & Zhu, S. (1995). Speed of sound in seawater as a function
+  of salinity, temperature, and pressure. *The Journal of the Acoustical
+  Society of America*, 97(3), 1732-1736.
+  [doi:10.1121/1.413048](https://doi.org/10.1121/1.413048).
+  La reformulación ITS-90 de los coeficientes UNESCO, la forma implementada.
+  Citado por [Propagación submarina del sonido](/phonometry/es/guides/underwater-propagation/).
+- Del Grosso, V. A. (1974). New equation for the speed of sound in natural
+  waters (with comparisons to other equations). *The Journal of the
+  Acoustical Society of America*, 56(4), 1084-1091.
+  [doi:10.1121/1.1903388](https://doi.org/10.1121/1.1903388).
+  La ecuación alternativa de velocidad del sonido basada en presión.
+  Citado por [Propagación submarina del sonido](/phonometry/es/guides/underwater-propagation/).
+- Mackenzie, K. V. (1981). Nine-term equation for sound speed in the oceans.
+  *The Journal of the Acoustical Society of America*, 70(3), 807-812.
+  [doi:10.1121/1.386920](https://doi.org/10.1121/1.386920).
+  La ecuación de nueve términos basada en profundidad.
+  Citado por [Propagación submarina del sonido](/phonometry/es/guides/underwater-propagation/).
+- Leroy, C. C., & Parthiot, F. (1998). Depth-pressure relationships in the
+  oceans and seas. *The Journal of the Acoustical Society of America*, 103(3),
+  1346-1352.
+  [doi:10.1121/1.421275](https://doi.org/10.1121/1.421275).
+  La conversión de profundidad a presión que usan las ecuaciones de
+  velocidad del sonido.
+  Citado por [Propagación submarina del sonido](/phonometry/es/guides/underwater-propagation/).
+- Wenz, G. M. (1962). Acoustic ambient noise in the ocean: Spectra and
+  sources. *The Journal of the Acoustical Society of America*, 34(12),
+  1936-1956.
+  [doi:10.1121/1.1909155](https://doi.org/10.1121/1.1909155).
+  El estudio clásico del ruido ambiental tras las componentes espectrales de
+  viento y térmica.
+  Citado por [Propagación submarina del sonido](/phonometry/es/guides/underwater-propagation/).
+- Carey, W. M., & Evans, R. B. (2011). *Ocean ambient noise: Measurement and
+  theory*. Springer.
+  [doi:10.1007/978-1-4419-7832-5](https://doi.org/10.1007/978-1-4419-7832-5).
+  El tratamiento moderno del ruido ambiental oceánico: la "regla de los
+  cincos" del viento y la derivación del ruido térmico de Mellen.
+  Citado por [Propagación submarina del sonido](/phonometry/es/guides/underwater-propagation/).
+- MacGillivray, A., & de Jong, C. (2021). A reference spectrum model for
+  estimating source levels of marine shipping based on automated
+  identification system data. *Journal of Marine Science and Engineering*,
+  9(4), 369.
+  [doi:10.3390/jmse9040369](https://doi.org/10.3390/jmse9040369).
+  El modelo JOMOPANS-ECHO de nivel de fuente de buques (acceso abierto) y su
+  calculadora de referencia.
+  Citado por [Propagación submarina del sonido](/phonometry/es/guides/underwater-propagation/).
+- Wales, S. C., & Heitmeyer, R. M. (2002). An ensemble source spectra model
+  for merchant ship-radiated noise. *The Journal of the Acoustical Society of
+  America*, 111(3), 1211-1231.
+  [doi:10.1121/1.1427355](https://doi.org/10.1121/1.1427355).
+  El modelo de espectro de conjunto de fuentes de buques mercantes.
+  Citado por [Propagación submarina del sonido](/phonometry/es/guides/underwater-propagation/).
 
 ## Habla
 

--- a/site/src/content/docs/es/reference/bibliography.md
+++ b/site/src/content/docs/es/reference/bibliography.md
@@ -632,7 +632,7 @@ que las guías incorporan sus secciones de Referencias.
   measurements: Part I: Pure water and magnesium sulfate contributions.
   *The Journal of the Acoustical Society of America*, 72(3), 896-907.
   [doi:10.1121/1.388170](https://doi.org/10.1121/1.388170).
-  Las mitades de agua pura y sulfato de magnesio del modelo de referencia de
+  Las componentes de agua pura y sulfato de magnesio del modelo de referencia de
   absorción en agua de mar.
   Citado por [Propagación submarina del sonido](/phonometry/es/guides/underwater-propagation/).
 - Francois, R. E., & Garrison, G. R. (1982). Sound absorption based on ocean
@@ -651,7 +651,7 @@ que las guías incorporan sus secciones de Referencias.
 - Thorp, W. H. (1967). Analytic description of the low-frequency attenuation
   coefficient. *The Journal of the Acoustical Society of America*, 42(1), 270.
   [doi:10.1121/1.1910566](https://doi.org/10.1121/1.1910566).
-  La fórmula de absorción de baja frecuencia solo en frecuencia.
+  La fórmula de absorción de baja frecuencia dependiente solo de la frecuencia.
   Citado por [Propagación submarina del sonido](/phonometry/es/guides/underwater-propagation/).
 - Chen, C.-T., & Millero, F. J. (1977). Speed of sound in seawater at high
   pressures. *The Journal of the Acoustical Society of America*, 62(5),

--- a/site/src/content/docs/guides/aircraft-noise.md
+++ b/site/src/content/docs/guides/aircraft-noise.md
@@ -194,6 +194,56 @@ geometry behind takeoff roll, the Eq. 4-13b average runway-segment speed and
 the recommended 30 m floor on NPD lookups. Seven branch-covering receptor
 events of the reference workbook are reproduced end-to-end in the test suite.
 
+## References
+
+- International Civil Aviation Organization. (2017). *Annex 16 to the
+  Convention on International Civil Aviation: Environmental protection —
+  Volume I: Aircraft noise* (8th ed.).
+  [ICAO store](https://store.icao.int/en/annex-16-environmental-protection-volume-i-aircraft-noise).
+  The normative Appendix 2 EPNL procedure implemented by the noisiness, tone
+  correction and EPNL sections.
+- International Civil Aviation Organization. (2018). *Environmental technical
+  manual — Volume I: Procedures for the noise certification of aircraft*
+  (Doc 9501, 3rd ed.).
+  [ICAO store](https://store.icao.int/en/environmental-technical-manual-volume-1-procedures-for-the-noise-certification-of-aircraft-doc-9501-1).
+  The worked examples (Table 3-7 tone correction, Table 4-4 integrated-method
+  EPNL) used as the numeric oracles.
+- International Electrotechnical Commission. (1995). *Electroacoustics —
+  Instruments for measurement of aircraft noise — Performance requirements for
+  systems to measure one-third-octave-band sound pressure levels in noise
+  certification of transport-category aeroplanes* (IEC 61265:1995; since
+  revised as [IEC 61265:2018](https://webstore.iec.ch/en/publication/32635),
+  the 1995 edition is the implemented one).
+  [IEC webstore](https://webstore.iec.ch/en/publication/5076).
+  The measurement-system tolerances checked by the verifier.
+- SAE International. (2013). *Application of pure-tone atmospheric absorption
+  losses to one-third octave-band data* (SAE ARP 5534, reaffirmed 2021).
+  [sae.org](https://www.sae.org/standards/content/arp5534/).
+  The SAE-Method band attenuation of the atmospheric-absorption section.
+- SAE International. (2012). *Standard values of atmospheric absorption as a
+  function of temperature and humidity* (SAE ARP 866B, stabilized 2012).
+  [sae.org](https://www.sae.org/standards/content/arp866b/).
+  The predecessor SAE atmospheric-absorption practice, source of the 50
+  dB-limited Approximate Method the SAE Method is contrasted with.
+- SAE International. (2006). *Method for predicting lateral attenuation of
+  airplane noise* (SAE AIR 5662).
+  [sae.org](https://www.sae.org/standards/content/air5662/).
+  The soft-ground lateral-attenuation model that Doc 29 §4.5.4 adopts in the
+  single-event contour section.
+- European Civil Aviation Conference. (2016). *Report on standard method of
+  computing noise contours around civil airports* (ECAC.CEAC Doc 29, 4th ed.),
+  Volume 2: Technical guide.
+  [ECAC documents page](https://www.ecac-ceac.org/documents/ecac-documents-and-international-agreements),
+  [free PDF](https://www.ecac-ceac.org/images/documents/ECAC-Doc_29_4th_edition_Dec_2016_Volume_2.pdf).
+  The NPD interpolation and the single-event segment chain of the airport
+  noise sections.
+- European Civil Aviation Conference. (2026). *Report on standard method of
+  computing noise contours around civil airports* (ECAC.CEAC Doc 29, 5th ed.),
+  Volume 3: Reference cases and verification framework.
+  [ECAC documents page](https://www.ecac-ceac.org/documents/ecac-documents-and-international-agreements),
+  [free PDF](https://www.ecac-ceac.org/images/documents/ECAC-CEAC-DOC_29_5th_Edition-REPORT_ON_STANDARD_METHOD_OF_COMPUTING_NOISE_CONTOURS_AROUND_CIVIL_AIRPORTS-Volume_3-REFERENCE_CASES_AND_VERIFICATION_FRAMEWORK.pdf).
+  The reference workbook the single-event chain is validated against.
+
 ## Standards
 
 ICAO Annex 16 Vol. I Appendix 2 (EPNL procedure), ICAO Doc 9501

--- a/site/src/content/docs/guides/rotorcraft-noise.md
+++ b/site/src/content/docs/guides/rotorcraft-noise.md
@@ -60,10 +60,43 @@ ground effect, off-node bilinear lookups on the reference hemispheres of all
 eleven rotorcraft types, and end to end against the NORAH2 prototype's
 single-event histories (0.1 dB(A) over hard ground, 0.5 dB over soft ground).
 
+## References
+
+- European Civil Aviation Conference. (2026). *Report on standard method of
+  computing rotorcraft noise contours* (ECAC.CEAC Doc 32, 1st ed.).
+  [ECAC documents page](https://www.ecac-ceac.org/documents/ecac-documents-and-international-agreements),
+  [free PDF](https://www.ecac-ceac.org/images/documents/ECAC-CEAC-DOC_32-REPORT_ON_STANDARD_METHOD_OF_COMPUTING_ROTORCRAFT_NOISE_CONTOURS.pdf).
+  The standard rotorcraft contour method whose hemisphere source model and
+  propagation adjustments this page implements.
+- Olsen, H., Tuinstra, M., & van Oosten, N. (2024). *Rotorcraft noise
+  modelling guidance* (Research Project NOISE SC01, deliverable D1.5d,
+  contract EASA.2020.FC.06). European Union Aviation Safety Agency.
+  [EASA project page](https://www.easa.europa.eu/en/research-projects/environmental-research-rotorcraft-noise),
+  [free PDF](https://www.easa.europa.eu/en/downloads/132005/en).
+  The equation-level guidance (Eq. 13-35) behind the implementation, with the
+  Table 4 attenuation values and the reference hemispheres used as oracles.
+- Chien, C. F., & Soroka, W. W. (1975). Sound propagation along an impedance
+  plane. *Journal of Sound and Vibration*, 43(1), 9-20.
+  [doi:10.1016/0022-460X(75)90200-X](https://doi.org/10.1016/0022-460X(75)90200-X).
+  The two-ray interference solution over an impedance plane behind the
+  ground-effect adjustment.
+- Delany, M. E., & Bazley, E. N. (1970). Acoustical properties of fibrous
+  absorbent materials. *Applied Acoustics*, 3(2), 105-116.
+  [doi:10.1016/0003-682X(70)90031-9](https://doi.org/10.1016/0003-682X(70)90031-9).
+  The one-parameter flow-resistivity impedance model the ground effect
+  evaluates.
+- Kephalopoulos, S., Paviotti, M., & Anfosso-Lédée, F. (2012). *Common noise
+  assessment methods in Europe (CNOSSOS-EU)* (EUR 25379 EN). Publications
+  Office of the European Union.
+  [doi:10.2788/31776](https://doi.org/10.2788/31776),
+  [JRC repository](https://publications.jrc.ec.europa.eu/repository/handle/JRC72550).
+  The flow-resistivity ground classes `"A"`-`"H"` accepted by
+  `ground_effect_adjustment`.
+
 ## Standards
 
 ECAC Doc 32, 1st ed. (rotorcraft noise contours); NORAH2 modelling
-guidance (EASA.2020.FC.06 SC03.D1.5d) §A.3-A.4: the noise hemisphere, spherical
+guidance (EASA.2020.FC.06 SC01.D1.5d) §A.3-A.4: the noise hemisphere, spherical
 spreading, atmospheric attenuation (ISO 9613-1, Table 4) and the Chien-Soroka
 ground effect (Delany-Bazley impedance, CNOSSOS flow resistivity). Flight-path
 integration (SEL/LAmax/EPNL), ground-grid contours and terrain shielding are a

--- a/site/src/content/docs/guides/underwater-acoustics.md
+++ b/site/src/content/docs/guides/underwater-acoustics.md
@@ -139,6 +139,21 @@ res.plot()
 
 </details>
 
+## References
+
+- Urick, R. J. (1983). *Principles of underwater sound* (3rd ed.).
+  McGraw-Hill; reprinted 1996 by Peninsula Publishing.
+  ISBN 978-0-932146-62-5.
+  [Open Library record](https://openlibrary.org/books/OL9317725M).
+  The classic treatment of underwater sound levels and of ship radiated
+  noise behind the reference conventions of sections 1-2.
+- Ainslie, M. A. (2010). *Principles of sonar performance modelling*.
+  Springer.
+  [doi:10.1007/978-3-540-87662-5](https://doi.org/10.1007/978-3-540-87662-5).
+  The systematic treatment of underwater acoustical quantities in the line
+  that ISO 18405 standardised; supports the reference levels and the source
+  level of sections 1-2.
+
 ## Standards
 
 ISO 18405:2017, *Underwater acoustics — Terminology*: the 1 µPa

--- a/site/src/content/docs/guides/underwater-propagation.md
+++ b/site/src/content/docs/guides/underwater-propagation.md
@@ -197,6 +197,93 @@ ph.parabolic_equation(50.0, [0.0, 200.0], [1500.0, 1500.0],
 All three assume a range-independent water column with a pressure-release
 surface.
 
+## References
+
+- Francois, R. E., & Garrison, G. R. (1982). Sound absorption based on ocean
+  measurements: Part I: Pure water and magnesium sulfate contributions.
+  *The Journal of the Acoustical Society of America*, 72(3), 896-907.
+  [doi:10.1121/1.388170](https://doi.org/10.1121/1.388170).
+  The pure-water and magnesium-sulfate halves of the default absorption
+  model of the transmission-loss section.
+- Francois, R. E., & Garrison, G. R. (1982). Sound absorption based on ocean
+  measurements. Part II: Boric acid contribution and equation for total
+  absorption. *The Journal of the Acoustical Society of America*, 72(6),
+  1879-1890.
+  [doi:10.1121/1.388673](https://doi.org/10.1121/1.388673).
+  The boric-acid term and the complete Francois-Garrison total-absorption
+  equation, the implemented default.
+- Ainslie, M. A., & McColm, J. G. (1998). A simplified formula for viscous and
+  chemical absorption in sea water. *The Journal of the Acoustical Society of
+  America*, 103(3), 1671-1672.
+  [doi:10.1121/1.421258](https://doi.org/10.1121/1.421258).
+  The legible simplified absorption model (`"ainslie-mccolm"`).
+- Thorp, W. H. (1967). Analytic description of the low-frequency attenuation
+  coefficient. *The Journal of the Acoustical Society of America*, 42(1), 270.
+  [doi:10.1121/1.1910566](https://doi.org/10.1121/1.1910566).
+  The frequency-only low-frequency absorption formula (`"thorp"`).
+- Chen, C.-T., & Millero, F. J. (1977). Speed of sound in seawater at high
+  pressures. *The Journal of the Acoustical Society of America*, 62(5),
+  1129-1135.
+  [doi:10.1121/1.381646](https://doi.org/10.1121/1.381646).
+  The UNESCO international-standard sound-speed equation.
+- Wong, G. S. K., & Zhu, S. (1995). Speed of sound in seawater as a function
+  of salinity, temperature, and pressure. *The Journal of the Acoustical
+  Society of America*, 97(3), 1732-1736.
+  [doi:10.1121/1.413048](https://doi.org/10.1121/1.413048).
+  The ITS-90 recast of the UNESCO coefficients, the implemented form.
+- Del Grosso, V. A. (1974). New equation for the speed of sound in natural
+  waters (with comparisons to other equations). *The Journal of the
+  Acoustical Society of America*, 56(4), 1084-1091.
+  [doi:10.1121/1.1903388](https://doi.org/10.1121/1.1903388).
+  The alternative pressure-based sound-speed equation (`"del-grosso"`).
+- Mackenzie, K. V. (1981). Nine-term equation for sound speed in the oceans.
+  *The Journal of the Acoustical Society of America*, 70(3), 807-812.
+  [doi:10.1121/1.386920](https://doi.org/10.1121/1.386920).
+  The depth-based nine-term equation and its 1550.744 m/s check value.
+- Leroy, C. C., & Parthiot, F. (1998). Depth-pressure relationships in the
+  oceans and seas. *The Journal of the Acoustical Society of America*, 103(3),
+  1346-1352.
+  [doi:10.1121/1.421275](https://doi.org/10.1121/1.421275).
+  The depth-to-pressure conversion feeding the UNESCO and Del Grosso
+  equations.
+- Urick, R. J. (1983). *Principles of underwater sound* (3rd ed.).
+  McGraw-Hill; reprinted 1996 by Peninsula Publishing.
+  ISBN 978-0-932146-62-5.
+  [Open Library record](https://openlibrary.org/books/OL9317725M).
+  The sonar-equation framework (signal excess, figure of merit).
+- Medwin, H., & Clay, C. S. (1998). *Fundamentals of acoustical oceanography*.
+  Academic Press. ISBN 978-0-12-487570-8.
+  [Publisher page](https://shop.elsevier.com/books/fundamentals-of-acoustical-oceanography/medwin/978-0-12-487570-8).
+  The fluid-fluid Rayleigh reflection coefficient and critical grazing angle
+  of the seabed-reflection section.
+- Wenz, G. M. (1962). Acoustic ambient noise in the ocean: Spectra and
+  sources. *The Journal of the Acoustical Society of America*, 34(12),
+  1936-1956.
+  [doi:10.1121/1.1909155](https://doi.org/10.1121/1.1909155).
+  The ambient-noise survey behind the wind and thermal components of the
+  ocean ambient-noise section.
+- Carey, W. M., & Evans, R. B. (2011). *Ocean ambient noise: Measurement and
+  theory*. Springer.
+  [doi:10.1007/978-1-4419-7832-5](https://doi.org/10.1007/978-1-4419-7832-5).
+  The wind "rule of fives" anchor and the Mellen thermal-noise derivation.
+- MacGillivray, A., & de Jong, C. (2021). A reference spectrum model for
+  estimating source levels of marine shipping based on automated
+  identification system data. *Journal of Marine Science and Engineering*,
+  9(4), 369.
+  [doi:10.3390/jmse9040369](https://doi.org/10.3390/jmse9040369).
+  The JOMOPANS-ECHO ship source-level model (open access); its File S1
+  calculator is the validation oracle.
+- Wales, S. C., & Heitmeyer, R. M. (2002). An ensemble source spectra model
+  for merchant ship-radiated noise. *The Journal of the Acoustical Society of
+  America*, 111(3), 1211-1231.
+  [doi:10.1121/1.1427355](https://doi.org/10.1121/1.1427355).
+  The ensemble merchant-ship spectrum model of the ship-traffic section.
+- Jensen, F. B., Kuperman, W. A., Porter, M. B., & Schmidt, H. (2011).
+  *Computational ocean acoustics* (2nd ed.). Springer.
+  [doi:10.1007/978-1-4419-8678-8](https://doi.org/10.1007/978-1-4419-8678-8).
+  The normal-mode, ray-tracing and split-step Fourier parabolic-equation
+  solvers of the numerical-solvers section.
+
 ## See also
 
 - API reference: [`underwater.propagation`](/phonometry/reference/api/underwater/propagation/), [`underwater.numerical_propagation`](/phonometry/reference/api/underwater/numerical-propagation/) and [`underwater.sound_speed`](/phonometry/reference/api/underwater/sound-speed/).

--- a/site/src/content/docs/reference/api/aeroacoustics/rotorcraft-noise.md
+++ b/site/src/content/docs/reference/api/aeroacoustics/rotorcraft-noise.md
@@ -17,7 +17,7 @@ receiver adds the propagation adjustment `ΔLp = ΔLs + ΔLa + ΔLg (+ ΔLd)`
 (spherical spreading, atmospheric absorption, ground effect and — later — shielding).
 
 This module provides the source and propagation primitives (clean-room, from the
-NORAH2 guidance SC03.D1.5d, the basis of ECAC Doc 32):
+NORAH2 guidance SC01.D1.5d, the basis of ECAC Doc 32):
 
 * [`hemisphere_source_level`](/phonometry/reference/api/aeroacoustics/rotorcraft-noise/#hemisphere_source_level) -- the interpolated source level `L(fc, φ, θ)`
   from a [`RotorcraftHemisphere`](/phonometry/reference/api/aeroacoustics/rotorcraft-noise/#rotorcrafthemisphere), bilinear over the 10° grid (Eq. 13) with
@@ -31,7 +31,7 @@ NORAH2 guidance SC03.D1.5d, the basis of ECAC Doc 32):
   and the CNOSSOS flow-resistivity classes.
 
 Source (clean-room): ECAC Doc 32, 1st ed.; NORAH2 rotorcraft-noise modelling
-guidance (EASA.2020.FC.06 SC03.D1.5d), §A.3-A.4. The atmospheric term is validated
+guidance (EASA.2020.FC.06 SC01.D1.5d), §A.3-A.4. The atmospheric term is validated
 against the guidance Table 4 (one-third-octave attenuation per km at ICAO
 reference conditions).
 

--- a/site/src/content/docs/reference/bibliography.md
+++ b/site/src/content/docs/reference/bibliography.md
@@ -436,8 +436,10 @@ list grows as guides gain their References sections.
   Office of the European Union.
   [doi:10.2788/31776](https://doi.org/10.2788/31776),
   [JRC repository](https://publications.jrc.ec.europa.eu/repository/handle/JRC72550).
-  The common EU noise-mapping framework, contrasted with ISO 9613-2.
-  Cited by [Outdoor Sound Propagation](/phonometry/guides/outdoor-propagation/).
+  The common EU noise-mapping framework, contrasted with ISO 9613-2; its
+  flow-resistivity ground classes are reused by the rotorcraft ground effect.
+  Cited by [Outdoor Sound Propagation](/phonometry/guides/outdoor-propagation/)
+  and [Rotorcraft noise](/phonometry/guides/rotorcraft-noise/).
 - International Organization for Standardization. (1993). *Acoustics —
   Attenuation of sound during propagation outdoors — Part 1: Calculation of
   the absorption of sound by the atmosphere* (ISO 9613-1:1993).
@@ -491,6 +493,200 @@ list grows as guides gain their References sections.
   [IEC webstore](https://webstore.iec.ch/en/publication/5432).
   Declared values and their uncertainty for a batch of turbines.
   Cited by [Wind-turbine noise](/phonometry/guides/wind-turbine-noise/).
+
+## Aircraft noise
+
+- International Civil Aviation Organization. (2017). *Annex 16 to the
+  Convention on International Civil Aviation: Environmental protection —
+  Volume I: Aircraft noise* (8th ed.).
+  [ICAO store](https://store.icao.int/en/annex-16-environmental-protection-volume-i-aircraft-noise).
+  The aircraft noise-certification standard whose Appendix 2 defines the
+  EPNL procedure.
+  Cited by [Aircraft noise](/phonometry/guides/aircraft-noise/).
+- International Civil Aviation Organization. (2018). *Environmental technical
+  manual — Volume I: Procedures for the noise certification of aircraft*
+  (Doc 9501, 3rd ed.).
+  [ICAO store](https://store.icao.int/en/environmental-technical-manual-volume-1-procedures-for-the-noise-certification-of-aircraft-doc-9501-1).
+  The certification guidance whose worked examples (tone correction,
+  integrated-method EPNL) serve as numeric oracles.
+  Cited by [Aircraft noise](/phonometry/guides/aircraft-noise/).
+- International Electrotechnical Commission. (1995). *Electroacoustics —
+  Instruments for measurement of aircraft noise — Performance requirements for
+  systems to measure one-third-octave-band sound pressure levels in noise
+  certification of transport-category aeroplanes* (IEC 61265:1995; since
+  revised as [IEC 61265:2018](https://webstore.iec.ch/en/publication/32635),
+  the 1995 edition is the implemented one).
+  [IEC webstore](https://webstore.iec.ch/en/publication/5076).
+  The aircraft-noise measurement-system performance tolerances.
+  Cited by [Aircraft noise](/phonometry/guides/aircraft-noise/).
+- SAE International. (2013). *Application of pure-tone atmospheric absorption
+  losses to one-third octave-band data* (SAE ARP 5534, reaffirmed 2021).
+  [sae.org](https://www.sae.org/standards/content/arp5534/).
+  The SAE-Method one-third-octave-band atmospheric absorption for aircraft
+  flyover spectra.
+  Cited by [Aircraft noise](/phonometry/guides/aircraft-noise/).
+- SAE International. (2012). *Standard values of atmospheric absorption as a
+  function of temperature and humidity* (SAE ARP 866B, stabilized 2012).
+  [sae.org](https://www.sae.org/standards/content/arp866b/).
+  The predecessor SAE atmospheric-absorption practice, source of the older
+  50 dB-limited Approximate Method.
+  Cited by [Aircraft noise](/phonometry/guides/aircraft-noise/).
+- SAE International. (2006). *Method for predicting lateral attenuation of
+  airplane noise* (SAE AIR 5662).
+  [sae.org](https://www.sae.org/standards/content/air5662/).
+  The soft-ground lateral-attenuation model adopted by ECAC Doc 29.
+  Cited by [Aircraft noise](/phonometry/guides/aircraft-noise/).
+- European Civil Aviation Conference. (2016). *Report on standard method of
+  computing noise contours around civil airports* (ECAC.CEAC Doc 29, 4th ed.),
+  Volume 2: Technical guide.
+  [ECAC documents page](https://www.ecac-ceac.org/documents/ecac-documents-and-international-agreements),
+  [free PDF](https://www.ecac-ceac.org/images/documents/ECAC-Doc_29_4th_edition_Dec_2016_Volume_2.pdf).
+  The European airport noise-contour method: NPD interpolation and the
+  single-event segment calculation.
+  Cited by [Aircraft noise](/phonometry/guides/aircraft-noise/).
+- European Civil Aviation Conference. (2026). *Report on standard method of
+  computing noise contours around civil airports* (ECAC.CEAC Doc 29, 5th ed.),
+  Volume 3: Reference cases and verification framework.
+  [ECAC documents page](https://www.ecac-ceac.org/documents/ecac-documents-and-international-agreements),
+  [free PDF](https://www.ecac-ceac.org/images/documents/ECAC-CEAC-DOC_29_5th_Edition-REPORT_ON_STANDARD_METHOD_OF_COMPUTING_NOISE_CONTOURS_AROUND_CIVIL_AIRPORTS-Volume_3-REFERENCE_CASES_AND_VERIFICATION_FRAMEWORK.pdf).
+  The reference cases and workbook used to validate the single-event chain.
+  Cited by [Aircraft noise](/phonometry/guides/aircraft-noise/).
+- European Civil Aviation Conference. (2026). *Report on standard method of
+  computing rotorcraft noise contours* (ECAC.CEAC Doc 32, 1st ed.).
+  [ECAC documents page](https://www.ecac-ceac.org/documents/ecac-documents-and-international-agreements),
+  [free PDF](https://www.ecac-ceac.org/images/documents/ECAC-CEAC-DOC_32-REPORT_ON_STANDARD_METHOD_OF_COMPUTING_ROTORCRAFT_NOISE_CONTOURS.pdf).
+  The standard rotorcraft contour method built on the noise hemisphere.
+  Cited by [Rotorcraft noise](/phonometry/guides/rotorcraft-noise/).
+- Olsen, H., Tuinstra, M., & van Oosten, N. (2024). *Rotorcraft noise
+  modelling guidance* (Research Project NOISE SC01, deliverable D1.5d,
+  contract EASA.2020.FC.06). European Union Aviation Safety Agency.
+  [EASA project page](https://www.easa.europa.eu/en/research-projects/environmental-research-rotorcraft-noise),
+  [free PDF](https://www.easa.europa.eu/en/downloads/132005/en).
+  The NORAH2 equation-level modelling guidance, whose tables and reference
+  hemispheres serve as oracles.
+  Cited by [Rotorcraft noise](/phonometry/guides/rotorcraft-noise/).
+- Chien, C. F., & Soroka, W. W. (1975). Sound propagation along an impedance
+  plane. *Journal of Sound and Vibration*, 43(1), 9-20.
+  [doi:10.1016/0022-460X(75)90200-X](https://doi.org/10.1016/0022-460X(75)90200-X).
+  The two-ray interference solution over an impedance plane behind the
+  rotorcraft ground effect.
+  Cited by [Rotorcraft noise](/phonometry/guides/rotorcraft-noise/).
+- Delany, M. E., & Bazley, E. N. (1970). Acoustical properties of fibrous
+  absorbent materials. *Applied Acoustics*, 3(2), 105-116.
+  [doi:10.1016/0003-682X(70)90031-9](https://doi.org/10.1016/0003-682X(70)90031-9).
+  The one-parameter flow-resistivity ground-impedance model.
+  Cited by [Rotorcraft noise](/phonometry/guides/rotorcraft-noise/).
+
+## Underwater sound
+
+- Urick, R. J. (1983). *Principles of underwater sound* (3rd ed.).
+  McGraw-Hill; reprinted 1996 by Peninsula Publishing.
+  ISBN 978-0-932146-62-5.
+  [Open Library record](https://openlibrary.org/books/OL9317725M).
+  The classic monograph on underwater sound: level conventions, ship
+  radiated noise and the sonar-equation framework.
+  Cited by [Underwater acoustics](/phonometry/guides/underwater-acoustics/) and
+  [Underwater sound propagation](/phonometry/guides/underwater-propagation/).
+- Ainslie, M. A. (2010). *Principles of sonar performance modelling*.
+  Springer.
+  [doi:10.1007/978-3-540-87662-5](https://doi.org/10.1007/978-3-540-87662-5).
+  The systematic treatment of underwater acoustical quantities in the line
+  that ISO 18405 standardised.
+  Cited by [Underwater acoustics](/phonometry/guides/underwater-acoustics/).
+- Medwin, H., & Clay, C. S. (1998). *Fundamentals of acoustical oceanography*.
+  Academic Press. ISBN 978-0-12-487570-8.
+  [Publisher page](https://shop.elsevier.com/books/fundamentals-of-acoustical-oceanography/medwin/978-0-12-487570-8).
+  Ocean acoustics from first principles; the fluid-fluid Rayleigh
+  reflection coefficient of the seabed model.
+  Cited by [Underwater sound propagation](/phonometry/guides/underwater-propagation/).
+- Jensen, F. B., Kuperman, W. A., Porter, M. B., & Schmidt, H. (2011).
+  *Computational ocean acoustics* (2nd ed.). Springer.
+  [doi:10.1007/978-1-4419-8678-8](https://doi.org/10.1007/978-1-4419-8678-8).
+  The reference monograph on numerical propagation: normal modes, ray
+  tracing and the parabolic equation.
+  Cited by [Underwater sound propagation](/phonometry/guides/underwater-propagation/).
+- Francois, R. E., & Garrison, G. R. (1982). Sound absorption based on ocean
+  measurements: Part I: Pure water and magnesium sulfate contributions.
+  *The Journal of the Acoustical Society of America*, 72(3), 896-907.
+  [doi:10.1121/1.388170](https://doi.org/10.1121/1.388170).
+  The pure-water and magnesium-sulfate halves of the reference seawater
+  absorption model.
+  Cited by [Underwater sound propagation](/phonometry/guides/underwater-propagation/).
+- Francois, R. E., & Garrison, G. R. (1982). Sound absorption based on ocean
+  measurements. Part II: Boric acid contribution and equation for total
+  absorption. *The Journal of the Acoustical Society of America*, 72(6),
+  1879-1890.
+  [doi:10.1121/1.388673](https://doi.org/10.1121/1.388673).
+  The boric-acid term and the complete total-absorption equation.
+  Cited by [Underwater sound propagation](/phonometry/guides/underwater-propagation/).
+- Ainslie, M. A., & McColm, J. G. (1998). A simplified formula for viscous and
+  chemical absorption in sea water. *The Journal of the Acoustical Society of
+  America*, 103(3), 1671-1672.
+  [doi:10.1121/1.421258](https://doi.org/10.1121/1.421258).
+  The legible simplified seawater absorption formula.
+  Cited by [Underwater sound propagation](/phonometry/guides/underwater-propagation/).
+- Thorp, W. H. (1967). Analytic description of the low-frequency attenuation
+  coefficient. *The Journal of the Acoustical Society of America*, 42(1), 270.
+  [doi:10.1121/1.1910566](https://doi.org/10.1121/1.1910566).
+  The frequency-only low-frequency absorption formula.
+  Cited by [Underwater sound propagation](/phonometry/guides/underwater-propagation/).
+- Chen, C.-T., & Millero, F. J. (1977). Speed of sound in seawater at high
+  pressures. *The Journal of the Acoustical Society of America*, 62(5),
+  1129-1135.
+  [doi:10.1121/1.381646](https://doi.org/10.1121/1.381646).
+  The UNESCO international-standard sound-speed equation.
+  Cited by [Underwater sound propagation](/phonometry/guides/underwater-propagation/).
+- Wong, G. S. K., & Zhu, S. (1995). Speed of sound in seawater as a function
+  of salinity, temperature, and pressure. *The Journal of the Acoustical
+  Society of America*, 97(3), 1732-1736.
+  [doi:10.1121/1.413048](https://doi.org/10.1121/1.413048).
+  The ITS-90 recast of the UNESCO sound-speed coefficients, the implemented
+  form.
+  Cited by [Underwater sound propagation](/phonometry/guides/underwater-propagation/).
+- Del Grosso, V. A. (1974). New equation for the speed of sound in natural
+  waters (with comparisons to other equations). *The Journal of the
+  Acoustical Society of America*, 56(4), 1084-1091.
+  [doi:10.1121/1.1903388](https://doi.org/10.1121/1.1903388).
+  The alternative pressure-based sound-speed equation.
+  Cited by [Underwater sound propagation](/phonometry/guides/underwater-propagation/).
+- Mackenzie, K. V. (1981). Nine-term equation for sound speed in the oceans.
+  *The Journal of the Acoustical Society of America*, 70(3), 807-812.
+  [doi:10.1121/1.386920](https://doi.org/10.1121/1.386920).
+  The depth-based nine-term sound-speed equation.
+  Cited by [Underwater sound propagation](/phonometry/guides/underwater-propagation/).
+- Leroy, C. C., & Parthiot, F. (1998). Depth-pressure relationships in the
+  oceans and seas. *The Journal of the Acoustical Society of America*, 103(3),
+  1346-1352.
+  [doi:10.1121/1.421275](https://doi.org/10.1121/1.421275).
+  The depth-to-pressure conversion used by the sound-speed equations.
+  Cited by [Underwater sound propagation](/phonometry/guides/underwater-propagation/).
+- Wenz, G. M. (1962). Acoustic ambient noise in the ocean: Spectra and
+  sources. *The Journal of the Acoustical Society of America*, 34(12),
+  1936-1956.
+  [doi:10.1121/1.1909155](https://doi.org/10.1121/1.1909155).
+  The classic ambient-noise survey behind the wind and thermal spectrum
+  components.
+  Cited by [Underwater sound propagation](/phonometry/guides/underwater-propagation/).
+- Carey, W. M., & Evans, R. B. (2011). *Ocean ambient noise: Measurement and
+  theory*. Springer.
+  [doi:10.1007/978-1-4419-7832-5](https://doi.org/10.1007/978-1-4419-7832-5).
+  The modern treatment of ocean ambient noise: the wind "rule of fives" and
+  the Mellen thermal-noise derivation.
+  Cited by [Underwater sound propagation](/phonometry/guides/underwater-propagation/).
+- MacGillivray, A., & de Jong, C. (2021). A reference spectrum model for
+  estimating source levels of marine shipping based on automated
+  identification system data. *Journal of Marine Science and Engineering*,
+  9(4), 369.
+  [doi:10.3390/jmse9040369](https://doi.org/10.3390/jmse9040369).
+  The open-access JOMOPANS-ECHO ship source-level model and its reference
+  calculator.
+  Cited by [Underwater sound propagation](/phonometry/guides/underwater-propagation/).
+- Wales, S. C., & Heitmeyer, R. M. (2002). An ensemble source spectra model
+  for merchant ship-radiated noise. *The Journal of the Acoustical Society of
+  America*, 111(3), 1211-1231.
+  [doi:10.1121/1.1427355](https://doi.org/10.1121/1.1427355).
+  The ensemble merchant-ship source-spectrum model.
+  Cited by [Underwater sound propagation](/phonometry/guides/underwater-propagation/).
 
 ## Speech
 

--- a/src/phonometry/aircraft/rotorcraft_noise.py
+++ b/src/phonometry/aircraft/rotorcraft_noise.py
@@ -10,7 +10,7 @@ receiver adds the propagation adjustment ``ΔLp = ΔLs + ΔLa + ΔLg (+ ΔLd)``
 (spherical spreading, atmospheric absorption, ground effect and — later — shielding).
 
 This module provides the source and propagation primitives (clean-room, from the
-NORAH2 guidance SC03.D1.5d, the basis of ECAC Doc 32):
+NORAH2 guidance SC01.D1.5d, the basis of ECAC Doc 32):
 
 * :func:`hemisphere_source_level` -- the interpolated source level ``L(fc, φ, θ)``
   from a :class:`RotorcraftHemisphere`, bilinear over the 10° grid (Eq. 13) with
@@ -24,7 +24,7 @@ NORAH2 guidance SC03.D1.5d, the basis of ECAC Doc 32):
   and the CNOSSOS flow-resistivity classes.
 
 Source (clean-room): ECAC Doc 32, 1st ed.; NORAH2 rotorcraft-noise modelling
-guidance (EASA.2020.FC.06 SC03.D1.5d), §A.3-A.4. The atmospheric term is validated
+guidance (EASA.2020.FC.06 SC01.D1.5d), §A.3-A.4. The atmospheric term is validated
 against the guidance Table 4 (one-third-octave attenuation per km at ICAO
 reference conditions).
 """


### PR DESCRIPTION
## Summary

References sections for the four remaining guides without them (aircraft noise, rotorcraft noise, underwater acoustics and underwater propagation), with every link verified at authoring time, in the three content trees.

- Aircraft noise: ICAO Annex 16 Volume I and the Doc 9501 environmental technical manual (the page's tone-correction oracle), the SAE atmospheric-absorption chain (ARP 5534, ARP 866B, AIR 5662), IEC 61265 with its revision note, and both implemented ECAC Doc 29 editions including the validation workbook; ICAO Doc 9911 deliberately omitted since the page implements Doc 29.
- Rotorcraft noise: ECAC Doc 32 and the NORAH2 guidance deliverable through its citable EASA record, plus the ground-effect sources (Chien and Soroka, Delany and Bazley, CNOSSOS-EU). Along the way the deliverable identifier in our own module docstring turned out wrong (the EASA record is research project NOISE SC01, not SC03): fixed at the source, the generated API page regenerated, and the finding recorded in the errata registry.
- Underwater: Urick via the in-print Peninsula reprint record and Ainslie's sonar-performance monograph; the propagation page cites its full source set (both Francois and Garrison parts, Ainslie and McColm, Thorp, the five sound-speed formulations, Medwin and Clay, Wenz, Carey and Evans, the JOMOPANS-ECHO paper, Wales and Heitmeyer, and Jensen et al.), every journal DOI verified against the Crossref record.
- The bibliography gains Aircraft noise (12 entries) and Underwater sound (17 entries) groups with back-links.

## Test plan

Conformance byte-identical; i18n parity (56 pairs); site build with links validator at 0 errors; html-validate; ruff and mypy clean and the rotorcraft tests passing after the docstring correction; API drift gate satisfied by regeneration. A review pass propagated the identifier fix everywhere it appears and cleaned two wrap artifacts.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

