### PR TITLE
docs: reproduction snippets for every legacy data figure

### DIFF
--- a/docs/aircraft-noise.md
+++ b/docs/aircraft-noise.md
@@ -125,6 +125,32 @@ print(report["passed"], report["checks"])
   <img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/aircraft_atmospheric_absorption.svg" alt="Aircraft atmospheric absorption versus frequency for two path lengths: the SAE-Method one-third-octave-band attenuation rises with frequency and stays below the pure-tone mid-band value at high absorption" width="82%">
 </picture>
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import aircraft
+
+freqs = 1000.0 * 10.0 ** (np.arange(-13, 11) / 10.0)   # 50 Hz-10 kHz thirds
+fig, ax = plt.subplots()
+# solid: SAE band attenuation, dashed: pure-tone mid-band
+for s in (1000.0, 7620.0):
+    att = aircraft.sae_band_attenuation(freqs, s, temperature=25.0, relative_humidity=70.0)
+    line, = ax.semilogx(att.frequency, att.band_attenuation, marker="o",
+                        markersize=3, label=f"SAE band ({s:.0f} m)")
+    ax.semilogx(att.frequency, att.midband_attenuation, "--", alpha=0.6,
+                color=line.get_color())
+ax.set(xlabel="Frequency [Hz]", ylabel="Attenuation [dB]",
+       title="Aircraft atmospheric absorption at 25 °C, 70% RH")
+ax.grid(True, which="both", alpha=0.3)
+ax.legend()
+plt.show()
+```
+
+</details>
+
 Correcting a measured flyover spectrum to reference atmospheric conditions
 needs the one-third-octave-band attenuation over the path. The pure-tone
 coefficient is the ISO 9613-1 one (identical, per ARP 5534 §3.1) already
@@ -158,6 +184,34 @@ Part 36 test window), over path lengths to 7620 m, and is reciprocal
   <img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/airport_noise.svg" alt="Noise-power-distance curves for two engine power settings: the event level falls log-linearly with slant distance between the tabulated nodes, higher power giving a higher level" width="82%">
 </picture>
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+from phonometry import aircraft
+
+# A schematic NPD table: SEL vs slant distance for two thrust settings.
+powers = [12000.0, 20000.0]
+distances = [200.0, 400.0, 630.0, 1000.0, 2000.0, 4000.0, 6300.0, 10000.0]
+levels = [[98.5, 92.0, 88.2, 83.6, 76.8, 69.4, 63.9, 56.8],
+          [107.2, 100.9, 97.2, 92.7, 86.0, 78.5, 72.9, 65.6]]
+
+fig, ax = plt.subplots()
+for p in (20000.0, 12000.0):
+    curve = aircraft.npd_curve(powers, distances, levels, power=p)
+    line, = ax.semilogx(curve.distance, curve.level, label=f"P = {p:.0f} N")
+    ax.semilogx(curve.table_distances, curve.table_levels, "o", markersize=4,
+                color=line.get_color())
+ax.set(xlabel="Slant distance [m]", ylabel="Event level [dB]",
+       title="Noise-power-distance curves (ECAC Doc 29)")
+ax.grid(True, which="both", alpha=0.3)
+ax.legend()
+plt.show()
+```
+
+</details>
+
 The ECAC Doc 29 airport-noise method describes an aircraft with **noise-power-
 distance (NPD)** tables — the event level (`LAmax` or `SEL`) of steady straight
 flight versus engine power and slant distance. `npd_level` reads an event level
@@ -184,6 +238,37 @@ curve.plot()   # NPD curve with the tabulated nodes (needs matplotlib)
   <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/airport_contour_dark.png">
   <img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/airport_contour.png" alt="Single-event SEL contour of a departure: an elongated footprint along the flight track, loudest near the ground roll and decaying as the aircraft climbs away" width="90%">
 </picture>
+
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import aircraft
+
+# NPD tables (SEL and LAmax) for one aircraft, two power settings.
+powers = [8000.0, 12000.0]
+distances = [60.0, 120.0, 240.0, 480.0, 960.0, 1920.0, 3840.0, 7680.0]
+sel = [[98.0, 92.0, 86.0, 80.0, 74.0, 68.0, 62.0, 56.0],
+       [104.0, 98.0, 92.0, 86.0, 80.0, 74.0, 68.0, 62.0]]
+lmax = [[94.0, 88.0, 82.0, 76.0, 70.0, 64.0, 58.0, 52.0],
+        [100.0, 94.0, 88.0, 82.0, 76.0, 70.0, 64.0, 58.0]]
+
+# Departure: ground roll along +x, then a steady climb.
+xs = np.linspace(0.0, 18000.0, 40)
+z = np.clip((xs - 1500.0) * 0.11, 0.0, 2500.0)
+power = np.where(xs < 3000.0, 12000.0, 10000.0)
+path = np.column_stack([xs, np.zeros_like(xs), z, power, np.full_like(xs, 82.3)])
+
+contour = aircraft.noise_contour(path, powers, distances, sel, lmax,
+                                 x=np.linspace(-2500.0, 20000.0, 56),
+                                 y=np.linspace(-6000.0, 6000.0, 44))
+contour.plot()   # single-event SEL footprint (needs matplotlib)
+plt.show()
+```
+
+</details>
 
 The full ECAC Doc 29 single-event calculation places a flight path's noise at a
 receiver by breaking the path into segments and, for each, correcting the NPD
@@ -228,6 +313,7 @@ directly behind (`ψ = 180°`).
 <summary>Show the code for this figure</summary>
 
 ```python
+import matplotlib.pyplot as plt
 import numpy as np
 import phonometry as ph
 
@@ -235,6 +321,15 @@ az = np.linspace(90.0, 270.0, 361)              # rearward semicircle
 psi = np.where(az <= 180.0, az, 360.0 - az)     # ΔSOR is left/right symmetric
 jet = [ph.start_of_roll_directivity(p, 300.0, "jet") for p in psi]
 prop = [ph.start_of_roll_directivity(p, 300.0, "turboprop") for p in psi]
+
+ax = plt.subplot(projection="polar")
+ax.set_theta_zero_location("N")                 # nose up, azimuth clockwise
+ax.set_theta_direction(-1)
+ax.plot(np.radians(az), jet, label="Turbofan jet")
+ax.plot(np.radians(az), prop, label="Turboprop")
+ax.set_rlim(-16.0, 0.0)                         # radial axis: dB re abeam
+ax.legend(loc="lower center")
+plt.show()
 ```
 
 </details>

--- a/docs/block-processing.md
+++ b/docs/block-processing.md
@@ -21,6 +21,43 @@ single full-signal pass.
 result exactly; without state, every block boundary restarts the filter
 transient.*
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import metrology
+
+# 1 kHz octave band: four stateful blocks vs one continuous pass
+fs, block = 8000, 1000
+rng = np.random.default_rng(42)
+x = rng.standard_normal(4 * block)
+t = np.arange(x.size) / fs
+
+bank = metrology.OctaveFilterBank(fs, fraction=1, limits=[900, 1100],
+                                  stateful=True, resample=False)
+streamed = np.concatenate([
+    bank.filter(x[i * block:(i + 1) * block], sigbands=True,
+                detrend=False, calculate_level=False)[2][0]
+    for i in range(4)
+])
+offline = metrology.OctaveFilterBank(fs, fraction=1, limits=[900, 1100],
+                                     resample=False).filter(
+    x, sigbands=True, detrend=False, calculate_level=False)[2][0]
+print(np.max(np.abs(streamed - offline)))     # 0.0 (bit-exact)
+
+fig, ax = plt.subplots(figsize=(9, 4.5))
+ax.plot(t, offline, linewidth=2.5, alpha=0.35, label="Continuous (whole signal)")
+ax.plot(t, streamed, label="Stateful blocks (state carried)")
+ax.axvline(block / fs, color="gray", linestyle=":", label="Block boundary")
+ax.set(xlim=(0.11, 0.17), xlabel="Time [s]", ylabel="Amplitude")
+ax.legend()
+plt.show()
+```
+
+</details>
+
 Create a stateful filter bank with `stateful=True`. The internal state is
 zero-initialized by default but may be initialized for step-response
 steady-state (like `scipy.signal.sosfilt_zi`) with `steady_ic=True`. The

--- a/docs/dynamic-stiffness.md
+++ b/docs/dynamic-stiffness.md
@@ -15,6 +15,23 @@ excludes floating floors.)
 
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/dynamic_stiffness_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/dynamic_stiffness.svg" alt="Floating-floor natural frequency as a function of the resilient layer's dynamic stiffness per unit area, for a light 40 kg/m² and a heavy 120 kg/m² floating floor, on a logarithmic stiffness axis, with a worked design point at 10 MN/m³ marked" width="82%"></picture>
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+import phonometry as ph
+
+s = np.logspace(np.log10(2.0), np.log10(100.0), 300)   # MN/m3
+for m in (40.0, 120.0):
+    plt.semilogx(s, ph.natural_frequency(s * 1e6, m), label=f"m' = {m:g} kg/m²")
+plt.xlabel("Dynamic stiffness s' [MN/m³]"); plt.ylabel("Natural frequency f₀ [Hz]")
+plt.legend(); plt.show()
+```
+
+</details>
+
 ## 1. Dynamic stiffness and resonance
 
 The dynamic stiffness per unit area is a dynamic force per area divided by the
@@ -87,23 +104,6 @@ res = ph.floating_floor_resonance(
 print(round(res.dynamic_stiffness / 1e6, 2), round(res.natural_frequency, 1))
 # 10.49 47.1
 ```
-
-<details>
-<summary>Show the code for this figure</summary>
-
-```python
-import matplotlib.pyplot as plt
-import numpy as np
-import phonometry as ph
-
-s = np.logspace(np.log10(2.0), np.log10(100.0), 300)   # MN/m3
-for m in (40.0, 120.0):
-    plt.semilogx(s, ph.natural_frequency(s * 1e6, m), label=f"m' = {m:g} kg/m²")
-plt.xlabel("Dynamic stiffness s' [MN/m³]"); plt.ylabel("Natural frequency f₀ [Hz]")
-plt.legend(); plt.show()
-```
-
-</details>
 
 The `DynamicStiffnessResult` carries the apparent, enclosed-gas and installed
 stiffnesses, the test resonance and the installed-floor natural frequency, and

--- a/docs/filter-banks.md
+++ b/docs/filter-banks.md
@@ -161,6 +161,24 @@ Full spectral view of the filter banks for Octave (1/1) and 1/3-Octave fractions
 | **Elliptic** | <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_ellip_fraction_1_order_6_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_ellip_fraction_1_order_6.svg" alt="Elliptic octave-band filter bank frequency response" width="100%"></picture> | <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_ellip_fraction_3_order_6_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_ellip_fraction_3_order_6.svg" alt="Elliptic one-third-octave filter bank frequency response" width="100%"></picture> |
 | **Bessel** | <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_bessel_fraction_1_order_6_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_bessel_fraction_1_order_6.svg" alt="Bessel octave-band filter bank frequency response" width="100%"></picture> | <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_bessel_fraction_3_order_6_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_bessel_fraction_3_order_6.svg" alt="Bessel one-third-octave filter bank frequency response" width="100%"></picture> |
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+from phonometry import metrology
+
+# One figure per architecture and fraction: the whole response gallery
+fs = 48000
+for ftype in ("butter", "cheby1", "cheby2", "ellip", "bessel"):
+    for fraction in (1, 3):
+        # show=True draws the bank's frequency response
+        metrology.OctaveFilterBank(fs=fs, fraction=fraction, order=6,
+                                   limits=[12, 20000], filter_type=ftype,
+                                   show=True)
+```
+
+</details>
+
 ## 5. Filter Usage and Examples
 
 ### 1. Butterworth (`butter`)
@@ -183,6 +201,19 @@ spl, freq = octave_filter(x, fs, filter_type='butter')
 
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_butter_fraction_3_order_6_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_butter_fraction_3_order_6.svg" alt="Butterworth one-third-octave filter bank frequency response" width="60%"></picture>
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+from phonometry import metrology
+
+# Draw this bank's response (1/3 octave, order 6, Butterworth)
+metrology.OctaveFilterBank(fs=48000, fraction=3, order=6, limits=[12, 20000],
+                           filter_type='butter', show=True)
+```
+
+</details>
+
 ### 2. Chebyshev I (`cheby1`)
 
 Chebyshev Type I filters provide a **steeper roll-off** than Butterworth at the
@@ -196,6 +227,19 @@ spl, freq = octave_filter(x, fs, filter_type='cheby1', ripple=0.1)
 ```
 
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_cheby1_fraction_3_order_6_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_cheby1_fraction_3_order_6.svg" alt="Chebyshev I one-third-octave filter bank frequency response" width="60%"></picture>
+
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+from phonometry import metrology
+
+# Draw this bank's response (1/3 octave, order 6, Chebyshev I)
+metrology.OctaveFilterBank(fs=48000, fraction=3, order=6, limits=[12, 20000],
+                           filter_type='cheby1', ripple=0.1, show=True)
+```
+
+</details>
 
 ### 3. Chebyshev II (`cheby2`)
 
@@ -212,6 +256,19 @@ spl, freq = octave_filter(x, fs, filter_type='cheby2')
 
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_cheby2_fraction_3_order_6_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_cheby2_fraction_3_order_6.svg" alt="Chebyshev II one-third-octave filter bank frequency response" width="60%"></picture>
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+from phonometry import metrology
+
+# Draw this bank's response (1/3 octave, order 6, Chebyshev II)
+metrology.OctaveFilterBank(fs=48000, fraction=3, order=6, limits=[12, 20000],
+                           filter_type='cheby2', show=True)
+```
+
+</details>
+
 ### 4. Elliptic (`ellip`)
 
 Elliptic (Cauer) filters have the **shortest transition width** (steepest
@@ -224,6 +281,19 @@ spl, freq = octave_filter(x, fs, filter_type='ellip', ripple=0.1)
 ```
 
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_ellip_fraction_3_order_6_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_ellip_fraction_3_order_6.svg" alt="Elliptic one-third-octave filter bank frequency response" width="60%"></picture>
+
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+from phonometry import metrology
+
+# Draw this bank's response (1/3 octave, order 6, Elliptic)
+metrology.OctaveFilterBank(fs=48000, fraction=3, order=6, limits=[12, 20000],
+                           filter_type='ellip', ripple=0.1, show=True)
+```
+
+</details>
 
 ### 5. Bessel (`bessel`)
 
@@ -238,6 +308,19 @@ spl, freq = octave_filter(x, fs, filter_type='bessel')
 ```
 
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_bessel_fraction_3_order_6_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_bessel_fraction_3_order_6.svg" alt="Bessel one-third-octave filter bank frequency response" width="60%"></picture>
+
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+from phonometry import metrology
+
+# Draw this bank's response (1/3 octave, order 6, Bessel)
+metrology.OctaveFilterBank(fs=48000, fraction=3, order=6, limits=[12, 20000],
+                           filter_type='bessel', show=True)
+```
+
+</details>
 
 ### 6. Linkwitz-Riley (`linkwitz_riley`)
 

--- a/docs/installed-structure-borne.md
+++ b/docs/installed-structure-borne.md
@@ -19,6 +19,35 @@ with the source mobility instead it yields `L_Ws,c` (Annex I.3, Table I.8).
 
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/installed_structure_borne_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/installed_structure_borne.svg" alt="The EN 12354-5 cascade per octave band: the characteristic structure-borne power level, the installed power level after subtracting the coupling term, the per-path normalised sound pressure levels, and their energetic total" width="82%"></picture>
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import building
+
+# EN 15657 characteristic source power and illustrative point mobilities.
+bands = np.array([63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
+lws_c = np.array([78.0, 82.0, 84.0, 81.0, 77.0, 72.0, 66.0])
+ys = (2e-4 + 1e-4j) * (bands / 250.0)        # source mobility
+yi = (3e-5 + 1e-5j) * np.ones_like(bands)    # receiver mobility
+dc = np.array([float(building.coupling_term(a, b)) for a, b in zip(ys, yi)])
+
+# Two transmission paths: the excited floor and a flanking wall.
+paths = [
+    {"adjustment_term": 6.0, "element_area": 12.0,
+     "flanking_reduction_index": np.linspace(44.0, 62.0, 7)},
+    {"adjustment_term": 7.0, "element_area": 9.0,
+     "flanking_reduction_index": np.linspace(46.0, 64.0, 7)},
+]
+res = building.installed_source_prediction(lws_c, dc, paths, frequencies=bands)
+res.plot()   # characteristic and installed power, per-path levels and the total
+plt.show()
+```
+
+</details>
+
 ## 1. Coupling and installed power
 
 Only part of the characteristic power is injected into the supporting element;
@@ -92,26 +121,6 @@ print(round(res.overall_level, 1))       # band-summed level [dB]
 The `InstalledSourceResult` carries the per-path levels, the total per band, the
 installed power level and `.overall_level`, and its `.plot()` draws the whole
 cascade.
-
-<details>
-<summary>Show the code for this figure</summary>
-
-```python
-import matplotlib.pyplot as plt
-import numpy as np
-import phonometry as ph
-
-bands = np.array([63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
-lws_c = np.array([78.0, 82.0, 84.0, 81.0, 77.0, 72.0, 66.0])
-ys = (2e-4 + 1e-4j) * (bands / 250.0); yi = (3e-5 + 1e-5j) * np.ones_like(bands)
-dc = np.array([float(ph.coupling_term(a, b)) for a, b in zip(ys, yi)])
-paths = [{"adjustment_term": 6.0,
-          "flanking_reduction_index": np.linspace(44, 62, 7), "element_area": 12.0}]
-res = ph.installed_source_prediction(lws_c, dc, paths, frequencies=bands)
-res.plot(); plt.show()
-```
-
-</details>
 
 ## References
 

--- a/docs/insulation-field.md
+++ b/docs/insulation-field.md
@@ -527,6 +527,35 @@ into the standardized `DnT` — up where the room is live (`T > T0`), down where
 it is dead. The automatic rating is formed only for exactly 5 octave (or 16
 one-third-octave) values.*
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import building
+
+# Octave-band levels (125-2000 Hz) and the measured receiving-room T.
+bands = [125, 250, 500, 1000, 2000]
+l1 = np.array([88.0, 90.0, 92.0, 92.0, 90.0])
+l2 = np.array([55.0, 51.0, 47.0, 41.0, 35.0])
+k = building.reverberation_index([0.70, 0.60, 0.50, 0.45, 0.40])   # k = 10 lg(T/0.5)
+res = building.survey_airborne_insulation(l1, l2, k, volume=50.0)
+
+x = np.arange(len(bands))
+fig, ax = plt.subplots()
+ax.fill_between(x, res.d, res.d_nt, alpha=0.2, label="k = 10 lg(T/T0)")
+ax.plot(x, res.d, "--o", label="D (level difference)")
+ax.plot(x, res.d_nt, "-s", label="DnT (standardized)")
+ax.set_xticks(x, [str(b) for b in bands])
+ax.set(xlabel="Frequency [Hz]", ylabel="Level difference [dB]",
+       title=f"ISO 10052 survey method: DnT,w = {res.rating.rating} dB")
+ax.legend()
+plt.show()
+```
+
+</details>
+
 ### `survey_airborne_insulation()` and friends — parameters
 
 | Parameter | Type | Units | Range / default | Notes |

--- a/docs/insulation-lab.md
+++ b/docs/insulation-lab.md
@@ -167,6 +167,39 @@ otherwise). Subareas scanned separately are combined first with
 towards the specimen enters with a negative area, applying the minus-sign rule
 of Clause 6.4.6 while $S_m$ keeps the unsigned area sum.*
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import building
+
+# A light wall: source-room SPL Lp1 = 85 dB and the measured normal intensity
+# level LIn over the Sm = 12 m2 surface, 16 one-third-octave bands.
+freqs = [100, 125, 160, 200, 250, 315, 400, 500, 630, 800,
+         1000, 1250, 1600, 2000, 2500, 3150]
+l_in = np.array([57.8, 61.9, 60.5, 55.6, 55.8, 55.5, 53.4, 51.6,
+                 50.2, 47.7, 46.4, 45.7, 44.8, 45.2, 47.2, 52.7])
+kc = building.adaptation_term_kc(freqs)           # Annex B adaptation term
+res = building.intensity_sound_reduction(np.full(16, 85.0), l_in,
+                                         measurement_area=12.0, area=10.0,
+                                         kc=kc)
+
+x = np.arange(len(freqs))
+fig, ax = plt.subplots()
+ax.fill_between(x, res.r_i, res.r_i_modified, alpha=0.2, label="Kc adaptation")
+ax.plot(x, res.r_i, "-o", label="RI (intensity)")
+ax.plot(x, res.r_i_modified, "--s", label="RI,M = RI + Kc")
+ax.set_xticks(x, [str(f) for f in freqs], rotation=45)
+ax.set(xlabel="Frequency [Hz]", ylabel="Sound reduction index [dB]",
+       title=f"RI,w = {res.rating.rating} dB, RI,M,w = {res.rating_modified.rating} dB")
+ax.legend()
+plt.show()
+```
+
+</details>
+
 ### `intensity_sound_reduction()` / `adaptation_term_kc()` parameters
 
 | Parameter | Type | Units | Range / default | Notes |

--- a/docs/levels.md
+++ b/docs/levels.md
@@ -94,6 +94,41 @@ print(f"LA10={stats[10]:.1f}  LA50={stats[50]:.1f}  LA90={stats[90]:.1f} dB")
 
 *L10 tracks the event peaks, L50 the median level and L90 the background.*
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import numpy as np
+import matplotlib.pyplot as plt
+from phonometry import metrology
+
+# The fluctuating signal of the ln_levels example: 0.5 s of background
+# alternating with 0.5 s of ~10 dB louder events, repeated 3 times
+fs = 48000
+rng = np.random.default_rng(0)
+segment = fs // 2
+quiet = 0.02 * rng.standard_normal(segment)
+loud = 0.06 * rng.standard_normal(segment)
+varying = np.tile(np.concatenate([quiet, loud]), 3)
+
+# Fast mean-square envelope -> level vs time, plus the percentile levels
+envelope = metrology.time_weighting(varying, fs, mode="fast")
+level_t = 10 * np.log10(np.maximum(envelope, 1e-12) / (2e-5) ** 2)
+stats = metrology.ln_levels(varying, fs, n=(10, 50, 90))
+t = np.arange(varying.size) / fs
+
+fig, ax = plt.subplots()
+ax.plot(t, level_t, linewidth=0.8, label="Fast level Lp(t)")
+for i, (n_value, style) in enumerate([(10, "--"), (50, "-"), (90, "-.")], 1):
+    ax.axhline(float(stats[n_value]), color=f"C{i}", linestyle=style,
+               label=f"L{n_value} = {stats[n_value]:.1f} dB")
+ax.set(xlabel="Time [s]", ylabel="Level [dB]")
+ax.legend(loc="lower right")
+plt.show()
+```
+
+</details>
+
 Options: `mode` selects the envelope ballistics (`'fast'`, `'slow'`,
 `'impulse'`), `weighting` applies A/C weighting first, and
 `calibration_factor`/`dbfs` behave as in `leq`. The integrator attack transient
@@ -196,6 +231,40 @@ railway noise models.
 
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/sel_concept_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/sel_concept.svg" alt="A vehicle pass-by level history with its Leq over the whole event and the equal-energy one-second SEL block" width="80%"></picture>
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import numpy as np
+import matplotlib.pyplot as plt
+from phonometry import metrology
+
+# A vehicle pass-by: noise under a gaussian energy envelope (dBFS analysis)
+fs = 48000
+t = np.arange(int(8.0 * fs)) / fs
+rng = np.random.default_rng(11)
+x = 0.3 * np.exp(-0.5 * ((t - 4.0) / 1.1) ** 2) * rng.standard_normal(t.size)
+
+level = 10 * np.log10(np.maximum(metrology.time_weighting(x, fs, mode="fast"), 1e-12))
+l_sel = float(metrology.sel(x, fs, dbfs=True))
+l_eq = float(metrology.leq(x, dbfs=True))
+print(f"Leq = {l_eq:.1f} dBFS, SEL = {l_sel:.1f} dBFS")
+# Leq = -16.6 dBFS, SEL = -7.6 dBFS -> the 1 s block carries the event energy
+
+fig, ax = plt.subplots()
+ax.plot(t, level, linewidth=1.0, label="Fast level of the event")
+ax.hlines(l_eq, 0, 8, color="C2", linestyle="--",
+          label=f"Leq over the whole event = {l_eq:.1f} dBFS")
+ax.fill_between([3.5, 4.5], -55, l_sel, color="C1", alpha=0.25)
+ax.hlines(l_sel, 3.5, 4.5, color="C1", linewidth=2,
+          label=f"SEL = {l_sel:.1f} dBFS: same energy in 1 s")
+ax.set(xlabel="Time [s]", ylabel="Level [dBFS]", ylim=(-55, l_sel + 6))
+ax.legend(loc="lower left")
+plt.show()
+```
+
+</details>
+
 ### Noise dose: sound exposure and LEX,8h
 
 Occupational regulations limit the daily *dose*, not the level. IEC 61252
