### PR TITLE
docs: settle the Spanish register for underlying-something phrasing

### DIFF
--- a/site/src/content/docs/es/getting-started.md
+++ b/site/src/content/docs/es/getting-started.md
@@ -123,4 +123,4 @@ float64, así que es seguro pasar directamente la salida de `wavfile.read`.
 - [Bancos de filtros](/phonometry/es/guides/filter-banks/) — elige una arquitectura e inspecciona sus respuestas
 - [Calibración y dBFS](/phonometry/es/guides/calibration/) — obtén valores SPL reales
 - [Referencia de la API](/phonometry/es/reference/api/) — todos los parámetros de cada función
-- [Bibliografía](/phonometry/es/reference/bibliography/) — los libros y artículos tras cada guía, cada uno con un enlace verificado
+- [Bibliografía](/phonometry/es/reference/bibliography/) — los libros y artículos que sustentan cada guía, cada uno con un enlace verificado

--- a/site/src/content/docs/es/guides/aircraft-noise.md
+++ b/site/src/content/docs/es/guides/aircraft-noise.md
@@ -160,7 +160,7 @@ de los segmentos de rodaje de despegue, `start_of_roll_directivity` (ΔSOR).
 sobre una malla en tierra (marca los segmentos de rodaje con una máscara
 `ground_roll`).
 
-El mecanismo tras estas correcciones de suelo es la interferencia de dos
+El mecanismo que explica estas correcciones de suelo es la interferencia de dos
 caminos: la onda directa y su reflexión en el suelo. Abajo, una fuente de
 400 Hz a 1,5 m sobre un plano rígido forma el patrón de lóbulos, con la fuente
 imagen dibujada como fantasma bajo el suelo y un receptor situado en un mínimo