@@ -246,6 +315,44 @@ r = composite_rating_level([(63.2, 12, 0.0),    # day
 ```
 
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/lden_profile_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/lden_profile.svg" alt="Synthetic 24-hour urban LAeq profile with day, evening and night bands, the +5 and +10 dB weighted period levels and the resulting Lden" width="80%"></picture>
+
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import numpy as np
+import matplotlib.pyplot as plt
+from phonometry import environmental
+
+# Synthetic hourly LAeq of an urban road (dB), hours 00 to 23
+laeq_h = np.array([48, 46, 45, 45, 46, 50, 56, 64, 66, 65, 63, 63,
+                   64, 63, 63, 64, 65, 66, 65, 64, 63, 62, 61, 50], dtype=float)
+
+def period_leq(idx):
+    return 10 * np.log10(np.mean(10 ** (laeq_h[idx] / 10)))  # energy mean
+
+ld = period_leq(np.arange(7, 19))                # day 07-19
+le = period_leq(np.arange(19, 23))               # evening 19-23
+ln_ = period_leq(np.r_[23, np.arange(0, 7)])     # night 23-07
+l_den = environmental.lden(ld, le, ln_)
+print(f"Lden = {l_den:.1f} dB")   # Lden = 64.3 dB
+
+fig, ax = plt.subplots()
+ax.axvspan(19, 23, color="C1", alpha=0.15)                                # evening
+ax.axvspan(23, 24, color="C0", alpha=0.15); ax.axvspan(0, 7, color="C0", alpha=0.15)
+ax.step(np.arange(25), np.r_[laeq_h, laeq_h[-1]], where="post",
+        color="0.3", label="Hourly LAeq")
+ax.hlines(ld, 7, 19, color="C2", linestyle="--", label="Lday (+0 dB)")
+ax.hlines(le + 5, 19, 23, color="C1", linestyle="--", label="Levening + 5 dB")
+ax.hlines([ln_ + 10, ln_ + 10], [23, 0], [24, 7], color="C0",
+          linestyle="--", label="Lnight + 10 dB")
+ax.hlines(l_den, 0, 24, color="C3", linewidth=2, label=f"Lden = {l_den:.1f} dB")
+ax.set(xlabel="Hour of day", ylabel="Level [dB]", xlim=(0, 24))
+ax.legend(loc="upper left", fontsize=8, ncol=2)
+plt.show()
+```
+
+</details>
 
 ### `lden()` / `ldn()` / `composite_rating_level()` parameters
 
@@ -354,6 +461,36 @@ levels, freq, times = bank.spectrogram(recording, window_time=0.125, overlap=0.5
 
 *A logarithmic sweep plus two tone bursts, resolved in time and in standardized
 1/3-octave bands.*
+
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import numpy as np
+import matplotlib.pyplot as plt
+from scipy.signal import chirp
+from phonometry import metrology
+
+# Log sweep 80 Hz -> 8 kHz plus two tone bursts, in a little noise
+fs = 48000
+t = np.arange(int(4.0 * fs)) / fs
+x = 0.5 * chirp(t, f0=80, t1=4.0, f1=8000, method="logarithmic")
+x[int(1.0 * fs):int(1.3 * fs)] += np.sin(2 * np.pi * 4000 * t[: int(0.3 * fs)])
+x[int(2.5 * fs):int(2.8 * fs)] += np.sin(2 * np.pi * 250 * t[: int(0.3 * fs)])
+x += 0.01 * np.random.default_rng(42).standard_normal(t.size)
+
+bank = metrology.OctaveFilterBank(fs=fs, fraction=3, order=6, limits=[50.0, 12000.0])
+levels, freq, times = bank.spectrogram(x, window_time=0.125, overlap=0.5)
+
+fig, ax = plt.subplots()
+mesh = ax.pcolormesh(times, freq, levels, shading="auto")
+ax.set_yscale("log")
+ax.set(xlabel="Time [s]", ylabel="Frequency [Hz]")
+fig.colorbar(mesh, label="Level [dB]")
+plt.show()
+```
+
+</details>
 
 - Multichannel input `(channels, samples)` returns `(channels, bands, frames)`.
 - `times` holds each window's center in seconds.

--- a/docs/loudness.md
+++ b/docs/loudness.md
@@ -127,6 +127,29 @@ phon = loudness_level(73.0, 63.0)           # 73 dB @ 63 Hz -> 40 phon
 
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/equal_loudness_contours_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/equal_loudness_contours.svg" alt="ISO 226:2023 normal equal-loudness-level contours from 20 to 90 phon with the hearing threshold curve" width="80%"></picture>
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+from phonometry import psychoacoustics
+
+# ISO 226:2023 Formula (1) at the 29 preferred frequencies of Table 1
+fig, ax = plt.subplots()
+for phon in [20, 40, 60, 80, 90]:
+    freqs, spl = psychoacoustics.equal_loudness_contour(float(phon))
+    ax.semilogx(freqs, spl, color="C0")
+    ax.annotate(f"{phon} phon", xy=(1000, phon + 1), fontsize=9)
+ft, tf = psychoacoustics.hearing_threshold()
+ax.semilogx(ft, tf, "--", color="C1", label="Hearing threshold $T_f$")
+ax.set(xlabel="Frequency [Hz]", ylabel="Sound pressure level [dB re 20 µPa]")
+ax.grid(True, which="both", alpha=0.3)
+ax.legend()
+plt.show()
+```
+
+</details>
+
 Validity per clause 4.1: 20-90 phon (80 phon above 4 kHz); the implementation
 is verified against the Annex B tables in CI. Note this is the loudness of
 *pure tones* — the loudness of arbitrary signals in sones is what the ISO 532
@@ -160,6 +183,39 @@ auditory filters and their loudness summation.
 Zwicker doubles the sone value every +10 phon, while the Sottek model grows
 more slowly (about 1.65× per 10 dB), an intrinsic difference between the
 auditory summations, not a calibration error.*
+
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import psychoacoustics
+
+# 1 kHz tone, 20..80 dB SPL: all three models pass through 1 sone at 40 dB
+fs = 48000
+t = np.arange(fs) / fs
+levels = np.arange(20.0, 81.0, 10.0)
+zw, mg, ec = [], [], []
+for spl in levels:
+    x = np.sqrt(2) * 2e-5 * 10 ** (spl / 20) * np.sin(2 * np.pi * 1000 * t)
+    zw.append(psychoacoustics.loudness_zwicker(x, fs, stationary=True).loudness)
+    mg.append(
+        psychoacoustics.loudness_moore_glasberg_from_spectrum([(1000.0, float(spl))]).loudness
+    )
+    ec.append(psychoacoustics.loudness_ecma(x, fs).loudness)
+
+fig, ax = plt.subplots()
+ax.plot(levels, zw, "o-", label="Zwicker (ISO 532-1)")
+ax.plot(levels, mg, "s--", label="Moore-Glasberg (ISO 532-2)")
+ax.plot(levels, ec, "^-.", label="Sottek (ECMA-418-2)")
+ax.plot(40.0, 1.0, "o", color="k", markerfacecolor="none", markersize=10)   # the shared anchor
+ax.set(xlabel="Sound pressure level [dB SPL]", ylabel="Total loudness N [sone]")
+ax.legend()
+plt.show()
+```
+
+</details>
 
 ### Moore-Glasberg loudness (ISO 532-2)
 

--- a/docs/mechanical-mobility.md
+++ b/docs/mechanical-mobility.md
@@ -18,6 +18,29 @@ ISO 9611, ISO 10846, EN 15657 and EN 12354-5.
 
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/mechanical_mobility_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/mechanical_mobility.svg" alt="Normalized receptance, mobility and accelerance magnitudes of a single-degree-of-freedom resonator on a log-log frequency axis, all peaking at the resonance where the mobility is stiffness-controlled below and mass-controlled above" width="82%"></picture>
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+import phonometry as ph
+
+m, k, c = 2.0, 8000.0, 5.0
+f = np.logspace(np.log10(0.5), np.log10(200.0), 500)
+w = 2.0 * np.pi * f
+h = ph.sdof_receptance(f, m, k, c)
+for label, frf in (("receptance |H|", np.abs(h)),
+                   ("mobility |Y|", np.abs(1j * w * h)),
+                   ("accelerance |A|", np.abs(-(w**2) * h))):
+    plt.loglog(f, frf / frf.max(), label=label)
+plt.axvline(ph.resonance_frequency(m, k), ls="--", color="0.6")
+plt.xlabel("Frequency [Hz]"); plt.ylabel("Normalized magnitude")
+plt.legend(); plt.show()
+```
+
+</details>
+
 ## 1. The frequency-response-function family (Table 1)
 
 For a harmonic motion `x·e^{jωt}` the velocity is `jω·x` and the acceleration
@@ -149,29 +172,6 @@ res = ph.sdof_mobility_result(f, mass=2.0, stiffness=8000.0, damping=5.0)
 z = res.to("impedance")                        # impedance = 1/Y per frequency
 print(res.frequencies[int(np.argmax(res.magnitude))].round(1))   # ~10.1 Hz
 ```
-
-<details>
-<summary>Show the code for this figure</summary>
-
-```python
-import matplotlib.pyplot as plt
-import numpy as np
-import phonometry as ph
-
-m, k, c = 2.0, 8000.0, 5.0
-f = np.logspace(np.log10(0.5), np.log10(200.0), 500)
-w = 2.0 * np.pi * f
-h = ph.sdof_receptance(f, m, k, c)
-for label, frf in (("receptance |H|", np.abs(h)),
-                   ("mobility |Y|", np.abs(1j * w * h)),
-                   ("accelerance |A|", np.abs(-(w**2) * h))):
-    plt.loglog(f, frf / frf.max(), label=label)
-plt.axvline(ph.resonance_frequency(m, k), ls="--", color="0.6")
-plt.xlabel("Frequency [Hz]"); plt.ylabel("Normalized magnitude")
-plt.legend(); plt.show()
-```
-
-</details>
 
 ## References
 

--- a/docs/multichannel.md
+++ b/docs/multichannel.md
@@ -14,6 +14,39 @@ performance gains over iterative loops.
 *Simultaneous analysis of a Stereo signal: Left Channel (Pink Noise) vs Right
 Channel (Log Sine Sweep).*
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from scipy.signal import chirp
+from phonometry import octave_filter
+
+# Stereo test signal: pink noise left, logarithmic sine sweep right
+fs, duration = 48000, 5
+t = np.linspace(0, duration, fs * duration, endpoint=False)
+rng = np.random.default_rng(42)
+spec = np.fft.rfft(rng.standard_normal(t.size))
+spec[1:] /= np.sqrt(np.arange(1, spec.size))   # 1/f shaping: pink noise
+left = np.fft.irfft(spec, t.size)
+right = chirp(t, f0=50, t1=duration, f1=10000, method="logarithmic")
+
+x = np.stack([left, right])                    # (2, n_samples)
+spl, freq = octave_filter(x, fs, fraction=3, limits=[20, 20000])
+
+fig, axes = plt.subplots(2, 1, figsize=(9, 7), sharex=True)
+for ax, levels, name in zip(axes, spl, ["Left: pink noise", "Right: log sweep"]):
+    ax.semilogx(freq, levels, marker="o", label=name)
+    ax.set_ylabel("Level [dB]")
+    ax.grid(True, which="both", alpha=0.3)
+    ax.legend()
+axes[-1].set_xlabel("Frequency [Hz]")
+plt.show()
+```
+
+</details>
+
 The convention is consistent across the whole library: time is always the
 **last axis**. This applies to `octave_filter`, `OctaveFilterBank`,
 `weighting_filter`, `time_weighting`, `leq`, `laeq`, `ln_levels` and

--- a/docs/psychoacoustic-annoyance.md
+++ b/docs/psychoacoustic-annoyance.md
@@ -14,6 +14,35 @@ convenience that derives all four sensations from a recording.
 
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/psychoacoustic_annoyance_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/psychoacoustic_annoyance.svg" alt="Psychoacoustic annoyance PA against percentile loudness N5 for three sensation profiles: a neutral baseline where PA equals N5, a sharp sound and a rough-and-fluctuating sound both lifted above the baseline, with the worked example PA = 30.82 marked" width="82%"></picture>
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+import phonometry as ph
+
+n5 = np.linspace(4.0, 60.0, 200)
+profiles = [
+    ("Baseline: S = 1.75 acum, F = R = 0", 1.75, 0.0, 0.0),
+    ("Sharp: S = 3.5 acum", 3.5, 0.0, 0.0),
+    ("Rough + fluctuating: F = 1.2 vacil, R = 0.7 asper", 2.0, 1.2, 0.7),
+]
+fig, ax = plt.subplots()
+for label, s, f, r in profiles:
+    pa = [ph.psychoacoustic_annoyance(v, s, f, r).annoyance for v in n5]
+    ax.plot(n5, pa, label=label)
+
+ex = ph.psychoacoustic_annoyance(30.0, 2.0, 0.5, 0.3)
+ax.plot([30.0], [ex.annoyance], "o", label=f"Worked example (PA = {ex.annoyance:.2f})")
+ax.set_xlabel("Percentile loudness N5 [sone]")
+ax.set_ylabel("Psychoacoustic annoyance PA")
+ax.legend()
+plt.show()
+```
+
+</details>
+
 ## 1. The four sensations
 
 Psychoacoustic annoyance rests on four hearing sensations, each with its own
@@ -59,35 +88,6 @@ The figure above sweeps `PA` against `N5` for three profiles: a neutral baseline
 rough-and-fluctuating sound — both lifted above the baseline — with the worked
 example marked.
 
-<details>
-<summary>Show the code for this figure</summary>
-
-```python
-import matplotlib.pyplot as plt
-import numpy as np
-import phonometry as ph
-
-n5 = np.linspace(4.0, 60.0, 200)
-profiles = [
-    ("Baseline: S = 1.75 acum, F = R = 0", 1.75, 0.0, 0.0),
-    ("Sharp: S = 3.5 acum", 3.5, 0.0, 0.0),
-    ("Rough + fluctuating: F = 1.2 vacil, R = 0.7 asper", 2.0, 1.2, 0.7),
-]
-fig, ax = plt.subplots()
-for label, s, f, r in profiles:
-    pa = [ph.psychoacoustic_annoyance(v, s, f, r).annoyance for v in n5]
-    ax.plot(n5, pa, label=label)
-
-ex = ph.psychoacoustic_annoyance(30.0, 2.0, 0.5, 0.3)
-ax.plot([30.0], [ex.annoyance], "o", label=f"Worked example (PA = {ex.annoyance:.2f})")
-ax.set_xlabel("Percentile loudness N5 [sone]")
-ax.set_ylabel("Psychoacoustic annoyance PA")
-ax.legend()
-plt.show()
-```
-
-</details>
-
 ### 2.1 From a signal (engineering estimate)
 
 `psychoacoustic_annoyance_from_signal` is a convenience that derives all four
@@ -119,28 +119,6 @@ rather than the ~70 Hz roughness peak. By definition, a 1 kHz tone at 60 dB,
 100 % amplitude-modulated at 4 Hz, produces `1 vacil`.
 
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/fluctuation_strength_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/fluctuation_strength.svg" alt="Fluctuation strength versus modulation frequency on a log axis: the closed-form AM broadband-noise curve and the AM-tone signal-model sweep both show a band-pass characteristic peaking at 4 Hz" width="82%"></picture>
-
-### 3.1 Closed form for AM broadband noise (Eq. 10.2)
-
-For sinusoidally amplitude-modulated broadband noise, Fastl & Zwicker give a
-closed form (Eq. 10.2) in modulation factor `m`, level `L` and modulation
-frequency `fmod`:
-
-$$
-F = \frac{5.8\,(1.25\,m - 0.25)\,[0.05\,(L/\mathrm{dB}) - 1]}
-{(f_{mod}/5\,\mathrm{Hz})^2 + (4\,\mathrm{Hz}/f_{mod}) + 1.5}\ \ \mathrm{vacil}.
-$$
-
-The denominator is the `4 Hz` band-pass: it bottoms out near `fmod ≈ 3.7 Hz` and
-rises on either side. The result is clamped at `0` (the sensation vanishes below
-~20 dB or `m < 0.2`). This exact form is the value to quote for AM broadband
-noise.
-
-```python
-import phonometry as ph
-
-print(round(ph.fluctuation_strength_am_noise(60.0, 1.0, 4.0), 4))   # 3.6943 vacil
-```
 
 <details>
 <summary>Show the code for this figure</summary>
@@ -179,6 +157,28 @@ plt.show()
 ```
 
 </details>
+
+### 3.1 Closed form for AM broadband noise (Eq. 10.2)
+
+For sinusoidally amplitude-modulated broadband noise, Fastl & Zwicker give a
+closed form (Eq. 10.2) in modulation factor `m`, level `L` and modulation
+frequency `fmod`:
+
+$$
+F = \frac{5.8\,(1.25\,m - 0.25)\,[0.05\,(L/\mathrm{dB}) - 1]}
+{(f_{mod}/5\,\mathrm{Hz})^2 + (4\,\mathrm{Hz}/f_{mod}) + 1.5}\ \ \mathrm{vacil}.
+$$
+
+The denominator is the `4 Hz` band-pass: it bottoms out near `fmod ≈ 3.7 Hz` and
+rises on either side. The result is clamped at `0` (the sensation vanishes below
+~20 dB or `m < 0.2`). This exact form is the value to quote for AM broadband
+noise.
+
+```python
+import phonometry as ph
+
+print(round(ph.fluctuation_strength_am_noise(60.0, 1.0, 4.0), 4))   # 3.6943 vacil
+```
 
 ### 3.2 The Osses 2016 signal model
 

--- a/docs/reverberation-prediction.md
+++ b/docs/reverberation-prediction.md
@@ -27,6 +27,29 @@ $c_0 = 343\ \mathrm{m/s}$) and the air-absorption term $4mV$.
 
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/reverberation_models_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/reverberation_models.svg" alt="Reverberation time per octave band for a 10 by 7 by 3.5 metre room with an absorptive floor and ceiling but hard walls, computed by five models. Fitzroy gives the longest times, Sabine and Eyring the mid-range, Millington-Sette the shortest, and Arau-Puchades sits between Eyring and Sabine" width="82%"></picture>
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+from phonometry import environmental, room
+
+# A 10 x 7 x 3.5 m room: hard end walls, lightly treated side walls and a
+# very absorptive floor/ceiling pair (carpet plus an acoustic ceiling).
+bands = [125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0]
+alpha_x = [0.06, 0.07, 0.08, 0.09, 0.10, 0.10]
+alpha_y = [0.12, 0.14, 0.16, 0.18, 0.20, 0.20]
+alpha_z = [0.30, 0.50, 0.65, 0.78, 0.82, 0.80]
+m = environmental.air_attenuation_m(bands, 20.0, 50.0)   # air at 20 C / 50 % RH
+res = room.reverberation_time_models((10.0, 7.0, 3.5),
+                                     (alpha_x, alpha_y, alpha_z),
+                                     air_attenuation=m, frequencies=bands)
+res.plot()   # the five model curves per band
+plt.show()
+```
+
+</details>
+
 ## 1. Sabine, Eyring and Millington-Sette
 
 The three statistical models take the room volume and a list of

--- a/docs/rotorcraft-noise.md
+++ b/docs/rotorcraft-noise.md
@@ -55,6 +55,35 @@ The hemisphere level at 60 m is carried to the receiver by three adjustments
   <img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/rotorcraft_ground_effect.svg" alt="Rotorcraft ground-effect adjustment versus one-third-octave frequency for hard (asphalt) and soft (grass) ground: low-frequency reinforcement, a deep destructive interference dip, and the incoherent +3 dB high-frequency region, the dip deeper over hard ground" width="82%">
 </picture>
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import aircraft
+
+freqs = 1000.0 * 10.0 ** (np.arange(-13, 11) / 10.0)   # 50 Hz-10 kHz thirds
+hs, hr, dp = 150.0, 1.5, 500.0                          # overflight geometry
+grass = aircraft.ground_effect_adjustment(freqs, hs, hr, dp, flow_resistivity="D")
+asphalt = aircraft.ground_effect_adjustment(freqs, hs, hr, dp, flow_resistivity="G")
+
+fig, ax = plt.subplots()
+ax.axhline(0.0, color="0.5", linewidth=1.0)
+ax.semilogx(freqs, asphalt, marker="o", markersize=3,
+            label="Hard (asphalt/concrete, class G)")
+ax.semilogx(freqs, grass, marker="s", markersize=3,
+            label="Soft (grass/pasture, class D)")
+ax.set(xlabel="One-third-octave-band centre frequency [Hz]",
+       ylabel="Ground-effect adjustment ΔLg [dB]",
+       title="Rotorcraft ground effect (ECAC Doc 32, Chien-Soroka)")
+ax.grid(True, which="both", alpha=0.3)
+ax.legend()
+plt.show()
+```
+
+</details>
+
 ```python
 import numpy as np
 import phonometry as ph

--- a/docs/sound-power.md
+++ b/docs/sound-power.md
@@ -36,6 +36,43 @@ of the page walks each in turn.
 
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/sound_power_methods_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/sound_power_methods.svg" alt="The three sound power routes side by side: an enveloping pressure surface over a reflecting plane (ISO 3744/3746), a source in a reverberation room sampled by microphones (ISO 3741) and an intensity probe scanning a surface around the source (ISO 9614-2)" width="92%"></picture>
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import emission
+
+# One steady source (octave-band LW below) determined by three routes.
+freqs = np.array([125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
+lw_true = np.array([85.0, 88.0, 90.0, 89.0, 86.0, 82.0])
+
+# ISO 3744: SPL at 10 positions on a hemisphere, r = 2 m (10 lg(S/S0) = 14 dB).
+pres = emission.sound_power_pressure(np.tile(lw_true - 14.0, (10, 1)),
+                                     "hemisphere", radius=2.0,
+                                     frequencies=freqs)
+# ISO 9614-2: uniform normal intensity scanned over six 0.5 m2 segments.
+i_n = np.tile(10.0 ** (lw_true / 10.0) * 1e-12 / 3.0, (6, 1))
+inten = emission.sound_power_intensity(i_n, np.full(6, 0.5),
+                                       frequencies=freqs, band_type="octave")
+# ISO 3741: comparison against a reference source of known LW = 84 dB per band.
+comp = emission.sound_power_comparison(lw_true - 20.0, np.full(6, 64.0),
+                                       np.full(6, 84.0), frequencies=freqs)
+
+fig, ax = plt.subplots()
+for res, style, ms, label in ((pres, "-o", 11, "pressure (ISO 3744)"),
+                              (inten, "--s", 8, "intensity (ISO 9614-2)"),
+                              (comp, ":^", 5, "reference source (ISO 3741)")):
+    ax.semilogx(freqs, res.sound_power_level, style, markersize=ms,
+                label=f"{label}: LWA = {res.sound_power_level_a:.1f} dB")
+ax.set(xlabel="Frequency [Hz]", ylabel="Sound power level LW [dB]")
+ax.legend()
+plt.show()
+```
+
+</details>
+
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_power_two_rooms_dark.gif"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_power_two_rooms.gif" alt="Animation: the same source in an anechoic room and in a reverberation room produces different microphone pressures, and the free-field and diffuse-field formulas converge to the same sound power level L_W" width="640" height="360" loading="lazy"></picture>
 
 [Watch the high-resolution video (WebM)](https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_power_two_rooms.webm)

--- a/docs/sound-quality.md
+++ b/docs/sound-quality.md
@@ -26,6 +26,33 @@ $k = 0.108$ sits inside the normative window 0.105–0.115).
 
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/sharpness_weighting_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/sharpness_weighting.svg" alt="DIN 45692 sharpness weighting g(z) against critical-band rate on a log axis, comparing the DIN, von Bismarck and Aures curves with the 15.8 and 15 Bark knees marked" width="80%"></picture>
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+
+# DIN 45692 sharpness weighting g(z): Eq. (1) plus the informative Annex B variants
+z = np.arange(1, 241) * 0.1                     # Bark bins, 0.1 .. 24.0
+g_din = np.where(z > 15.8, 0.15 * np.exp(0.42 * (z - 15.8)) + 0.85, 1.0)
+g_bis = np.where(z > 15.0, 0.2 * np.exp(0.308 * (z - 15.0)) + 0.8, 1.0)
+n = 4.0                                         # Aures depends on the total loudness (sone)
+g_aures = 0.078 * np.exp(0.171 * z) / z * (n / np.log(n * 0.05 + 1.0))
+
+fig, ax = plt.subplots()
+ax.semilogy(z, g_din, label="DIN 45692 g(z)")
+ax.semilogy(z, g_bis, "--", label="von Bismarck (Annex B)")
+ax.semilogy(z, g_aures, "-.", label="Aures (Annex B, N = 4 sone)")
+ax.axvline(15.8, linestyle=":", color="0.5")    # DIN knee: g rises beyond 15.8 Bark
+ax.set(xlabel="Critical-band rate z [Bark]", ylabel="Weighting g(z)")
+ax.grid(True, which="both", alpha=0.3)
+ax.legend()
+plt.show()
+```
+
+</details>
+
 ```python
 import numpy as np
 from phonometry import sharpness_din

--- a/docs/speech-transmission.md
+++ b/docs/speech-transmission.md
@@ -48,6 +48,38 @@ results, band-weighted, into the index: the STI is an effective SNR of the
 
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/sti_vs_t60_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/sti_vs_t60.svg" alt="STI versus reverberation time with the IEC 60268-16 Annex F rating bands shaded" width="80%"></picture>
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import numpy as np
+import matplotlib.pyplot as plt
+from phonometry import sti_from_impulse_response
+
+fs = 48000
+
+# STI vs reverberation time: sweep sti_from_impulse_response over synthetic
+# exponential decays (white noise x exp(-6.9077 t / T60)) at a T60 grid,
+# exactly the physics behind the curve above:
+rng = np.random.default_rng(0)
+t60_grid = np.array([0.3, 0.5, 0.8, 1.2, 1.6, 2.0, 2.5, 3.0, 4.0, 5.0])
+sti_values = []
+for t60 in t60_grid:
+    t = np.arange(int(2 * t60 * fs)) / fs
+    ir = rng.standard_normal(t.size) * np.exp(-6.9077 * t / t60)
+    sti_values.append(sti_from_impulse_response(ir, fs).sti)
+
+fig, ax = plt.subplots()
+ax.semilogx(t60_grid, sti_values, "o-")
+ax.set_xlabel("Reverberation time T60 [s]")
+ax.set_ylabel("STI")
+ax.set_ylim(0.0, 1.0)
+ax.grid(True, which="both", alpha=0.3)
+plt.show()
+```
+
+</details>
+
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_sti_chain_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_sti_chain.svg" alt="STI measurement chain: STIPA source signal through the room to the microphone and the MTF analysis" width="92%"></picture>
 
 ## 2. Indirect and direct (STIPA) measurement
@@ -70,38 +102,6 @@ recording = test                       # in practice, the microphone signal afte
 res = stipa(recording, fs)
 res.plot()   # per-band modulation transfer index (MTI) bars, STI + rating in the title
 ```
-
-<details>
-<summary>Show the code for this figure</summary>
-
-```python
-import numpy as np
-import matplotlib.pyplot as plt
-from phonometry import sti_from_impulse_response
-
-fs = 48000
-
-# STI vs reverberation time: sweep sti_from_impulse_response over synthetic
-# exponential decays (white noise x exp(-6.9077 t / T60)) at a T60 grid —
-# exactly the physics behind the curve above:
-rng = np.random.default_rng(0)
-t60_grid = np.array([0.3, 0.5, 0.8, 1.2, 1.6, 2.0, 2.5, 3.0, 4.0, 5.0])
-sti_values = []
-for t60 in t60_grid:
-    t = np.arange(int(2 * t60 * fs)) / fs
-    ir = rng.standard_normal(t.size) * np.exp(-6.9077 * t / t60)
-    sti_values.append(sti_from_impulse_response(ir, fs).sti)
-
-fig, ax = plt.subplots()
-ax.semilogx(t60_grid, sti_values, "o-")
-ax.set_xlabel("Reverberation time T60 [s]")
-ax.set_ylabel("STI")
-ax.set_ylim(0.0, 1.0)
-ax.grid(True, which="both", alpha=0.3)
-plt.show()
-```
-
-</details>
 
 `stipa` emits a `UserWarning` when the recording is shorter than the
 recommended 15 s (IEC 60268-16 STIPA practice, 15 s to 25 s): below that the

--- a/docs/structure-borne-power.md
+++ b/docs/structure-borne-power.md
@@ -17,6 +17,36 @@ installed-equipment prediction consumes.
 
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/structure_borne_power_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/structure_borne_power.svg" alt="Reception-plate structure-borne sound power level per one-third-octave band of a source determined on a low-mobility and a high-mobility reception plate, which agree within the method" width="82%"></picture>
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import building
+
+# The same pump-like source measured on a heavy and on a light reception plate.
+bands = np.array([50.0, 100.0, 200.0, 400.0, 800.0, 1600.0, 3150.0])
+lv_low = np.array([88.0, 90.0, 87.0, 84.0, 80.0, 76.0, 71.0])
+
+low = building.reception_plate_power(lv_low, bands, mass_per_area=600.0,
+                                     area=2.0, reverberation_time=0.8)
+high = building.reception_plate_power(lv_low + 6.0, bands, mass_per_area=150.0,
+                                      area=2.0, reverberation_time=0.5)
+
+x = np.arange(bands.size)
+fig, ax = plt.subplots()
+ax.bar(x - 0.2, low.power_level, width=0.4, label="low-mobility plate")
+ax.bar(x + 0.2, high.power_level, width=0.4, label="high-mobility plate")
+ax.set_xticks(x, [f"{b:g}" for b in bands])
+ax.set(xlabel="Frequency [Hz]",
+       ylabel="Structure-borne power level $L_{Ws}$ [dB re 1 pW]")
+ax.legend()
+plt.show()
+```
+
+</details>
+
 ## 1. The reception-plate relations
 
 Why a plate at all? Characterising the source by its contact forces directly
@@ -120,29 +150,6 @@ print(float(ph.source_mobility_from_levels(lvf, lfb)))      # |Y_S,eq| in m/(N·
 The direct source-side counterpart is the ISO 9611 free velocity level (re
 `v₀ = 5·10⁻⁸ m/s`) measured at the contact points of resiliently mounted
 machinery; its equation (9) position average is `mean_free_velocity_level()`.
-
-<details>
-<summary>Show the code for this figure</summary>
-
-```python
-import matplotlib.pyplot as plt
-import numpy as np
-import phonometry as ph
-
-bands = np.array([50.0, 100.0, 200.0, 400.0, 800.0, 1600.0, 3150.0])
-lv_low = np.array([88.0, 90.0, 87.0, 84.0, 80.0, 76.0, 71.0])
-low = ph.reception_plate_power(lv_low, bands, mass_per_area=600.0, area=2.0,
-                               reverberation_time=0.8)
-high = ph.reception_plate_power(lv_low + 6.0, bands, mass_per_area=150.0, area=2.0,
-                                reverberation_time=0.5)
-x = np.arange(bands.size)
-plt.bar(x - 0.2, low.power_level, width=0.4, label="low-mobility plate")
-plt.bar(x + 0.2, high.power_level, width=0.4, label="high-mobility plate")
-plt.xticks(x, [f"{b:g}" for b in bands]); plt.legend()
-plt.xlabel("Frequency [Hz]"); plt.ylabel("$L_{Ws}$ [dB re 1 pW]"); plt.show()
-```
-
-</details>
 
 ## References
 

--- a/docs/tone-audibility.md
+++ b/docs/tone-audibility.md
@@ -15,6 +15,27 @@ lives in [environmental measurement](levels.md)); the mean audibility
 
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/tone_audibility_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/tone_audibility.svg" alt="Per-tone audibility ΔL of the nine tones of the ISO/PAS 20065 Annex E combustion-engine spectrum, with the decisive tone at 137.3 Hz highlighted and the ΔL = 0 dB audibility threshold marked" width="82%"></picture>
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+from phonometry import psychoacoustics
+
+# ISO/PAS 20065 Annex E combustion-engine spectrum 1: nine tones (fT, LT, LS)
+# from a narrow-band spectrum with line spacing 2.7 Hz
+fT = [118.4, 137.3, 158.8, 314.9, 433.4, 592.2, 629.8, 643.3, 1582.7]
+LT = [64.56, 67.96, 68.63, 68.50, 73.17, 78.31, 75.00, 79.75, 71.07]
+LS = [48.91, 49.22, 50.50, 52.85, 58.29, 59.53, 59.71, 61.98, 54.16]
+
+res = psychoacoustics.assess_tones(fT, LT, LS, 2.7)
+print(round(res.decisive_audibility, 2), res.decisive_frequency)  # 5.01 137.3
+res.plot()   # per-tone audibility bars, decisive tone highlighted
+plt.show()
+```
+
+</details>
+
 ## 1. The critical band about the tone
 
 Each tone of frequency `fT` is evaluated inside a critical band whose width is
@@ -224,23 +245,6 @@ ph.resolve_tones_separately(118.4, 137.3, 4.0, 5.0) # False → combine (Δf < f
 > (`fD = 21 * 10 ^ (1.2 * Abs(Log(fT / 212) / Log(10)) ^ 1.8)`). Reassuringly,
 > evaluated at the Annex E tones the threshold (`≈ 24 Hz` at 137.3 Hz) keeps
 > them combined, consistent with that example's FG grouping.
-
-<details>
-<summary>Show the code for this figure</summary>
-
-```python
-import matplotlib.pyplot as plt
-import phonometry as ph
-
-fT = [118.4, 137.3, 158.8, 314.9, 433.4, 592.2, 629.8, 643.3, 1582.7]
-LT = [64.56, 67.96, 68.63, 68.50, 73.17, 78.31, 75.00, 79.75, 71.07]
-LS = [48.91, 49.22, 50.50, 52.85, 58.29, 59.53, 59.71, 61.98, 54.16]
-res = ph.assess_tones(fT, LT, LS, 2.7)
-res.plot()
-plt.tight_layout(); plt.show()
-```
-
-</details>
 
 ## References
 

--- a/docs/transfer-stiffness.md
+++ b/docs/transfer-stiffness.md
@@ -19,6 +19,37 @@ prediction standards — ISO 9611, EN 15657 and EN 12354-5.
 
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/transfer_stiffness_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/transfer_stiffness.svg" alt="Dynamic transfer stiffness level of a Kelvin-Voigt isolator: the true level (flat at 120 dB, rising with the damping term at high frequency) and the indirect-method estimate, which diverges at the mass/spring resonance where the transmissibility is not small and converges to the true level above three times the resonance" width="82%"></picture>
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import vibration
+
+# Kelvin-Voigt isolator k + jwc loaded by an 8 kg blocking mass.
+k, c, m2 = 1.0e6, 120.0, 8.0
+f0 = np.sqrt(k / m2) / (2.0 * np.pi)
+f = np.logspace(np.log10(f0 / 5.0), np.log10(f0 * 40.0), 600)
+
+k_true = k + 1j * 2.0 * np.pi * f * c
+t = vibration.base_transmissibility(f, m2, k, c)
+k_indirect = vibration.transfer_stiffness_indirect(f, t, m2)  # warns where T is not small
+
+fig, ax = plt.subplots()
+ax.semilogx(f, vibration.transfer_stiffness_level(k_true),
+            label="true $L_k$ of $k+j\\omega c$")
+ax.semilogx(f, vibration.transfer_stiffness_level(k_indirect), "--",
+            label="indirect method $-(2\\pi f)^2 m_2 T$")
+ax.axvline(f0, color="0.6", linestyle=":", label="resonance $f_0$")
+ax.set(xlabel="Frequency [Hz]", ylabel="Transfer stiffness level $L_k$ [dB re 1 N/m]")
+ax.grid(True, which="both", alpha=0.3)
+ax.legend()
+plt.show()
+```
+
+</details>
+
 ## 1. The transfer-stiffness level and loss factor
 
 Results are reported as a **level** re the reference stiffness `k₀ = 1 N/m`
@@ -147,28 +178,6 @@ k = 1e6 + 5e4j                                  # N/m, at 250 Hz
 Z = ph.convert_frf(k, 250.0, "dynamic_stiffness", "impedance")
 print(abs(complex(ph.convert_frf(Z, 250.0, "impedance", "dynamic_stiffness"))))  # 1.0012e6
 ```
-
-<details>
-<summary>Show the code for this figure</summary>
-
-```python
-import matplotlib.pyplot as plt
-import numpy as np
-import phonometry as ph
-
-k, c, m2 = 1e6, 120.0, 8.0
-f0 = np.sqrt(k / m2) / (2 * np.pi)
-f = np.logspace(np.log10(f0 / 5), np.log10(f0 * 40), 600)
-w = 2 * np.pi * f
-t = ph.base_transmissibility(f, m2, k, c)
-plt.semilogx(f, ph.transfer_stiffness_level(k + 1j * w * c), label="true $L_k$")
-plt.semilogx(f, ph.transfer_stiffness_level(ph.transfer_stiffness_indirect(f, t, m2)),
-             "--", label="indirect method")
-plt.axvline(f0, ls=":", color="0.6"); plt.legend()
-plt.xlabel("Frequency [Hz]"); plt.ylabel("$L_k$ [dB re 1 N/m]"); plt.show()
-```
-
-</details>
 
 ## References
 

--- a/docs/underwater-propagation.md
+++ b/docs/underwater-propagation.md
@@ -16,6 +16,26 @@ the underwater reference levels (ISO 18405/17208/18406) in
   <img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/underwater_transmission_loss.svg" alt="Underwater transmission loss versus range at 10 kHz: the total loss with the geometrical-spreading and volume-absorption contributions drawn separately, loss increasing downward" width="82%">
 </picture>
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import underwater
+
+# 10 kHz at 10 °C, 35 ppt, 100 m depth; practical spreading with R0 = 1000 m.
+ranges = np.linspace(10.0, 20_000.0, 400)
+tl = underwater.transmission_loss(ranges, 10e3, law="practical",
+                                  transition_range=1000.0, temperature=10.0,
+                                  salinity=35.0, depth=100.0)
+print(f"alpha = {tl.absorption_coefficient:.2f} dB/km")   # alpha = 0.95 dB/km
+tl.plot()   # total TL with the spreading and absorption contributions
+plt.show()
+```
+
+</details>
+
 The transmission loss is
 
 $$
@@ -57,6 +77,24 @@ tl.plot()   # TL vs range with the spreading/absorption split (needs matplotlib)
   <img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/underwater_sound_speed.svg" alt="A sea-water sound-speed profile computed with the UNESCO equation: a warm mixed layer near the surface, a thermocline where the speed drops, a sound-channel axis at the minimum, and the speed rising again with pressure at depth" width="62%">
 </picture>
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import underwater
+
+# A warm mixed layer, a thermocline down to 4 °C and an isothermal deep layer.
+depths = np.linspace(0.0, 3000.0, 121)
+temps = 4.0 + 14.0 / (1.0 + (np.maximum(depths - 80.0, 0.0) / 250.0) ** 2)
+profile = underwater.sound_speed_profile(depths, temps, 35.0, model="unesco")
+profile.plot()   # sound speed vs depth, minimum at the sound-channel axis
+plt.show()
+```
+
+</details>
+
 `sea_water_sound_speed(T, S, depth, model=…)` evaluates the sound speed with the
 **UNESCO / Chen–Millero** equation (default, the international standard, in the
 Wong & Zhu 1995 ITS-90 form), **Del Grosso** (1974) or **Mackenzie** (1981). The
@@ -94,6 +132,25 @@ can cross entire oceans.
   <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/sonar_equation_dark.svg">
   <img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/sonar_equation.svg" alt="The passive sonar equation: signal excess falling with transmission loss, crossing zero (the detection limit) at the figure of merit" width="82%">
 </picture>
+
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import underwater
+
+tl = np.linspace(40.0, 120.0, 400)
+se = underwater.passive_sonar_equation(source_level=140.0, transmission_loss=tl,
+                                       noise_level=60.0, directivity_index=15.0,
+                                       detection_threshold=8.0)
+print(f"figure of merit = {se.figure_of_merit:.1f} dB")  # figure of merit = 87.0 dB
+se.plot()   # signal excess vs transmission loss, zero crossing at the FOM
+plt.show()
+```
+
+</details>
 
 The sonar equation combines the performance terms into the **signal excess**
 $SE$ (detection when $SE \ge 0$) and the **figure of merit** (the maximum
@@ -136,6 +193,25 @@ the source convention, dB re 1 µPa²/Hz **at 1 m**.
   <img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/seabed_reflection.svg" alt="Bottom reflection loss versus grazing angle for a fast sandy seabed: zero loss below the critical grazing angle (total reflection) rising sharply above it" width="82%">
 </picture>
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import underwater
+
+# Rayleigh fluid-fluid reflection: water over a fast sandy bottom.
+phi = np.linspace(0.0, 90.0, 361)
+bl = underwater.bottom_reflection_loss(phi, rho1=1000.0, c1=1500.0,
+                                       rho2=1900.0, c2=1650.0)
+print(f"critical angle = {bl.critical_angle:.1f} deg")   # critical angle = 24.6 deg
+bl.plot()   # bottom loss vs grazing angle
+plt.show()
+```
+
+</details>
+
 A plane wave striking the seabed reflects with the fluid–fluid **Rayleigh
 reflection coefficient** (Medwin & Clay). For a faster bottom ($c_2 > c_1$) there
 is a **critical grazing angle** $\varphi_c = \arccos(c_1/c_2)$, below which
@@ -165,6 +241,29 @@ sediment attenuation is out of scope.
   <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/ocean_ambient_noise_dark.svg">
   <img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/ocean_ambient_noise.svg" alt="Wenz ambient-noise spectrum levels for two wind speeds: wind-dominated at mid frequencies falling at 5 dB per octave and thermal noise rising above about 50 kHz" width="82%">
 </picture>
+
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import underwater
+
+# Wenz ambient noise (wind rule of fives + Mellen thermal) at two wind speeds.
+freqs = np.logspace(2, 5.5, 300)
+fig, ax = plt.subplots()
+for u in (5.0, 20.0):
+    noise = underwater.ocean_ambient_noise(freqs, wind_speed_knots=u)
+    ax.semilogx(noise.frequency, noise.spectrum_level, label=f"Total ({u:.0f} kn)")
+ax.semilogx(freqs, underwater.thermal_noise_spectrum(freqs), ":", label="Thermal")
+ax.set(xlabel="Frequency [Hz]", ylabel="Spectrum level [dB re 1 µPa²/Hz]")
+ax.legend()
+ax.grid(True, which="both", alpha=0.3)
+plt.show()
+```
+
+</details>
 
 The ambient-noise spectrum level (dB re 1 µPa²/Hz) is the energy sum of the two
 physically grounded Wenz components: **wind / sea-surface** noise via the "rule
@@ -200,6 +299,30 @@ supplied through the `shipping` argument.
   <img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/ship_traffic_noise.svg" alt="JOMOPANS-ECHO predicted source-level spectra for a container ship, a cruise ship and a tug: cargo vessels show a low-frequency hump below 100 Hz" width="82%">
 </picture>
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+from phonometry import underwater
+
+# JOMOPANS-ECHO source spectra for three vessel classes (speed, length).
+fig, ax = plt.subplots()
+for vessel_class, speed, length in (("containership", 18.0, 300.0),
+                                    ("cruise", 17.1, 250.0),
+                                    ("tug", 3.7, 30.0)):
+    s = underwater.ship_source_spectrum(speed, length, vessel_class=vessel_class)
+    ax.semilogx(s.frequency, s.source_psd,
+                label=f"{vessel_class} ({speed:.0f} kn, {length:.0f} m)")
+ax.set(xlabel="Frequency [Hz]",
+       ylabel="Source spectral density [dB re 1 µPa²/Hz at 1 m]")
+ax.legend()
+ax.grid(True, which="both", alpha=0.3)
+plt.show()
+```
+
+</details>
+
 When no measured spectrum is available, a ship's underwater source level can be
 **estimated** from its class, speed and length. Three semi-empirical models are
 available: **JOMOPANS-ECHO** (MacGillivray & de Jong 2021, per vessel class,
@@ -233,6 +356,29 @@ calculator (File S1) to better than 0.01 dB.
   <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/numerical_propagation_dark.png">
   <img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/numerical_propagation.png" alt="Three numerical solvers: a Munk sound-speed profile, ray paths forming convergence zones, and transmission loss versus range from the normal-mode and parabolic-equation solvers agreeing in trend" width="100%">
 </picture>
+
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import underwater
+
+# A Munk deep-water sound-speed profile.
+z = np.linspace(0.0, 5000.0, 60)
+eta = 2.0 * (z - 1300.0) / 1300.0
+c = 1500.0 * (1.0 + 0.00737 * (eta - 1.0 + np.exp(-eta)))
+
+# Split-step Fourier PE at 50 Hz; a coarse grid keeps the run fast.
+field = underwater.parabolic_equation(50.0, z, c, source_depth=1000.0,
+                                      max_range=50_000.0, range_step=50.0,
+                                      n_depth_points=512)
+field.plot()   # TL(z, r) field showing the convergence zones
+plt.show()
+```
+
+</details>
 
 For range-independent (horizontally stratified) environments the field can be
 computed numerically. Three solvers are provided (Jensen et al.,

--- a/docs/vibration-sound-power.md
+++ b/docs/vibration-sound-power.md
@@ -27,6 +27,34 @@ standards (ISO 9611, EN 15657, EN 12354-5).
 
 <picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/vibration_sound_power_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/vibration_sound_power.svg" alt="Radiated sound power level per octave band of a vibrating surface, comparing the ISO/TS 7849-1 upper limit with a fixed radiation factor of one against the ISO/TS 7849-2 engineering value with a measured radiation factor, with the band-summed totals marked" width="82%"></picture>
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import emission
+
+# Surface velocity levels and a measured radiation factor per octave band.
+bands = np.array([125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
+lv = np.array([78.0, 82.0, 85.0, 83.0, 79.0, 74.0])
+eps = np.array([0.20, 0.45, 0.75, 0.95, 1.00, 1.00])
+
+lw_max = emission.radiated_sound_power_level(lv, 1.6)  # Part 1, eps = 1
+lw_eng = emission.radiated_sound_power_level(lv, 1.6, radiation_factor=eps)  # Part 2
+
+x = np.arange(bands.size)
+fig, ax = plt.subplots()
+ax.bar(x - 0.2, lw_max, width=0.4, label="Part 1 upper limit ($\\varepsilon$ = 1)")
+ax.bar(x + 0.2, lw_eng, width=0.4, label="Part 2 engineering ($\\varepsilon$ measured)")
+ax.set_xticks(x, [f"{b:g}" for b in bands])
+ax.set(xlabel="Frequency [Hz]", ylabel="Sound power level $L_W$ [dB re 1 pW]")
+ax.legend()
+plt.show()
+```
+
+</details>
+
 ## 1. The two parts
 
 The two parts differ only in the radiation factor. **Part 1 (survey)** assumes
@@ -100,27 +128,6 @@ fixed `ε = 1`
 with a band-by-band `εⱼ` determined from one reference measurement of the
 radiated power (ISO 9614 intensity), after which the velocity survey can be
 repeated cheaply on nominally identical machines.
-
-<details>
-<summary>Show the code for this figure</summary>
-
-```python
-import matplotlib.pyplot as plt
-import numpy as np
-import phonometry as ph
-
-bands = np.array([125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
-lv = np.array([78.0, 82.0, 85.0, 83.0, 79.0, 74.0])
-eps = np.array([0.20, 0.45, 0.75, 0.95, 1.00, 1.00])
-x = np.arange(bands.size)
-plt.bar(x - 0.2, ph.radiated_sound_power_level(lv, 1.6), width=0.4, label="Part 1 (ε=1)")
-plt.bar(x + 0.2, ph.radiated_sound_power_level(lv, 1.6, radiation_factor=eps),
-        width=0.4, label="Part 2 (ε measured)")
-plt.xticks(x, [f"{b:g}" for b in bands]); plt.legend()
-plt.xlabel("Frequency [Hz]"); plt.ylabel("$L_W$ [dB re 1 pW]"); plt.show()
-```
-
-</details>
 
 ## References
 

--- a/docs/why-phonometry.md
+++ b/docs/why-phonometry.md
@@ -71,6 +71,37 @@ how the burst aligns with the block boundaries.
 *Measured Fast envelopes (blue) matching the Table 4 reference values
 (dashed) within 0.1 dB for 200/50/10 ms bursts.*
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import metrology
+
+# 4 kHz tone bursts vs the IEC 61672-1 Table 4 reference maxima (FAST)
+fs = 48000
+t = np.arange(2 * fs) / fs
+steady = np.sin(2 * np.pi * 4000 * t)
+ref = metrology.time_weighting(steady, fs, mode="fast")[int(1.5 * fs):].mean()
+
+fig, axes = plt.subplots(1, 3, figsize=(12, 4), sharey=True)
+for ax, (duration, target) in zip(axes, [(0.2, -1.0), (0.05, -4.8), (0.01, -11.1)]):
+    burst = np.zeros_like(t)
+    start, n = int(0.5 * fs), round(duration * fs)
+    burst[start:start + n] = steady[start:start + n]
+    env = metrology.time_weighting(burst, fs, mode="fast")
+    ax.plot(t, 10 * np.log10(np.maximum(env / ref, 1e-6)), label="FAST envelope")
+    ax.axhline(target, linestyle="--", label=f"IEC target {target} dB")
+    ax.set(xlim=(0.4, 1.4), ylim=(-30, 3), xlabel="Time [s]",
+           title=f"{duration * 1000:g} ms burst")
+    ax.legend()
+axes[0].set_ylabel("Level re steady state [dB]")
+plt.show()
+```
+
+</details>
+
 ## What this means in practice
 
 - If you need **standard-compliant Fast/Slow/Impulse envelopes** (sound level

--- a/site/src/content/docs/es/guides/aircraft-noise.md
+++ b/site/src/content/docs/es/guides/aircraft-noise.md
@@ -105,6 +105,32 @@ print(report["passed"], report["checks"])
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/aircraft_atmospheric_absorption_es.svg" alt="Absorción atmosférica aeronáutica frente a la frecuencia para dos distancias; la atenuación de banda del método SAE queda por debajo del valor de tono puro medio de banda a alta absorción" style="width:82%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/aircraft_atmospheric_absorption_es_dark.svg" alt="Absorción atmosférica aeronáutica frente a la frecuencia para dos distancias; la atenuación de banda del método SAE queda por debajo del valor de tono puro medio de banda a alta absorción" style="width:82%">
 
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import aircraft
+
+freqs = 1000.0 * 10.0 ** (np.arange(-13, 11) / 10.0)   # tercios 50 Hz-10 kHz
+fig, ax = plt.subplots()
+# continua: atenuación de banda SAE, discontinua: tono puro medio de banda
+for s in (1000.0, 7620.0):
+    att = aircraft.sae_band_attenuation(freqs, s, temperature=25.0, relative_humidity=70.0)
+    line, = ax.semilogx(att.frequency, att.band_attenuation, marker="o",
+                        markersize=3, label=f"Banda SAE ({s:.0f} m)")
+    ax.semilogx(att.frequency, att.midband_attenuation, "--", alpha=0.6,
+                color=line.get_color())
+ax.set(xlabel="Frecuencia [Hz]", ylabel="Atenuación [dB]",
+       title="Absorción atmosférica aeronáutica a 25 °C, 70% HR")
+ax.grid(True, which="both", alpha=0.3)
+ax.legend()
+plt.show()
+```
+
+</details>
+
 Corregir un sobrevuelo medido a condiciones atmosféricas de referencia requiere
 la atenuación en bandas de 1/3 de octava sobre el trayecto. El coeficiente de
 tono puro es el de ISO 9613-1 (idéntico, según ARP 5534 §3.1) que da
@@ -129,6 +155,34 @@ Válido ~6–32 °C, 20–95 % HR (ventana 14 CFR Part 36), hasta 7620 m, recíp
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/airport_noise_es.svg" alt="Curvas nivel-potencia-distancia para dos ajustes de potencia; el nivel de evento cae log-linealmente con la distancia oblicua entre los nodos tabulados" style="width:82%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/airport_noise_es_dark.svg" alt="Curvas nivel-potencia-distancia para dos ajustes de potencia; el nivel de evento cae log-linealmente con la distancia oblicua entre los nodos tabulados" style="width:82%">
 
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+import matplotlib.pyplot as plt
+from phonometry import aircraft
+
+# Una tabla NPD esquemática: SEL frente a distancia oblicua para dos empujes.
+powers = [12000.0, 20000.0]
+distances = [200.0, 400.0, 630.0, 1000.0, 2000.0, 4000.0, 6300.0, 10000.0]
+levels = [[98.5, 92.0, 88.2, 83.6, 76.8, 69.4, 63.9, 56.8],
+          [107.2, 100.9, 97.2, 92.7, 86.0, 78.5, 72.9, 65.6]]
+
+fig, ax = plt.subplots()
+for p in (20000.0, 12000.0):
+    curve = aircraft.npd_curve(powers, distances, levels, power=p)
+    line, = ax.semilogx(curve.distance, curve.level, label=f"P = {p:.0f} N")
+    ax.semilogx(curve.table_distances, curve.table_levels, "o", markersize=4,
+                color=line.get_color())
+ax.set(xlabel="Distancia oblicua [m]", ylabel="Nivel de evento [dB]",
+       title="Curvas nivel-potencia-distancia (ECAC Doc 29)")
+ax.grid(True, which="both", alpha=0.3)
+ax.legend()
+plt.show()
+```
+
+</details>
+
 El método de ruido de aeropuerto de ECAC Doc 29 describe la aeronave con tablas
 **nivel-potencia-distancia (NPD)**. `npd_level` lee el nivel de evento
 (`LAmax`/`SEL`) para una potencia y distancia arbitrarias, interpolando
@@ -150,6 +204,37 @@ Es el motor NPD que sustenta el método.
 ## Contornos de ruido de aeropuerto (evento único)
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/airport_contour.png" alt="Contorno SEL de un despegue: huella alargada a lo largo de la trayectoria, más intensa cerca del rodaje" style="width:90%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/airport_contour_dark.png" alt="Contorno SEL de un despegue: huella alargada a lo largo de la trayectoria, más intensa cerca del rodaje" style="width:90%">
+
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import aircraft
+
+# Tablas NPD (SEL y LAmax) de una aeronave, dos ajustes de potencia.
+powers = [8000.0, 12000.0]
+distances = [60.0, 120.0, 240.0, 480.0, 960.0, 1920.0, 3840.0, 7680.0]
+sel = [[98.0, 92.0, 86.0, 80.0, 74.0, 68.0, 62.0, 56.0],
+       [104.0, 98.0, 92.0, 86.0, 80.0, 74.0, 68.0, 62.0]]
+lmax = [[94.0, 88.0, 82.0, 76.0, 70.0, 64.0, 58.0, 52.0],
+        [100.0, 94.0, 88.0, 82.0, 76.0, 70.0, 64.0, 58.0]]
+
+# Despegue: rodaje a lo largo de +x y después un ascenso constante.
+xs = np.linspace(0.0, 18000.0, 40)
+z = np.clip((xs - 1500.0) * 0.11, 0.0, 2500.0)
+power = np.where(xs < 3000.0, 12000.0, 10000.0)
+path = np.column_stack([xs, np.zeros_like(xs), z, power, np.full_like(xs, 82.3)])
+
+contour = aircraft.noise_contour(path, powers, distances, sel, lmax,
+                                 x=np.linspace(-2500.0, 20000.0, 56),
+                                 y=np.linspace(-6000.0, 6000.0, 44))
+contour.plot()   # huella SEL de evento único (requiere matplotlib)
+plt.show()
+```
+
+</details>
 
 El cálculo de evento único trocea la trayectoria en segmentos y corrige el nivel
 base NPD por segmento (§4.3-4.5): `impedance_adjustment` (T, p),
@@ -173,6 +258,31 @@ de chorro: máxima hacia un acimut ψ ≈ 120° respecto al morro, y decreciente
 través (ψ = 90°) y directamente detrás (ψ = 180°).
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/airport_sor_es.svg" alt="Diagrama polar de la directividad de inicio de rodaje ΔSOR sobre el semicírculo trasero para reactor turbofán y turbohélice, con un lóbulo cerca de 120° respecto al morro" style="width:75%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/airport_sor_es_dark.svg" alt="Diagrama polar de la directividad de inicio de rodaje ΔSOR sobre el semicírculo trasero para reactor turbofán y turbohélice, con un lóbulo cerca de 120° respecto al morro" style="width:75%">
+
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+import phonometry as ph
+
+az = np.linspace(90.0, 270.0, 361)              # semicírculo trasero
+psi = np.where(az <= 180.0, az, 360.0 - az)     # ΔSOR es simétrico izquierda/derecha
+jet = [ph.start_of_roll_directivity(p, 300.0, "jet") for p in psi]
+prop = [ph.start_of_roll_directivity(p, 300.0, "turboprop") for p in psi]
+
+ax = plt.subplot(projection="polar")
+ax.set_theta_zero_location("N")                 # morro arriba, acimut horario
+ax.set_theta_direction(-1)
+ax.plot(np.radians(az), jet, label="Reactor turbofán")
+ax.plot(np.radians(az), prop, label="Turbohélice")
+ax.set_rlim(-16.0, 0.0)                         # eje radial: dB respecto al través
+ax.legend(loc="lower center")
+plt.show()
+```
+
+</details>
 
 ```python
 import numpy as np

--- a/site/src/content/docs/es/guides/block-processing.md
+++ b/site/src/content/docs/es/guides/block-processing.md
@@ -22,6 +22,43 @@ bloques coinciden con una única pasada sobre la señal completa.
 con el resultado continuo; sin estado, cada frontera de bloque reinicia el
 transitorio del filtro.*
 
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import metrology
+
+# Banda de octava de 1 kHz: cuatro bloques con estado frente a una pasada continua
+fs, block = 8000, 1000
+rng = np.random.default_rng(42)
+x = rng.standard_normal(4 * block)
+t = np.arange(x.size) / fs
+
+bank = metrology.OctaveFilterBank(fs, fraction=1, limits=[900, 1100],
+                                  stateful=True, resample=False)
+streamed = np.concatenate([
+    bank.filter(x[i * block:(i + 1) * block], sigbands=True,
+                detrend=False, calculate_level=False)[2][0]
+    for i in range(4)
+])
+offline = metrology.OctaveFilterBank(fs, fraction=1, limits=[900, 1100],
+                                     resample=False).filter(
+    x, sigbands=True, detrend=False, calculate_level=False)[2][0]
+print(np.max(np.abs(streamed - offline)))     # 0.0 (exacto bit a bit)
+
+fig, ax = plt.subplots(figsize=(9, 4.5))
+ax.plot(t, offline, linewidth=2.5, alpha=0.35, label="Continuo (señal completa)")
+ax.plot(t, streamed, label="Bloques con estado (estado conservado)")
+ax.axvline(block / fs, color="gray", linestyle=":", label="Frontera de bloque")
+ax.set(xlim=(0.11, 0.17), xlabel="Tiempo [s]", ylabel="Amplitud")
+ax.legend()
+plt.show()
+```
+
+</details>
+
 Crea un banco con estado usando `stateful=True`. El estado interno se inicializa
 a cero por defecto, pero puede inicializarse al régimen permanente de la
 respuesta al escalón (como `scipy.signal.sosfilt_zi`) con `steady_ic=True`.

--- a/site/src/content/docs/es/guides/dynamic-stiffness.md
+++ b/site/src/content/docs/es/guides/dynamic-stiffness.md
@@ -16,6 +16,23 @@ reacción local y excluye expresamente los suelos flotantes.)
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/dynamic_stiffness_es.svg" alt="Frecuencia natural del suelo flotante frente a la rigidez dinámica por unidad de área de la capa resiliente para un suelo flotante ligero y uno pesado, con un punto de diseño" style="width:82%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/dynamic_stiffness_es_dark.svg" alt="Frecuencia natural del suelo flotante frente a la rigidez dinámica por unidad de área de la capa resiliente para un suelo flotante ligero y uno pesado, con un punto de diseño" style="width:82%">
 
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+import phonometry as ph
+
+s = np.logspace(np.log10(2.0), np.log10(100.0), 300)   # MN/m3
+for m in (40.0, 120.0):
+    plt.semilogx(s, ph.natural_frequency(s * 1e6, m), label=f"m' = {m:g} kg/m²")
+plt.xlabel("Rigidez dinámica s' [MN/m³]"); plt.ylabel("Frecuencia natural f₀ [Hz]")
+plt.legend(); plt.show()
+```
+
+</details>
+
 ## 1. Rigidez dinámica y resonancia
 
 La rigidez dinámica por unidad de área es una fuerza dinámica por área dividida
@@ -90,23 +107,6 @@ res = ph.floating_floor_resonance(
 print(round(res.dynamic_stiffness / 1e6, 2), round(res.natural_frequency, 1))
 # 10.49 47.1
 ```
-
-<details>
-<summary>Mostrar el código de esta figura</summary>
-
-```python
-import matplotlib.pyplot as plt
-import numpy as np
-import phonometry as ph
-
-s = np.logspace(np.log10(2.0), np.log10(100.0), 300)   # MN/m3
-for m in (40.0, 120.0):
-    plt.semilogx(s, ph.natural_frequency(s * 1e6, m), label=f"m' = {m:g} kg/m²")
-plt.xlabel("Rigidez dinámica s' [MN/m³]"); plt.ylabel("Frecuencia natural f₀ [Hz]")
-plt.legend(); plt.show()
-```
-
-</details>
 
 El `DynamicStiffnessResult` contiene las rigideces aparente, del gas encerrado e
 instalada, la resonancia del ensayo y la frecuencia natural del suelo instalado,

--- a/site/src/content/docs/es/guides/filter-banks.md
+++ b/site/src/content/docs/es/guides/filter-banks.md
@@ -173,6 +173,24 @@ Vista espectral completa de los bancos para octava (1/1) y tercio de octava (1/3
 | **Elíptico** | <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_ellip_fraction_1_order_6_es.svg" alt="Respuesta en frecuencia del banco elíptico de banda de octava" style="width:100%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_ellip_fraction_1_order_6_es_dark.svg" alt="Respuesta en frecuencia del banco elíptico de banda de octava" style="width:100%"> | <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_ellip_fraction_3_order_6_es.svg" alt="Respuesta en frecuencia del banco elíptico de tercio de octava" style="width:100%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_ellip_fraction_3_order_6_es_dark.svg" alt="Respuesta en frecuencia del banco elíptico de tercio de octava" style="width:100%"> |
 | **Bessel** | <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_bessel_fraction_1_order_6_es.svg" alt="Respuesta en frecuencia del banco Bessel de banda de octava" style="width:100%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_bessel_fraction_1_order_6_es_dark.svg" alt="Respuesta en frecuencia del banco Bessel de banda de octava" style="width:100%"> | <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_bessel_fraction_3_order_6_es.svg" alt="Respuesta en frecuencia del banco Bessel de tercio de octava" style="width:100%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_bessel_fraction_3_order_6_es_dark.svg" alt="Respuesta en frecuencia del banco Bessel de tercio de octava" style="width:100%"> |
 
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+from phonometry import metrology
+
+# Una figura por arquitectura y fracción: la galería completa de respuestas
+fs = 48000
+for ftype in ("butter", "cheby1", "cheby2", "ellip", "bessel"):
+    for fraction in (1, 3):
+        # show=True dibuja la respuesta en frecuencia del banco
+        metrology.OctaveFilterBank(fs=fs, fraction=fraction, order=6,
+                                   limits=[12, 20000], filter_type=ftype,
+                                   show=True)
+```
+
+</details>
+
 ## 5. Uso y ejemplos por tipo de filtro
 
 ### 1. Butterworth (`butter`)
@@ -195,6 +213,19 @@ spl, freq = octave_filter(x, fs, filter_type='butter')
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_butter_fraction_3_order_6_es.svg" alt="Respuesta en frecuencia del banco Butterworth de tercio de octava" style="width:60%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_butter_fraction_3_order_6_es_dark.svg" alt="Respuesta en frecuencia del banco Butterworth de tercio de octava" style="width:60%">
 
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+from phonometry import metrology
+
+# Dibuja la respuesta de este banco (1/3 de octava, orden 6, Butterworth)
+metrology.OctaveFilterBank(fs=48000, fraction=3, order=6, limits=[12, 20000],
+                           filter_type='butter', show=True)
+```
+
+</details>
+
 ### 2. Chebyshev I (`cheby1`)
 
 Los filtros Chebyshev tipo I ofrecen una **caída más abrupta** que Butterworth a
@@ -208,6 +239,19 @@ spl, freq = octave_filter(x, fs, filter_type='cheby1', ripple=0.1)
 ```
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_cheby1_fraction_3_order_6_es.svg" alt="Respuesta en frecuencia del banco Chebyshev I de tercio de octava" style="width:60%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_cheby1_fraction_3_order_6_es_dark.svg" alt="Respuesta en frecuencia del banco Chebyshev I de tercio de octava" style="width:60%">
+
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+from phonometry import metrology
+
+# Dibuja la respuesta de este banco (1/3 de octava, orden 6, Chebyshev I)
+metrology.OctaveFilterBank(fs=48000, fraction=3, order=6, limits=[12, 20000],
+                           filter_type='cheby1', ripple=0.1, show=True)
+```
+
+</details>
 
 ### 3. Chebyshev II (`cheby2`)
 
@@ -225,6 +269,19 @@ spl, freq = octave_filter(x, fs, filter_type='cheby2')
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_cheby2_fraction_3_order_6_es.svg" alt="Respuesta en frecuencia del banco Chebyshev II de tercio de octava" style="width:60%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_cheby2_fraction_3_order_6_es_dark.svg" alt="Respuesta en frecuencia del banco Chebyshev II de tercio de octava" style="width:60%">
 
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+from phonometry import metrology
+
+# Dibuja la respuesta de este banco (1/3 de octava, orden 6, Chebyshev II)
+metrology.OctaveFilterBank(fs=48000, fraction=3, order=6, limits=[12, 20000],
+                           filter_type='cheby2', show=True)
+```
+
+</details>
+
 ### 4. Elíptico (`ellip`)
 
 Los filtros elípticos (Cauer) tienen la **transición más corta** (caída más
@@ -239,6 +296,19 @@ spl, freq = octave_filter(x, fs, filter_type='ellip', ripple=0.1)
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_ellip_fraction_3_order_6_es.svg" alt="Respuesta en frecuencia del banco elíptico de tercio de octava" style="width:60%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_ellip_fraction_3_order_6_es_dark.svg" alt="Respuesta en frecuencia del banco elíptico de tercio de octava" style="width:60%">
 
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+from phonometry import metrology
+
+# Dibuja la respuesta de este banco (1/3 de octava, orden 6, elíptico)
+metrology.OctaveFilterBank(fs=48000, fraction=3, order=6, limits=[12, 20000],
+                           filter_type='ellip', ripple=0.1, show=True)
+```
+
+</details>
+
 ### 5. Bessel (`bessel`)
 
 Los filtros Bessel están optimizados para una **respuesta de fase lineal** y un
@@ -252,6 +322,19 @@ spl, freq = octave_filter(x, fs, filter_type='bessel')
 ```
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_bessel_fraction_3_order_6_es.svg" alt="Respuesta en frecuencia del banco Bessel de tercio de octava" style="width:60%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_bessel_fraction_3_order_6_es_dark.svg" alt="Respuesta en frecuencia del banco Bessel de tercio de octava" style="width:60%">
+
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+from phonometry import metrology
+
+# Dibuja la respuesta de este banco (1/3 de octava, orden 6, Bessel)
+metrology.OctaveFilterBank(fs=48000, fraction=3, order=6, limits=[12, 20000],
+                           filter_type='bessel', show=True)
+```
+
+</details>
 
 ### 6. Linkwitz-Riley (`linkwitz_riley`)
 

--- a/site/src/content/docs/es/guides/installed-structure-borne.md
+++ b/site/src/content/docs/es/guides/installed-structure-borne.md
@@ -21,6 +21,35 @@ con la movilidad de la fuente en su lugar da `L_Ws,c` (Anexo I.3, Tabla I.8).
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/installed_structure_borne_es.svg" alt="La cascada de EN 12354-5 por banda de octava: potencia característica, potencia instalada tras el término de acoplamiento, niveles de presión sonora por camino y su total energético" style="width:82%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/installed_structure_borne_es_dark.svg" alt="La cascada de EN 12354-5 por banda de octava: potencia característica, potencia instalada tras el término de acoplamiento, niveles de presión sonora por camino y su total energético" style="width:82%">
 
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import building
+
+# Potencia característica EN 15657 y movilidades puntuales ilustrativas.
+bands = np.array([63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
+lws_c = np.array([78.0, 82.0, 84.0, 81.0, 77.0, 72.0, 66.0])
+ys = (2e-4 + 1e-4j) * (bands / 250.0)        # movilidad de la fuente
+yi = (3e-5 + 1e-5j) * np.ones_like(bands)    # movilidad del receptor
+dc = np.array([float(building.coupling_term(a, b)) for a, b in zip(ys, yi)])
+
+# Dos vías de transmisión: el forjado excitado y una pared de flanco.
+paths = [
+    {"adjustment_term": 6.0, "element_area": 12.0,
+     "flanking_reduction_index": np.linspace(44.0, 62.0, 7)},
+    {"adjustment_term": 7.0, "element_area": 9.0,
+     "flanking_reduction_index": np.linspace(46.0, 64.0, 7)},
+]
+res = building.installed_source_prediction(lws_c, dc, paths, frequencies=bands)
+res.plot()   # potencia característica e instalada, niveles por vía y el total
+plt.show()
+```
+
+</details>
+
 ## 1. Acoplamiento y potencia instalada
 
 Solo parte de la potencia característica se inyecta en el elemento soporte; la
@@ -96,26 +125,6 @@ print(round(res.overall_level, 1))       # nivel sumado en bandas [dB]
 El `InstalledSourceResult` transporta los niveles por camino, el total por banda,
 el nivel de potencia instalada y `.overall_level`, y su `.plot()` dibuja toda la
 cascada.
-
-<details>
-<summary>Mostrar el código de esta figura</summary>
-
-```python
-import matplotlib.pyplot as plt
-import numpy as np
-import phonometry as ph
-
-bands = np.array([63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
-lws_c = np.array([78.0, 82.0, 84.0, 81.0, 77.0, 72.0, 66.0])
-ys = (2e-4 + 1e-4j) * (bands / 250.0); yi = (3e-5 + 1e-5j) * np.ones_like(bands)
-dc = np.array([float(ph.coupling_term(a, b)) for a, b in zip(ys, yi)])
-paths = [{"adjustment_term": 6.0,
-          "flanking_reduction_index": np.linspace(44, 62, 7), "element_area": 12.0}]
-res = ph.installed_source_prediction(lws_c, dc, paths, frequencies=bands)
-res.plot(); plt.show()
-```
-
-</details>
 
 ## Referencias
 

--- a/site/src/content/docs/es/guides/insulation-field.md
+++ b/site/src/content/docs/es/guides/insulation-field.md
@@ -105,7 +105,7 @@ w.plot()   # R' medido frente a la referencia ISO 717-1 desplazada, desviaciones
 ```
 
 <details>
-<summary>Ver el código de esta figura</summary>
+<summary>Mostrar el código de esta figura</summary>
 
 ```python
 import matplotlib.pyplot as plt
@@ -253,7 +253,7 @@ res_imp.plot()   # L'nT medido frente a la referencia ISO 717-2 desplazada, exce
 ```
 
 <details>
-<summary>Ver el código de esta figura</summary>
+<summary>Mostrar el código de esta figura</summary>
 
 ```python
 import matplotlib.pyplot as plt
@@ -437,7 +437,7 @@ son insensibles a mayúsculas y con alias (`rprime_w`/`dnt_w`→`r_w`,
 `reduce_by_independent_measurements` ($u/\sqrt{m}$).
 
 <details>
-<summary>Ver el código de esta figura</summary>
+<summary>Mostrar el código de esta figura</summary>
 
 ```python
 import matplotlib.pyplot as plt
@@ -535,6 +535,35 @@ res.plot()   # DnT vs curva de referencia ISO 717-1 desplazada (necesita matplot
 bruta `D` hacia la estandarizada `DnT` — hacia arriba donde la sala es viva
 (`T > T0`), hacia abajo donde es apagada. El índice automático solo se forma con
 exactamente 5 valores de octava (o 16 de tercio de octava).*
+
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import building
+
+# Niveles por bandas de octava (125-2000 Hz) y el T medido de la sala receptora.
+bands = [125, 250, 500, 1000, 2000]
+l1 = np.array([88.0, 90.0, 92.0, 92.0, 90.0])
+l2 = np.array([55.0, 51.0, 47.0, 41.0, 35.0])
+k = building.reverberation_index([0.70, 0.60, 0.50, 0.45, 0.40])   # k = 10 lg(T/0.5)
+res = building.survey_airborne_insulation(l1, l2, k, volume=50.0)
+
+x = np.arange(len(bands))
+fig, ax = plt.subplots()
+ax.fill_between(x, res.d, res.d_nt, alpha=0.2, label="k = 10 lg(T/T0)")
+ax.plot(x, res.d, "--o", label="D (diferencia de niveles)")
+ax.plot(x, res.d_nt, "-s", label="DnT (estandarizada)")
+ax.set_xticks(x, [str(b) for b in bands])
+ax.set(xlabel="Frecuencia [Hz]", ylabel="Diferencia de niveles [dB]",
+       title=f"Método de control ISO 10052: DnT,w = {res.rating.rating} dB")
+ax.legend()
+plt.show()
+```
+
+</details>
 
 ### Parámetros de `survey_airborne_insulation()` y afines
 

--- a/site/src/content/docs/es/guides/insulation-lab.md
+++ b/site/src/content/docs/es/guides/insulation-lab.md
@@ -176,6 +176,39 @@ subárea cuya energía neta fluye de vuelta hacia el espécimen se introduce con
 área negativa, aplicando la regla del signo menos de la Cláusula 6.4.6
 mientras $S_m$ conserva la suma de áreas sin signo.*
 
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import building
+
+# Una pared ligera: SPL de la sala emisora Lp1 = 85 dB y el nivel de intensidad
+# normal medido LIn sobre la superficie Sm = 12 m2, 16 bandas de tercio de octava.
+freqs = [100, 125, 160, 200, 250, 315, 400, 500, 630, 800,
+         1000, 1250, 1600, 2000, 2500, 3150]
+l_in = np.array([57.8, 61.9, 60.5, 55.6, 55.8, 55.5, 53.4, 51.6,
+                 50.2, 47.7, 46.4, 45.7, 44.8, 45.2, 47.2, 52.7])
+kc = building.adaptation_term_kc(freqs)           # término de adaptación del Anexo B
+res = building.intensity_sound_reduction(np.full(16, 85.0), l_in,
+                                         measurement_area=12.0, area=10.0,
+                                         kc=kc)
+
+x = np.arange(len(freqs))
+fig, ax = plt.subplots()
+ax.fill_between(x, res.r_i, res.r_i_modified, alpha=0.2, label="Adaptación Kc")
+ax.plot(x, res.r_i, "-o", label="RI (intensidad)")
+ax.plot(x, res.r_i_modified, "--s", label="RI,M = RI + Kc")
+ax.set_xticks(x, [str(f) for f in freqs], rotation=45)
+ax.set(xlabel="Frecuencia [Hz]", ylabel="Índice de reducción sonora [dB]",
+       title=f"RI,w = {res.rating.rating} dB, RI,M,w = {res.rating_modified.rating} dB")
+ax.legend()
+plt.show()
+```
+
+</details>
+
 ### Parámetros de `intensity_sound_reduction()` / `adaptation_term_kc()`
 
 | Parámetro | Tipo | Unidades | Rango / def. | Notas |
@@ -227,7 +260,7 @@ como `ci_delta` en el resultado y de forma independiente como
 `impact_improvement_adaptation_term()`.
 
 <details>
-<summary>Ver el código de esta figura</summary>
+<summary>Mostrar el código de esta figura</summary>
 
 ```python
 import matplotlib.pyplot as plt

--- a/site/src/content/docs/es/guides/levels.md
+++ b/site/src/content/docs/es/guides/levels.md
@@ -97,6 +97,41 @@ print(f"LA10={stats[10]:.1f}  LA50={stats[50]:.1f}  LA90={stats[90]:.1f} dB")
 
 *L10 sigue los picos de los eventos, L50 el nivel mediano y L90 el fondo.*
 
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+import numpy as np
+import matplotlib.pyplot as plt
+from phonometry import metrology
+
+# La señal fluctuante del ejemplo de ln_levels: 0.5 s de fondo alternando
+# con 0.5 s de eventos ~10 dB más fuertes, repetido 3 veces
+fs = 48000
+rng = np.random.default_rng(0)
+segment = fs // 2
+quiet = 0.02 * rng.standard_normal(segment)
+loud = 0.06 * rng.standard_normal(segment)
+varying = np.tile(np.concatenate([quiet, loud]), 3)
+
+# Envolvente cuadrática media Fast -> nivel frente al tiempo, y los percentiles
+envelope = metrology.time_weighting(varying, fs, mode="fast")
+level_t = 10 * np.log10(np.maximum(envelope, 1e-12) / (2e-5) ** 2)
+stats = metrology.ln_levels(varying, fs, n=(10, 50, 90))
+t = np.arange(varying.size) / fs
+
+fig, ax = plt.subplots()
+ax.plot(t, level_t, linewidth=0.8, label="Nivel Fast Lp(t)")
+for i, (n_value, style) in enumerate([(10, "--"), (50, "-"), (90, "-.")], 1):
+    ax.axhline(float(stats[n_value]), color=f"C{i}", linestyle=style,
+               label=f"L{n_value} = {stats[n_value]:.1f} dB")
+ax.set(xlabel="Tiempo [s]", ylabel="Nivel [dB]")
+ax.legend(loc="lower right")
+plt.show()
+```
+
+</details>
+
 Opciones: `mode` selecciona la ponderación temporal de la envolvente (`'fast'`, `'slow'`,
 `'impulse'`), `weighting` aplica antes la ponderación A/C, y
 `calibration_factor`/`dbfs` se comportan como en `leq`. El transitorio de ataque
@@ -201,6 +236,40 @@ bloque básico de los modelos de ruido aeroportuario y ferroviario.
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/sel_concept_es.svg" alt="Historia del nivel del paso de un vehículo con su Leq sobre el evento completo y el bloque SEL de un segundo con la misma energía" style="width:80%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/sel_concept_es_dark.svg" alt="Historia del nivel del paso de un vehículo con su Leq sobre el evento completo y el bloque SEL de un segundo con la misma energía" style="width:80%">
 
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+import numpy as np
+import matplotlib.pyplot as plt
+from phonometry import metrology
+
+# El paso de un vehículo: ruido bajo una envolvente de energía gaussiana (análisis en dBFS)
+fs = 48000
+t = np.arange(int(8.0 * fs)) / fs
+rng = np.random.default_rng(11)
+x = 0.3 * np.exp(-0.5 * ((t - 4.0) / 1.1) ** 2) * rng.standard_normal(t.size)
+
+level = 10 * np.log10(np.maximum(metrology.time_weighting(x, fs, mode="fast"), 1e-12))
+l_sel = float(metrology.sel(x, fs, dbfs=True))
+l_eq = float(metrology.leq(x, dbfs=True))
+print(f"Leq = {l_eq:.1f} dBFS, SEL = {l_sel:.1f} dBFS")
+# Leq = -16.6 dBFS, SEL = -7.6 dBFS -> el bloque de 1 s lleva la energía del evento
+
+fig, ax = plt.subplots()
+ax.plot(t, level, linewidth=1.0, label="Nivel Fast del evento")
+ax.hlines(l_eq, 0, 8, color="C2", linestyle="--",
+          label=f"Leq sobre el evento completo = {l_eq:.1f} dBFS")
+ax.fill_between([3.5, 4.5], -55, l_sel, color="C1", alpha=0.25)
+ax.hlines(l_sel, 3.5, 4.5, color="C1", linewidth=2,
+          label=f"SEL = {l_sel:.1f} dBFS: la misma energía en 1 s")
+ax.set(xlabel="Tiempo [s]", ylabel="Nivel [dBFS]", ylim=(-55, l_sel + 6))
+ax.legend(loc="lower left")
+plt.show()
+```
+
+</details>
+
 ### Dosis de ruido: exposición sonora y LEX,8h
 
 Las normativas laborales limitan la *dosis* diaria, no el nivel. IEC 61252 la
@@ -252,6 +321,44 @@ r = composite_rating_level([(63.2, 12, 0.0),    # día
 ```
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/lden_profile_es.svg" alt="Perfil LAeq urbano sintético de 24 horas con las bandas de día, tarde y noche, los niveles por periodo ponderados con +5 y +10 dB y el Lden resultante" style="width:80%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/lden_profile_es_dark.svg" alt="Perfil LAeq urbano sintético de 24 horas con las bandas de día, tarde y noche, los niveles por periodo ponderados con +5 y +10 dB y el Lden resultante" style="width:80%">
+
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+import numpy as np
+import matplotlib.pyplot as plt
+from phonometry import environmental
+
+# LAeq horario sintético de una vía urbana (dB), horas 00 a 23
+laeq_h = np.array([48, 46, 45, 45, 46, 50, 56, 64, 66, 65, 63, 63,
+                   64, 63, 63, 64, 65, 66, 65, 64, 63, 62, 61, 50], dtype=float)
+
+def period_leq(idx):
+    return 10 * np.log10(np.mean(10 ** (laeq_h[idx] / 10)))  # media energética
+
+ld = period_leq(np.arange(7, 19))                # día 07-19
+le = period_leq(np.arange(19, 23))               # tarde 19-23
+ln_ = period_leq(np.r_[23, np.arange(0, 7)])     # noche 23-07
+l_den = environmental.lden(ld, le, ln_)
+print(f"Lden = {l_den:.1f} dB")   # Lden = 64.3 dB
+
+fig, ax = plt.subplots()
+ax.axvspan(19, 23, color="C1", alpha=0.15)                                # tarde
+ax.axvspan(23, 24, color="C0", alpha=0.15); ax.axvspan(0, 7, color="C0", alpha=0.15)
+ax.step(np.arange(25), np.r_[laeq_h, laeq_h[-1]], where="post",
+        color="0.3", label="LAeq horario")
+ax.hlines(ld, 7, 19, color="C2", linestyle="--", label="Ldía (+0 dB)")
+ax.hlines(le + 5, 19, 23, color="C1", linestyle="--", label="Ltarde + 5 dB")
+ax.hlines([ln_ + 10, ln_ + 10], [23, 0], [24, 7], color="C0",
+          linestyle="--", label="Lnoche + 10 dB")
+ax.hlines(l_den, 0, 24, color="C3", linewidth=2, label=f"Lden = {l_den:.1f} dB")
+ax.set(xlabel="Hora del día", ylabel="Nivel [dB]", xlim=(0, 24))
+ax.legend(loc="upper left", fontsize=8, ncol=2)
+plt.show()
+```
+
+</details>
 
 ### Parámetros de `lden()` / `ldn()` / `composite_rating_level()`
 
@@ -358,6 +465,36 @@ levels, freq, times = bank.spectrogram(recording, window_time=0.125, overlap=0.5
 
 *Un barrido logarítmico y dos ráfagas de tono, resueltos en el tiempo y en
 bandas normalizadas de tercio de octava.*
+
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+import numpy as np
+import matplotlib.pyplot as plt
+from scipy.signal import chirp
+from phonometry import metrology
+
+# Barrido logarítmico de 80 Hz -> 8 kHz más dos ráfagas de tono, con algo de ruido
+fs = 48000
+t = np.arange(int(4.0 * fs)) / fs
+x = 0.5 * chirp(t, f0=80, t1=4.0, f1=8000, method="logarithmic")
+x[int(1.0 * fs):int(1.3 * fs)] += np.sin(2 * np.pi * 4000 * t[: int(0.3 * fs)])
+x[int(2.5 * fs):int(2.8 * fs)] += np.sin(2 * np.pi * 250 * t[: int(0.3 * fs)])
+x += 0.01 * np.random.default_rng(42).standard_normal(t.size)
+
+bank = metrology.OctaveFilterBank(fs=fs, fraction=3, order=6, limits=[50.0, 12000.0])
+levels, freq, times = bank.spectrogram(x, window_time=0.125, overlap=0.5)
+
+fig, ax = plt.subplots()
+mesh = ax.pcolormesh(times, freq, levels, shading="auto")
+ax.set_yscale("log")
+ax.set(xlabel="Tiempo [s]", ylabel="Frecuencia [Hz]")
+fig.colorbar(mesh, label="Nivel [dB]")
+plt.show()
+```
+
+</details>
 
 - Una entrada multicanal `(channels, samples)` devuelve `(channels, bands, frames)`.
 - `times` contiene el centro de cada ventana en segundos.

--- a/site/src/content/docs/es/guides/loudness.md
+++ b/site/src/content/docs/es/guides/loudness.md
@@ -63,7 +63,7 @@ res.plot()   # N'(z) sobre la escala Bark — el patrón de sonoridad específic
 ```
 
 <details>
-<summary>Ver el código de esta figura</summary>
+<summary>Mostrar el código de esta figura</summary>
 
 ```python
 import matplotlib.pyplot as plt
@@ -132,6 +132,29 @@ phon = loudness_level(73.0, 63.0)           # 73 dB @ 63 Hz -> 40 fonios
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/equal_loudness_contours_es.svg" alt="Curvas isofónicas normales de ISO 226:2023 de 20 a 90 fonios con la curva del umbral de audición" style="width:80%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/equal_loudness_contours_es_dark.svg" alt="Curvas isofónicas normales de ISO 226:2023 de 20 a 90 fonios con la curva del umbral de audición" style="width:80%">
 
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+import matplotlib.pyplot as plt
+from phonometry import psychoacoustics
+
+# Fórmula (1) de ISO 226:2023 en las 29 frecuencias preferentes de la Tabla 1
+fig, ax = plt.subplots()
+for phon in [20, 40, 60, 80, 90]:
+    freqs, spl = psychoacoustics.equal_loudness_contour(float(phon))
+    ax.semilogx(freqs, spl, color="C0")
+    ax.annotate(f"{phon} fonios", xy=(1000, phon + 1), fontsize=9)
+ft, tf = psychoacoustics.hearing_threshold()
+ax.semilogx(ft, tf, "--", color="C1", label="Umbral de audición $T_f$")
+ax.set(xlabel="Frecuencia [Hz]", ylabel="Nivel de presión sonora [dB re 20 µPa]")
+ax.grid(True, which="both", alpha=0.3)
+ax.legend()
+plt.show()
+```
+
+</details>
+
 Validez según el apartado 4.1: 20–90 fonios (80 fonios por encima de 4 kHz); la
 implementación se verifica en CI contra las tablas del Anexo B. Ojo: esto es la
 sonoridad de *tonos puros* — la sonoridad de señales arbitrarias en sonos es lo
@@ -164,6 +187,39 @@ modelos difieren en sus filtros auditivos y en su suma de sonoridad.
 nivel: Zwicker duplica el valor en sonos cada +10 fonios, mientras que el modelo
 de Sottek crece más lentamente (alrededor de 1,65× por cada 10 dB), una
 diferencia intrínseca entre las sumas auditivas, no un error de calibración.*
+
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import psychoacoustics
+
+# Tono de 1 kHz, 20..80 dB SPL: los tres modelos pasan por 1 sono a 40 dB
+fs = 48000
+t = np.arange(fs) / fs
+levels = np.arange(20.0, 81.0, 10.0)
+zw, mg, ec = [], [], []
+for spl in levels:
+    x = np.sqrt(2) * 2e-5 * 10 ** (spl / 20) * np.sin(2 * np.pi * 1000 * t)
+    zw.append(psychoacoustics.loudness_zwicker(x, fs, stationary=True).loudness)
+    mg.append(
+        psychoacoustics.loudness_moore_glasberg_from_spectrum([(1000.0, float(spl))]).loudness
+    )
+    ec.append(psychoacoustics.loudness_ecma(x, fs).loudness)
+
+fig, ax = plt.subplots()
+ax.plot(levels, zw, "o-", label="Zwicker (ISO 532-1)")
+ax.plot(levels, mg, "s--", label="Moore-Glasberg (ISO 532-2)")
+ax.plot(levels, ec, "^-.", label="Sottek (ECMA-418-2)")
+ax.plot(40.0, 1.0, "o", color="k", markerfacecolor="none", markersize=10)   # el ancla compartida
+ax.set(xlabel="Nivel de presión sonora [dB SPL]", ylabel="Sonoridad total N [sonos]")
+ax.legend()
+plt.show()
+```
+
+</details>
 
 ### Sonoridad de Moore-Glasberg (ISO 532-2)
 
@@ -199,7 +255,7 @@ res.plot()   # sonoridad específica N'(i) sobre la escala del número ERB (Cam)
 ```
 
 <details>
-<summary>Ver el código de esta figura</summary>
+<summary>Mostrar el código de esta figura</summary>
 
 ```python
 import matplotlib.pyplot as plt
@@ -261,7 +317,7 @@ res.plot()   # sonoridad de corto plazo S'(t) y de largo plazo S''(t) frente al 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/moore_glasberg_time_loudness_es.svg" alt="Trazas de sonoridad de corto plazo y de largo plazo de Moore-Glasberg para un pulso de tono, mostrando el ataque rápido de la sonoridad de corto plazo y la relajación más lenta de la de largo plazo" style="width:80%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/moore_glasberg_time_loudness_es_dark.svg" alt="Trazas de sonoridad de corto plazo y de largo plazo de Moore-Glasberg para un pulso de tono, mostrando el ataque rápido de la sonoridad de corto plazo y la relajación más lenta de la de largo plazo" style="width:80%">
 
 <details>
-<summary>Ver el código de esta figura</summary>
+<summary>Mostrar el código de esta figura</summary>
 
 ```python
 import matplotlib.pyplot as plt
@@ -325,7 +381,7 @@ res.plot()   # sonoridad específica media N'(z) + N(l) dependiente del tiempo a
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/sottek_specific_loudness_es.svg" alt="Sonoridad específica media N'(z) del modelo de Sottek sobre las 53 bandas Bark_HMS para un tono de 1 kHz, con máximo en la banda crítica del tono" style="width:80%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/sottek_specific_loudness_es_dark.svg" alt="Sonoridad específica media N'(z) del modelo de Sottek sobre las 53 bandas Bark_HMS para un tono de 1 kHz, con máximo en la banda crítica del tono" style="width:80%">
 
 <details>
-<summary>Ver el código de esta figura</summary>
+<summary>Mostrar el código de esta figura</summary>
 
 ```python
 import matplotlib.pyplot as plt

--- a/site/src/content/docs/es/guides/mechanical-mobility.md
+++ b/site/src/content/docs/es/guides/mechanical-mobility.md
@@ -17,6 +17,29 @@ transmisión de ruido estructural: ISO 9611, ISO 10846, EN 15657 y EN 12354-5.
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/mechanical_mobility_es.svg" alt="Magnitudes normalizadas de receptancia, movilidad y acelerancia de un resonador de un grado de libertad en un eje de frecuencia log-log, todas con máximo en la resonancia" style="width:82%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/mechanical_mobility_es_dark.svg" alt="Magnitudes normalizadas de receptancia, movilidad y acelerancia de un resonador de un grado de libertad en un eje de frecuencia log-log, todas con máximo en la resonancia" style="width:82%">
 
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+import phonometry as ph
+
+m, k, c = 2.0, 8000.0, 5.0
+f = np.logspace(np.log10(0.5), np.log10(200.0), 500)
+w = 2.0 * np.pi * f
+h = ph.sdof_receptance(f, m, k, c)
+for label, frf in (("receptancia |H|", np.abs(h)),
+                   ("movilidad |Y|", np.abs(1j * w * h)),
+                   ("acelerancia |A|", np.abs(-(w**2) * h))):
+    plt.loglog(f, frf / frf.max(), label=label)
+plt.axvline(ph.resonance_frequency(m, k), ls="--", color="0.6")
+plt.xlabel("Frecuencia [Hz]"); plt.ylabel("Magnitud normalizada")
+plt.legend(); plt.show()
+```
+
+</details>
+
 ## 1. La familia de funciones de respuesta en frecuencia (Tabla 1)
 
 Para un movimiento armónico `x·e^{jωt}` la velocidad es `jω·x` y la aceleración
@@ -155,29 +178,6 @@ res = ph.sdof_mobility_result(f, mass=2.0, stiffness=8000.0, damping=5.0)
 z = res.to("impedance")                        # impedancia = 1/Y por frecuencia
 print(res.frequencies[int(np.argmax(res.magnitude))].round(1))   # ~10.1 Hz
 ```
-
-<details>
-<summary>Mostrar el código de esta figura</summary>
-
-```python
-import matplotlib.pyplot as plt
-import numpy as np
-import phonometry as ph
-
-m, k, c = 2.0, 8000.0, 5.0
-f = np.logspace(np.log10(0.5), np.log10(200.0), 500)
-w = 2.0 * np.pi * f
-h = ph.sdof_receptance(f, m, k, c)
-for label, frf in (("receptancia |H|", np.abs(h)),
-                   ("movilidad |Y|", np.abs(1j * w * h)),
-                   ("acelerancia |A|", np.abs(-(w**2) * h))):
-    plt.loglog(f, frf / frf.max(), label=label)
-plt.axvline(ph.resonance_frequency(m, k), ls="--", color="0.6")
-plt.xlabel("Frecuencia [Hz]"); plt.ylabel("Magnitud normalizada")
-plt.legend(); plt.show()
-```
-
-</details>
 
 ## Referencias
 

--- a/site/src/content/docs/es/guides/multichannel.md
+++ b/site/src/content/docs/es/guides/multichannel.md
@@ -15,6 +15,39 @@ ganancias de rendimiento significativas frente a bucles iterativos.
 *Análisis simultáneo de una señal estéreo: canal izquierdo (ruido rosa) vs canal
 derecho (barrido senoidal logarítmico).*
 
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from scipy.signal import chirp
+from phonometry import octave_filter
+
+# Señal estéreo de prueba: ruido rosa a la izquierda, barrido logarítmico a la derecha
+fs, duration = 48000, 5
+t = np.linspace(0, duration, fs * duration, endpoint=False)
+rng = np.random.default_rng(42)
+spec = np.fft.rfft(rng.standard_normal(t.size))
+spec[1:] /= np.sqrt(np.arange(1, spec.size))   # conformado 1/f: ruido rosa
+left = np.fft.irfft(spec, t.size)
+right = chirp(t, f0=50, t1=duration, f1=10000, method="logarithmic")
+
+x = np.stack([left, right])                    # (2, n_samples)
+spl, freq = octave_filter(x, fs, fraction=3, limits=[20, 20000])
+
+fig, axes = plt.subplots(2, 1, figsize=(9, 7), sharex=True)
+for ax, levels, name in zip(axes, spl, ["Izquierdo: ruido rosa", "Derecho: barrido logarítmico"]):
+    ax.semilogx(freq, levels, marker="o", label=name)
+    ax.set_ylabel("Nivel [dB]")
+    ax.grid(True, which="both", alpha=0.3)
+    ax.legend()
+axes[-1].set_xlabel("Frecuencia [Hz]")
+plt.show()
+```
+
+</details>
+
 La convención es consistente en toda la librería: el tiempo siempre es el
 **último eje**. Aplica a `octave_filter`, `OctaveFilterBank`, `weighting_filter`,
 `time_weighting`, `leq`, `laeq`, `ln_levels` y `spectrogram`.

--- a/site/src/content/docs/es/guides/psychoacoustic-annoyance.md
+++ b/site/src/content/docs/es/guides/psychoacoustic-annoyance.md
@@ -16,6 +16,35 @@ a partir de una grabación.
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/psychoacoustic_annoyance.svg" alt="Molestia psicoacústica PA frente a la sonoridad percentil N5 para tres perfiles de sensación: una base neutra donde PA es igual a N5, un sonido agudo y un sonido áspero y fluctuante ambos elevados sobre la base, con el ejemplo resuelto PA = 30,82 marcado" style="width:82%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/psychoacoustic_annoyance_dark.svg" alt="Molestia psicoacústica PA frente a la sonoridad percentil N5 para tres perfiles de sensación: una base neutra donde PA es igual a N5, un sonido agudo y un sonido áspero y fluctuante ambos elevados sobre la base, con el ejemplo resuelto PA = 30,82 marcado" style="width:82%">
 
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+import phonometry as ph
+
+n5 = np.linspace(4.0, 60.0, 200)
+profiles = [
+    ("Base neutra: S = 1.75 acum, F = R = 0", 1.75, 0.0, 0.0),
+    ("Sonido agudo: S = 3.5 acum", 3.5, 0.0, 0.0),
+    ("Áspero + fluctuante: F = 1.2 vacil, R = 0.7 asper", 2.0, 1.2, 0.7),
+]
+fig, ax = plt.subplots()
+for label, s, f, r in profiles:
+    pa = [ph.psychoacoustic_annoyance(v, s, f, r).annoyance for v in n5]
+    ax.plot(n5, pa, label=label)
+
+ex = ph.psychoacoustic_annoyance(30.0, 2.0, 0.5, 0.3)
+ax.plot([30.0], [ex.annoyance], "o", label=f"Ejemplo resuelto (PA = {ex.annoyance:.2f})")
+ax.set_xlabel("Sonoridad percentil N5 [sonios]")
+ax.set_ylabel("Molestia psicoacústica PA")
+ax.legend()
+plt.show()
+```
+
+</details>
+
 ## 1. Las cuatro sensaciones
 
 La molestia psicoacústica se apoya en cuatro sensaciones auditivas, cada una con
@@ -62,35 +91,6 @@ La figura de arriba barre `PA` frente a `N5` para tres perfiles: una base neutra
 sonido áspero y fluctuante — ambos elevados sobre la base — con el ejemplo
 resuelto marcado.
 
-<details>
-<summary>Ver el código de esta figura</summary>
-
-```python
-import matplotlib.pyplot as plt
-import numpy as np
-import phonometry as ph
-
-n5 = np.linspace(4.0, 60.0, 200)
-profiles = [
-    ("Baseline: S = 1.75 acum, F = R = 0", 1.75, 0.0, 0.0),
-    ("Sharp: S = 3.5 acum", 3.5, 0.0, 0.0),
-    ("Rough + fluctuating: F = 1.2 vacil, R = 0.7 asper", 2.0, 1.2, 0.7),
-]
-fig, ax = plt.subplots()
-for label, s, f, r in profiles:
-    pa = [ph.psychoacoustic_annoyance(v, s, f, r).annoyance for v in n5]
-    ax.plot(n5, pa, label=label)
-
-ex = ph.psychoacoustic_annoyance(30.0, 2.0, 0.5, 0.3)
-ax.plot([30.0], [ex.annoyance], "o", label=f"Worked example (PA = {ex.annoyance:.2f})")
-ax.set_xlabel("Percentile loudness N5 [sone]")
-ax.set_ylabel("Psychoacoustic annoyance PA")
-ax.legend()
-plt.show()
-```
-
-</details>
-
 ### 2.1 A partir de una señal (estimación de ingeniería)
 
 `psychoacoustic_annoyance_from_signal` es una utilidad que deriva las cuatro
@@ -127,30 +127,8 @@ amplitud al 100 % a 4 Hz, produce `1 vacil`.
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/fluctuation_strength.svg" alt="Intensidad de fluctuación frente a la frecuencia de modulación en un eje logarítmico: la curva de forma cerrada para ruido de banda ancha AM y el barrido del modelo de señal para tono AM muestran ambos una característica de paso de banda con máximo a 4 Hz" style="width:82%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/fluctuation_strength_dark.svg" alt="Intensidad de fluctuación frente a la frecuencia de modulación en un eje logarítmico: la curva de forma cerrada para ruido de banda ancha AM y el barrido del modelo de señal para tono AM muestran ambos una característica de paso de banda con máximo a 4 Hz" style="width:82%">
 
-### 3.1 Forma cerrada para ruido de banda ancha AM (Ec. 10.2)
-
-Para ruido de banda ancha modulado sinusoidalmente en amplitud, Fastl y Zwicker
-dan una forma cerrada (Ec. 10.2) en función del factor de modulación `m`, el
-nivel `L` y la frecuencia de modulación `fmod`:
-
-$$
-F = \frac{5{,}8\,(1{,}25\,m - 0{,}25)\,[0{,}05\,(L/\mathrm{dB}) - 1]}
-{(f_{mod}/5\,\mathrm{Hz})^2 + (4\,\mathrm{Hz}/f_{mod}) + 1{,}5}\ \ \mathrm{vacil}.
-$$
-
-El denominador es el paso de banda a `4 Hz`: alcanza su mínimo cerca de
-`fmod ≈ 3,7 Hz` y crece a ambos lados. El resultado se limita a `0` (la sensación
-desaparece por debajo de ~20 dB o `m < 0,2`). Esta forma exacta es el valor a
-citar para el ruido de banda ancha AM.
-
-```python
-import phonometry as ph
-
-print(round(ph.fluctuation_strength_am_noise(60.0, 1.0, 4.0), 4))   # 3.6943 vacil
-```
-
 <details>
-<summary>Ver el código de esta figura</summary>
+<summary>Mostrar el código de esta figura</summary>
 
 ```python
 import matplotlib.pyplot as plt
@@ -173,12 +151,12 @@ for fm in fm_tone:
     f_tone.append(ph.fluctuation_strength(am, float(fs)).fluctuation_strength)
 
 fig, ax = plt.subplots()
-ax.semilogx(fmod, f_bbn, label="AM broadband noise (closed form)")
+ax.semilogx(fmod, f_bbn, label="Ruido de banda ancha AM (forma cerrada)")
 ax2 = ax.twinx()
-ax2.plot(fm_tone, f_tone, "s--", color="tab:green", label="AM tone (signal model)")
+ax2.plot(fm_tone, f_tone, "s--", color="tab:green", label="Tono AM (modelo de señal)")
 ax.axvline(4.0, ls="--", color="0.4")
-ax.set_xlabel("Modulation frequency f_mod [Hz]")
-ax.set_ylabel("Fluctuation strength F [vacil]")
+ax.set_xlabel("Frecuencia de modulación f_mod [Hz]")
+ax.set_ylabel("Intensidad de fluctuación F [vacil]")
 h1, l1 = ax.get_legend_handles_labels()
 h2, l2 = ax2.get_legend_handles_labels()
 ax.legend(h1 + h2, l1 + l2, loc="upper right")
@@ -186,6 +164,28 @@ plt.show()
 ```
 
 </details>
+
+### 3.1 Forma cerrada para ruido de banda ancha AM (Ec. 10.2)
+
+Para ruido de banda ancha modulado sinusoidalmente en amplitud, Fastl y Zwicker
+dan una forma cerrada (Ec. 10.2) en función del factor de modulación `m`, el
+nivel `L` y la frecuencia de modulación `fmod`:
+
+$$
+F = \frac{5{,}8\,(1{,}25\,m - 0{,}25)\,[0{,}05\,(L/\mathrm{dB}) - 1]}
+{(f_{mod}/5\,\mathrm{Hz})^2 + (4\,\mathrm{Hz}/f_{mod}) + 1{,}5}\ \ \mathrm{vacil}.
+$$
+
+El denominador es el paso de banda a `4 Hz`: alcanza su mínimo cerca de
+`fmod ≈ 3,7 Hz` y crece a ambos lados. El resultado se limita a `0` (la sensación
+desaparece por debajo de ~20 dB o `m < 0,2`). Esta forma exacta es el valor a
+citar para el ruido de banda ancha AM.
+
+```python
+import phonometry as ph
+
+print(round(ph.fluctuation_strength_am_noise(60.0, 1.0, 4.0), 4))   # 3.6943 vacil
+```
 
 ### 3.2 El modelo de señal de Osses 2016
 

--- a/site/src/content/docs/es/guides/reverberation-prediction.md
+++ b/site/src/content/docs/es/guides/reverberation-prediction.md
@@ -29,6 +29,29 @@ $c_0 = 343\ \mathrm{m/s}$) y el término de absorción del aire $4mV$.
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/reverberation_models_es.svg" alt="Tiempo de reverberación por banda de octava para una sala con suelo y techo absorbentes pero paredes duras, calculado por cinco modelos" style="width:82%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/reverberation_models_es_dark.svg" alt="Tiempo de reverberación por banda de octava para una sala con suelo y techo absorbentes pero paredes duras, calculado por cinco modelos" style="width:82%">
 
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+import matplotlib.pyplot as plt
+from phonometry import environmental, room
+
+# Una sala de 10 x 7 x 3.5 m: paredes frontales duras, paredes laterales con
+# tratamiento ligero y un par suelo/techo muy absorbente (moqueta y techo acústico).
+bands = [125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0]
+alpha_x = [0.06, 0.07, 0.08, 0.09, 0.10, 0.10]
+alpha_y = [0.12, 0.14, 0.16, 0.18, 0.20, 0.20]
+alpha_z = [0.30, 0.50, 0.65, 0.78, 0.82, 0.80]
+m = environmental.air_attenuation_m(bands, 20.0, 50.0)   # aire a 20 C / 50 % HR
+res = room.reverberation_time_models((10.0, 7.0, 3.5),
+                                     (alpha_x, alpha_y, alpha_z),
+                                     air_attenuation=m, frequencies=bands)
+res.plot()   # las cinco curvas de modelo por banda
+plt.show()
+```
+
+</details>
+
 ## 1. Sabine, Eyring y Millington-Sette
 
 Los tres modelos estadísticos toman el volumen de la sala y una lista de

--- a/site/src/content/docs/es/guides/rotorcraft-noise.md
+++ b/site/src/content/docs/es/guides/rotorcraft-noise.md
@@ -31,6 +31,35 @@ h.plot()                                          # directividad proa-popa
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/rotorcraft_ground_effect_es.svg" alt="Ajuste por efecto de suelo de rotorcraft frente a la frecuencia de 1/3 de octava para suelo duro y blando, con refuerzo a baja frecuencia, un valle de interferencia profundo y la región incoherente de alta frecuencia" style="width:82%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/rotorcraft_ground_effect_es_dark.svg" alt="Ajuste por efecto de suelo de rotorcraft frente a la frecuencia de 1/3 de octava para suelo duro y blando, con refuerzo a baja frecuencia, un valle de interferencia profundo y la región incoherente de alta frecuencia" style="width:82%">
 
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import aircraft
+
+freqs = 1000.0 * 10.0 ** (np.arange(-13, 11) / 10.0)   # tercios 50 Hz-10 kHz
+hs, hr, dp = 150.0, 1.5, 500.0                          # geometría de sobrevuelo
+grass = aircraft.ground_effect_adjustment(freqs, hs, hr, dp, flow_resistivity="D")
+asphalt = aircraft.ground_effect_adjustment(freqs, hs, hr, dp, flow_resistivity="G")
+
+fig, ax = plt.subplots()
+ax.axhline(0.0, color="0.5", linewidth=1.0)
+ax.semilogx(freqs, asphalt, marker="o", markersize=3,
+            label="Duro (asfalto/hormigón, clase G)")
+ax.semilogx(freqs, grass, marker="s", markersize=3,
+            label="Blando (hierba/pasto, clase D)")
+ax.set(xlabel="Frecuencia central de banda de tercio de octava [Hz]",
+       ylabel="Ajuste por efecto de suelo ΔLg [dB]",
+       title="Efecto de suelo de rotorcraft (ECAC Doc 32, Chien-Soroka)")
+ax.grid(True, which="both", alpha=0.3)
+ax.legend()
+plt.show()
+```
+
+</details>
+
 El nivel del hemisferio a 60 m se lleva al receptor con tres ajustes (§A.4):
 `spherical_spreading_adjustment` (`ΔLs = −20·log10(r/60)`, Ec. 24),
 `atmospheric_adjustment` (`ΔLa = −α(f)·(r − 60)` con el coeficiente de

--- a/site/src/content/docs/es/guides/sound-power.md
+++ b/site/src/content/docs/es/guides/sound-power.md
@@ -39,6 +39,43 @@ turno.
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/sound_power_methods_es.svg" alt="Las tres vías de potencia sonora en paralelo: una superficie envolvente de presión sobre un plano reflectante (ISO 3744/3746), una fuente en una sala reverberante muestreada por micrófonos (ISO 3741) y una sonda de intensidad barriendo una superficie alrededor de la fuente (ISO 9614-2)" style="width:92%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/sound_power_methods_es_dark.svg" alt="Las tres vías de potencia sonora en paralelo: una superficie envolvente de presión sobre un plano reflectante (ISO 3744/3746), una fuente en una sala reverberante muestreada por micrófonos (ISO 3741) y una sonda de intensidad barriendo una superficie alrededor de la fuente (ISO 9614-2)" style="width:92%">
 
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import emission
+
+# Una fuente estacionaria (LW por bandas de octava abajo) por tres vías.
+freqs = np.array([125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
+lw_true = np.array([85.0, 88.0, 90.0, 89.0, 86.0, 82.0])
+
+# ISO 3744: SPL en 10 posiciones de una semiesfera, r = 2 m (10 lg(S/S0) = 14 dB).
+pres = emission.sound_power_pressure(np.tile(lw_true - 14.0, (10, 1)),
+                                     "hemisphere", radius=2.0,
+                                     frequencies=freqs)
+# ISO 9614-2: intensidad normal uniforme barrida sobre seis segmentos de 0.5 m2.
+i_n = np.tile(10.0 ** (lw_true / 10.0) * 1e-12 / 3.0, (6, 1))
+inten = emission.sound_power_intensity(i_n, np.full(6, 0.5),
+                                       frequencies=freqs, band_type="octave")
+# ISO 3741: comparación con una fuente de referencia de LW = 84 dB conocido por banda.
+comp = emission.sound_power_comparison(lw_true - 20.0, np.full(6, 64.0),
+                                       np.full(6, 84.0), frequencies=freqs)
+
+fig, ax = plt.subplots()
+for res, style, ms, label in ((pres, "-o", 11, "presión (ISO 3744)"),
+                              (inten, "--s", 8, "intensidad (ISO 9614-2)"),
+                              (comp, ":^", 5, "fuente de referencia (ISO 3741)")):
+    ax.semilogx(freqs, res.sound_power_level, style, markersize=ms,
+                label=f"{label}: LWA = {res.sound_power_level_a:.1f} dB")
+ax.set(xlabel="Frecuencia [Hz]", ylabel="Nivel de potencia sonora LW [dB]")
+ax.legend()
+plt.show()
+```
+
+</details>
+
 <video class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_power_two_rooms_es.webm" preload="none" poster="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_power_two_rooms_es_poster.jpg" width="2400" height="1350" loop muted controls playsinline title="Animación: la misma fuente en una cámara anecoica y en una cámara reverberante produce presiones de micrófono distintas, y las fórmulas de campo libre y campo difuso convergen al mismo nivel de potencia sonora L_W" style="width:88%"></video><video class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_power_two_rooms_es_dark.webm" preload="none" poster="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_power_two_rooms_es_dark_poster.jpg" width="2400" height="1350" loop muted controls playsinline title="Animación: la misma fuente en una cámara anecoica y en una cámara reverberante produce presiones de micrófono distintas, y las fórmulas de campo libre y campo difuso convergen al mismo nivel de potencia sonora L_W" style="width:88%"></video>
 
 ### Una ruta de decisión
@@ -174,7 +211,7 @@ correcciones de fondo (`K1`) y ambiental (`K2`) más el término de superficie
 número único `LWA` del título.*
 
 <details>
-<summary>Ver el código de esta figura</summary>
+<summary>Mostrar el código de esta figura</summary>
 
 ```python
 import matplotlib.pyplot as plt
@@ -343,7 +380,7 @@ de octava, y la suma energética ponderada A entre las 21 bandas da el `LWA` del
 título.*
 
 <details>
-<summary>Ver el código de esta figura</summary>
+<summary>Mostrar el código de esta figura</summary>
 
 ```python
 import matplotlib.pyplot as plt
@@ -486,7 +523,7 @@ criterios de indicadores de campo en grado de ingeniería, así que las seis
 barras se sostienen, y el total ponderado A de 90,9 dB(A) encabeza el título.*
 
 <details>
-<summary>Ver el código de esta figura</summary>
+<summary>Mostrar el código de esta figura</summary>
 
 ```python
 import matplotlib.pyplot as plt
@@ -634,7 +671,7 @@ de área, ruido de fondo y meteorológica dan `LW(f)`, y la suma energética pon
 A entre bandas da el número único `LWA` del título.*
 
 <details>
-<summary>Ver el código de esta figura</summary>
+<summary>Mostrar el código de esta figura</summary>
 
 ```python
 import matplotlib.pyplot as plt
@@ -721,7 +758,7 @@ ISO 9614-3 la declara no aplicable —la figura la trama y la agrisa mientras la
 cuatro bandas determinadas y el total ponderado A se mantienen.*
 
 <details>
-<summary>Ver el código de esta figura</summary>
+<summary>Mostrar el código de esta figura</summary>
 
 ```python
 import matplotlib.pyplot as plt

--- a/site/src/content/docs/es/guides/sound-quality.md
+++ b/site/src/content/docs/es/guides/sound-quality.md
@@ -28,6 +28,33 @@ la $k = 0{,}108$ derivada queda dentro de la ventana normativa 0,105–0,115).
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/sharpness_weighting_es.svg" alt="Ponderación de nitidez g(z) de DIN 45692 frente a la razón de banda crítica en eje logarítmico, comparando las curvas DIN, von Bismarck y Aures con los codos de 15,8 y 15 Bark marcados" style="width:80%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/sharpness_weighting_es_dark.svg" alt="Ponderación de nitidez g(z) de DIN 45692 frente a la razón de banda crítica en eje logarítmico, comparando las curvas DIN, von Bismarck y Aures con los codos de 15,8 y 15 Bark marcados" style="width:80%">
 
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+
+# Ponderación de nitidez g(z) de DIN 45692: Ec. (1) más las variantes informativas del Anexo B
+z = np.arange(1, 241) * 0.1                     # bins de Bark, 0.1 .. 24.0
+g_din = np.where(z > 15.8, 0.15 * np.exp(0.42 * (z - 15.8)) + 0.85, 1.0)
+g_bis = np.where(z > 15.0, 0.2 * np.exp(0.308 * (z - 15.0)) + 0.8, 1.0)
+n = 4.0                                         # Aures depende de la sonoridad total (sonos)
+g_aures = 0.078 * np.exp(0.171 * z) / z * (n / np.log(n * 0.05 + 1.0))
+
+fig, ax = plt.subplots()
+ax.semilogy(z, g_din, label="DIN 45692 g(z)")
+ax.semilogy(z, g_bis, "--", label="von Bismarck (Anexo B)")
+ax.semilogy(z, g_aures, "-.", label="Aures (Anexo B, N = 4 sonos)")
+ax.axvline(15.8, linestyle=":", color="0.5")    # codo DIN: g crece a partir de 15.8 Bark
+ax.set(xlabel="Razón de banda crítica z [Bark]", ylabel="Ponderación g(z)")
+ax.grid(True, which="both", alpha=0.3)
+ax.legend()
+plt.show()
+```
+
+</details>
+
 ```python
 import numpy as np
 from phonometry import sharpness_din
@@ -117,7 +144,7 @@ res.plot()   # aspereza R(l50) dependiente del tiempo + mapa de calor de asperez
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/tonality_roughness_demo_es.svg" alt="Demostración de calidad sonora ECMA-418-2: un sonido tonal puntúa alta tonalidad y aspereza casi nula, mientras que un sonido modulado en amplitud a 70 Hz puntúa alta aspereza y baja tonalidad" style="width:80%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/tonality_roughness_demo_es_dark.svg" alt="Demostración de calidad sonora ECMA-418-2: un sonido tonal puntúa alta tonalidad y aspereza casi nula, mientras que un sonido modulado en amplitud a 70 Hz puntúa alta aspereza y baja tonalidad" style="width:80%">
 
 <details>
-<summary>Ver el código de esta figura</summary>
+<summary>Mostrar el código de esta figura</summary>
 
 ```python
 import matplotlib.pyplot as plt

--- a/site/src/content/docs/es/guides/speech-transmission.md
+++ b/site/src/content/docs/es/guides/speech-transmission.md
@@ -53,6 +53,38 @@ efectiva de la *envolvente*, llevada a [0, 1].
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/sti_vs_t60_es.svg" alt="STI frente al tiempo de reverberación con las bandas de calificación del Anexo F de IEC 60268-16 sombreadas" style="width:80%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/sti_vs_t60_es_dark.svg" alt="STI frente al tiempo de reverberación con las bandas de calificación del Anexo F de IEC 60268-16 sombreadas" style="width:80%">
 
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+import numpy as np
+import matplotlib.pyplot as plt
+from phonometry import sti_from_impulse_response
+
+fs = 48000
+
+# STI frente al tiempo de reverberación: barre sti_from_impulse_response sobre
+# decaimientos exponenciales sintéticos (ruido blanco x exp(-6.9077 t / T60))
+# en una rejilla de T60, exactamente la física de la curva de arriba:
+rng = np.random.default_rng(0)
+t60_grid = np.array([0.3, 0.5, 0.8, 1.2, 1.6, 2.0, 2.5, 3.0, 4.0, 5.0])
+sti_values = []
+for t60 in t60_grid:
+    t = np.arange(int(2 * t60 * fs)) / fs
+    ir = rng.standard_normal(t.size) * np.exp(-6.9077 * t / t60)
+    sti_values.append(sti_from_impulse_response(ir, fs).sti)
+
+fig, ax = plt.subplots()
+ax.semilogx(t60_grid, sti_values, "o-")
+ax.set_xlabel("Tiempo de reverberación T60 [s]")
+ax.set_ylabel("STI")
+ax.set_ylim(0.0, 1.0)
+ax.grid(True, which="both", alpha=0.3)
+plt.show()
+```
+
+</details>
+
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_sti_chain_es.svg" alt="Cadena de medición del STI: señal de la fuente STIPA a través de la sala hasta el micrófono y el análisis de la MTF" style="width:92%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_sti_chain_es_dark.svg" alt="Cadena de medición del STI: señal de la fuente STIPA a través de la sala hasta el micrófono y el análisis de la MTF" style="width:92%">
 
 ## 2. Medición indirecta y directa (STIPA)
@@ -75,38 +107,6 @@ recording = test                       # en la práctica, la señal del micrófo
 res = stipa(recording, fs)
 res.plot()   # barras del índice de transferencia de modulación (MTI) por banda; STI y valoración en el título
 ```
-
-<details>
-<summary>Ver el código de esta figura</summary>
-
-```python
-import numpy as np
-import matplotlib.pyplot as plt
-from phonometry import sti_from_impulse_response
-
-fs = 48000
-
-# STI frente al tiempo de reverberación: barre sti_from_impulse_response sobre
-# decaimientos exponenciales sintéticos (ruido blanco x exp(-6.9077 t / T60))
-# en una rejilla de T60 — exactamente la física de la curva de arriba:
-rng = np.random.default_rng(0)
-t60_grid = np.array([0.3, 0.5, 0.8, 1.2, 1.6, 2.0, 2.5, 3.0, 4.0, 5.0])
-sti_values = []
-for t60 in t60_grid:
-    t = np.arange(int(2 * t60 * fs)) / fs
-    ir = rng.standard_normal(t.size) * np.exp(-6.9077 * t / t60)
-    sti_values.append(sti_from_impulse_response(ir, fs).sti)
-
-fig, ax = plt.subplots()
-ax.semilogx(t60_grid, sti_values, "o-")
-ax.set_xlabel("Tiempo de reverberación T60 [s]")
-ax.set_ylabel("STI")
-ax.set_ylim(0.0, 1.0)
-ax.grid(True, which="both", alpha=0.3)
-plt.show()
-```
-
-</details>
 
 `stipa` emite un `UserWarning` cuando la grabación es más corta que los 15 s
 recomendados (práctica STIPA de IEC 60268-16, de 15 s a 25 s): por debajo de eso

--- a/site/src/content/docs/es/guides/structure-borne-power.md
+++ b/site/src/content/docs/es/guides/structure-borne-power.md
@@ -19,6 +19,36 @@ equipos instalados de EN 12354-5.
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/structure_borne_power_es.svg" alt="Nivel de potencia sonora estructural inyectada en placa receptora por banda de tercio de octava, determinado en una placa de baja movilidad y otra de alta movilidad" style="width:82%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/structure_borne_power_es_dark.svg" alt="Nivel de potencia sonora estructural inyectada en placa receptora por banda de tercio de octava, determinado en una placa de baja movilidad y otra de alta movilidad" style="width:82%">
 
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import building
+
+# La misma fuente tipo bomba medida sobre una placa receptora pesada y otra ligera.
+bands = np.array([50.0, 100.0, 200.0, 400.0, 800.0, 1600.0, 3150.0])
+lv_low = np.array([88.0, 90.0, 87.0, 84.0, 80.0, 76.0, 71.0])
+
+low = building.reception_plate_power(lv_low, bands, mass_per_area=600.0,
+                                     area=2.0, reverberation_time=0.8)
+high = building.reception_plate_power(lv_low + 6.0, bands, mass_per_area=150.0,
+                                      area=2.0, reverberation_time=0.5)
+
+x = np.arange(bands.size)
+fig, ax = plt.subplots()
+ax.bar(x - 0.2, low.power_level, width=0.4, label="placa de baja movilidad")
+ax.bar(x + 0.2, high.power_level, width=0.4, label="placa de alta movilidad")
+ax.set_xticks(x, [f"{b:g}" for b in bands])
+ax.set(xlabel="Frecuencia [Hz]",
+       ylabel="Nivel de potencia estructural $L_{Ws}$ [dB re 1 pW]")
+ax.legend()
+plt.show()
+```
+
+</details>
+
 ## 1. Las relaciones de la placa receptora
 
 ¿Por qué una placa? Caracterizar la fuente directamente por sus fuerzas de
@@ -127,29 +157,6 @@ El homólogo directo del lado de la fuente es el nivel de velocidad libre de
 ISO 9611 (re `v₀ = 5·10⁻⁸ m/s`) medido en los puntos de contacto de maquinaria
 montada elásticamente; su media por posiciones de la ecuación (9) es
 `mean_free_velocity_level()`.
-
-<details>
-<summary>Mostrar el código de esta figura</summary>
-
-```python
-import matplotlib.pyplot as plt
-import numpy as np
-import phonometry as ph
-
-bands = np.array([50.0, 100.0, 200.0, 400.0, 800.0, 1600.0, 3150.0])
-lv_low = np.array([88.0, 90.0, 87.0, 84.0, 80.0, 76.0, 71.0])
-low = ph.reception_plate_power(lv_low, bands, mass_per_area=600.0, area=2.0,
-                               reverberation_time=0.8)
-high = ph.reception_plate_power(lv_low + 6.0, bands, mass_per_area=150.0, area=2.0,
-                                reverberation_time=0.5)
-x = np.arange(bands.size)
-plt.bar(x - 0.2, low.power_level, width=0.4, label="placa de baja movilidad")
-plt.bar(x + 0.2, high.power_level, width=0.4, label="placa de alta movilidad")
-plt.xticks(x, [f"{b:g}" for b in bands]); plt.legend()
-plt.xlabel("Frecuencia [Hz]"); plt.ylabel("$L_{Ws}$ [dB re 1 pW]"); plt.show()
-```
-
-</details>
 
 ## Referencias
 

--- a/site/src/content/docs/es/guides/tone-audibility.md
+++ b/site/src/content/docs/es/guides/tone-audibility.md
@@ -17,6 +17,27 @@ media `ΔL` que produce alimenta el ajuste tonal `Kt` de ISO 1996-2.
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/tone_audibility_es.svg" alt="Audibilidad ΔL por tono de los nueve tonos del espectro del motor de combustión del Anexo E de ISO/PAS 20065, con el tono decisivo a 137,3 Hz resaltado y el umbral ΔL = 0 dB marcado" style="width:82%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/tone_audibility_es_dark.svg" alt="Audibilidad ΔL por tono de los nueve tonos del espectro del motor de combustión del Anexo E de ISO/PAS 20065, con el tono decisivo a 137,3 Hz resaltado y el umbral ΔL = 0 dB marcado" style="width:82%">
 
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+import matplotlib.pyplot as plt
+from phonometry import psychoacoustics
+
+# Espectro 1 del motor de combustión (Anexo E de ISO/PAS 20065): nueve tonos
+# (fT, LT, LS) de un espectro de banda estrecha con separación de líneas de 2.7 Hz
+fT = [118.4, 137.3, 158.8, 314.9, 433.4, 592.2, 629.8, 643.3, 1582.7]
+LT = [64.56, 67.96, 68.63, 68.50, 73.17, 78.31, 75.00, 79.75, 71.07]
+LS = [48.91, 49.22, 50.50, 52.85, 58.29, 59.53, 59.71, 61.98, 54.16]
+
+res = psychoacoustics.assess_tones(fT, LT, LS, 2.7)
+print(round(res.decisive_audibility, 2), res.decisive_frequency)  # 5.01 137.3
+res.plot()   # barras de audibilidad por tono, con el tono decisivo resaltado
+plt.show()
+```
+
+</details>
+
 ## 1. La banda crítica en torno al tono
 
 Cada tono de frecuencia `fT` se evalúa dentro de una banda crítica cuyo ancho es

--- a/site/src/content/docs/es/guides/transfer-stiffness.md
+++ b/site/src/content/docs/es/guides/transfer-stiffness.md
@@ -21,6 +21,37 @@ de predicción en edificación: ISO 9611, EN 15657 y EN 12354-5.
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/transfer_stiffness_es.svg" alt="Nivel de rigidez dinámica de transferencia de un aislador Kelvin-Voigt: el nivel real y la estimación por el método indirecto, que diverge en la resonancia masa/resorte y converge por encima de ella" style="width:82%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/transfer_stiffness_es_dark.svg" alt="Nivel de rigidez dinámica de transferencia de un aislador Kelvin-Voigt: el nivel real y la estimación por el método indirecto, que diverge en la resonancia masa/resorte y converge por encima de ella" style="width:82%">
 
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import vibration
+
+# Aislador Kelvin-Voigt k + jwc cargado con una masa de bloqueo de 8 kg.
+k, c, m2 = 1.0e6, 120.0, 8.0
+f0 = np.sqrt(k / m2) / (2.0 * np.pi)
+f = np.logspace(np.log10(f0 / 5.0), np.log10(f0 * 40.0), 600)
+
+k_true = k + 1j * 2.0 * np.pi * f * c
+t = vibration.base_transmissibility(f, m2, k, c)
+k_indirect = vibration.transfer_stiffness_indirect(f, t, m2)  # avisa donde T no es pequeña
+
+fig, ax = plt.subplots()
+ax.semilogx(f, vibration.transfer_stiffness_level(k_true),
+            label="$L_k$ real de $k+j\\omega c$")
+ax.semilogx(f, vibration.transfer_stiffness_level(k_indirect), "--",
+            label="método indirecto $-(2\\pi f)^2 m_2 T$")
+ax.axvline(f0, color="0.6", linestyle=":", label="resonancia $f_0$")
+ax.set(xlabel="Frecuencia [Hz]", ylabel="Nivel de rigidez de transferencia $L_k$ [dB re 1 N/m]")
+ax.grid(True, which="both", alpha=0.3)
+ax.legend()
+plt.show()
+```
+
+</details>
+
 ## 1. El nivel de rigidez de transferencia y el factor de pérdidas
 
 Los resultados se expresan como un **nivel** re la rigidez de referencia
@@ -153,28 +184,6 @@ k = 1e6 + 5e4j                                  # N/m, a 250 Hz
 Z = ph.convert_frf(k, 250.0, "dynamic_stiffness", "impedance")
 print(abs(complex(ph.convert_frf(Z, 250.0, "impedance", "dynamic_stiffness"))))  # 1.0012e6
 ```
-
-<details>
-<summary>Mostrar el código de esta figura</summary>
-
-```python
-import matplotlib.pyplot as plt
-import numpy as np
-import phonometry as ph
-
-k, c, m2 = 1e6, 120.0, 8.0
-f0 = np.sqrt(k / m2) / (2 * np.pi)
-f = np.logspace(np.log10(f0 / 5), np.log10(f0 * 40), 600)
-w = 2 * np.pi * f
-t = ph.base_transmissibility(f, m2, k, c)
-plt.semilogx(f, ph.transfer_stiffness_level(k + 1j * w * c), label="$L_k$ real")
-plt.semilogx(f, ph.transfer_stiffness_level(ph.transfer_stiffness_indirect(f, t, m2)),
-             "--", label="método indirecto")
-plt.axvline(f0, ls=":", color="0.6"); plt.legend()
-plt.xlabel("Frecuencia [Hz]"); plt.ylabel("$L_k$ [dB re 1 N/m]"); plt.show()
-```
-
-</details>
 
 ## Referencias
 

--- a/site/src/content/docs/es/guides/underwater-propagation.md
+++ b/site/src/content/docs/es/guides/underwater-propagation.md
@@ -13,6 +13,26 @@ la **pérdida por transmisión**, la **velocidad del sonido** en agua de mar, la
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/underwater_transmission_loss_es.svg" alt="Pérdida por transmisión submarina frente a la distancia a 10 kHz, con las contribuciones de ensanchamiento geométrico y absorción de volumen dibujadas por separado, la pérdida creciente hacia abajo" style="width:82%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/underwater_transmission_loss_es_dark.svg" alt="Pérdida por transmisión submarina frente a la distancia a 10 kHz, con las contribuciones de ensanchamiento geométrico y absorción de volumen dibujadas por separado, la pérdida creciente hacia abajo" style="width:82%">
 
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import underwater
+
+# 10 kHz a 10 °C, 35 ppt y 100 m de profundidad; ensanchamiento "practical" con R0 = 1000 m.
+ranges = np.linspace(10.0, 20_000.0, 400)
+tl = underwater.transmission_loss(ranges, 10e3, law="practical",
+                                  transition_range=1000.0, temperature=10.0,
+                                  salinity=35.0, depth=100.0)
+print(f"alpha = {tl.absorption_coefficient:.2f} dB/km")   # alpha = 0.95 dB/km
+tl.plot()   # TL total con las contribuciones de ensanchamiento y absorción
+plt.show()
+```
+
+</details>
+
 La pérdida por transmisión es
 
 $$
@@ -40,6 +60,24 @@ tl.plot()   # TL frente a distancia con la separación ensanchamiento/absorción
 ## Velocidad del sonido en agua de mar
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/underwater_sound_speed_es.svg" alt="Perfil de velocidad del sonido en agua de mar con la ecuación UNESCO: capa de mezcla cálida, termoclina, eje del canal sonoro en el mínimo y la velocidad creciendo con la presión en profundidad" style="width:60%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/underwater_sound_speed_es_dark.svg" alt="Perfil de velocidad del sonido en agua de mar con la ecuación UNESCO: capa de mezcla cálida, termoclina, eje del canal sonoro en el mínimo y la velocidad creciendo con la presión en profundidad" style="width:60%">
+
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import underwater
+
+# Capa de mezcla cálida, termoclina hasta 4 °C y capa profunda isoterma.
+depths = np.linspace(0.0, 3000.0, 121)
+temps = 4.0 + 14.0 / (1.0 + (np.maximum(depths - 80.0, 0.0) / 250.0) ** 2)
+profile = underwater.sound_speed_profile(depths, temps, 35.0, model="unesco")
+profile.plot()   # velocidad del sonido frente a profundidad, mínimo en el eje del canal
+plt.show()
+```
+
+</details>
 
 `sea_water_sound_speed(T, S, depth, model=…)` usa la ecuación **UNESCO /
 Chen–Millero** (por defecto, en la forma Wong & Zhu 1995 ITS-90), **Del Grosso**
@@ -69,6 +107,25 @@ es la razón de que el sonido de baja frecuencia pueda cruzar océanos enteros.
 ## Ecuación del sonar
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/sonar_equation_es.svg" alt="Ecuación del sonar pasivo: el exceso de señal cae con la pérdida por transmisión y cruza el cero, el límite de detección, en la figura de mérito" style="width:82%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/sonar_equation_es_dark.svg" alt="Ecuación del sonar pasivo: el exceso de señal cae con la pérdida por transmisión y cruza el cero, el límite de detección, en la figura de mérito" style="width:82%">
+
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import underwater
+
+tl = np.linspace(40.0, 120.0, 400)
+se = underwater.passive_sonar_equation(source_level=140.0, transmission_loss=tl,
+                                       noise_level=60.0, directivity_index=15.0,
+                                       detection_threshold=8.0)
+print(f"figura de mérito = {se.figure_of_merit:.1f} dB")  # figura de mérito = 87.0 dB
+se.plot()   # exceso de señal frente a pérdida por transmisión, cruce por cero en la FOM
+plt.show()
+```
+
+</details>
 
 La ecuación del sonar da el **exceso de señal** $SE$ (detección cuando
 $SE \ge 0$) y la **figura de mérito** (la máxima pérdida por transmisión
@@ -104,6 +161,25 @@ convención de fuente, dB re 1 µPa²/Hz **a 1 m**.
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/seabed_reflection_es.svg" alt="Pérdida por reflexión en el fondo frente al ángulo rasante para un fondo arenoso rápido: pérdida nula por debajo del ángulo rasante crítico, creciendo bruscamente por encima" style="width:82%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/seabed_reflection_es_dark.svg" alt="Pérdida por reflexión en el fondo frente al ángulo rasante para un fondo arenoso rápido: pérdida nula por debajo del ángulo rasante crítico, creciendo bruscamente por encima" style="width:82%">
 
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import underwater
+
+# Reflexión de Rayleigh fluido-fluido: agua sobre un fondo arenoso rápido.
+phi = np.linspace(0.0, 90.0, 361)
+bl = underwater.bottom_reflection_loss(phi, rho1=1000.0, c1=1500.0,
+                                       rho2=1900.0, c2=1650.0)
+print(f"ángulo crítico = {bl.critical_angle:.1f} deg")   # ángulo crítico = 24.6 deg
+bl.plot()   # pérdida en el fondo frente al ángulo rasante
+plt.show()
+```
+
+</details>
+
 Una onda plana que incide en el fondo se refleja con el **coeficiente de
 reflexión de Rayleigh** fluido–fluido (Medwin & Clay). Para un fondo más rápido ($c_2 > c_1$)
 existe un **ángulo rasante crítico** $\varphi_c = \arccos(c_1/c_2)$, por
@@ -124,6 +200,29 @@ bl.plot()   # pérdida por reflexión frente al ángulo rasante
 ## Ruido ambiental oceánico
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/ocean_ambient_noise_es.svg" alt="Niveles espectrales de ruido ambiental de Wenz para dos velocidades de viento, con el ruido de viento cayendo 5 dB por octava y el ruido térmico creciendo por encima de unos 50 kHz" style="width:82%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/ocean_ambient_noise_es_dark.svg" alt="Niveles espectrales de ruido ambiental de Wenz para dos velocidades de viento, con el ruido de viento cayendo 5 dB por octava y el ruido térmico creciendo por encima de unos 50 kHz" style="width:82%">
+
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import underwater
+
+# Ruido ambiental de Wenz (regla de los cincos + térmico de Mellen) a dos vientos.
+freqs = np.logspace(2, 5.5, 300)
+fig, ax = plt.subplots()
+for u in (5.0, 20.0):
+    noise = underwater.ocean_ambient_noise(freqs, wind_speed_knots=u)
+    ax.semilogx(noise.frequency, noise.spectrum_level, label=f"Total ({u:.0f} kn)")
+ax.semilogx(freqs, underwater.thermal_noise_spectrum(freqs), ":", label="Térmico")
+ax.set(xlabel="Frecuencia [Hz]", ylabel="Nivel espectral [dB re 1 µPa²/Hz]")
+ax.legend()
+ax.grid(True, which="both", alpha=0.3)
+plt.show()
+```
+
+</details>
 
 El nivel espectral de ruido ambiental es la suma energética de las componentes
 físicas de Wenz: el ruido de **viento / superficie** por la "regla de los cincos"
@@ -146,6 +245,30 @@ noise.plot()   # espectro compuesto con las componentes viento/térmico
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/ship_traffic_noise_es.svg" alt="Espectros de nivel de fuente predichos por JOMOPANS-ECHO para un portacontenedores, un crucero y un remolcador, con los buques de carga mostrando una joroba de baja frecuencia por debajo de 100 Hz" style="width:82%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/ship_traffic_noise_es_dark.svg" alt="Espectros de nivel de fuente predichos por JOMOPANS-ECHO para un portacontenedores, un crucero y un remolcador, con los buques de carga mostrando una joroba de baja frecuencia por debajo de 100 Hz" style="width:82%">
 
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+import matplotlib.pyplot as plt
+from phonometry import underwater
+
+# Espectros de fuente JOMOPANS-ECHO para tres clases de buque (velocidad, eslora).
+fig, ax = plt.subplots()
+for vessel_class, speed, length in (("containership", 18.0, 300.0),
+                                    ("cruise", 17.1, 250.0),
+                                    ("tug", 3.7, 30.0)):
+    s = underwater.ship_source_spectrum(speed, length, vessel_class=vessel_class)
+    ax.semilogx(s.frequency, s.source_psd,
+                label=f"{vessel_class} ({speed:.0f} kn, {length:.0f} m)")
+ax.set(xlabel="Frecuencia [Hz]",
+       ylabel="Densidad espectral de fuente [dB re 1 µPa²/Hz a 1 m]")
+ax.legend()
+ax.grid(True, which="both", alpha=0.3)
+plt.show()
+```
+
+</details>
+
 Cuando no hay espectro medido, el nivel de fuente de un buque puede
 **estimarse** a partir de su clase, velocidad y eslora con **JOMOPANS-ECHO**
 (MacGillivray & de Jong 2021, por defecto, validado contra 1862 medidas),
@@ -166,6 +289,29 @@ noise = ph.ocean_ambient_noise(ship.frequency, wind_speed_knots=10.0,
 ## Solvers numéricos
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/numerical_propagation_es.png" alt="Un perfil de velocidad del sonido de Munk, trayectorias de rayos formando zonas de convergencia, y la pérdida por transmisión de modos normales frente a la ecuación parabólica coincidiendo en tendencia" style="width:100%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/numerical_propagation_es_dark.png" alt="Un perfil de velocidad del sonido de Munk, trayectorias de rayos formando zonas de convergencia, y la pérdida por transmisión de modos normales frente a la ecuación parabólica coincidiendo en tendencia" style="width:100%">
+
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import underwater
+
+# Un perfil de Munk de velocidad del sonido en aguas profundas.
+z = np.linspace(0.0, 5000.0, 60)
+eta = 2.0 * (z - 1300.0) / 1300.0
+c = 1500.0 * (1.0 + 0.00737 * (eta - 1.0 + np.exp(-eta)))
+
+# PE split-step de Fourier a 50 Hz; una malla gruesa mantiene el cálculo rápido.
+field = underwater.parabolic_equation(50.0, z, c, source_depth=1000.0,
+                                      max_range=50_000.0, range_step=50.0,
+                                      n_depth_points=512)
+field.plot()   # campo TL(z, r) mostrando las zonas de convergencia
+plt.show()
+```
+
+</details>
 
 Para entornos independientes de la distancia el campo puede calcularse
 numéricamente con tres solvers (Jensen et al., *Computational Ocean Acoustics*):

--- a/site/src/content/docs/es/guides/vibration-sound-power.md
+++ b/site/src/content/docs/es/guides/vibration-sound-power.md
@@ -30,6 +30,34 @@ en edificación (ISO 9611, EN 15657, EN 12354-5).
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/vibration_sound_power_es.svg" alt="Nivel de potencia sonora radiada por banda de octava, comparando el límite superior de la ISO/TS 7849-1 (factor de radiación igual a uno) con el valor de ingeniería de la ISO/TS 7849-2 (factor de radiación medido)" style="width:82%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/vibration_sound_power_es_dark.svg" alt="Nivel de potencia sonora radiada por banda de octava, comparando el límite superior de la ISO/TS 7849-1 (factor de radiación igual a uno) con el valor de ingeniería de la ISO/TS 7849-2 (factor de radiación medido)" style="width:82%">
 
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import emission
+
+# Niveles de velocidad superficial y un factor de radiación medido por banda.
+bands = np.array([125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
+lv = np.array([78.0, 82.0, 85.0, 83.0, 79.0, 74.0])
+eps = np.array([0.20, 0.45, 0.75, 0.95, 1.00, 1.00])
+
+lw_max = emission.radiated_sound_power_level(lv, 1.6)  # Parte 1, eps = 1
+lw_eng = emission.radiated_sound_power_level(lv, 1.6, radiation_factor=eps)  # Parte 2
+
+x = np.arange(bands.size)
+fig, ax = plt.subplots()
+ax.bar(x - 0.2, lw_max, width=0.4, label="límite superior Parte 1 ($\\varepsilon$ = 1)")
+ax.bar(x + 0.2, lw_eng, width=0.4, label="ingeniería Parte 2 ($\\varepsilon$ medido)")
+ax.set_xticks(x, [f"{b:g}" for b in bands])
+ax.set(xlabel="Frecuencia [Hz]", ylabel="Nivel de potencia sonora $L_W$ [dB re 1 pW]")
+ax.legend()
+plt.show()
+```
+
+</details>
+
 ## 1. Las dos partes
 
 Las dos partes difieren solo en el factor de radiación. La **Parte 1 (control)**
@@ -105,27 +133,6 @@ sustituye el `ε = 1` fijo por un `εⱼ` banda a banda determinado a partir de 
 referencia de la potencia radiada (intensidad ISO 9614), tras lo cual la
 medición de velocidad puede repetirse a bajo coste en máquinas nominalmente
 idénticas.
-
-<details>
-<summary>Mostrar el código de esta figura</summary>
-
-```python
-import matplotlib.pyplot as plt
-import numpy as np
-import phonometry as ph
-
-bands = np.array([125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
-lv = np.array([78.0, 82.0, 85.0, 83.0, 79.0, 74.0])
-eps = np.array([0.20, 0.45, 0.75, 0.95, 1.00, 1.00])
-x = np.arange(bands.size)
-plt.bar(x - 0.2, ph.radiated_sound_power_level(lv, 1.6), width=0.4, label="Parte 1 (ε=1)")
-plt.bar(x + 0.2, ph.radiated_sound_power_level(lv, 1.6, radiation_factor=eps),
-        width=0.4, label="Parte 2 (ε medido)")
-plt.xticks(x, [f"{b:g}" for b in bands]); plt.legend()
-plt.xlabel("Frecuencia [Hz]"); plt.ylabel("$L_W$ [dB re 1 pW]"); plt.show()
-```
-
-</details>
 
 ## Referencias
 

--- a/site/src/content/docs/es/guides/weighting.md
+++ b/site/src/content/docs/es/guides/weighting.md
@@ -337,6 +337,40 @@ desviación cero, holgadamente dentro del corredor de clase 1 (sombreado); los
 límites más amplios de clase 2 se muestran punteados. El corredor se ensancha
 en los extremos de banda donde solo se aplica un límite unilateral.*
 
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import WeightingFilter, verify_weighting_class, weighting_class_limits
+
+freqs, lower1, upper1 = weighting_class_limits(1)
+_, lower2, upper2 = weighting_class_limits(2)
+lo1, lo2 = np.clip(lower1, -7, 7), np.clip(lower2, -7, 7)
+
+fig, ax = plt.subplots(figsize=(10, 6.5))
+ax.fill_between(freqs, lo1, upper1, step="mid", alpha=0.10,
+                label="Región de aceptación de clase 1")
+ax.plot(freqs, upper1, drawstyle="steps-mid", label="Límite superior/inferior de clase 1")
+ax.plot(freqs, lo1, drawstyle="steps-mid", color="C1")
+ax.plot(freqs, upper2, ":", drawstyle="steps-mid", label="Límite superior/inferior de clase 2")
+ax.plot(freqs, lo2, ":", drawstyle="steps-mid", color="C2")
+
+for curve, marker in (("A", "o"), ("C", "s")):
+    bands = verify_weighting_class(WeightingFilter(48000, curve))["bands"]
+    f = [b["freq"] for b in bands]
+    dev = [b["deviation_db"] for b in bands]
+    ax.plot(f, dev, marker=marker, label=f"Desviación de la ponderación {curve} (48 kHz)")
+
+ax.set(xscale="log", xlim=(10, 20000), ylim=(-7, 7),
+       xlabel="Frecuencia [Hz]", ylabel="Desviación respecto al objetivo de diseño [dB]")
+ax.legend(fontsize=8, ncol=2)
+plt.show()
+```
+
+</details>
+
 ## Referencias
 
 - Fletcher, H., & Munson, W. A. (1933). Loudness, its definition, measurement

--- a/site/src/content/docs/guides/aircraft-noise.md
+++ b/site/src/content/docs/guides/aircraft-noise.md
@@ -103,6 +103,32 @@ print(report["passed"], report["checks"])
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/aircraft_atmospheric_absorption.svg" alt="Aircraft atmospheric absorption versus frequency for two path lengths; the SAE-Method band attenuation stays below the pure-tone mid-band value at high absorption" style="width:82%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/aircraft_atmospheric_absorption_dark.svg" alt="Aircraft atmospheric absorption versus frequency for two path lengths; the SAE-Method band attenuation stays below the pure-tone mid-band value at high absorption" style="width:82%">
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import aircraft
+
+freqs = 1000.0 * 10.0 ** (np.arange(-13, 11) / 10.0)   # 50 Hz-10 kHz thirds
+fig, ax = plt.subplots()
+# solid: SAE band attenuation, dashed: pure-tone mid-band
+for s in (1000.0, 7620.0):
+    att = aircraft.sae_band_attenuation(freqs, s, temperature=25.0, relative_humidity=70.0)
+    line, = ax.semilogx(att.frequency, att.band_attenuation, marker="o",
+                        markersize=3, label=f"SAE band ({s:.0f} m)")
+    ax.semilogx(att.frequency, att.midband_attenuation, "--", alpha=0.6,
+                color=line.get_color())
+ax.set(xlabel="Frequency [Hz]", ylabel="Attenuation [dB]",
+       title="Aircraft atmospheric absorption at 25 °C, 70% RH")
+ax.grid(True, which="both", alpha=0.3)
+ax.legend()
+plt.show()
+```
+
+</details>
+
 Correcting a measured flyover to reference atmospheric conditions needs the
 one-third-octave-band attenuation over the path. The pure-tone coefficient is
 the ISO 9613-1 one (identical, per ARP 5534 §3.1) provided by `air_attenuation`;
@@ -126,6 +152,34 @@ Valid roughly 6–32 °C, 20–95 % RH (14 CFR Part 36 window), to 7620 m, recip
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/airport_noise.svg" alt="Noise-power-distance curves for two engine power settings, the event level falling log-linearly with slant distance between the tabulated nodes" style="width:82%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/airport_noise_dark.svg" alt="Noise-power-distance curves for two engine power settings, the event level falling log-linearly with slant distance between the tabulated nodes" style="width:82%">
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+from phonometry import aircraft
+
+# A schematic NPD table: SEL vs slant distance for two thrust settings.
+powers = [12000.0, 20000.0]
+distances = [200.0, 400.0, 630.0, 1000.0, 2000.0, 4000.0, 6300.0, 10000.0]
+levels = [[98.5, 92.0, 88.2, 83.6, 76.8, 69.4, 63.9, 56.8],
+          [107.2, 100.9, 97.2, 92.7, 86.0, 78.5, 72.9, 65.6]]
+
+fig, ax = plt.subplots()
+for p in (20000.0, 12000.0):
+    curve = aircraft.npd_curve(powers, distances, levels, power=p)
+    line, = ax.semilogx(curve.distance, curve.level, label=f"P = {p:.0f} N")
+    ax.semilogx(curve.table_distances, curve.table_levels, "o", markersize=4,
+                color=line.get_color())
+ax.set(xlabel="Slant distance [m]", ylabel="Event level [dB]",
+       title="Noise-power-distance curves (ECAC Doc 29)")
+ax.grid(True, which="both", alpha=0.3)
+ax.legend()
+plt.show()
+```
+
+</details>
+
 The ECAC Doc 29 airport-noise method describes an aircraft with **noise-power-
 distance (NPD)** tables. `npd_level` reads the event level (`LAmax`/`SEL`) for an
 arbitrary power and distance, interpolating linearly in power (Eq. 4-3) and
@@ -147,6 +201,37 @@ This is the NPD engine underneath the method.
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/airport_contour.png" alt="Single-event SEL contour of a departure: an elongated footprint along the flight track, loudest near the ground roll" style="width:90%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/airport_contour_dark.png" alt="Single-event SEL contour of a departure: an elongated footprint along the flight track, loudest near the ground roll" style="width:90%">
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import aircraft
+
+# NPD tables (SEL and LAmax) for one aircraft, two power settings.
+powers = [8000.0, 12000.0]
+distances = [60.0, 120.0, 240.0, 480.0, 960.0, 1920.0, 3840.0, 7680.0]
+sel = [[98.0, 92.0, 86.0, 80.0, 74.0, 68.0, 62.0, 56.0],
+       [104.0, 98.0, 92.0, 86.0, 80.0, 74.0, 68.0, 62.0]]
+lmax = [[94.0, 88.0, 82.0, 76.0, 70.0, 64.0, 58.0, 52.0],
+        [100.0, 94.0, 88.0, 82.0, 76.0, 70.0, 64.0, 58.0]]
+
+# Departure: ground roll along +x, then a steady climb.
+xs = np.linspace(0.0, 18000.0, 40)
+z = np.clip((xs - 1500.0) * 0.11, 0.0, 2500.0)
+power = np.where(xs < 3000.0, 12000.0, 10000.0)
+path = np.column_stack([xs, np.zeros_like(xs), z, power, np.full_like(xs, 82.3)])
+
+contour = aircraft.noise_contour(path, powers, distances, sel, lmax,
+                                 x=np.linspace(-2500.0, 20000.0, 56),
+                                 y=np.linspace(-6000.0, 6000.0, 44))
+contour.plot()   # single-event SEL footprint (needs matplotlib)
+plt.show()
+```
+
+</details>
+
 The full single-event calculation breaks a flight path into segments and
 corrects the NPD baseline per segment (§4.3-4.5): `impedance_adjustment` (T, p),
 `lateral_attenuation` (β,ℓ), `engine_installation_correction` (φ, mounting),
@@ -167,6 +252,31 @@ noise: strongest near an azimuth ψ ≈ 120° from the nose, falling off abeam
 (ψ = 90°) and directly behind (ψ = 180°).
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/airport_sor.svg" alt="Polar diagram of the start-of-roll directivity ΔSOR over the rearward semicircle for turbofan-jet and turboprop aircraft, both showing a lobe near 120° from the nose" style="width:75%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/airport_sor_dark.svg" alt="Polar diagram of the start-of-roll directivity ΔSOR over the rearward semicircle for turbofan-jet and turboprop aircraft, both showing a lobe near 120° from the nose" style="width:75%">
+
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+import phonometry as ph
+
+az = np.linspace(90.0, 270.0, 361)              # rearward semicircle
+psi = np.where(az <= 180.0, az, 360.0 - az)     # ΔSOR is left/right symmetric
+jet = [ph.start_of_roll_directivity(p, 300.0, "jet") for p in psi]
+prop = [ph.start_of_roll_directivity(p, 300.0, "turboprop") for p in psi]
+
+ax = plt.subplot(projection="polar")
+ax.set_theta_zero_location("N")                 # nose up, azimuth clockwise
+ax.set_theta_direction(-1)
+ax.plot(np.radians(az), jet, label="Turbofan jet")
+ax.plot(np.radians(az), prop, label="Turboprop")
+ax.set_rlim(-16.0, 0.0)                         # radial axis: dB re abeam
+ax.legend(loc="lower center")
+plt.show()
+```
+
+</details>
 
 ```python
 import numpy as np

--- a/site/src/content/docs/guides/block-processing.md
+++ b/site/src/content/docs/guides/block-processing.md
@@ -22,6 +22,43 @@ single full-signal pass.
 result exactly; without state, every block boundary restarts the filter
 transient.*
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import metrology
+
+# 1 kHz octave band: four stateful blocks vs one continuous pass
+fs, block = 8000, 1000
+rng = np.random.default_rng(42)
+x = rng.standard_normal(4 * block)
+t = np.arange(x.size) / fs
+
+bank = metrology.OctaveFilterBank(fs, fraction=1, limits=[900, 1100],
+                                  stateful=True, resample=False)
+streamed = np.concatenate([
+    bank.filter(x[i * block:(i + 1) * block], sigbands=True,
+                detrend=False, calculate_level=False)[2][0]
+    for i in range(4)
+])
+offline = metrology.OctaveFilterBank(fs, fraction=1, limits=[900, 1100],
+                                     resample=False).filter(
+    x, sigbands=True, detrend=False, calculate_level=False)[2][0]
+print(np.max(np.abs(streamed - offline)))     # 0.0 (bit-exact)
+
+fig, ax = plt.subplots(figsize=(9, 4.5))
+ax.plot(t, offline, linewidth=2.5, alpha=0.35, label="Continuous (whole signal)")
+ax.plot(t, streamed, label="Stateful blocks (state carried)")
+ax.axvline(block / fs, color="gray", linestyle=":", label="Block boundary")
+ax.set(xlim=(0.11, 0.17), xlabel="Time [s]", ylabel="Amplitude")
+ax.legend()
+plt.show()
+```
+
+</details>
+
 Create a stateful filter bank with `stateful=True`. The internal state is
 zero-initialized by default but may be initialized for step-response
 steady-state (like `scipy.signal.sosfilt_zi`) with `steady_ic=True`. The

--- a/site/src/content/docs/guides/dynamic-stiffness.md
+++ b/site/src/content/docs/guides/dynamic-stiffness.md
@@ -16,6 +16,23 @@ explicitly excludes floating floors.)
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/dynamic_stiffness.svg" alt="Floating-floor natural frequency versus the resilient layer's dynamic stiffness per unit area for a light and a heavy floating floor, with a worked design point" style="width:82%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/dynamic_stiffness_dark.svg" alt="Floating-floor natural frequency versus the resilient layer's dynamic stiffness per unit area for a light and a heavy floating floor, with a worked design point" style="width:82%">
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+import phonometry as ph
+
+s = np.logspace(np.log10(2.0), np.log10(100.0), 300)   # MN/m3
+for m in (40.0, 120.0):
+    plt.semilogx(s, ph.natural_frequency(s * 1e6, m), label=f"m' = {m:g} kg/m²")
+plt.xlabel("Dynamic stiffness s' [MN/m³]"); plt.ylabel("Natural frequency f₀ [Hz]")
+plt.legend(); plt.show()
+```
+
+</details>
+
 ## 1. Dynamic stiffness and resonance
 
 The dynamic stiffness per unit area is a dynamic force per area divided by the
@@ -88,23 +105,6 @@ res = ph.floating_floor_resonance(
 print(round(res.dynamic_stiffness / 1e6, 2), round(res.natural_frequency, 1))
 # 10.49 47.1
 ```
-
-<details>
-<summary>Show the code for this figure</summary>
-
-```python
-import matplotlib.pyplot as plt
-import numpy as np
-import phonometry as ph
-
-s = np.logspace(np.log10(2.0), np.log10(100.0), 300)   # MN/m3
-for m in (40.0, 120.0):
-    plt.semilogx(s, ph.natural_frequency(s * 1e6, m), label=f"m' = {m:g} kg/m²")
-plt.xlabel("Dynamic stiffness s' [MN/m³]"); plt.ylabel("Natural frequency f₀ [Hz]")
-plt.legend(); plt.show()
-```
-
-</details>
 
 The `DynamicStiffnessResult` carries the apparent, enclosed-gas and installed
 stiffnesses, the test resonance and the installed-floor natural frequency, and

--- a/site/src/content/docs/guides/filter-banks.md
+++ b/site/src/content/docs/guides/filter-banks.md
@@ -162,6 +162,24 @@ Full spectral view of the filter banks for Octave (1/1) and 1/3-Octave fractions
 | **Elliptic** | <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_ellip_fraction_1_order_6.svg" alt="Elliptic octave-band filter bank frequency response" style="width:100%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_ellip_fraction_1_order_6_dark.svg" alt="Elliptic octave-band filter bank frequency response" style="width:100%"> | <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_ellip_fraction_3_order_6.svg" alt="Elliptic one-third-octave filter bank frequency response" style="width:100%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_ellip_fraction_3_order_6_dark.svg" alt="Elliptic one-third-octave filter bank frequency response" style="width:100%"> |
 | **Bessel** | <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_bessel_fraction_1_order_6.svg" alt="Bessel octave-band filter bank frequency response" style="width:100%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_bessel_fraction_1_order_6_dark.svg" alt="Bessel octave-band filter bank frequency response" style="width:100%"> | <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_bessel_fraction_3_order_6.svg" alt="Bessel one-third-octave filter bank frequency response" style="width:100%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_bessel_fraction_3_order_6_dark.svg" alt="Bessel one-third-octave filter bank frequency response" style="width:100%"> |
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+from phonometry import metrology
+
+# One figure per architecture and fraction: the whole response gallery
+fs = 48000
+for ftype in ("butter", "cheby1", "cheby2", "ellip", "bessel"):
+    for fraction in (1, 3):
+        # show=True draws the bank's frequency response
+        metrology.OctaveFilterBank(fs=fs, fraction=fraction, order=6,
+                                   limits=[12, 20000], filter_type=ftype,
+                                   show=True)
+```
+
+</details>
+
 ## 5. Filter Usage and Examples
 
 ### 1. Butterworth (`butter`)
@@ -184,6 +202,19 @@ spl, freq = octave_filter(x, fs, filter_type='butter')
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_butter_fraction_3_order_6.svg" alt="Butterworth one-third-octave filter bank frequency response" style="width:60%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_butter_fraction_3_order_6_dark.svg" alt="Butterworth one-third-octave filter bank frequency response" style="width:60%">
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+from phonometry import metrology
+
+# Draw this bank's response (1/3 octave, order 6, Butterworth)
+metrology.OctaveFilterBank(fs=48000, fraction=3, order=6, limits=[12, 20000],
+                           filter_type='butter', show=True)
+```
+
+</details>
+
 ### 2. Chebyshev I (`cheby1`)
 
 Chebyshev Type I filters provide a **steeper roll-off** than Butterworth at the
@@ -197,6 +228,19 @@ spl, freq = octave_filter(x, fs, filter_type='cheby1', ripple=0.1)
 ```
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_cheby1_fraction_3_order_6.svg" alt="Chebyshev I one-third-octave filter bank frequency response" style="width:60%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_cheby1_fraction_3_order_6_dark.svg" alt="Chebyshev I one-third-octave filter bank frequency response" style="width:60%">
+
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+from phonometry import metrology
+
+# Draw this bank's response (1/3 octave, order 6, Chebyshev I)
+metrology.OctaveFilterBank(fs=48000, fraction=3, order=6, limits=[12, 20000],
+                           filter_type='cheby1', ripple=0.1, show=True)
+```
+
+</details>
 
 ### 3. Chebyshev II (`cheby2`)
 
@@ -213,6 +257,19 @@ spl, freq = octave_filter(x, fs, filter_type='cheby2')
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_cheby2_fraction_3_order_6.svg" alt="Chebyshev II one-third-octave filter bank frequency response" style="width:60%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_cheby2_fraction_3_order_6_dark.svg" alt="Chebyshev II one-third-octave filter bank frequency response" style="width:60%">
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+from phonometry import metrology
+
+# Draw this bank's response (1/3 octave, order 6, Chebyshev II)
+metrology.OctaveFilterBank(fs=48000, fraction=3, order=6, limits=[12, 20000],
+                           filter_type='cheby2', show=True)
+```
+
+</details>
+
 ### 4. Elliptic (`ellip`)
 
 Elliptic (Cauer) filters have the **shortest transition width** (steepest
@@ -225,6 +282,19 @@ spl, freq = octave_filter(x, fs, filter_type='ellip', ripple=0.1)
 ```
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_ellip_fraction_3_order_6.svg" alt="Elliptic one-third-octave filter bank frequency response" style="width:60%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_ellip_fraction_3_order_6_dark.svg" alt="Elliptic one-third-octave filter bank frequency response" style="width:60%">
+
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+from phonometry import metrology
+
+# Draw this bank's response (1/3 octave, order 6, Elliptic)
+metrology.OctaveFilterBank(fs=48000, fraction=3, order=6, limits=[12, 20000],
+                           filter_type='ellip', ripple=0.1, show=True)
+```
+
+</details>
 
 ### 5. Bessel (`bessel`)
 
@@ -239,6 +309,19 @@ spl, freq = octave_filter(x, fs, filter_type='bessel')
 ```
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_bessel_fraction_3_order_6.svg" alt="Bessel one-third-octave filter bank frequency response" style="width:60%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/filter_bessel_fraction_3_order_6_dark.svg" alt="Bessel one-third-octave filter bank frequency response" style="width:60%">
+
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+from phonometry import metrology
+
+# Draw this bank's response (1/3 octave, order 6, Bessel)
+metrology.OctaveFilterBank(fs=48000, fraction=3, order=6, limits=[12, 20000],
+                           filter_type='bessel', show=True)
+```
+
+</details>
 
 ### 6. Linkwitz-Riley (`linkwitz_riley`)
 

--- a/site/src/content/docs/guides/installed-structure-borne.md
+++ b/site/src/content/docs/guides/installed-structure-borne.md
@@ -20,6 +20,35 @@ with the source mobility instead it yields `L_Ws,c` (Annex I.3, Table I.8).
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/installed_structure_borne.svg" alt="The EN 12354-5 cascade per octave band: characteristic power, installed power after the coupling term, per-path sound pressure levels and their energetic total" style="width:82%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/installed_structure_borne_dark.svg" alt="The EN 12354-5 cascade per octave band: characteristic power, installed power after the coupling term, per-path sound pressure levels and their energetic total" style="width:82%">
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import building
+
+# EN 15657 characteristic source power and illustrative point mobilities.
+bands = np.array([63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
+lws_c = np.array([78.0, 82.0, 84.0, 81.0, 77.0, 72.0, 66.0])
+ys = (2e-4 + 1e-4j) * (bands / 250.0)        # source mobility
+yi = (3e-5 + 1e-5j) * np.ones_like(bands)    # receiver mobility
+dc = np.array([float(building.coupling_term(a, b)) for a, b in zip(ys, yi)])
+
+# Two transmission paths: the excited floor and a flanking wall.
+paths = [
+    {"adjustment_term": 6.0, "element_area": 12.0,
+     "flanking_reduction_index": np.linspace(44.0, 62.0, 7)},
+    {"adjustment_term": 7.0, "element_area": 9.0,
+     "flanking_reduction_index": np.linspace(46.0, 64.0, 7)},
+]
+res = building.installed_source_prediction(lws_c, dc, paths, frequencies=bands)
+res.plot()   # characteristic and installed power, per-path levels and the total
+plt.show()
+```
+
+</details>
+
 ## 1. Coupling and installed power
 
 Only part of the characteristic power is injected into the supporting element;
@@ -93,26 +122,6 @@ print(round(res.overall_level, 1))       # band-summed level [dB]
 The `InstalledSourceResult` carries the per-path levels, the total per band, the
 installed power level and `.overall_level`, and its `.plot()` draws the whole
 cascade.
-
-<details>
-<summary>Show the code for this figure</summary>
-
-```python
-import matplotlib.pyplot as plt
-import numpy as np
-import phonometry as ph
-
-bands = np.array([63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
-lws_c = np.array([78.0, 82.0, 84.0, 81.0, 77.0, 72.0, 66.0])
-ys = (2e-4 + 1e-4j) * (bands / 250.0); yi = (3e-5 + 1e-5j) * np.ones_like(bands)
-dc = np.array([float(ph.coupling_term(a, b)) for a, b in zip(ys, yi)])
-paths = [{"adjustment_term": 6.0,
-          "flanking_reduction_index": np.linspace(44, 62, 7), "element_area": 12.0}]
-res = ph.installed_source_prediction(lws_c, dc, paths, frequencies=bands)
-res.plot(); plt.show()
-```
-
-</details>
 
 ## References
 

--- a/site/src/content/docs/guides/insulation-field.md
+++ b/site/src/content/docs/guides/insulation-field.md
@@ -529,6 +529,35 @@ into the standardized `DnT` — up where the room is live (`T > T0`), down where
 it is dead. The automatic rating is formed only for exactly 5 octave (or 16
 one-third-octave) values.*
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import building
+
+# Octave-band levels (125-2000 Hz) and the measured receiving-room T.
+bands = [125, 250, 500, 1000, 2000]
+l1 = np.array([88.0, 90.0, 92.0, 92.0, 90.0])
+l2 = np.array([55.0, 51.0, 47.0, 41.0, 35.0])
+k = building.reverberation_index([0.70, 0.60, 0.50, 0.45, 0.40])   # k = 10 lg(T/0.5)
+res = building.survey_airborne_insulation(l1, l2, k, volume=50.0)
+
+x = np.arange(len(bands))
+fig, ax = plt.subplots()
+ax.fill_between(x, res.d, res.d_nt, alpha=0.2, label="k = 10 lg(T/T0)")
+ax.plot(x, res.d, "--o", label="D (level difference)")
+ax.plot(x, res.d_nt, "-s", label="DnT (standardized)")
+ax.set_xticks(x, [str(b) for b in bands])
+ax.set(xlabel="Frequency [Hz]", ylabel="Level difference [dB]",
+       title=f"ISO 10052 survey method: DnT,w = {res.rating.rating} dB")
+ax.legend()
+plt.show()
+```
+
+</details>
+
 ### `survey_airborne_insulation()` and friends — parameters
 
 | Parameter | Type | Units | Range / default | Notes |

--- a/site/src/content/docs/guides/insulation-lab.md
+++ b/site/src/content/docs/guides/insulation-lab.md
@@ -169,6 +169,39 @@ otherwise). Subareas scanned separately are combined first with
 towards the specimen enters with a negative area, applying the minus-sign rule
 of Clause 6.4.6 while $S_m$ keeps the unsigned area sum.*
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import building
+
+# A light wall: source-room SPL Lp1 = 85 dB and the measured normal intensity
+# level LIn over the Sm = 12 m2 surface, 16 one-third-octave bands.
+freqs = [100, 125, 160, 200, 250, 315, 400, 500, 630, 800,
+         1000, 1250, 1600, 2000, 2500, 3150]
+l_in = np.array([57.8, 61.9, 60.5, 55.6, 55.8, 55.5, 53.4, 51.6,
+                 50.2, 47.7, 46.4, 45.7, 44.8, 45.2, 47.2, 52.7])
+kc = building.adaptation_term_kc(freqs)           # Annex B adaptation term
+res = building.intensity_sound_reduction(np.full(16, 85.0), l_in,
+                                         measurement_area=12.0, area=10.0,
+                                         kc=kc)
+
+x = np.arange(len(freqs))
+fig, ax = plt.subplots()
+ax.fill_between(x, res.r_i, res.r_i_modified, alpha=0.2, label="Kc adaptation")
+ax.plot(x, res.r_i, "-o", label="RI (intensity)")
+ax.plot(x, res.r_i_modified, "--s", label="RI,M = RI + Kc")
+ax.set_xticks(x, [str(f) for f in freqs], rotation=45)
+ax.set(xlabel="Frequency [Hz]", ylabel="Sound reduction index [dB]",
+       title=f"RI,w = {res.rating.rating} dB, RI,M,w = {res.rating_modified.rating} dB")
+ax.legend()
+plt.show()
+```
+
+</details>
+
 ### `intensity_sound_reduction()` / `adaptation_term_kc()` parameters
 
 | Parameter | Type | Units | Range / default | Notes |

--- a/site/src/content/docs/guides/levels.md
+++ b/site/src/content/docs/guides/levels.md
@@ -95,6 +95,41 @@ print(f"LA10={stats[10]:.1f}  LA50={stats[50]:.1f}  LA90={stats[90]:.1f} dB")
 
 *L10 tracks the event peaks, L50 the median level and L90 the background.*
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import numpy as np
+import matplotlib.pyplot as plt
+from phonometry import metrology
+
+# The fluctuating signal of the ln_levels example: 0.5 s of background
+# alternating with 0.5 s of ~10 dB louder events, repeated 3 times
+fs = 48000
+rng = np.random.default_rng(0)
+segment = fs // 2
+quiet = 0.02 * rng.standard_normal(segment)
+loud = 0.06 * rng.standard_normal(segment)
+varying = np.tile(np.concatenate([quiet, loud]), 3)
+
+# Fast mean-square envelope -> level vs time, plus the percentile levels
+envelope = metrology.time_weighting(varying, fs, mode="fast")
+level_t = 10 * np.log10(np.maximum(envelope, 1e-12) / (2e-5) ** 2)
+stats = metrology.ln_levels(varying, fs, n=(10, 50, 90))
+t = np.arange(varying.size) / fs
+
+fig, ax = plt.subplots()
+ax.plot(t, level_t, linewidth=0.8, label="Fast level Lp(t)")
+for i, (n_value, style) in enumerate([(10, "--"), (50, "-"), (90, "-.")], 1):
+    ax.axhline(float(stats[n_value]), color=f"C{i}", linestyle=style,
+               label=f"L{n_value} = {stats[n_value]:.1f} dB")
+ax.set(xlabel="Time [s]", ylabel="Level [dB]")
+ax.legend(loc="lower right")
+plt.show()
+```
+
+</details>
+
 Options: `mode` selects the envelope ballistics (`'fast'`, `'slow'`,
 `'impulse'`), `weighting` applies A/C weighting first, and
 `calibration_factor`/`dbfs` behave as in `leq`. The integrator attack transient
@@ -197,6 +232,40 @@ railway noise models.
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/sel_concept.svg" alt="A vehicle pass-by level history with its Leq over the whole event and the equal-energy one-second SEL block" style="width:80%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/sel_concept_dark.svg" alt="A vehicle pass-by level history with its Leq over the whole event and the equal-energy one-second SEL block" style="width:80%">
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import numpy as np
+import matplotlib.pyplot as plt
+from phonometry import metrology
+
+# A vehicle pass-by: noise under a gaussian energy envelope (dBFS analysis)
+fs = 48000
+t = np.arange(int(8.0 * fs)) / fs
+rng = np.random.default_rng(11)
+x = 0.3 * np.exp(-0.5 * ((t - 4.0) / 1.1) ** 2) * rng.standard_normal(t.size)
+
+level = 10 * np.log10(np.maximum(metrology.time_weighting(x, fs, mode="fast"), 1e-12))
+l_sel = float(metrology.sel(x, fs, dbfs=True))
+l_eq = float(metrology.leq(x, dbfs=True))
+print(f"Leq = {l_eq:.1f} dBFS, SEL = {l_sel:.1f} dBFS")
+# Leq = -16.6 dBFS, SEL = -7.6 dBFS -> the 1 s block carries the event energy
+
+fig, ax = plt.subplots()
+ax.plot(t, level, linewidth=1.0, label="Fast level of the event")
+ax.hlines(l_eq, 0, 8, color="C2", linestyle="--",
+          label=f"Leq over the whole event = {l_eq:.1f} dBFS")
+ax.fill_between([3.5, 4.5], -55, l_sel, color="C1", alpha=0.25)
+ax.hlines(l_sel, 3.5, 4.5, color="C1", linewidth=2,
+          label=f"SEL = {l_sel:.1f} dBFS: same energy in 1 s")
+ax.set(xlabel="Time [s]", ylabel="Level [dBFS]", ylim=(-55, l_sel + 6))
+ax.legend(loc="lower left")
+plt.show()
+```
+
+</details>
+
 ### Noise dose: sound exposure and LEX,8h
 
 Occupational regulations limit the daily *dose*, not the level. IEC 61252
@@ -247,6 +316,44 @@ r = composite_rating_level([(63.2, 12, 0.0),    # day
 ```
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/lden_profile.svg" alt="Synthetic 24-hour urban LAeq profile with day, evening and night bands, the +5 and +10 dB weighted period levels and the resulting Lden" style="width:80%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/lden_profile_dark.svg" alt="Synthetic 24-hour urban LAeq profile with day, evening and night bands, the +5 and +10 dB weighted period levels and the resulting Lden" style="width:80%">
+
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import numpy as np
+import matplotlib.pyplot as plt
+from phonometry import environmental
+
+# Synthetic hourly LAeq of an urban road (dB), hours 00 to 23
+laeq_h = np.array([48, 46, 45, 45, 46, 50, 56, 64, 66, 65, 63, 63,
+                   64, 63, 63, 64, 65, 66, 65, 64, 63, 62, 61, 50], dtype=float)
+
+def period_leq(idx):
+    return 10 * np.log10(np.mean(10 ** (laeq_h[idx] / 10)))  # energy mean
+
+ld = period_leq(np.arange(7, 19))                # day 07-19
+le = period_leq(np.arange(19, 23))               # evening 19-23
+ln_ = period_leq(np.r_[23, np.arange(0, 7)])     # night 23-07
+l_den = environmental.lden(ld, le, ln_)
+print(f"Lden = {l_den:.1f} dB")   # Lden = 64.3 dB
+
+fig, ax = plt.subplots()
+ax.axvspan(19, 23, color="C1", alpha=0.15)                                # evening
+ax.axvspan(23, 24, color="C0", alpha=0.15); ax.axvspan(0, 7, color="C0", alpha=0.15)
+ax.step(np.arange(25), np.r_[laeq_h, laeq_h[-1]], where="post",
+        color="0.3", label="Hourly LAeq")
+ax.hlines(ld, 7, 19, color="C2", linestyle="--", label="Lday (+0 dB)")
+ax.hlines(le + 5, 19, 23, color="C1", linestyle="--", label="Levening + 5 dB")
+ax.hlines([ln_ + 10, ln_ + 10], [23, 0], [24, 7], color="C0",
+          linestyle="--", label="Lnight + 10 dB")
+ax.hlines(l_den, 0, 24, color="C3", linewidth=2, label=f"Lden = {l_den:.1f} dB")
+ax.set(xlabel="Hour of day", ylabel="Level [dB]", xlim=(0, 24))
+ax.legend(loc="upper left", fontsize=8, ncol=2)
+plt.show()
+```
+
+</details>
 
 ### `lden()` / `ldn()` / `composite_rating_level()` parameters
 
@@ -349,6 +456,36 @@ levels, freq, times = bank.spectrogram(recording, window_time=0.125, overlap=0.5
 
 *A logarithmic sweep plus two tone bursts, resolved in time and in standardized
 1/3-octave bands.*
+
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import numpy as np
+import matplotlib.pyplot as plt
+from scipy.signal import chirp
+from phonometry import metrology
+
+# Log sweep 80 Hz -> 8 kHz plus two tone bursts, in a little noise
+fs = 48000
+t = np.arange(int(4.0 * fs)) / fs
+x = 0.5 * chirp(t, f0=80, t1=4.0, f1=8000, method="logarithmic")
+x[int(1.0 * fs):int(1.3 * fs)] += np.sin(2 * np.pi * 4000 * t[: int(0.3 * fs)])
+x[int(2.5 * fs):int(2.8 * fs)] += np.sin(2 * np.pi * 250 * t[: int(0.3 * fs)])
+x += 0.01 * np.random.default_rng(42).standard_normal(t.size)
+
+bank = metrology.OctaveFilterBank(fs=fs, fraction=3, order=6, limits=[50.0, 12000.0])
+levels, freq, times = bank.spectrogram(x, window_time=0.125, overlap=0.5)
+
+fig, ax = plt.subplots()
+mesh = ax.pcolormesh(times, freq, levels, shading="auto")
+ax.set_yscale("log")
+ax.set(xlabel="Time [s]", ylabel="Frequency [Hz]")
+fig.colorbar(mesh, label="Level [dB]")
+plt.show()
+```
+
+</details>
 
 - Multichannel input `(channels, samples)` returns `(channels, bands, frames)`.
 - `times` holds each window's center in seconds.

--- a/site/src/content/docs/guides/loudness.md
+++ b/site/src/content/docs/guides/loudness.md
@@ -126,6 +126,29 @@ phon = loudness_level(73.0, 63.0)           # 73 dB @ 63 Hz -> 40 phon
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/equal_loudness_contours.svg" alt="ISO 226:2023 normal equal-loudness-level contours from 20 to 90 phon with the hearing threshold curve" style="width:80%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/equal_loudness_contours_dark.svg" alt="ISO 226:2023 normal equal-loudness-level contours from 20 to 90 phon with the hearing threshold curve" style="width:80%">
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+from phonometry import psychoacoustics
+
+# ISO 226:2023 Formula (1) at the 29 preferred frequencies of Table 1
+fig, ax = plt.subplots()
+for phon in [20, 40, 60, 80, 90]:
+    freqs, spl = psychoacoustics.equal_loudness_contour(float(phon))
+    ax.semilogx(freqs, spl, color="C0")
+    ax.annotate(f"{phon} phon", xy=(1000, phon + 1), fontsize=9)
+ft, tf = psychoacoustics.hearing_threshold()
+ax.semilogx(ft, tf, "--", color="C1", label="Hearing threshold $T_f$")
+ax.set(xlabel="Frequency [Hz]", ylabel="Sound pressure level [dB re 20 µPa]")
+ax.grid(True, which="both", alpha=0.3)
+ax.legend()
+plt.show()
+```
+
+</details>
+
 Validity per clause 4.1: 20-90 phon (80 phon above 4 kHz); the implementation
 is verified against the Annex B tables in CI. Note this is the loudness of
 *pure tones* — the loudness of arbitrary signals in sones is what the ISO 532
@@ -159,6 +182,39 @@ auditory filters and their loudness summation.
 Zwicker doubles the sone value every +10 phon, while the Sottek model grows
 more slowly (about 1.65× per 10 dB), an intrinsic difference between the
 auditory summations, not a calibration error.*
+
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import psychoacoustics
+
+# 1 kHz tone, 20..80 dB SPL: all three models pass through 1 sone at 40 dB
+fs = 48000
+t = np.arange(fs) / fs
+levels = np.arange(20.0, 81.0, 10.0)
+zw, mg, ec = [], [], []
+for spl in levels:
+    x = np.sqrt(2) * 2e-5 * 10 ** (spl / 20) * np.sin(2 * np.pi * 1000 * t)
+    zw.append(psychoacoustics.loudness_zwicker(x, fs, stationary=True).loudness)
+    mg.append(
+        psychoacoustics.loudness_moore_glasberg_from_spectrum([(1000.0, float(spl))]).loudness
+    )
+    ec.append(psychoacoustics.loudness_ecma(x, fs).loudness)
+
+fig, ax = plt.subplots()
+ax.plot(levels, zw, "o-", label="Zwicker (ISO 532-1)")
+ax.plot(levels, mg, "s--", label="Moore-Glasberg (ISO 532-2)")
+ax.plot(levels, ec, "^-.", label="Sottek (ECMA-418-2)")
+ax.plot(40.0, 1.0, "o", color="k", markerfacecolor="none", markersize=10)   # the shared anchor
+ax.set(xlabel="Sound pressure level [dB SPL]", ylabel="Total loudness N [sone]")
+ax.legend()
+plt.show()
+```
+
+</details>
 
 ### Moore-Glasberg loudness (ISO 532-2)
 

--- a/site/src/content/docs/guides/mechanical-mobility.md
+++ b/site/src/content/docs/guides/mechanical-mobility.md
@@ -17,6 +17,29 @@ ISO 9611, ISO 10846, EN 15657 and EN 12354-5.
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/mechanical_mobility.svg" alt="Normalized receptance, mobility and accelerance magnitudes of a single-degree-of-freedom resonator on a log-log frequency axis, all peaking at the resonance" style="width:82%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/mechanical_mobility_dark.svg" alt="Normalized receptance, mobility and accelerance magnitudes of a single-degree-of-freedom resonator on a log-log frequency axis, all peaking at the resonance" style="width:82%">
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+import phonometry as ph
+
+m, k, c = 2.0, 8000.0, 5.0
+f = np.logspace(np.log10(0.5), np.log10(200.0), 500)
+w = 2.0 * np.pi * f
+h = ph.sdof_receptance(f, m, k, c)
+for label, frf in (("receptance |H|", np.abs(h)),
+                   ("mobility |Y|", np.abs(1j * w * h)),
+                   ("accelerance |A|", np.abs(-(w**2) * h))):
+    plt.loglog(f, frf / frf.max(), label=label)
+plt.axvline(ph.resonance_frequency(m, k), ls="--", color="0.6")
+plt.xlabel("Frequency [Hz]"); plt.ylabel("Normalized magnitude")
+plt.legend(); plt.show()
+```
+
+</details>
+
 ## 1. The frequency-response-function family (Table 1)
 
 For a harmonic motion `x·e^{jωt}` the velocity is `jω·x` and the acceleration
@@ -148,29 +171,6 @@ res = ph.sdof_mobility_result(f, mass=2.0, stiffness=8000.0, damping=5.0)
 z = res.to("impedance")                        # impedance = 1/Y per frequency
 print(res.frequencies[int(np.argmax(res.magnitude))].round(1))   # ~10.1 Hz
 ```
-
-<details>
-<summary>Show the code for this figure</summary>
-
-```python
-import matplotlib.pyplot as plt
-import numpy as np
-import phonometry as ph
-
-m, k, c = 2.0, 8000.0, 5.0
-f = np.logspace(np.log10(0.5), np.log10(200.0), 500)
-w = 2.0 * np.pi * f
-h = ph.sdof_receptance(f, m, k, c)
-for label, frf in (("receptance |H|", np.abs(h)),
-                   ("mobility |Y|", np.abs(1j * w * h)),
-                   ("accelerance |A|", np.abs(-(w**2) * h))):
-    plt.loglog(f, frf / frf.max(), label=label)
-plt.axvline(ph.resonance_frequency(m, k), ls="--", color="0.6")
-plt.xlabel("Frequency [Hz]"); plt.ylabel("Normalized magnitude")
-plt.legend(); plt.show()
-```
-
-</details>
 
 ## References
 

--- a/site/src/content/docs/guides/multichannel.md
+++ b/site/src/content/docs/guides/multichannel.md
@@ -15,6 +15,39 @@ performance gains over iterative loops.
 *Simultaneous analysis of a Stereo signal: Left Channel (Pink Noise) vs Right
 Channel (Log Sine Sweep).*
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from scipy.signal import chirp
+from phonometry import octave_filter
+
+# Stereo test signal: pink noise left, logarithmic sine sweep right
+fs, duration = 48000, 5
+t = np.linspace(0, duration, fs * duration, endpoint=False)
+rng = np.random.default_rng(42)
+spec = np.fft.rfft(rng.standard_normal(t.size))
+spec[1:] /= np.sqrt(np.arange(1, spec.size))   # 1/f shaping: pink noise
+left = np.fft.irfft(spec, t.size)
+right = chirp(t, f0=50, t1=duration, f1=10000, method="logarithmic")
+
+x = np.stack([left, right])                    # (2, n_samples)
+spl, freq = octave_filter(x, fs, fraction=3, limits=[20, 20000])
+
+fig, axes = plt.subplots(2, 1, figsize=(9, 7), sharex=True)
+for ax, levels, name in zip(axes, spl, ["Left: pink noise", "Right: log sweep"]):
+    ax.semilogx(freq, levels, marker="o", label=name)
+    ax.set_ylabel("Level [dB]")
+    ax.grid(True, which="both", alpha=0.3)
+    ax.legend()
+axes[-1].set_xlabel("Frequency [Hz]")
+plt.show()
+```
+
+</details>
+
 The convention is consistent across the whole library: time is always the
 **last axis**. This applies to `octave_filter`, `OctaveFilterBank`,
 `weighting_filter`, `time_weighting`, `leq`, `laeq`, `ln_levels` and

--- a/site/src/content/docs/guides/psychoacoustic-annoyance.md
+++ b/site/src/content/docs/guides/psychoacoustic-annoyance.md
@@ -15,6 +15,35 @@ convenience that derives all four sensations from a recording.
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/psychoacoustic_annoyance.svg" alt="Psychoacoustic annoyance PA against percentile loudness N5 for three sensation profiles: a neutral baseline where PA equals N5, a sharp sound and a rough-and-fluctuating sound both lifted above the baseline, with the worked example PA = 30.82 marked" style="width:82%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/psychoacoustic_annoyance_dark.svg" alt="Psychoacoustic annoyance PA against percentile loudness N5 for three sensation profiles: a neutral baseline where PA equals N5, a sharp sound and a rough-and-fluctuating sound both lifted above the baseline, with the worked example PA = 30.82 marked" style="width:82%">
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+import phonometry as ph
+
+n5 = np.linspace(4.0, 60.0, 200)
+profiles = [
+    ("Baseline: S = 1.75 acum, F = R = 0", 1.75, 0.0, 0.0),
+    ("Sharp: S = 3.5 acum", 3.5, 0.0, 0.0),
+    ("Rough + fluctuating: F = 1.2 vacil, R = 0.7 asper", 2.0, 1.2, 0.7),
+]
+fig, ax = plt.subplots()
+for label, s, f, r in profiles:
+    pa = [ph.psychoacoustic_annoyance(v, s, f, r).annoyance for v in n5]
+    ax.plot(n5, pa, label=label)
+
+ex = ph.psychoacoustic_annoyance(30.0, 2.0, 0.5, 0.3)
+ax.plot([30.0], [ex.annoyance], "o", label=f"Worked example (PA = {ex.annoyance:.2f})")
+ax.set_xlabel("Percentile loudness N5 [sone]")
+ax.set_ylabel("Psychoacoustic annoyance PA")
+ax.legend()
+plt.show()
+```
+
+</details>
+
 ## 1. The four sensations
 
 Psychoacoustic annoyance rests on four hearing sensations, each with its own
@@ -60,35 +89,6 @@ The figure above sweeps `PA` against `N5` for three profiles: a neutral baseline
 rough-and-fluctuating sound — both lifted above the baseline — with the worked
 example marked.
 
-<details>
-<summary>Show the code for this figure</summary>
-
-```python
-import matplotlib.pyplot as plt
-import numpy as np
-import phonometry as ph
-
-n5 = np.linspace(4.0, 60.0, 200)
-profiles = [
-    ("Baseline: S = 1.75 acum, F = R = 0", 1.75, 0.0, 0.0),
-    ("Sharp: S = 3.5 acum", 3.5, 0.0, 0.0),
-    ("Rough + fluctuating: F = 1.2 vacil, R = 0.7 asper", 2.0, 1.2, 0.7),
-]
-fig, ax = plt.subplots()
-for label, s, f, r in profiles:
-    pa = [ph.psychoacoustic_annoyance(v, s, f, r).annoyance for v in n5]
-    ax.plot(n5, pa, label=label)
-
-ex = ph.psychoacoustic_annoyance(30.0, 2.0, 0.5, 0.3)
-ax.plot([30.0], [ex.annoyance], "o", label=f"Worked example (PA = {ex.annoyance:.2f})")
-ax.set_xlabel("Percentile loudness N5 [sone]")
-ax.set_ylabel("Psychoacoustic annoyance PA")
-ax.legend()
-plt.show()
-```
-
-</details>
-
 ### 2.1 From a signal (engineering estimate)
 
 `psychoacoustic_annoyance_from_signal` is a convenience that derives all four
@@ -122,28 +122,6 @@ rather than the ~70 Hz roughness peak. By definition, a 1 kHz tone at 60 dB,
 100 % amplitude-modulated at 4 Hz, produces `1 vacil`.
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/fluctuation_strength.svg" alt="Fluctuation strength versus modulation frequency on a log axis: the closed-form AM broadband-noise curve and the AM-tone signal-model sweep both show a band-pass characteristic peaking at 4 Hz" style="width:82%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/fluctuation_strength_dark.svg" alt="Fluctuation strength versus modulation frequency on a log axis: the closed-form AM broadband-noise curve and the AM-tone signal-model sweep both show a band-pass characteristic peaking at 4 Hz" style="width:82%">
-
-### 3.1 Closed form for AM broadband noise (Eq. 10.2)
-
-For sinusoidally amplitude-modulated broadband noise, Fastl & Zwicker give a
-closed form (Eq. 10.2) in modulation factor `m`, level `L` and modulation
-frequency `fmod`:
-
-$$
-F = \frac{5.8\,(1.25\,m - 0.25)\,[0.05\,(L/\mathrm{dB}) - 1]}
-{(f_{mod}/5\,\mathrm{Hz})^2 + (4\,\mathrm{Hz}/f_{mod}) + 1.5}\ \ \mathrm{vacil}.
-$$
-
-The denominator is the `4 Hz` band-pass: it bottoms out near `fmod ≈ 3.7 Hz` and
-rises on either side. The result is clamped at `0` (the sensation vanishes below
-~20 dB or `m < 0.2`). This exact form is the value to quote for AM broadband
-noise.
-
-```python
-import phonometry as ph
-
-print(round(ph.fluctuation_strength_am_noise(60.0, 1.0, 4.0), 4))   # 3.6943 vacil
-```
 
 <details>
 <summary>Show the code for this figure</summary>
@@ -182,6 +160,28 @@ plt.show()
 ```
 
 </details>
+
+### 3.1 Closed form for AM broadband noise (Eq. 10.2)
+
+For sinusoidally amplitude-modulated broadband noise, Fastl & Zwicker give a
+closed form (Eq. 10.2) in modulation factor `m`, level `L` and modulation
+frequency `fmod`:
+
+$$
+F = \frac{5.8\,(1.25\,m - 0.25)\,[0.05\,(L/\mathrm{dB}) - 1]}
+{(f_{mod}/5\,\mathrm{Hz})^2 + (4\,\mathrm{Hz}/f_{mod}) + 1.5}\ \ \mathrm{vacil}.
+$$
+
+The denominator is the `4 Hz` band-pass: it bottoms out near `fmod ≈ 3.7 Hz` and
+rises on either side. The result is clamped at `0` (the sensation vanishes below
+~20 dB or `m < 0.2`). This exact form is the value to quote for AM broadband
+noise.
+
+```python
+import phonometry as ph
+
+print(round(ph.fluctuation_strength_am_noise(60.0, 1.0, 4.0), 4))   # 3.6943 vacil
+```
 
 ### 3.2 The Osses 2016 signal model
 

--- a/site/src/content/docs/guides/reverberation-prediction.md
+++ b/site/src/content/docs/guides/reverberation-prediction.md
@@ -29,6 +29,29 @@ $c_0 = 343\ \mathrm{m/s}$) and the air-absorption term $4mV$.
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/reverberation_models.svg" alt="Reverberation time per octave band for a room with an absorptive floor and ceiling but hard walls, computed by five models" style="width:82%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/reverberation_models_dark.svg" alt="Reverberation time per octave band for a room with an absorptive floor and ceiling but hard walls, computed by five models" style="width:82%">
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+from phonometry import environmental, room
+
+# A 10 x 7 x 3.5 m room: hard end walls, lightly treated side walls and a
+# very absorptive floor/ceiling pair (carpet plus an acoustic ceiling).
+bands = [125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0]
+alpha_x = [0.06, 0.07, 0.08, 0.09, 0.10, 0.10]
+alpha_y = [0.12, 0.14, 0.16, 0.18, 0.20, 0.20]
+alpha_z = [0.30, 0.50, 0.65, 0.78, 0.82, 0.80]
+m = environmental.air_attenuation_m(bands, 20.0, 50.0)   # air at 20 C / 50 % RH
+res = room.reverberation_time_models((10.0, 7.0, 3.5),
+                                     (alpha_x, alpha_y, alpha_z),
+                                     air_attenuation=m, frequencies=bands)
+res.plot()   # the five model curves per band
+plt.show()
+```
+
+</details>
+
 ## 1. Sabine, Eyring and Millington-Sette
 
 The three statistical models take the room volume and a list of

--- a/site/src/content/docs/guides/rotorcraft-noise.md
+++ b/site/src/content/docs/guides/rotorcraft-noise.md
@@ -31,6 +31,35 @@ h.plot()                                          # fore-aft directivity
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/rotorcraft_ground_effect.svg" alt="Rotorcraft ground-effect adjustment versus one-third-octave frequency for hard and soft ground, showing low-frequency reinforcement, a deep interference dip and the incoherent high-frequency region" style="width:82%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/rotorcraft_ground_effect_dark.svg" alt="Rotorcraft ground-effect adjustment versus one-third-octave frequency for hard and soft ground, showing low-frequency reinforcement, a deep interference dip and the incoherent high-frequency region" style="width:82%">
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import aircraft
+
+freqs = 1000.0 * 10.0 ** (np.arange(-13, 11) / 10.0)   # 50 Hz-10 kHz thirds
+hs, hr, dp = 150.0, 1.5, 500.0                          # overflight geometry
+grass = aircraft.ground_effect_adjustment(freqs, hs, hr, dp, flow_resistivity="D")
+asphalt = aircraft.ground_effect_adjustment(freqs, hs, hr, dp, flow_resistivity="G")
+
+fig, ax = plt.subplots()
+ax.axhline(0.0, color="0.5", linewidth=1.0)
+ax.semilogx(freqs, asphalt, marker="o", markersize=3,
+            label="Hard (asphalt/concrete, class G)")
+ax.semilogx(freqs, grass, marker="s", markersize=3,
+            label="Soft (grass/pasture, class D)")
+ax.set(xlabel="One-third-octave-band centre frequency [Hz]",
+       ylabel="Ground-effect adjustment ΔLg [dB]",
+       title="Rotorcraft ground effect (ECAC Doc 32, Chien-Soroka)")
+ax.grid(True, which="both", alpha=0.3)
+ax.legend()
+plt.show()
+```
+
+</details>
+
 The 60 m hemisphere level is carried to the receiver by three adjustments
 (§A.4): `spherical_spreading_adjustment` (`ΔLs = −20·log10(r/60)`, Eq. 24),
 `atmospheric_adjustment` (`ΔLa = −α(f)·(r − 60)` with the ISO 9613-1 coefficient,

--- a/site/src/content/docs/guides/sound-power.md
+++ b/site/src/content/docs/guides/sound-power.md
@@ -37,6 +37,43 @@ of the page walks each in turn.
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/sound_power_methods.svg" alt="The three sound power routes side by side: an enveloping pressure surface over a reflecting plane (ISO 3744/3746), a source in a reverberation room sampled by microphones (ISO 3741) and an intensity probe scanning a surface around the source (ISO 9614-2)" style="width:92%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/sound_power_methods_dark.svg" alt="The three sound power routes side by side: an enveloping pressure surface over a reflecting plane (ISO 3744/3746), a source in a reverberation room sampled by microphones (ISO 3741) and an intensity probe scanning a surface around the source (ISO 9614-2)" style="width:92%">
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import emission
+
+# One steady source (octave-band LW below) determined by three routes.
+freqs = np.array([125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
+lw_true = np.array([85.0, 88.0, 90.0, 89.0, 86.0, 82.0])
+
+# ISO 3744: SPL at 10 positions on a hemisphere, r = 2 m (10 lg(S/S0) = 14 dB).
+pres = emission.sound_power_pressure(np.tile(lw_true - 14.0, (10, 1)),
+                                     "hemisphere", radius=2.0,
+                                     frequencies=freqs)
+# ISO 9614-2: uniform normal intensity scanned over six 0.5 m2 segments.
+i_n = np.tile(10.0 ** (lw_true / 10.0) * 1e-12 / 3.0, (6, 1))
+inten = emission.sound_power_intensity(i_n, np.full(6, 0.5),
+                                       frequencies=freqs, band_type="octave")
+# ISO 3741: comparison against a reference source of known LW = 84 dB per band.
+comp = emission.sound_power_comparison(lw_true - 20.0, np.full(6, 64.0),
+                                       np.full(6, 84.0), frequencies=freqs)
+
+fig, ax = plt.subplots()
+for res, style, ms, label in ((pres, "-o", 11, "pressure (ISO 3744)"),
+                              (inten, "--s", 8, "intensity (ISO 9614-2)"),
+                              (comp, ":^", 5, "reference source (ISO 3741)")):
+    ax.semilogx(freqs, res.sound_power_level, style, markersize=ms,
+                label=f"{label}: LWA = {res.sound_power_level_a:.1f} dB")
+ax.set(xlabel="Frequency [Hz]", ylabel="Sound power level LW [dB]")
+ax.legend()
+plt.show()
+```
+
+</details>
+
 <video class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_power_two_rooms.webm" preload="none" poster="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_power_two_rooms_poster.jpg" width="2400" height="1350" loop muted controls playsinline title="Animation: the same source in an anechoic room and in a reverberation room produces different microphone pressures, and the free-field and diffuse-field formulas converge to the same sound power level L_W" style="width:88%"></video><video class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_power_two_rooms_dark.webm" preload="none" poster="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/anim_power_two_rooms_dark_poster.jpg" width="2400" height="1350" loop muted controls playsinline title="Animation: the same source in an anechoic room and in a reverberation room produces different microphone pressures, and the free-field and diffuse-field formulas converge to the same sound power level L_W" style="width:88%"></video>
 
 ### A decision path

--- a/site/src/content/docs/guides/sound-quality.md
+++ b/site/src/content/docs/guides/sound-quality.md
@@ -27,6 +27,33 @@ $k = 0.108$ sits inside the normative window 0.105–0.115).
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/sharpness_weighting.svg" alt="DIN 45692 sharpness weighting g(z) against critical-band rate on a log axis, comparing the DIN, von Bismarck and Aures curves with the 15.8 and 15 Bark knees marked" style="width:80%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/sharpness_weighting_dark.svg" alt="DIN 45692 sharpness weighting g(z) against critical-band rate on a log axis, comparing the DIN, von Bismarck and Aures curves with the 15.8 and 15 Bark knees marked" style="width:80%">
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+
+# DIN 45692 sharpness weighting g(z): Eq. (1) plus the informative Annex B variants
+z = np.arange(1, 241) * 0.1                     # Bark bins, 0.1 .. 24.0
+g_din = np.where(z > 15.8, 0.15 * np.exp(0.42 * (z - 15.8)) + 0.85, 1.0)
+g_bis = np.where(z > 15.0, 0.2 * np.exp(0.308 * (z - 15.0)) + 0.8, 1.0)
+n = 4.0                                         # Aures depends on the total loudness (sone)
+g_aures = 0.078 * np.exp(0.171 * z) / z * (n / np.log(n * 0.05 + 1.0))
+
+fig, ax = plt.subplots()
+ax.semilogy(z, g_din, label="DIN 45692 g(z)")
+ax.semilogy(z, g_bis, "--", label="von Bismarck (Annex B)")
+ax.semilogy(z, g_aures, "-.", label="Aures (Annex B, N = 4 sone)")
+ax.axvline(15.8, linestyle=":", color="0.5")    # DIN knee: g rises beyond 15.8 Bark
+ax.set(xlabel="Critical-band rate z [Bark]", ylabel="Weighting g(z)")
+ax.grid(True, which="both", alpha=0.3)
+ax.legend()
+plt.show()
+```
+
+</details>
+
 ```python
 import numpy as np
 from phonometry import sharpness_din

--- a/site/src/content/docs/guides/speech-transmission.md
+++ b/site/src/content/docs/guides/speech-transmission.md
@@ -50,6 +50,38 @@ results, band-weighted, into the index: the STI is an effective SNR of the
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/sti_vs_t60.svg" alt="STI versus reverberation time with the IEC 60268-16 Annex F rating bands shaded" style="width:80%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/sti_vs_t60_dark.svg" alt="STI versus reverberation time with the IEC 60268-16 Annex F rating bands shaded" style="width:80%">
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import numpy as np
+import matplotlib.pyplot as plt
+from phonometry import sti_from_impulse_response
+
+fs = 48000
+
+# STI vs reverberation time: sweep sti_from_impulse_response over synthetic
+# exponential decays (white noise x exp(-6.9077 t / T60)) at a T60 grid,
+# exactly the physics behind the curve above:
+rng = np.random.default_rng(0)
+t60_grid = np.array([0.3, 0.5, 0.8, 1.2, 1.6, 2.0, 2.5, 3.0, 4.0, 5.0])
+sti_values = []
+for t60 in t60_grid:
+    t = np.arange(int(2 * t60 * fs)) / fs
+    ir = rng.standard_normal(t.size) * np.exp(-6.9077 * t / t60)
+    sti_values.append(sti_from_impulse_response(ir, fs).sti)
+
+fig, ax = plt.subplots()
+ax.semilogx(t60_grid, sti_values, "o-")
+ax.set_xlabel("Reverberation time T60 [s]")
+ax.set_ylabel("STI")
+ax.set_ylim(0.0, 1.0)
+ax.grid(True, which="both", alpha=0.3)
+plt.show()
+```
+
+</details>
+
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_sti_chain.svg" alt="STI measurement chain: STIPA source signal through the room to the microphone and the MTF analysis" style="width:92%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_sti_chain_dark.svg" alt="STI measurement chain: STIPA source signal through the room to the microphone and the MTF analysis" style="width:92%">
 
 ## 2. Indirect and direct (STIPA) measurement
@@ -72,38 +104,6 @@ recording = test                       # in practice, the microphone signal afte
 res = stipa(recording, fs)
 res.plot()   # per-band modulation transfer index (MTI) bars, STI + rating in the title
 ```
-
-<details>
-<summary>Show the code for this figure</summary>
-
-```python
-import numpy as np
-import matplotlib.pyplot as plt
-from phonometry import sti_from_impulse_response
-
-fs = 48000
-
-# STI vs reverberation time: sweep sti_from_impulse_response over synthetic
-# exponential decays (white noise x exp(-6.9077 t / T60)) at a T60 grid —
-# exactly the physics behind the curve above:
-rng = np.random.default_rng(0)
-t60_grid = np.array([0.3, 0.5, 0.8, 1.2, 1.6, 2.0, 2.5, 3.0, 4.0, 5.0])
-sti_values = []
-for t60 in t60_grid:
-    t = np.arange(int(2 * t60 * fs)) / fs
-    ir = rng.standard_normal(t.size) * np.exp(-6.9077 * t / t60)
-    sti_values.append(sti_from_impulse_response(ir, fs).sti)
-
-fig, ax = plt.subplots()
-ax.semilogx(t60_grid, sti_values, "o-")
-ax.set_xlabel("Reverberation time T60 [s]")
-ax.set_ylabel("STI")
-ax.set_ylim(0.0, 1.0)
-ax.grid(True, which="both", alpha=0.3)
-plt.show()
-```
-
-</details>
 
 `stipa` emits a `UserWarning` when the recording is shorter than the
 recommended 15 s (IEC 60268-16 STIPA practice, 15 s to 25 s): below that the

--- a/site/src/content/docs/guides/structure-borne-power.md
+++ b/site/src/content/docs/guides/structure-borne-power.md
@@ -18,6 +18,36 @@ installed-equipment prediction consumes.
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/structure_borne_power.svg" alt="Reception-plate structure-borne sound power level per one-third-octave band determined on a low-mobility and a high-mobility reception plate" style="width:82%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/structure_borne_power_dark.svg" alt="Reception-plate structure-borne sound power level per one-third-octave band determined on a low-mobility and a high-mobility reception plate" style="width:82%">
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import building
+
+# The same pump-like source measured on a heavy and on a light reception plate.
+bands = np.array([50.0, 100.0, 200.0, 400.0, 800.0, 1600.0, 3150.0])
+lv_low = np.array([88.0, 90.0, 87.0, 84.0, 80.0, 76.0, 71.0])
+
+low = building.reception_plate_power(lv_low, bands, mass_per_area=600.0,
+                                     area=2.0, reverberation_time=0.8)
+high = building.reception_plate_power(lv_low + 6.0, bands, mass_per_area=150.0,
+                                      area=2.0, reverberation_time=0.5)
+
+x = np.arange(bands.size)
+fig, ax = plt.subplots()
+ax.bar(x - 0.2, low.power_level, width=0.4, label="low-mobility plate")
+ax.bar(x + 0.2, high.power_level, width=0.4, label="high-mobility plate")
+ax.set_xticks(x, [f"{b:g}" for b in bands])
+ax.set(xlabel="Frequency [Hz]",
+       ylabel="Structure-borne power level $L_{Ws}$ [dB re 1 pW]")
+ax.legend()
+plt.show()
+```
+
+</details>
+
 ## 1. The reception-plate relations
 
 Why a plate at all? Characterising the source by its contact forces directly
@@ -121,29 +151,6 @@ print(float(ph.source_mobility_from_levels(lvf, lfb)))      # |Y_S,eq| in m/(N·
 The direct source-side counterpart is the ISO 9611 free velocity level (re
 `v₀ = 5·10⁻⁸ m/s`) measured at the contact points of resiliently mounted
 machinery; its equation (9) position average is `mean_free_velocity_level()`.
-
-<details>
-<summary>Show the code for this figure</summary>
-
-```python
-import matplotlib.pyplot as plt
-import numpy as np
-import phonometry as ph
-
-bands = np.array([50.0, 100.0, 200.0, 400.0, 800.0, 1600.0, 3150.0])
-lv_low = np.array([88.0, 90.0, 87.0, 84.0, 80.0, 76.0, 71.0])
-low = ph.reception_plate_power(lv_low, bands, mass_per_area=600.0, area=2.0,
-                               reverberation_time=0.8)
-high = ph.reception_plate_power(lv_low + 6.0, bands, mass_per_area=150.0, area=2.0,
-                                reverberation_time=0.5)
-x = np.arange(bands.size)
-plt.bar(x - 0.2, low.power_level, width=0.4, label="low-mobility plate")
-plt.bar(x + 0.2, high.power_level, width=0.4, label="high-mobility plate")
-plt.xticks(x, [f"{b:g}" for b in bands]); plt.legend()
-plt.xlabel("Frequency [Hz]"); plt.ylabel("$L_{Ws}$ [dB re 1 pW]"); plt.show()
-```
-
-</details>
 
 ## References
 

--- a/site/src/content/docs/guides/tone-audibility.md
+++ b/site/src/content/docs/guides/tone-audibility.md
@@ -15,6 +15,27 @@ audibility `ΔL` it produces feeds the ISO 1996-2 tonal adjustment `Kt`.
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/tone_audibility.svg" alt="Per-tone audibility ΔL of the nine tones of the ISO/PAS 20065 Annex E combustion-engine spectrum, with the decisive tone at 137.3 Hz highlighted and the ΔL = 0 dB threshold marked" style="width:82%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/tone_audibility_dark.svg" alt="Per-tone audibility ΔL of the nine tones of the ISO/PAS 20065 Annex E combustion-engine spectrum, with the decisive tone at 137.3 Hz highlighted and the ΔL = 0 dB threshold marked" style="width:82%">
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+from phonometry import psychoacoustics
+
+# ISO/PAS 20065 Annex E combustion-engine spectrum 1: nine tones (fT, LT, LS)
+# from a narrow-band spectrum with line spacing 2.7 Hz
+fT = [118.4, 137.3, 158.8, 314.9, 433.4, 592.2, 629.8, 643.3, 1582.7]
+LT = [64.56, 67.96, 68.63, 68.50, 73.17, 78.31, 75.00, 79.75, 71.07]
+LS = [48.91, 49.22, 50.50, 52.85, 58.29, 59.53, 59.71, 61.98, 54.16]
+
+res = psychoacoustics.assess_tones(fT, LT, LS, 2.7)
+print(round(res.decisive_audibility, 2), res.decisive_frequency)  # 5.01 137.3
+res.plot()   # per-tone audibility bars, decisive tone highlighted
+plt.show()
+```
+
+</details>
+
 ## 1. The critical band about the tone
 
 Each tone of frequency `fT` is evaluated inside a critical band whose width is

--- a/site/src/content/docs/guides/transfer-stiffness.md
+++ b/site/src/content/docs/guides/transfer-stiffness.md
@@ -20,6 +20,37 @@ prediction standards — ISO 9611, EN 15657 and EN 12354-5.
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/transfer_stiffness.svg" alt="Dynamic transfer stiffness level of a Kelvin-Voigt isolator: the true level and the indirect-method estimate, which diverges at the mass/spring resonance and converges above it" style="width:82%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/transfer_stiffness_dark.svg" alt="Dynamic transfer stiffness level of a Kelvin-Voigt isolator: the true level and the indirect-method estimate, which diverges at the mass/spring resonance and converges above it" style="width:82%">
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import vibration
+
+# Kelvin-Voigt isolator k + jwc loaded by an 8 kg blocking mass.
+k, c, m2 = 1.0e6, 120.0, 8.0
+f0 = np.sqrt(k / m2) / (2.0 * np.pi)
+f = np.logspace(np.log10(f0 / 5.0), np.log10(f0 * 40.0), 600)
+
+k_true = k + 1j * 2.0 * np.pi * f * c
+t = vibration.base_transmissibility(f, m2, k, c)
+k_indirect = vibration.transfer_stiffness_indirect(f, t, m2)  # warns where T is not small
+
+fig, ax = plt.subplots()
+ax.semilogx(f, vibration.transfer_stiffness_level(k_true),
+            label="true $L_k$ of $k+j\\omega c$")
+ax.semilogx(f, vibration.transfer_stiffness_level(k_indirect), "--",
+            label="indirect method $-(2\\pi f)^2 m_2 T$")
+ax.axvline(f0, color="0.6", linestyle=":", label="resonance $f_0$")
+ax.set(xlabel="Frequency [Hz]", ylabel="Transfer stiffness level $L_k$ [dB re 1 N/m]")
+ax.grid(True, which="both", alpha=0.3)
+ax.legend()
+plt.show()
+```
+
+</details>
+
 ## 1. The transfer-stiffness level and loss factor
 
 Results are reported as a **level** re the reference stiffness `k₀ = 1 N/m`
@@ -149,28 +180,6 @@ k = 1e6 + 5e4j                                  # N/m, at 250 Hz
 Z = ph.convert_frf(k, 250.0, "dynamic_stiffness", "impedance")
 print(abs(complex(ph.convert_frf(Z, 250.0, "impedance", "dynamic_stiffness"))))  # 1.0012e6
 ```
-
-<details>
-<summary>Show the code for this figure</summary>
-
-```python
-import matplotlib.pyplot as plt
-import numpy as np
-import phonometry as ph
-
-k, c, m2 = 1e6, 120.0, 8.0
-f0 = np.sqrt(k / m2) / (2 * np.pi)
-f = np.logspace(np.log10(f0 / 5), np.log10(f0 * 40), 600)
-w = 2 * np.pi * f
-t = ph.base_transmissibility(f, m2, k, c)
-plt.semilogx(f, ph.transfer_stiffness_level(k + 1j * w * c), label="true $L_k$")
-plt.semilogx(f, ph.transfer_stiffness_level(ph.transfer_stiffness_indirect(f, t, m2)),
-             "--", label="indirect method")
-plt.axvline(f0, ls=":", color="0.6"); plt.legend()
-plt.xlabel("Frequency [Hz]"); plt.ylabel("$L_k$ [dB re 1 N/m]"); plt.show()
-```
-
-</details>
 
 ## References
 

--- a/site/src/content/docs/guides/underwater-propagation.md
+++ b/site/src/content/docs/guides/underwater-propagation.md
@@ -12,6 +12,26 @@ equation**, **seabed reflection loss** and the **ocean ambient-noise** spectrum.
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/underwater_transmission_loss.svg" alt="Underwater transmission loss versus range at 10 kHz with the geometrical-spreading and volume-absorption contributions drawn separately, loss increasing downward" style="width:82%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/underwater_transmission_loss_dark.svg" alt="Underwater transmission loss versus range at 10 kHz with the geometrical-spreading and volume-absorption contributions drawn separately, loss increasing downward" style="width:82%">
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import underwater
+
+# 10 kHz at 10 °C, 35 ppt, 100 m depth; practical spreading with R0 = 1000 m.
+ranges = np.linspace(10.0, 20_000.0, 400)
+tl = underwater.transmission_loss(ranges, 10e3, law="practical",
+                                  transition_range=1000.0, temperature=10.0,
+                                  salinity=35.0, depth=100.0)
+print(f"alpha = {tl.absorption_coefficient:.2f} dB/km")   # alpha = 0.95 dB/km
+tl.plot()   # total TL with the spreading and absorption contributions
+plt.show()
+```
+
+</details>
+
 The transmission loss is
 
 $$
@@ -39,6 +59,24 @@ tl.plot()   # TL vs range with the spreading/absorption split (needs matplotlib)
 ## Speed of sound in sea water
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/underwater_sound_speed.svg" alt="A sea-water sound-speed profile from the UNESCO equation: warm mixed layer, thermocline, a sound-channel axis at the minimum, and the speed rising with pressure at depth" style="width:60%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/underwater_sound_speed_dark.svg" alt="A sea-water sound-speed profile from the UNESCO equation: warm mixed layer, thermocline, a sound-channel axis at the minimum, and the speed rising with pressure at depth" style="width:60%">
+
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import underwater
+
+# A warm mixed layer, a thermocline down to 4 °C and an isothermal deep layer.
+depths = np.linspace(0.0, 3000.0, 121)
+temps = 4.0 + 14.0 / (1.0 + (np.maximum(depths - 80.0, 0.0) / 250.0) ** 2)
+profile = underwater.sound_speed_profile(depths, temps, 35.0, model="unesco")
+profile.plot()   # sound speed vs depth, minimum at the sound-channel axis
+plt.show()
+```
+
+</details>
 
 `sea_water_sound_speed(T, S, depth, model=…)` uses the **UNESCO / Chen–Millero**
 equation (default, in the Wong & Zhu 1995 ITS-90 form), **Del Grosso** (1974) or
@@ -68,6 +106,25 @@ can cross entire oceans.
 ## Sonar equation
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/sonar_equation.svg" alt="The passive sonar equation: signal excess falling with transmission loss and crossing zero, the detection limit, at the figure of merit" style="width:82%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/sonar_equation_dark.svg" alt="The passive sonar equation: signal excess falling with transmission loss and crossing zero, the detection limit, at the figure of merit" style="width:82%">
+
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import underwater
+
+tl = np.linspace(40.0, 120.0, 400)
+se = underwater.passive_sonar_equation(source_level=140.0, transmission_loss=tl,
+                                       noise_level=60.0, directivity_index=15.0,
+                                       detection_threshold=8.0)
+print(f"figure of merit = {se.figure_of_merit:.1f} dB")  # figure of merit = 87.0 dB
+se.plot()   # signal excess vs transmission loss, zero crossing at the FOM
+plt.show()
+```
+
+</details>
 
 The sonar equation gives the **signal excess** $SE$ (detection when
 $SE \ge 0$) and the **figure of merit** (the maximum allowable transmission
@@ -103,6 +160,25 @@ Sonar, propagation and ambient levels are in dB re a plane wave of 1 µPa rms
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/seabed_reflection.svg" alt="Bottom reflection loss versus grazing angle for a fast sandy seabed: zero loss below the critical grazing angle, rising sharply above it" style="width:82%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/seabed_reflection_dark.svg" alt="Bottom reflection loss versus grazing angle for a fast sandy seabed: zero loss below the critical grazing angle, rising sharply above it" style="width:82%">
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import underwater
+
+# Rayleigh fluid-fluid reflection: water over a fast sandy bottom.
+phi = np.linspace(0.0, 90.0, 361)
+bl = underwater.bottom_reflection_loss(phi, rho1=1000.0, c1=1500.0,
+                                       rho2=1900.0, c2=1650.0)
+print(f"critical angle = {bl.critical_angle:.1f} deg")   # critical angle = 24.6 deg
+bl.plot()   # bottom loss vs grazing angle
+plt.show()
+```
+
+</details>
+
 A plane wave striking the seabed reflects with the fluid–fluid **Rayleigh
 reflection coefficient** (Medwin & Clay). For a faster bottom ($c_2 > c_1$) there is a **critical
 grazing angle** $\varphi_c = \arccos(c_1/c_2)$, below which the wave is
@@ -123,6 +199,29 @@ bl.plot()   # bottom loss vs grazing angle (needs matplotlib)
 ## Ocean ambient noise
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/ocean_ambient_noise.svg" alt="Wenz ambient-noise spectrum levels for two wind speeds, with wind noise falling at 5 dB per octave and thermal noise rising above about 50 kHz" style="width:82%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/ocean_ambient_noise_dark.svg" alt="Wenz ambient-noise spectrum levels for two wind speeds, with wind noise falling at 5 dB per octave and thermal noise rising above about 50 kHz" style="width:82%">
+
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import underwater
+
+# Wenz ambient noise (wind rule of fives + Mellen thermal) at two wind speeds.
+freqs = np.logspace(2, 5.5, 300)
+fig, ax = plt.subplots()
+for u in (5.0, 20.0):
+    noise = underwater.ocean_ambient_noise(freqs, wind_speed_knots=u)
+    ax.semilogx(noise.frequency, noise.spectrum_level, label=f"Total ({u:.0f} kn)")
+ax.semilogx(freqs, underwater.thermal_noise_spectrum(freqs), ":", label="Thermal")
+ax.set(xlabel="Frequency [Hz]", ylabel="Spectrum level [dB re 1 µPa²/Hz]")
+ax.legend()
+ax.grid(True, which="both", alpha=0.3)
+plt.show()
+```
+
+</details>
 
 The ambient-noise spectrum level is the energy sum of the physically grounded
 Wenz components: **wind / sea-surface** noise via the "rule of fives" (the
@@ -145,6 +244,30 @@ noise.plot()   # composite spectrum with wind/thermal components (needs matplotl
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/ship_traffic_noise.svg" alt="JOMOPANS-ECHO predicted source-level spectra for a container ship, a cruise ship and a tug, with cargo vessels showing a low-frequency hump below 100 Hz" style="width:82%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/ship_traffic_noise_dark.svg" alt="JOMOPANS-ECHO predicted source-level spectra for a container ship, a cruise ship and a tug, with cargo vessels showing a low-frequency hump below 100 Hz" style="width:82%">
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+from phonometry import underwater
+
+# JOMOPANS-ECHO source spectra for three vessel classes (speed, length).
+fig, ax = plt.subplots()
+for vessel_class, speed, length in (("containership", 18.0, 300.0),
+                                    ("cruise", 17.1, 250.0),
+                                    ("tug", 3.7, 30.0)):
+    s = underwater.ship_source_spectrum(speed, length, vessel_class=vessel_class)
+    ax.semilogx(s.frequency, s.source_psd,
+                label=f"{vessel_class} ({speed:.0f} kn, {length:.0f} m)")
+ax.set(xlabel="Frequency [Hz]",
+       ylabel="Source spectral density [dB re 1 µPa²/Hz at 1 m]")
+ax.legend()
+ax.grid(True, which="both", alpha=0.3)
+plt.show()
+```
+
+</details>
+
 When no measured spectrum is available, a ship's source level can be
 **estimated** from its class, speed and length with **JOMOPANS-ECHO**
 (MacGillivray & de Jong 2021, the default, validated against 1862 measurements),
@@ -165,6 +288,29 @@ noise = ph.ocean_ambient_noise(ship.frequency, wind_speed_knots=10.0,
 ## Numerical solvers
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/numerical_propagation.png" alt="A Munk sound-speed profile, ray paths forming convergence zones, and normal-mode versus parabolic-equation transmission loss agreeing in trend" style="width:100%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/numerical_propagation_dark.png" alt="A Munk sound-speed profile, ray paths forming convergence zones, and normal-mode versus parabolic-equation transmission loss agreeing in trend" style="width:100%">
+
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import underwater
+
+# A Munk deep-water sound-speed profile.
+z = np.linspace(0.0, 5000.0, 60)
+eta = 2.0 * (z - 1300.0) / 1300.0
+c = 1500.0 * (1.0 + 0.00737 * (eta - 1.0 + np.exp(-eta)))
+
+# Split-step Fourier PE at 50 Hz; a coarse grid keeps the run fast.
+field = underwater.parabolic_equation(50.0, z, c, source_depth=1000.0,
+                                      max_range=50_000.0, range_step=50.0,
+                                      n_depth_points=512)
+field.plot()   # TL(z, r) field showing the convergence zones
+plt.show()
+```
+
+</details>
 
 For range-independent environments the field can be computed numerically with
 three solvers (Jensen et al., *Computational Ocean Acoustics*):

--- a/site/src/content/docs/guides/vibration-sound-power.md
+++ b/site/src/content/docs/guides/vibration-sound-power.md
@@ -28,6 +28,34 @@ standards (ISO 9611, EN 15657, EN 12354-5).
 
 <img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/vibration_sound_power.svg" alt="Radiated sound power level per octave band, comparing the ISO/TS 7849-1 upper limit (radiation factor of one) with the ISO/TS 7849-2 engineering value (measured radiation factor)" style="width:82%"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/vibration_sound_power_dark.svg" alt="Radiated sound power level per octave band, comparing the ISO/TS 7849-1 upper limit (radiation factor of one) with the ISO/TS 7849-2 engineering value (measured radiation factor)" style="width:82%">
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import emission
+
+# Surface velocity levels and a measured radiation factor per octave band.
+bands = np.array([125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
+lv = np.array([78.0, 82.0, 85.0, 83.0, 79.0, 74.0])
+eps = np.array([0.20, 0.45, 0.75, 0.95, 1.00, 1.00])
+
+lw_max = emission.radiated_sound_power_level(lv, 1.6)  # Part 1, eps = 1
+lw_eng = emission.radiated_sound_power_level(lv, 1.6, radiation_factor=eps)  # Part 2
+
+x = np.arange(bands.size)
+fig, ax = plt.subplots()
+ax.bar(x - 0.2, lw_max, width=0.4, label="Part 1 upper limit ($\\varepsilon$ = 1)")
+ax.bar(x + 0.2, lw_eng, width=0.4, label="Part 2 engineering ($\\varepsilon$ measured)")
+ax.set_xticks(x, [f"{b:g}" for b in bands])
+ax.set(xlabel="Frequency [Hz]", ylabel="Sound power level $L_W$ [dB re 1 pW]")
+ax.legend()
+plt.show()
+```
+
+</details>
+
 ## 1. The two parts
 
 The two parts differ only in the radiation factor. **Part 1 (survey)** assumes
@@ -101,27 +129,6 @@ fixed `ε = 1`
 with a band-by-band `εⱼ` determined from one reference measurement of the
 radiated power (ISO 9614 intensity), after which the velocity survey can be
 repeated cheaply on nominally identical machines.
-
-<details>
-<summary>Show the code for this figure</summary>
-
-```python
-import matplotlib.pyplot as plt
-import numpy as np
-import phonometry as ph
-
-bands = np.array([125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0])
-lv = np.array([78.0, 82.0, 85.0, 83.0, 79.0, 74.0])
-eps = np.array([0.20, 0.45, 0.75, 0.95, 1.00, 1.00])
-x = np.arange(bands.size)
-plt.bar(x - 0.2, ph.radiated_sound_power_level(lv, 1.6), width=0.4, label="Part 1 (ε=1)")
-plt.bar(x + 0.2, ph.radiated_sound_power_level(lv, 1.6, radiation_factor=eps),
-        width=0.4, label="Part 2 (ε measured)")
-plt.xticks(x, [f"{b:g}" for b in bands]); plt.legend()
-plt.xlabel("Frequency [Hz]"); plt.ylabel("$L_W$ [dB re 1 pW]"); plt.show()
-```
-
-</details>
 
 ## References
 

--- a/site/src/content/docs/guides/weighting.md
+++ b/site/src/content/docs/guides/weighting.md
@@ -330,6 +330,40 @@ well inside the class 1 corridor (shaded); the wider class 2 limits are
 dotted. The corridor widens at the band extremes where only a one-sided
 limit applies.*
 
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import WeightingFilter, verify_weighting_class, weighting_class_limits
+
+freqs, lower1, upper1 = weighting_class_limits(1)
+_, lower2, upper2 = weighting_class_limits(2)
+lo1, lo2 = np.clip(lower1, -7, 7), np.clip(lower2, -7, 7)
+
+fig, ax = plt.subplots(figsize=(10, 6.5))
+ax.fill_between(freqs, lo1, upper1, step="mid", alpha=0.10,
+                label="Class 1 acceptance region")
+ax.plot(freqs, upper1, drawstyle="steps-mid", label="Class 1 upper/lower limit")
+ax.plot(freqs, lo1, drawstyle="steps-mid", color="C1")
+ax.plot(freqs, upper2, ":", drawstyle="steps-mid", label="Class 2 upper/lower limit")
+ax.plot(freqs, lo2, ":", drawstyle="steps-mid", color="C2")
+
+for curve, marker in (("A", "o"), ("C", "s")):
+    bands = verify_weighting_class(WeightingFilter(48000, curve))["bands"]
+    f = [b["freq"] for b in bands]
+    dev = [b["deviation_db"] for b in bands]
+    ax.plot(f, dev, marker=marker, label=f"{curve} weighting deviation (48 kHz)")
+
+ax.set(xscale="log", xlim=(10, 20000), ylim=(-7, 7),
+       xlabel="Frequency [Hz]", ylabel="Deviation from design goal [dB]")
+ax.legend(fontsize=8, ncol=2)
+plt.show()
+```
+
+</details>
+
 ## References
 
 - Fletcher, H., & Munson, W. A. (1933). Loudness, its definition, measurement


### PR DESCRIPTION
## Summary

Every data figure in the documentation now carries a reproduction snippet, closing the legacy gap in the three content trees.

- The audit's estimate undercounted: 47 figure-snippet gaps existed across 24 guides. 30 snippet concepts are newly written (the filter-response gallery as one combined snippet plus per-design blocks, following the modern pages' precedent), 5 misplaced blocks are relocated next to their figures, 4 non-conforming legacy blocks are rewritten, and 2 docs-only snippets are mirrored onto their site pages. Only setup diagrams and animations remain snippet-free, by convention.
- All newly authored snippets use the modular subpackage API (`from phonometry import <domain>` with qualified calls), matching the documented namespace form; pre-existing flat-API blocks are deliberately untouched pending the announced conversion sweep. One API inconsistency surfaced along the way: `octave_filter` is exported only at the top level and by no subpackage, so its snippet keeps a flat import; exporting it from metrology is a follow-up candidate.
- Every added block was executed exactly as printed (119 runs across EN and ES, exit 0), with printed-value comments verified against real output; the transfer-stiffness trio intentionally emits the documented ISO 10846-3 validity warning because the figure illustrates the invalid region.

## Test plan

Conformance byte-identical; i18n parity (56 pairs); site build with links validator at 0 errors; html-validate clean; EN blocks byte-identical between the GitHub docs and the site; a review pass fixed an unplotted polar figure and three Spanish wording items before this PR.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