--- a/site/src/content/docs/es/guides/block-processing.md
+++ b/site/src/content/docs/es/guides/block-processing.md
@@ -157,7 +157,7 @@ for x in audio_stream(block):            # tu callback de captura
 - Oppenheim, A. V., & Schafer, R. W. (2010). *Discrete-time signal processing*
   (3.ª ed.). Pearson. ISBN 978-0-13-198842-2.
   [Ficha en Open Library](https://openlibrary.org/isbn/9780131988422).
-  Las estructuras de filtro en forma directa y la recursión de estado tras
+  Las estructuras de filtro en forma directa y la recursión de estado que sustentan
   la ecuación del estado transportado de arriba.
 
 ## Normas

--- a/site/src/content/docs/es/guides/calibration.md
+++ b/site/src/content/docs/es/guides/calibration.md
@@ -243,7 +243,7 @@ como una conversión a float.
 - International Electrotechnical Commission. (2013). *Electroacoustics —
   Sound level meters — Part 3: Periodic tests* (IEC 61672-3:2013).
   [Catálogo IEC](https://webstore.iec.ch/en/publication/5710).
-  El procedimiento de verificación de laboratorio tras las comprobaciones
+  El procedimiento de verificación de laboratorio que sustenta las comprobaciones
   periódicas recomendadas arriba.
 
 ## Normas

--- a/site/src/content/docs/es/guides/electroacoustics.md
+++ b/site/src/content/docs/es/guides/electroacoustics.md
@@ -274,7 +274,7 @@ esconden dos normalizaciones:
 - Beranek, L. L., & Mellow, T. J. (2012). *Acoustics: Sound fields and
   transducers*. Academic Press. ISBN 978-0-12-391421-7.
   [doi:10.1016/C2011-0-05897-0](https://doi.org/10.1016/C2011-0-05897-0).
-  La física de transductores tras la sección 5: radiación del altavoz, presión
+  La física de transductores que sustenta la sección 5: radiación del altavoz, presión
   en el eje y la transición de campo cercano a campo lejano.
 
 ## Normas

--- a/site/src/content/docs/es/guides/filter-banks.md
+++ b/site/src/content/docs/es/guides/filter-banks.md
@@ -383,7 +383,7 @@ La clase de prestaciones más estricta, la **clase 0**, la definió la edición
 anterior **IEC 61260:1995** y su gemela estadounidense **ANSI S1.11-2004**
 (ambas retiradas/sustituidas pero aún referenciadas para instrumentos de
 laboratorio); IEC 61260-1:2014 la eliminó. Sus máscaras de clase 1/2 difieren
-ligeramente de la edición de 2014, así que vive tras un conmutador `edition` en
+ligeramente de la edición de 2014, así que se selecciona con un conmutador `edition` en
 lugar de mezclarse con la máscara de 2014:
 
 ```python

--- a/site/src/content/docs/es/guides/installed-structure-borne.md
+++ b/site/src/content/docs/es/guides/installed-structure-borne.md
@@ -124,7 +124,7 @@ res.plot(); plt.show()
   (3.ª ed.). Springer. ISBN 978-3-540-22696-3.
   [doi:10.1007/b137728](https://doi.org/10.1007/b137728).
   El acoplamiento de movilidades fuente-receptor y la transmisión estructural
-  a través de uniones tras el término de acoplamiento y el modelo de vías.
+  a través de uniones que sustentan el término de acoplamiento y el modelo de vías.
 
 ## Normas
 

--- a/site/src/content/docs/es/guides/insulation-field.md
+++ b/site/src/content/docs/es/guides/insulation-field.md
@@ -561,12 +561,12 @@ exactamente 5 valores de octava (o 16 de tercio de octava).*
   ISBN 978-0-7506-6526-1.
   [doi:10.4324/9780080550473](https://doi.org/10.4324/9780080550473).
   El tratamiento exhaustivo del aislamiento a ruido aéreo y de impactos: las
-  cadenas de medición, la estadística de salas tras las magnitudes de campo y
+  cadenas de medición, la estadística de salas que sustenta las magnitudes de campo y
   la interpretación de los índices globales.
 - Vigran, T. E. (2008). *Building acoustics*. CRC Press.
   ISBN 978-0-415-42853-8.
   [doi:10.1201/9781482266016](https://doi.org/10.1201/9781482266016).
-  Un manual compacto que acompaña la física de transmisión sonora tras estas
+  Un manual compacto que acompaña la física de transmisión sonora que sustenta estas
   mediciones.
 - International Organization for Standardization. (2020). *Acoustics —
   Rating of sound insulation in buildings and of building elements — Part 1:
@@ -604,9 +604,9 @@ ruido de equipos de servicio.
 - [Acústica de salas](/phonometry/es/guides/room-acoustics/) — la respuesta al impulso,
   los parámetros de sala y la absorción sonora sobre los que se apoya la cadena de aislamiento de esta guía.
 - [Niveles](/phonometry/es/guides/levels/) — el promediado en energía y las métricas de
-  nivel tras los niveles de las salas emisora/receptora.
+  nivel que sustentan los niveles de las salas emisora/receptora.
 - [Bancos de filtros](/phonometry/es/guides/filter-banks/) — los filtros de octava
   fraccionaria IEC 61260 usados para los espectros de aislamiento.
-- [Teoría](/phonometry/es/reference/theory/rooms-buildings/) — la derivación de la curva de referencia tras
+- [Teoría](/phonometry/es/reference/theory/rooms-buildings/) — la derivación de la curva de referencia que sustenta
   los índices ponderados de un solo número.
 - Referencia de la API: [`building.insulation`](/phonometry/es/reference/api/building/insulation/), [`building.survey_insulation`](/phonometry/es/reference/api/building/survey-insulation/) y [`building.building_uncertainty`](/phonometry/es/reference/api/building/building-uncertainty/).

--- a/site/src/content/docs/es/guides/levels.md
+++ b/site/src/content/docs/es/guides/levels.md
@@ -405,7 +405,7 @@ curvas isofónicas de ISO 226 viven con las métricas de percepción en
 - International Electrotechnical Commission. (2013). *Electroacoustics —
   Sound level meters — Part 1: Specifications* (IEC 61672-1:2013).
   [Catálogo IEC](https://webstore.iec.ch/en/publication/5708).
-  Las balísticas de envolvente tras los niveles percentiles, el pico
+  Las balísticas de envolvente que sustentan los niveles percentiles, el pico
   ponderado C y las referencias de ráfagas del SEL contra las que se
   verifica la implementación.
 - Kinsler, L. E., Frey, A. R., Coppens, A. B., & Sanders, J. V. (2000).

--- a/site/src/content/docs/es/guides/loudness.md
+++ b/site/src/content/docs/es/guides/loudness.md
@@ -362,17 +362,17 @@ Devuelve un `EcmaLoudness`: `loudness` (N, sone_HMS), `specific_loudness`
 - Fastl, H., & Zwicker, E. (2007). *Psychoacoustics: Facts and models*
   (3.ª ed.). Springer.
   [doi:10.1007/978-3-540-68888-4](https://doi.org/10.1007/978-3-540-68888-4).
-  La psicoacústica de bandas críticas y enmascaramiento tras el modelo de
+  La psicoacústica de bandas críticas y enmascaramiento que sustenta el modelo de
   Zwicker y la sensación de sonoridad que los modelos más nuevos refinan.
 - Fletcher, H., & Munson, W. A. (1933). Loudness, its definition, measurement
   and calculation. *The Journal of the Acoustical Society of America*, 5(2),
   82-108. [doi:10.1121/1.1915637](https://doi.org/10.1121/1.1915637).
-  Las mediciones originales de igual sonoridad tras el concepto de nivel de
+  Las mediciones originales de igual sonoridad que sustentan el concepto de nivel de
   sonoridad de la sección de tonos puros.
 - International Organization for Standardization. (2023). *Acoustics —
   Normal equal-loudness-level contours* (ISO 226:2023).
   [Catálogo iso.org](https://www.iso.org/standard/83117.html).
-  El modelo de isófonas y los parámetros de la Tabla 1 tras los niveles de
+  El modelo de isófonas y los parámetros de la Tabla 1 que sustentan los niveles de
   sonoridad de tonos puros.
 
 ## Normas
@@ -398,5 +398,5 @@ sonoridad del modelo de Sottek (sone_HMS).
   tonalidad y aspereza, la otra mitad de la calidad sonora.
 - [Molestia psicoacústica e intensidad de fluctuación](/phonometry/es/guides/psychoacoustic-annoyance/):
   el modelo de Zwicker y Fastl que consume la sonoridad percentil N5.
-- [Teoría](/phonometry/es/reference/theory/perception/): las ecuaciones tras los modelos de sonoridad.
+- [Teoría](/phonometry/es/reference/theory/perception/): las ecuaciones que sustentan los modelos de sonoridad.
 - Referencia de la API: [`psychoacoustics.loudness_zwicker`](/phonometry/es/reference/api/psychoacoustics/loudness-zwicker/), [`psychoacoustics.loudness_moore_glasberg`](/phonometry/es/reference/api/psychoacoustics/loudness-moore-glasberg/) y [`psychoacoustics.loudness_contours`](/phonometry/es/reference/api/psychoacoustics/loudness-contours/).

--- a/site/src/content/docs/es/guides/materials.md
+++ b/site/src/content/docs/es/guides/materials.md
@@ -561,7 +561,7 @@ print(float(single_number_rating_uncertainty(8.1).reported_expanded_uncertainty[
   Modelling sound absorbing materials* (2.ª ed.). Wiley.
   ISBN 978-0-470-74661-5.
   [doi:10.1002/9780470747339](https://doi.org/10.1002/9780470747339).
-  La teoría del material poroso tras las magnitudes medidas: la resistividad
+  La teoría del material poroso que sustenta las magnitudes medidas: la resistividad
   al flujo como entrada de modelo, y la impedancia superficial y la absorción
   que recupera el tubo.
 - Cox, T. J., & D'Antonio, P. (2017). *Acoustic absorbers and diffusers:
@@ -569,7 +569,7 @@ print(float(single_number_rating_uncertainty(8.1).reported_expanded_uncertainty[
   ISBN 978-1-4987-4099-9.
   [doi:10.1201/9781315369211](https://doi.org/10.1201/9781315369211).
   La medida y el diseño de absorbentes en la práctica: los métodos de tubo y
-  de cámara lado a lado, los montajes y la discusión del efecto de borde tras
+  de cámara lado a lado, los montajes y la discusión del efecto de borde que sustenta
   la sección de tubo o cámara reverberante.
 - International Organization for Standardization. (2003). *Acoustics —
   Measurement of sound absorption in a reverberation room* (ISO 354:2003).
@@ -589,7 +589,7 @@ print(float(single_number_rating_uncertainty(8.1).reported_expanded_uncertainty[
   transfer matrix method* (ASTM E2611-19, la edición implementada aquí;
   revisada después como [ASTM E2611-24](https://store.astm.org/e2611-24.html)).
   [Tienda ASTM](https://store.astm.org/e2611-19.html).
-  El método de matriz de transferencia con cuatro micrófonos tras los
+  El método de matriz de transferencia con cuatro micrófonos que sustenta los
   ayudantes de pérdida por transmisión.
 - International Organization for Standardization. (2018). *Acoustics —
   Determination of airflow resistance — Part 1: Static airflow method*

--- a/site/src/content/docs/es/guides/occupational-exposure.md
+++ b/site/src/content/docs/es/guides/occupational-exposure.md
@@ -185,7 +185,7 @@ otras estrategias no llevan desglose por tarea).
   `sound_exposure` (IEC 61252) y el LCpeak que estas estrategias declaran al
   lado.
 - [Incertidumbre de medición](/phonometry/es/guides/gum-uncertainty/) — la
-  maquinaria GUM tras las incertidumbres combinadas y expandidas.
+  maquinaria GUM que sustenta las incertidumbres combinadas y expandidas.
 - [Teoría](/phonometry/es/reference/theory/environment-transport/) — la derivación de las fórmulas de
   las estrategias y del presupuesto del anexo C.
 - Referencia de la API: [`hearing.occupational_exposure`](/phonometry/es/reference/api/hearing/occupational-exposure/).
@@ -210,7 +210,7 @@ otras estrategias no llevan desglose por tarea).
   (DHHS/NIOSH Publication No. 98-126).
   [doi:10.26616/NIOSHPUB98126](https://doi.org/10.26616/NIOSHPUB98126),
   [PDF gratuito](https://www.cdc.gov/niosh/docs/98-126/pdfs/98-126.pdf).
-  El documento de criterios de libre acceso tras el límite de exposición
+  El documento de criterios de libre acceso que sustenta el límite de exposición
   recomendado de 85 dB(A) y la justificación de conservación auditiva para
   medir la dosis diaria.
 

--- a/site/src/content/docs/es/guides/outdoor-propagation.md
+++ b/site/src/content/docs/es/guides/outdoor-propagation.md
@@ -296,7 +296,7 @@ print(round(directivity_omega(1.5, 1.5, 200.0), 2))                  # 3.01 dB
 print(round(meteorological_correction(200.0, 1.5, 1.5, 2.0), 2))     # 1.7 dB
 ```
 
-### La fuente imagen tras el efecto del suelo
+### La fuente imagen que explica el efecto del suelo
 
 Cada entrada de la Tabla 3 es un ajuste de ingeniería a una única imagen
 física: el receptor oye dos copias de la fuente, el rayo directo $r_1$ y una
@@ -502,7 +502,7 @@ ponderados A.
   (2.ª ed.). CRC Press.
   [doi:10.1201/9780429470806](https://doi.org/10.1201/9780429470806).
   Los modelos de impedancia del suelo, el coeficiente de reflexión de onda
-  esférica tras el mínimo del suelo de la sección 2 y los efectos
+  esférica que explica el mínimo del suelo de la sección 2 y los efectos
   meteorológicos sobre las barreras.
 - Maekawa, Z. (1968). Noise reduction by screens. *Applied Acoustics*, 1(3),
   157-173.
@@ -542,7 +542,7 @@ geométrica (Ec. (7)), la absorción atmosférica (Ec. (8)), el efecto del suelo
 apantallamiento por barreras (Ecs. (12)–(17)) y la corrección meteorológica
 (Ec. (21)/(22)). ISO 354:2003, *Acoustics — Measurement of sound absorption in
 a reverberation room* — solo la conversión $m = \alpha/(10 \lg e)$ del apartado
-8.1.2.1 tras `air_attenuation_m`; el método en cámara reverberante se trata en la
+8.1.2.1 en que se basa `air_attenuation_m`; el método en cámara reverberante se trata en la
 [guía de Acústica de salas](/phonometry/es/guides/room-acoustics/).
 
 ## Véase también

--- a/site/src/content/docs/es/guides/reverberation-prediction.md
+++ b/site/src/content/docs/es/guides/reverberation-prediction.md
@@ -244,7 +244,7 @@ campo no es difuso.
 - Eyring, C. F. (1930). Reverberation time in "dead" rooms. *The Journal of
   the Acoustical Society of America*, 1(2A), 217-241.
   [doi:10.1121/1.1915175](https://doi.org/10.1121/1.1915175).
-  La derivación por recorrido libre medio tras el término
+  La derivación por recorrido libre medio que sustenta el término
   $-S\ln(1-\bar\alpha)$ del §1.
 - Millington, G. (1932). A modified formula for reverberation. *The Journal
   of the Acoustical Society of America*, 4(1), 69-82.
@@ -262,7 +262,7 @@ campo no es difuso.
 - Kuttruff, H. (2016). *Room acoustics* (6.ª ed.). CRC Press.
   [doi:10.1201/9781315372150](https://doi.org/10.1201/9781315372150).
   La teoría del campo difuso, sus límites y la valoración moderna de las
-  fórmulas clásicas tras el §4.
+  fórmulas clásicas que sustentan el §4.
 - Everest, F. A. (2001). *Master handbook of acoustics* (4.ª ed.).
   McGraw-Hill. ISBN 978-0-07-136097-5.
   [Ficha en Open Library](https://openlibrary.org/isbn/9780071360975).

--- a/site/src/content/docs/es/guides/room-acoustics.md
+++ b/site/src/content/docs/es/guides/room-acoustics.md
@@ -602,7 +602,7 @@ con la forma de `t60`; `absorption_coefficient()` devuelve `alpha_s`;
   fraccionaria IEC 61260 usados para las curvas de decaimiento por banda y los espectros de
   aislamiento.
 - [Niveles](/phonometry/es/guides/levels/) — el promediado en energía y las métricas de
-  nivel tras los niveles de las salas emisora/receptora.
+  nivel que sustentan los niveles de las salas emisora/receptora.
 - [Teoría](/phonometry/es/reference/theory/rooms-buildings/) — la integración de Schroeder, las ventanas de
   regresión y la derivación de la curva de referencia.
 - Referencia de la API: [`room.room_acoustics`](/phonometry/es/reference/api/rooms/room-acoustics/), [`room.room_ir`](/phonometry/es/reference/api/rooms/room-ir/) y [`room.open_plan`](/phonometry/es/reference/api/rooms/open-plan/).
@@ -611,7 +611,7 @@ con la forma de `t60`; `absorption_coefficient()` devuelve `alpha_s`;
 
 - Kuttruff, H. (2016). *Room acoustics* (6.ª ed.). CRC Press.
   [doi:10.1201/9781315372150](https://doi.org/10.1201/9781315372150).
-  La monografía de referencia tras esta página: la teoría estadística de
+  La monografía de referencia que sustenta esta página: la teoría estadística de
   los campos sonoros en decaimiento, la frecuencia de Schroeder y los
   parámetros perceptivos de sala del §2.
 - Schroeder, M. R. (1965). New method of measuring reverberation time.
@@ -623,7 +623,7 @@ con la forma de `t60`; `absorption_coefficient()` devuelve `alpha_s`;
   Measuring room impulse responses: Impact of the decay range on derived
   room acoustic parameters. *Acta Acustica united with Acustica*, 98(6),
   907-915. [doi:10.3813/aaa.918574](https://doi.org/10.3813/aaa.918574).
-  El análisis de la INR tras la discusión del rango dinámico y los
+  El análisis de la INR que sustenta la discusión del rango dinámico y los
   indicadores de validez endurecidos del §2.
 - International Organization for Standardization. (2009). *Acoustics —
   Measurement of room acoustic parameters — Part 1: Performance spaces*

--- a/site/src/content/docs/es/guides/rotorcraft-noise.md
+++ b/site/src/content/docs/es/guides/rotorcraft-noise.md
@@ -75,13 +75,13 @@ sobre suelo duro, 0.5 dB sobre suelo blando).
   contrato EASA.2020.FC.06). European Union Aviation Safety Agency.
   [Página del proyecto en EASA](https://www.easa.europa.eu/en/research-projects/environmental-research-rotorcraft-noise),
   [PDF gratuito](https://www.easa.europa.eu/en/downloads/132005/en).
-  La guía a nivel de ecuación (Ec. 13-35) tras la implementación, con los
+  La guía a nivel de ecuación (Ec. 13-35) que sustenta la implementación, con los
   valores de atenuación de la Tabla 4 y los hemisferios de referencia usados
   como oráculos.
 - Chien, C. F., & Soroka, W. W. (1975). Sound propagation along an impedance
   plane. *Journal of Sound and Vibration*, 43(1), 9-20.
   [doi:10.1016/0022-460X(75)90200-X](https://doi.org/10.1016/0022-460X(75)90200-X).
-  La solución de interferencia de dos rayos sobre un plano de impedancia tras
+  La solución de interferencia de dos rayos sobre un plano de impedancia que sustenta
   el ajuste de efecto de suelo.
 - Delany, M. E., & Bazley, E. N. (1970). Acoustical properties of fibrous
   absorbent materials. *Applied Acoustics*, 3(2), 105-116.

--- a/site/src/content/docs/es/guides/sound-power.md
+++ b/site/src/content/docs/es/guides/sound-power.md
@@ -766,7 +766,7 @@ plt.show()
   índices de aislamiento a ruido aéreo y a impactos y las predicciones de emisión
   de EN 12354 que consumen una `LW` de fuente.
 - [Niveles](/phonometry/es/guides/levels/) — el promediado en energía y la ponderación A
-  tras `LWA`.
+  que sustentan `LWA`.
 - [Teoría](/phonometry/es/reference/theory/environment-transport/) — las derivaciones de Waterhouse, K1/K2 y
   C1/C2.
 - Referencia de la API: [`emission.sound_power`](/phonometry/es/reference/api/power/sound-power/), [`emission.sound_power_reverberation`](/phonometry/es/reference/api/power/sound-power-reverberation/) y [`emission.sound_power_intensity`](/phonometry/es/reference/api/power/sound-power-intensity/).

--- a/site/src/content/docs/es/guides/sound-quality.md
+++ b/site/src/content/docs/es/guides/sound-quality.md
@@ -178,8 +178,8 @@ matemática subyacente.
   (3.ª ed.). Springer.
   [doi:10.1007/978-3-540-68888-4](https://doi.org/10.1007/978-3-540-68888-4).
   La psicoacústica de las sensaciones que cuantifica esta página: el énfasis
-  en alta frecuencia tras la agudeza y la percepción de modulación rápida
-  tras la aspereza.
+  en alta frecuencia que sustenta la agudeza y la percepción de modulación rápida
+  que sustenta la aspereza.
 
 ## Normas
 

--- a/site/src/content/docs/es/guides/speech-intelligibility.md
+++ b/site/src/content/docs/es/guides/speech-intelligibility.md
@@ -46,7 +46,7 @@ totalmente audible, por lo que el índice se acerca a uno; el pequeño déficit 
 la propia **automáscara del habla** del oyente.
 
 La función de importancia es donde vive el conocimiento perceptivo de la
-norma. Desciende de los experimentos de articulación tras el índice de
+norma. Desciende de los experimentos de articulación que sustentan el índice de
 articulación de French y Steinberg: los oyentes puntuaban sílabas sin sentido
 oídas a través de filtros que eliminaban una parte del espectro cada vez, y la
 caída de acierto mide cuánta inteligibilidad transporta cada banda. El
@@ -259,7 +259,7 @@ para el lado del STI.
   sharpness y las métricas de percepción de lo que oye quien escucha.
 - [Bancos de filtros](/phonometry/es/guides/filter-banks/) — las bandas de tercio de octava
   sobre las que se evalúa el SII.
-- [Niveles](/phonometry/es/guides/levels/) — los niveles espectrales y de banda tras las
+- [Niveles](/phonometry/es/guides/levels/) — los niveles espectrales y de banda que sustentan las
   entradas de nivel espectral equivalente.
 - Referencia de la API: [`hearing.sii`](/phonometry/es/reference/api/speech/sii/).
 

--- a/site/src/content/docs/es/guides/speech-transmission.md
+++ b/site/src/content/docs/es/guides/speech-transmission.md
@@ -8,7 +8,7 @@ Un sistema de megafonía, un interfono, un aula reverberante — cada uno es un
 y cada uno degrada el habla a su manera. El **índice de transmisión del habla**
 (STI) de IEC 60268-16 califica ese canal con un único número en [0, 1] midiendo
 cuánta de la *envolvente* del habla sobrevive al trayecto. Esta página cubre la
-física de transferencia de modulación tras el índice, el método indirecto desde
+física de transferencia de modulación en la que se basa el índice, el método indirecto desde
 una respuesta al impulso medida en la sala y la medición STIPA directa con su
 señal de ensayo normalizada.
 

--- a/site/src/content/docs/es/guides/structure-borne-power.md
+++ b/site/src/content/docs/es/guides/structure-borne-power.md
@@ -158,7 +158,7 @@ plt.xlabel("Frecuencia [Hz]"); plt.ylabel("$L_{Ws}$ [dB re 1 pW]"); plt.show()
   (3.ª ed.). Springer. ISBN 978-3-540-22696-3.
   [doi:10.1007/b137728](https://doi.org/10.1007/b137728).
   El balance de potencia de la placa y el marco de movilidades
-  fuente-receptor tras el método de placa receptora y sus magnitudes de
+  fuente-receptor que sustentan el método de placa receptora y sus magnitudes de
   fuente de las Fórmulas 15-19.
 - International Organization for Standardization. (1996). *Acoustics —
   Characterization of sources of structure-borne sound with respect to sound

--- a/site/src/content/docs/es/guides/surface-scattering.md
+++ b/site/src/content/docs/es/guides/surface-scattering.md
@@ -475,7 +475,7 @@ print(round(s_min, 3), round(s_max, 3))    # 0.078 0.086  (metros)
   ISBN 978-1-4987-4099-9.
   [doi:10.1201/9781315369211](https://doi.org/10.1201/9781315369211).
   La monografía de referencia sobre teoría y diseño de difusores, de los
-  autores tras el método del coeficiente de difusión de ISO 17497-2: la
+  autores del método del coeficiente de difusión de ISO 17497-2: la
   distinción dispersión-difusión, los montajes de
   medida y la guía de diseño que esta página condensa.
 - International Organization for Standardization. (2004). *Acoustics —
@@ -489,7 +489,7 @@ print(round(s_min, 3), round(s_max, 3))    # 0.078 0.086  (metros)
   Sound-scattering properties of surfaces — Part 2: Measurement of the
   directional diffusion coefficient in a free field* (ISO 17497-2:2012).
   [Catálogo iso.org](https://www.iso.org/standard/55293.html).
-  El coeficiente de autocorrelación del goniómetro que hay tras la sección 2
+  El coeficiente de autocorrelación del goniómetro que sustenta la sección 2
   de esta página, su ponderación por área y el $d_n$ normalizado.
 
 ## Normas

--- a/site/src/content/docs/es/guides/transfer-stiffness.md
+++ b/site/src/content/docs/es/guides/transfer-stiffness.md
@@ -183,7 +183,7 @@ plt.xlabel("Frecuencia [Hz]"); plt.ylabel("$L_k$ [dB re 1 N/m]"); plt.show()
   (3.ª ed.). Springer. ISBN 978-3-540-22696-3.
   [doi:10.1007/b137728](https://doi.org/10.1007/b137728).
   Teoría del aislamiento de vibraciones: por qué el comportamiento de un
-  aislador depende de las movilidades de fuente y receptor, la física tras la
+  aislador depende de las movilidades de fuente y receptor, la física que sustenta la
   caracterización por fuerza bloqueada.
 - International Organization for Standardization. (2008). *Acoustics and
   vibration — Laboratory measurement of vibro-acoustic transfer properties of

--- a/site/src/content/docs/es/guides/underwater-acoustics.md
+++ b/site/src/content/docs/es/guides/underwater-acoustics.md
@@ -150,7 +150,7 @@ res.plot()
   ISBN 978-0-932146-62-5.
   [Ficha en Open Library](https://openlibrary.org/books/OL9317725M).
   El tratamiento clásico de los niveles de sonido submarino y del ruido
-  radiado por buques tras las convenciones de referencia de las
+  radiado por buques que sustenta las convenciones de referencia de las
   secciones 1-2.
 - Ainslie, M. A. (2010). *Principles of sonar performance modelling*.
   Springer.

--- a/site/src/content/docs/es/guides/underwater-propagation.md
+++ b/site/src/content/docs/es/guides/underwater-propagation.md
@@ -263,7 +263,7 @@ de presión-liberada.
   sources. *The Journal of the Acoustical Society of America*, 34(12),
   1936-1956.
   [doi:10.1121/1.1909155](https://doi.org/10.1121/1.1909155).
-  El estudio de ruido ambiental tras las componentes eólica y térmica de
+  El estudio de ruido ambiental que sustenta las componentes eólica y térmica de
   la sección de ruido ambiental oceánico.
 - Carey, W. M., & Evans, R. B. (2011). *Ocean ambient noise: Measurement and
   theory*. Springer.

--- a/site/src/content/docs/es/guides/vibration-sound-power.md
+++ b/site/src/content/docs/es/guides/vibration-sound-power.md
@@ -134,7 +134,7 @@ plt.xlabel("Frecuencia [Hz]"); plt.ylabel("$L_W$ [dB re 1 pW]"); plt.show()
   sound: Structural vibrations and sound radiation at audio frequencies*
   (3.ª ed.). Springer. ISBN 978-3-540-22696-3.
   [doi:10.1007/b137728](https://doi.org/10.1007/b137728).
-  El tratamiento de la eficiencia de radiación tras la sección 3: la
+  El tratamiento de la eficiencia de radiación que sustenta la sección 3: la
   coincidencia, la cancelación por debajo de la frecuencia crítica y la
   radiación de placas finitas.
 - International Organization for Standardization. (2009). *Acoustics —

--- a/site/src/content/docs/es/guides/wind-turbine-noise.md
+++ b/site/src/content/docs/es/guides/wind-turbine-noise.md
@@ -49,7 +49,7 @@ suelo, a su vez, es la razón de los 6 dB restados: una cápsula tumbada sobre
 una placa dura recibe una reflexión perfectamente coherente (duplicación de
 presión, $+6$ dB) en lugar del patrón de interferencia dependiente de la
 altura que muestrearía un micrófono en trípode (véase
-[la fuente imagen tras el efecto del suelo](/phonometry/es/guides/outdoor-propagation/)).
+[la fuente imagen que explica el efecto del suelo](/phonometry/es/guides/outdoor-propagation/)).
 
 ### Clases de viento y condiciones estandarizadas
 

--- a/site/src/content/docs/es/reference/bibliography.md
+++ b/site/src/content/docs/es/reference/bibliography.md
@@ -42,7 +42,7 @@ que las guías incorporan sus secciones de Referencias.
 - Oppenheim, A. V., & Schafer, R. W. (2010). *Discrete-time signal processing*
   (3.ª ed.). Pearson. ISBN 978-0-13-198842-2.
   [Ficha en Open Library](https://openlibrary.org/isbn/9780131988422).
-  La teoría de filtros digitales tras las cascadas SOS, la transformada
+  La teoría de filtros digitales que sustenta las cascadas SOS, la transformada
   bilineal y el diezmado multitasa que usan los bancos de filtros.
   Citado por [Bancos de filtros](/phonometry/es/guides/filter-banks/) y
   [Procesado por bloques](/phonometry/es/guides/block-processing/).
@@ -249,7 +249,7 @@ que las guías incorporan sus secciones de Referencias.
 - International Organization for Standardization. (2003). *Acoustics —
   Measurement of sound absorption in a reverberation room* (ISO 354:2003).
   [Catálogo iso.org](https://www.iso.org/standard/34545.html).
-  La medición de absorción en cámara reverberante tras los datos de
+  La medición de absorción en cámara reverberante que sustenta los datos de
   superficie.
   Citado por [Acústica de salas](/phonometry/es/guides/room-acoustics/) y
   [Absorción sonora en recintos](/phonometry/es/guides/enclosed-space-absorption/).
@@ -281,7 +281,7 @@ que las guías incorporan sus secciones de Referencias.
   ISBN 978-1-4987-4099-9.
   [doi:10.1201/9781315369211](https://doi.org/10.1201/9781315369211).
   La monografía sobre medida y diseño de absorbentes y difusores, de los
-  autores tras el método del coeficiente de difusión de ISO 17497-2.
+  autores del método del coeficiente de difusión de ISO 17497-2.
   Citado por [Materiales acústicos](/phonometry/es/guides/materials/) y
   [Dispersión superficial, difusión y absorción in situ](/phonometry/es/guides/surface-scattering/).
 - International Organization for Standardization. (2003). *Acoustics —
@@ -399,7 +399,7 @@ que las guías incorporan sus secciones de Referencias.
   vibration — Laboratory measurement of vibro-acoustic transfer properties of
   resilient elements — Part 1: Principles and guidelines* (ISO 10846-1:2008).
   [Catálogo iso.org](https://www.iso.org/standard/38936.html).
-  La idealización de fuerza de bloqueo tras la rigidez dinámica de
+  La idealización de fuerza de bloqueo que sustenta la rigidez dinámica de
   transferencia.
   Citado por [Rigidez dinámica de transferencia](/phonometry/es/guides/transfer-stiffness/).
 - International Organization for Standardization. (2009). *Acoustics —
@@ -432,14 +432,14 @@ que las guías incorporan sus secciones de Referencias.
   Academic Publishers. ISBN 978-1-4020-0390-5.
   [doi:10.1007/978-94-010-0660-6](https://doi.org/10.1007/978-94-010-0660-6).
   La teoría ondulatoria del sonido en exteriores (ecuación parabólica, fast
-  field program, refracción, turbulencia) tras las aproximaciones de
+  field program, refracción, turbulencia) que sustenta las aproximaciones de
   ingeniería de la ISO 9613-2.
   Citado por [Propagación del sonido en exteriores](/phonometry/es/guides/outdoor-propagation/).
 - Attenborough, K., & Van Renterghem, T. (2021). *Predicting outdoor sound*
   (2.ª ed.). CRC Press.
   [doi:10.1201/9780429470806](https://doi.org/10.1201/9780429470806).
   Los modelos de impedancia del suelo, el coeficiente de reflexión de onda
-  esférica tras el mínimo del suelo y los efectos meteorológicos sobre las
+  esférica que explica el mínimo del suelo y los efectos meteorológicos sobre las
   barreras.
   Citado por [Propagación del sonido en exteriores](/phonometry/es/guides/outdoor-propagation/).
 - Maekawa, Z. (1968). Noise reduction by screens. *Applied Acoustics*, 1(3),
@@ -591,7 +591,7 @@ que las guías incorporan sus secciones de Referencias.
 - Chien, C. F., & Soroka, W. W. (1975). Sound propagation along an impedance
   plane. *Journal of Sound and Vibration*, 43(1), 9-20.
   [doi:10.1016/0022-460X(75)90200-X](https://doi.org/10.1016/0022-460X(75)90200-X).
-  La solución de interferencia de dos rayos sobre un plano de impedancia tras
+  La solución de interferencia de dos rayos sobre un plano de impedancia que sustenta
   el efecto de suelo de rotorcraft.
   Citado por [Ruido de rotorcraft](/phonometry/es/guides/rotorcraft-noise/).
 - Delany, M. E., & Bazley, E. N. (1970). Acoustical properties of fibrous
@@ -687,7 +687,7 @@ que las guías incorporan sus secciones de Referencias.
   sources. *The Journal of the Acoustical Society of America*, 34(12),
   1936-1956.
   [doi:10.1121/1.1909155](https://doi.org/10.1121/1.1909155).
-  El estudio clásico del ruido ambiental tras las componentes espectrales de
+  El estudio clásico del ruido ambiental que sustenta las componentes espectrales de
   viento y térmica.
   Citado por [Propagación submarina del sonido](/phonometry/es/guides/underwater-propagation/).
 - Carey, W. M., & Evans, R. B. (2011). *Ocean ambient noise: Measurement and
@@ -724,7 +724,7 @@ que las guías incorporan sus secciones de Referencias.
   intelligibility of speech sounds. *The Journal of the Acoustical Society of
   America*, 19(1), 90-119.
   [doi:10.1121/1.1916407](https://doi.org/10.1121/1.1916407).
-  Los experimentos por bandas de articulación tras la función de importancia
+  Los experimentos por bandas de articulación que sustentan la función de importancia
   de banda del índice de inteligibilidad del habla.
   Citado por [Índice de inteligibilidad del habla](/phonometry/es/guides/speech-intelligibility/).
 
@@ -815,7 +815,7 @@ que las guías incorporan sus secciones de Referencias.
   (DHHS/NIOSH Publication No. 98-126).
   [doi:10.26616/NIOSHPUB98126](https://doi.org/10.26616/NIOSHPUB98126),
   [PDF gratuito](https://www.cdc.gov/niosh/docs/98-126/pdfs/98-126.pdf).
-  El documento de criterios de libre acceso tras el límite de exposición
+  El documento de criterios de libre acceso que sustenta el límite de exposición
   recomendado de 85 dB(A) y la discusión de conservación auditiva y umbral.
   Citado por [Pérdida auditiva inducida por ruido](/phonometry/es/guides/noise-induced-hearing-loss/) y
   [Exposición al ruido en el trabajo](/phonometry/es/guides/occupational-exposure/).

--- a/site/src/content/docs/es/reference/theory/environment-transport.md
+++ b/site/src/content/docs/es/reference/theory/environment-transport.md
@@ -289,7 +289,7 @@ Consulta la [guía de potencia sonora](/phonometry/es/guides/sound-power/) para 
 - Salomons, E. M. (2001). *Computational atmospheric acoustics*. Kluwer
   Academic Publishers. ISBN 978-1-4020-0390-5.
   [doi:10.1007/978-94-010-0660-6](https://doi.org/10.1007/978-94-010-0660-6).
-  La teoría ondulatoria de la propagación en exteriores tras las
+  La teoría ondulatoria de la propagación en exteriores que sustenta las
   aproximaciones de ingeniería de la sección de ISO 9613-2.
 - Attenborough, K., & Van Renterghem, T. (2021). *Predicting outdoor sound*
   (2.ª ed.). CRC Press.
@@ -304,7 +304,7 @@ Consulta la [guía de potencia sonora](/phonometry/es/guides/sound-power/) para 
 - Fahy, F. J. (1995). *Sound intensity* (2.ª ed.). E&FN Spon.
   ISBN 978-0-419-19810-9.
   [doi:10.4324/9780203475386](https://doi.org/10.4324/9780203475386).
-  La física de la intensidad tras los métodos de barrido: la intensidad
+  La física de la intensidad que sustenta los métodos de barrido: la intensidad
   activa y el presupuesto de error p-p.
 - International Organization for Standardization. (2016). *Acoustics —
   Description, measurement and assessment of environmental noise — Part 1:

--- a/site/src/content/docs/es/reference/theory/perception.md
+++ b/site/src/content/docs/es/reference/theory/perception.md
@@ -242,7 +242,7 @@ Consulta la [guía de pérdida auditiva inducida por ruido](/phonometry/es/guide
 - Fletcher, H., & Munson, W. A. (1933). Loudness, its definition, measurement
   and calculation. *The Journal of the Acoustical Society of America*, 5(2),
   82-108. [doi:10.1121/1.1915637](https://doi.org/10.1121/1.1915637).
-  Las mediciones originales de igual sonoridad tras el concepto de isófona
+  Las mediciones originales de igual sonoridad que sustentan el concepto de isófona
   de la primera sección.
 - Fastl, H., & Zwicker, E. (2007). *Psychoacoustics: Facts and models*
   (3.ª ed.). Springer.
@@ -258,7 +258,7 @@ Consulta la [guía de pérdida auditiva inducida por ruido](/phonometry/es/guide
   intelligibility of speech sounds. *The Journal of the Acoustical Society of
   America*, 19(1), 90-119.
   [doi:10.1121/1.1916407](https://doi.org/10.1121/1.1916407).
-  Los experimentos por bandas de articulación tras la función de importancia
+  Los experimentos por bandas de articulación que sustentan la función de importancia
   de banda del SII.
 - Passchier-Vermeer, W. (1974). Hearing loss due to continuous exposure to
   steady-state broad-band noise. *The Journal of the Acoustical Society of

--- a/site/src/content/docs/es/reference/theory/rooms-buildings.md
+++ b/site/src/content/docs/es/reference/theory/rooms-buildings.md
@@ -402,7 +402,7 @@ Consulta la [guía de materiales](/phonometry/es/guides/materials/) para su uso.
 
 - Kuttruff, H. (2016). *Room acoustics* (6.ª ed.). CRC Press.
   [doi:10.1201/9781315372150](https://doi.org/10.1201/9781315372150).
-  La teoría estadística del decaimiento tras la integración hacia atrás y
+  La teoría estadística del decaimiento que sustenta la integración hacia atrás y
   las relaciones de Sabine usadas a lo largo de esta página.
 - Schroeder, M. R. (1965). New method of measuring reverberation time.
   *The Journal of the Acoustical Society of America*, 37(3), 409-412.
@@ -413,7 +413,7 @@ Consulta la [guía de materiales](/phonometry/es/guides/materials/) para su uso.
   Measuring room impulse responses: Impact of the decay range on derived
   room acoustic parameters. *Acta Acustica united with Acustica*, 98(6),
   907-915. [doi:10.3813/aaa.918574](https://doi.org/10.3813/aaa.918574).
-  El análisis de la INR sobre el rango de decaimiento tras los umbrales de
+  El análisis de la INR sobre el rango de decaimiento que sustenta los umbrales de
   validez endurecidos de T20/T30.
 - Beranek, L. L. (1957). Revised criteria for noise in buildings. *Noise
   Control*, 3(1), 19-27.
@@ -440,7 +440,7 @@ Consulta la [guía de materiales](/phonometry/es/guides/materials/) para su uso.
   Theory, design and application* (3.ª ed.). CRC Press.
   ISBN 978-1-4987-4099-9.
   [doi:10.1201/9781315369211](https://doi.org/10.1201/9781315369211).
-  La medida y el diseño de absorbentes y difusores, de los autores tras el
+  La medida y el diseño de absorbentes y difusores, de los autores del
   método del coeficiente de difusión de ISO 17497-2.
 - Allard, J. F., & Atalla, N. (2009). *Propagation of sound in porous media:
   Modelling sound absorbing materials* (2.ª ed.). Wiley.

--- a/site/src/content/docs/es/reference/theory/signal-analysis.md
+++ b/site/src/content/docs/es/reference/theory/signal-analysis.md
@@ -352,7 +352,7 @@ Consulta la [guía de incertidumbre de medida](/phonometry/es/guides/gum-uncerta
 - Oppenheim, A. V., & Schafer, R. W. (2010). *Discrete-time signal processing*
   (3.ª ed.). Pearson. ISBN 978-0-13-198842-2.
   [Ficha en Open Library](https://openlibrary.org/isbn/9780131988422).
-  La teoría de filtros digitales tras las cascadas SOS, la transformada
+  La teoría de filtros digitales que sustenta las cascadas SOS, la transformada
   bilineal y el diezmado multitasa de la sección de diseño del banco de
   filtros.
 - Smith, J. O. *Introduction to digital filters with audio applications*
@@ -384,7 +384,7 @@ Consulta la [guía de incertidumbre de medida](/phonometry/es/guides/gum-uncerta
   como EN 61043:1994).
   [Tienda IEC](https://webstore.iec.ch/en/publication/4353).
   La norma de instrumentación p-p: el estimador por espectro cruzado y el
-  índice presión-intensidad residual tras la capacidad dinámica.
+  índice presión-intensidad residual que sustentan la capacidad dinámica.
 - International Organization for Standardization. (1993). *Acoustics —
   Determination of sound power levels of noise sources using sound
   intensity — Part 1: Measurement at discrete points* (ISO 9614-1:1993).

--- a/site/src/content/docs/es/reference/theory/vibration.md
+++ b/site/src/content/docs/es/reference/theory/vibration.md
@@ -77,7 +77,7 @@ Consulta la [guía de vibración en humanos](/phonometry/es/guides/human-vibrati
 - Griffin, M. J. (1996). *Handbook of human vibration*. Academic Press.
   ISBN 978-0-12-303041-2.
   [Página del editor](https://shop.elsevier.com/books/handbook-of-human-vibration/griffin/978-0-12-303041-2).
-  La evidencia biodinámica y de efectos sobre la salud tras las ponderaciones
+  La evidencia biodinámica y de efectos sobre la salud que sustenta las ponderaciones
   de ISO 8041-1, las medidas de dosis rms/MTVV/VDV y el razonamiento de
   lesión espinal del modelo de choques múltiples.
 - Mansfield, N. J. (2004). *Human response to vibration*. CRC Press.


### PR DESCRIPTION
## Summary

Settles the Spanish register for underlying-something phrasing across the documentation, occurrence by occurrence.

The Spanish pages used "tras" both in its correct temporal or positional sense and as a compact rendering of the English "behind" in the underlying sense ("la teoria tras las cascadas SOS"). Every occurrence in the ES trees was judged in context:

- 65 figurative occurrences changed: "que sustenta" or "que sustentan" (54, the dominant underlying-support pattern, with subject-number agreement verified case by case), "que explica" for causal or mechanism contexts (5), authorship restructures like "autores del metodo" (3), "en la que se basa" for code-symbol anchoring (2), and one full restructure for the edition switch.
- 19 genuine temporal, positional or sequential uses kept, including the physically-behind barrier, the reading-progression "el paso natural tras las guias" and the signal-chain sequences.
- The bibliography support notes now follow a single consistent pattern; the same phrase appearing twice with different senses ("el termino de acoplamiento") is split correctly by context.

A second native-editor pass re-judged every change and every kept occurrence against the merged current state (including one new temporal occurrence that arrived with the snippets PR) and ratified the set without amendments.

## Test plan

i18n parity (56 pairs), site build with links validator at 0 errors and html-validate all green on the merged state.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved Spanish wording across getting-started materials, guides, references, and theory pages.
  * Clarified how referenced research, standards, methods, and concepts support the documented explanations.
  * Refined descriptions related to acoustic calculations, measurements, propagation, perception, and noise analysis.
  * Preserved all links, formulas, technical content, and bibliography metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->