### PR TITLE
docs: didactic landing pages for every sidebar group and subgroup

### DIFF
--- a/site/.pa11yci.json
+++ b/site/.pa11yci.json
@@ -41,6 +41,10 @@
     "http://localhost:4321/phonometry/es/guides/loudness/",
     "http://localhost:4321/phonometry/es/reference/theory/",
     "http://localhost:4321/phonometry/reference/bibliography/",
-    "http://localhost:4321/phonometry/es/reference/bibliography/"
+    "http://localhost:4321/phonometry/es/reference/bibliography/",
+    "http://localhost:4321/phonometry/guides/sections/rooms-buildings/",
+    "http://localhost:4321/phonometry/guides/sections/room-acoustics/",
+    "http://localhost:4321/phonometry/es/guides/sections/rooms-buildings/",
+    "http://localhost:4321/phonometry/es/guides/sections/room-acoustics/"
   ]
 }

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -309,20 +309,35 @@ export default defineConfig({
           label: 'Core signal analysis',
           translations: { es: 'Análisis de señal' },
           items: [
+            { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/core-signal-analysis' },
             {
               label: 'Octave filtering',
               translations: { es: 'Filtrado en octavas' },
-              items: ['guides/filter-banks', 'guides/block-processing', 'guides/multichannel'],
+              items: [
+                { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/octave-filtering' },
+                'guides/filter-banks',
+                'guides/block-processing',
+                'guides/multichannel',
+              ],
             },
             {
               label: 'Levels and weighting',
               translations: { es: 'Niveles y ponderación' },
-              items: ['guides/weighting', 'guides/time-weighting', 'guides/levels'],
+              items: [
+                { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/levels-weighting' },
+                'guides/weighting',
+                'guides/time-weighting',
+                'guides/levels',
+              ],
             },
             {
               label: 'Calibration and uncertainty',
               translations: { es: 'Calibración e incertidumbre' },
-              items: ['guides/calibration', 'guides/gum-uncertainty'],
+              items: [
+                { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/calibration-uncertainty' },
+                'guides/calibration',
+                'guides/gum-uncertainty',
+              ],
             },
           ],
         },
@@ -330,10 +345,12 @@ export default defineConfig({
           label: 'Hearing and perception',
           translations: { es: 'Audición y percepción' },
           items: [
+            { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/hearing-perception' },
             {
               label: 'Psychoacoustics',
               translations: { es: 'Psicoacústica' },
               items: [
+                { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/psychoacoustics' },
                 'guides/loudness',
                 'guides/sound-quality',
                 'guides/tone-prominence',
@@ -344,12 +361,17 @@ export default defineConfig({
             {
               label: 'Speech',
               translations: { es: 'Habla' },
-              items: ['guides/speech-transmission', 'guides/speech-intelligibility'],
+              items: [
+                { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/speech' },
+                'guides/speech-transmission',
+                'guides/speech-intelligibility',
+              ],
             },
             {
               label: 'Hearing and exposure',
               translations: { es: 'Audición y exposición' },
               items: [
+                { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/hearing-exposure' },
                 'guides/hearing-threshold',
                 'guides/noise-induced-hearing-loss',
                 'guides/occupational-exposure',
@@ -361,10 +383,12 @@ export default defineConfig({
           label: 'Rooms and buildings',
           translations: { es: 'Salas y edificación' },
           items: [
+            { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/rooms-buildings' },
             {
               label: 'Room acoustics',
               translations: { es: 'Acústica de salas' },
               items: [
+                { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/room-acoustics' },
                 'guides/room-acoustics',
                 'guides/room-noise',
                 'guides/reverberation-prediction',
@@ -375,6 +399,7 @@ export default defineConfig({
               label: 'Sound insulation',
               translations: { es: 'Aislamiento acústico' },
               items: [
+                { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/sound-insulation' },
                 'guides/insulation-field',
                 'guides/insulation-lab',
                 'guides/insulation-prediction',
@@ -384,7 +409,11 @@ export default defineConfig({
             {
               label: 'Materials and surfaces',
               translations: { es: 'Materiales y superficies' },
-              items: ['guides/materials', 'guides/surface-scattering'],
+              items: [
+                { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/materials-surfaces' },
+                'guides/materials',
+                'guides/surface-scattering',
+              ],
             },
           ],
         },
@@ -392,10 +421,12 @@ export default defineConfig({
           label: 'Vibration and structure-borne sound',
           translations: { es: 'Vibración y ruido estructural' },
           items: [
+            { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/vibration' },
             {
               label: 'Structure-borne sources',
               translations: { es: 'Fuentes de ruido estructural' },
               items: [
+                { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/structure-borne' },
                 'guides/mechanical-mobility',
                 'guides/transfer-stiffness',
                 'guides/vibration-sound-power',
@@ -406,7 +437,11 @@ export default defineConfig({
             {
               label: 'Human vibration',
               translations: { es: 'Vibración en humanos' },
-              items: ['guides/human-vibration', 'guides/multiple-shock-vibration'],
+              items: [
+                { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/human-vibration' },
+                'guides/human-vibration',
+                'guides/multiple-shock-vibration',
+              ],
             },
           ],
         },
@@ -414,27 +449,46 @@ export default defineConfig({
           label: 'Environment and transport',
           translations: { es: 'Medio ambiente y transporte' },
           items: [
+            { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/environment-transport' },
             {
               label: 'Outdoor sound',
               translations: { es: 'Sonido en exteriores' },
-              items: ['guides/outdoor-propagation', 'guides/impulse-prominence'],
+              items: [
+                { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/outdoor-sound' },
+                'guides/outdoor-propagation',
+                'guides/impulse-prominence',
+              ],
             },
             {
               label: 'Aircraft and wind energy',
               translations: { es: 'Aeronaves y energía eólica' },
-              items: ['guides/aircraft-noise', 'guides/rotorcraft-noise', 'guides/wind-turbine-noise'],
+              items: [
+                { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/aircraft-wind' },
+                'guides/aircraft-noise',
+                'guides/rotorcraft-noise',
+                'guides/wind-turbine-noise',
+              ],
             },
           ],
         },
         {
           label: 'Underwater acoustics',
           translations: { es: 'Acústica submarina' },
-          items: ['guides/underwater-acoustics', 'guides/underwater-propagation'],
+          items: [
+            { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/underwater' },
+            'guides/underwater-acoustics',
+            'guides/underwater-propagation',
+          ],
         },
         {
           label: 'Sources and devices',
           translations: { es: 'Fuentes y dispositivos' },
-          items: ['guides/intensity', 'guides/sound-power', 'guides/electroacoustics'],
+          items: [
+            { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/sources-devices' },
+            'guides/intensity',
+            'guides/sound-power',
+            'guides/electroacoustics',
+          ],
         },
         {
           label: 'Reference',

--- a/site/src/components/Head.astro
+++ b/site/src/components/Head.astro
@@ -60,6 +60,7 @@ function titleCase(seg: string) {
 }
 const SECTION_LABELS: Record<string, { en: string; es: string }> = {
   guides: { en: 'Guides', es: 'Guías' },
+  sections: { en: 'Sections', es: 'Secciones' },
   reference: { en: 'Reference', es: 'Referencia' },
 };
 const segments = rel.split('/').filter(Boolean).filter((s) => s !== 'es');

--- a/site/src/content/docs/es/guides/sections/aircraft-wind.md
+++ b/site/src/content/docs/es/guides/sections/aircraft-wind.md
@@ -1,0 +1,55 @@
+---
+title: "Aeronaves y energía eólica"
+description: "Fuentes de transporte y energía con métricas de ruido fijadas internacionalmente: el EPNL del Anexo 16 de la ICAO y la maquinaria de aeropuertos de ECAC Doc 29, el método del hemisferio para rotorcraft de ECAC Doc 32, y la emisión y audibilidad tonal de aerogeneradores de IEC 61400-11."
+---
+
+Las aeronaves y los aerogeneradores son fuentes de ruido lo bastante
+importantes como para tener métricas propias negociadas internacionalmente,
+cada una fijada hasta el último decimal por un marco de certificación o de
+ensayo de tipo. Las tres páginas de esta sección implementan esos marcos, y
+comparten una misma anatomía: un **descriptor de fuente** rigurosamente
+normalizado, más **ajustes de propagación** normalizados que colocan la
+fuente en un receptor.
+
+[Ruido de aeronaves: nivel efectivo de ruido percibido](/phonometry/es/guides/aircraft-noise/)
+cubre la certificación de ala fija. El **EPNL** del Anexo 16 de la ICAO
+condensa una historia temporal en tercios de octava de un sobrevuelo en un
+único valor en EPNdB a través de la molestia percibida, una corrección tonal
+y una corrección de duración; la página añade el verificador de sistemas de medida IEC 61265, la
+absorción atmosférica SAE ARP 5534 usada en la cadena de certificación, y la
+interpolación ruido-potencia-distancia de ECAC Doc 29 que convierte niveles
+certificados en entradas para contornos de aeropuerto.
+
+[Ruido de rotorcraft: el método del hemisferio](/phonometry/es/guides/rotorcraft-noise/)
+cubre los helicópteros, cuya fuerte directividad derrota a un nivel de fuente
+de un solo número. ECAC Doc 32 describe en cambio la fuente como un
+**hemisferio de ruido** (niveles de banda sobre una malla de ángulos de
+emisión a una distancia de referencia de 60 m) y propaga cada rayo con
+divergencia esférica, absorción atmosférica y el efecto de suelo de
+Chien-Soroka.
+
+[Ruido de aerogeneradores: potencia y audibilidad tonal](/phonometry/es/guides/wind-turbine-noise/)
+cubre el ensayo de tipo de IEC 61400-11: el **nivel de potencia sonora
+aparente** que refiere la inmisión medida a una fuente puntual equivalente en
+el centro del rotor, y la cadena de audibilidad tonal que decide si un tono
+de paso de pala, multiplicadora o generador es audible sobre su ruido
+enmascarante.
+
+La física compartida conecta hacia fuera: la absorción atmosférica viene del
+mismo modelo ISO 9613-1 que
+[Propagación del sonido en exteriores](/phonometry/es/guides/outdoor-propagation/),
+y el ensayo de tonalidad de aerogeneradores es primo de los métodos de
+audibilidad tonal de
+[Psicoacústica](/phonometry/es/guides/sections/psychoacoustics/).
+
+## Páginas de esta sección
+
+- [Ruido de aeronaves: nivel efectivo de ruido percibido](/phonometry/es/guides/aircraft-noise/):
+  la cadena EPNL del Anexo 16 de la ICAO, el verificador IEC 61265, la absorción
+  SAE ARP 5534 y la interpolación NPD de ECAC Doc 29.
+- [Ruido de rotorcraft: el método del hemisferio](/phonometry/es/guides/rotorcraft-noise/):
+  el modelo de fuente de hemisferio de ruido de ECAC Doc 32 y sus ajustes de
+  propagación.
+- [Ruido de aerogeneradores: potencia y audibilidad tonal](/phonometry/es/guides/wind-turbine-noise/):
+  el nivel de potencia sonora aparente de IEC 61400-11 y la cadena de
+  audibilidad tonal.

--- a/site/src/content/docs/es/guides/sections/calibration-uncertainty.md
+++ b/site/src/content/docs/es/guides/sections/calibration-uncertainty.md
@@ -1,0 +1,46 @@
+---
+title: "Calibración e incertidumbre"
+description: "Las dos disciplinas que convierten un nivel calculado en una medición defendible: calibración SPL física frente a análisis digital en dBFS, y la propagación de la incertidumbre de medida por GUM y Monte Carlo."
+---
+
+Un nivel impreso por un programa no es todavía una medición. Dos cosas
+separan lo uno de lo otro: saber qué significan **físicamente** las muestras
+digitales, y saber cuánto podría razonablemente **equivocarse** el resultado.
+Esta sección cubre ambas, y aplican transversalmente a todas las demás
+páginas de la documentación.
+
+[Calibración y dBFS](/phonometry/es/guides/calibration/) se ocupa de la
+primera. phonometry trabaja en dos marcos de referencia: los **dB SPL**
+físicos, establecidos a partir de un tono de calibrador grabado (el ritual de
+campo de IEC 60942) o de una sensibilidad de micrófono conocida, y los
+**dBFS** digitales, niveles relativos al fondo de escala, apropiados cuando
+no existe referencia física o cuando se caracteriza la propia cadena digital.
+La página explica cómo se configura cada modo y, no menos importante, qué
+magnitudes tienen sentido en cada marco.
+
+[Incertidumbre de medida (GUM y Monte Carlo)](/phonometry/es/guides/gum-uncertainty/)
+se ocupa de la segunda, implementando la *Guía para la expresión de la
+incertidumbre de medida* (**ISO/IEC Guide 98-3:2008**) y su **Suplemento 1**
+de Monte Carlo. La ruta GUM propaga las incertidumbres típicas
+analíticamente, a través de los coeficientes de sensibilidad, hasta una
+incertidumbre combinada y expandida, con los grados de libertad efectivos de
+Welch-Satterthwaite; la ruta de Monte Carlo propaga numéricamente las
+distribuciones de probabilidad completas y produce intervalos de cobertura
+que siguen siendo honestos cuando el modelo es no lineal o las entradas
+distan de ser gaussianas. La página muestra ambas sobre los mismos modelos,
+incluyendo dónde divergen y por qué.
+
+Las dos páginas se encuentran en la práctica: un presupuesto de incertidumbre
+de una medición acústica casi siempre contiene un término de calibración, y
+varias normas implementadas en otras partes de la biblioteca (ISO 9612,
+ISO 12999-1) traen presupuestos de incertidumbre que son especializaciones de
+la maquinaria GUM descrita aquí.
+
+## Páginas de esta sección
+
+- [Calibración y dBFS](/phonometry/es/guides/calibration/): calibración SPL
+  física desde un tono de calibrador o una sensibilidad conocida, y el modo
+  digital de fondo de escala.
+- [Incertidumbre de medida (GUM y Monte Carlo)](/phonometry/es/guides/gum-uncertainty/):
+  la ley de propagación de la incertidumbre y el método de Monte Carlo,
+  incertidumbre expandida e intervalos de cobertura.

--- a/site/src/content/docs/es/guides/sections/core-signal-analysis.md
+++ b/site/src/content/docs/es/guides/sections/core-signal-analysis.md
@@ -1,0 +1,72 @@
+---
+title: "Análisis de señal"
+description: "El núcleo de medición de phonometry: bancos de filtros de octava fraccional, ponderación frecuencial y temporal, niveles integrados y estadísticos, calibración física e incertidumbre de medida, y cómo esas piezas se encadenan en un sonómetro en código."
+---
+
+Todo en phonometry empieza aquí. Esta sección cubre la cadena que convierte
+una señal digital en bruto en números acústicos conformes con las normas:
+dividirla en **bandas de octava fraccional** (ANSI S1.11 / IEC 61260-1),
+moldearla con las **ponderaciones frecuenciales** de IEC 61672-1, suavizarla
+con las **balísticas temporales Fast/Slow/Impulse** e integrarla en **Leq y
+niveles estadísticos**. Es, en la práctica, un sonómetro descompuesto en
+funciones componibles, y todas las demás secciones de la documentación se
+apoyan en él: un modelo de sonoridad consume niveles de banda calibrados, un
+parámetro de sala parte de una respuesta al impulso filtrada, una valoración
+ambiental es un Leq ajustado.
+
+Dos preocupaciones transversales completan el núcleo. La **calibración**
+decide qué significan físicamente las muestras digitales: los resultados
+pueden referirse a un tono de calibrador medido o a una sensibilidad conocida
+(dB SPL), o quedarse en escala digital completa (dBFS). Y la **incertidumbre
+de medida** (la GUM y su suplemento de Monte Carlo) cualifica cualquier
+resultado calculado a partir de entradas inciertas, que es lo que hace
+defendible un número en un informe.
+
+Si acabas de llegar a la biblioteca, lee primero
+[Bancos de filtros](/phonometry/es/guides/filter-banks/): presenta la
+descomposición en bandas que el resto de páginas da por supuesta. Después,
+[Niveles integrados y estadísticos](/phonometry/es/guides/levels/) muestra las
+métricas en las que terminan la mayoría de las mediciones, y
+[Calibración y dBFS](/phonometry/es/guides/calibration/) las ancla a unidades
+físicas.
+
+## [Filtrado en octavas](/phonometry/es/guides/sections/octave-filtering/)
+
+La descomposición en bandas de octava fraccional y las dos maneras de
+escalarla: bloques en streaming y arrays multicanal.
+
+- [Bancos de filtros](/phonometry/es/guides/filter-banks/): las cinco
+  arquitecturas de filtro, sus respuestas en frecuencia, la descomposición en
+  bandas y el filtrado de fase cero fuera de línea.
+- [Procesado por bloques](/phonometry/es/guides/block-processing/): análisis
+  en streaming con estado, que arrastra el estado de los filtros entre
+  búferes, para señales que no caben en memoria.
+- [Multicanal y rendimiento](/phonometry/es/guides/multichannel/): análisis
+  vectorizado de muchos canales a la vez, con notas de rendimiento.
+
+## [Niveles y ponderación](/phonometry/es/guides/sections/levels-weighting/)
+
+De la señal ponderada al nivel reportado: las ponderaciones frecuenciales,
+las balísticas temporales y los niveles integrados, estadísticos y de
+valoración.
+
+- [Ponderación frecuencial (A, C, G, Z)](/phonometry/es/guides/weighting/):
+  las curvas de respuesta del oído de IEC 61672-1 y la ponderación G para
+  infrasonido de ISO 7196.
+- [Ponderación temporal](/phonometry/es/guides/time-weighting/): las
+  balísticas exponenciales Fast, Slow e Impulse según IEC 61672-1.
+- [Niveles integrados y estadísticos](/phonometry/es/guides/levels/): Leq y
+  LAeq, niveles percentiles L10/L50/L90, LCpeak y SEL, dosis de ruido
+  (IEC 61252), Lden y niveles de valoración (ISO 1996-1), y espectrogramas de
+  octava.
+
+## [Calibración e incertidumbre](/phonometry/es/guides/sections/calibration-uncertainty/)
+
+Qué significan los números y cuánto fiarse de ellos.
+
+- [Calibración y dBFS](/phonometry/es/guides/calibration/): calibración SPL
+  física a partir de un tono de calibrador (IEC 60942) o de una sensibilidad
+  conocida, y el modo digital dBFS.
+- [Incertidumbre de medida (GUM y Monte Carlo)](/phonometry/es/guides/gum-uncertainty/):
+  la ley de propagación de la incertidumbre y el método de Monte Carlo de
+  ISO/IEC Guide 98-3, con incertidumbre expandida e intervalos de cobertura.

--- a/site/src/content/docs/es/guides/sections/environment-transport.md
+++ b/site/src/content/docs/es/guides/sections/environment-transport.md
@@ -1,0 +1,59 @@
+---
+title: "Medio ambiente y transporte"
+description: "El sonido en exteriores y las fuentes de transporte que lo dominan: el modelo de propagación ISO 9613, el ajuste por sonidos impulsivos NT ACOU 112, la certificación de ruido de aeronaves (EPNL, ECAC Doc 29), el método del hemisferio para rotorcraft y la emisión acústica de aerogeneradores."
+---
+
+El ruido ambiental es un problema fuente-camino-receptor estirado a lo largo
+de cientos de metros de aire libre. Esta sección cubre sus dos extremos. Las
+páginas de **sonido en exteriores** se ocupan del camino y de la evaluación:
+ISO 9613 predice, banda a banda, cuánto nivel sobrevive a la divergencia, la
+absorción del aire, el suelo y cualquier barrera de camino al receptor, y
+NT ACOU 112 cuantifica cuándo el carácter impulsivo hace el sonido recibido
+más molesto de lo que sugiere su LAeq.
+
+Las páginas de **aeronaves y energía eólica** se ocupan de fuentes de
+transporte que llegan con sus propias métricas fijadas internacionalmente. La
+certificación de ruido de aeronaves gira en torno al nivel efectivo de ruido
+percibido del Anexo 16 de la ICAO, con la maquinaria de contornos de
+aeropuerto de ECAC Doc 29 construida encima; los helicópteros tienen el
+modelo de fuente de hemisferio de ruido de ECAC Doc 32; y los aerogeneradores
+se valoran por
+la potencia sonora aparente y la audibilidad tonal de IEC 61400-11. Lo que
+los une es el patrón: un descriptor de fuente cuidadosamente normalizado más
+ajustes de propagación normalizados.
+
+Esta sección se apoya en el núcleo de la biblioteca más que ninguna otra: los
+niveles de valoración y el Lden en que termina la evaluación ambiental viven
+en [Niveles integrados y estadísticos](/phonometry/es/guides/levels/), y la
+absorción atmosférica que consume todo modelo de propagación se comparte con
+las páginas de salas y materiales. Empieza por
+[Propagación del sonido en exteriores](/phonometry/es/guides/outdoor-propagation/):
+introduce la contabilidad fuente-camino-receptor que las páginas de
+transporte reutilizan.
+
+## [Sonido en exteriores](/phonometry/es/guides/sections/outdoor-sound/)
+
+El camino de una fuente exterior a un receptor, y el carácter de lo que
+llega.
+
+- [Propagación del sonido en exteriores](/phonometry/es/guides/outdoor-propagation/):
+  absorción atmosférica (ISO 9613-1) y el método general de ISO 9613-2 con su
+  desglose de atenuación término a término.
+- [Prominencia de sonidos impulsivos (NT ACOU 112)](/phonometry/es/guides/impulse-prominence/):
+  la prominencia predicha de los sonidos impulsivos y el ajuste graduado
+  añadido al LAeq.
+
+## [Aeronaves y energía eólica](/phonometry/es/guides/sections/aircraft-wind/)
+
+Fuentes de transporte y energía con métricas de certificación propias.
+
+- [Ruido de aeronaves: nivel efectivo de ruido percibido](/phonometry/es/guides/aircraft-noise/):
+  el EPNL del Anexo 16 de la ICAO, el verificador de sistemas de medida IEC 61265,
+  la absorción atmosférica SAE ARP 5534 y la interpolación NPD de ECAC
+  Doc 29.
+- [Ruido de rotorcraft: el método del hemisferio](/phonometry/es/guides/rotorcraft-noise/):
+  el modelo de fuente de hemisferio de ruido de ECAC Doc 32 con sus ajustes
+  de propagación.
+- [Ruido de aerogeneradores: potencia y audibilidad tonal](/phonometry/es/guides/wind-turbine-noise/):
+  el nivel de potencia sonora aparente de IEC 61400-11 y la cadena de
+  audibilidad tonal.

--- a/site/src/content/docs/es/guides/sections/hearing-exposure.md
+++ b/site/src/content/docs/es/guides/sections/hearing-exposure.md
@@ -1,0 +1,52 @@
+---
+title: "Audición y exposición"
+description: "La estadística de la audición y el ruido que la daña: la distribución del umbral con la edad de ISO 7029 y el cero de referencia de ISO 389-7, el desplazamiento permanente del umbral inducido por ruido de ISO 1999, y el muestreo de exposición laboral de ISO 9612."
+---
+
+Esta sección conecta tres magnitudes que la regulación trata como una sola
+historia: dónde se sitúa el **umbral de audición** de una población, cómo se
+mide la **exposición laboral al ruido**, y cómo esa exposición **desplaza el
+umbral** de forma permanente a lo largo de una vida de trabajo.
+
+[Umbral de audición (edad y cero de referencia)](/phonometry/es/guides/hearing-threshold/)
+establece la línea base. **ISO 7029:2017** da la distribución estadística del
+umbral de audición con la edad para una población otológicamente normal: la
+pérdida lenta, que empieza por las altas frecuencias, de la presbiacusia,
+resuelta por edad, sexo y fractil de población. **ISO 389-7:2005** fija el
+otro extremo de la escala: el umbral de referencia de audición, el nivel de
+presión sonora físico al que corresponde el 0 dB HL audiométrico en escucha
+de campo libre y campo difuso.
+
+[Exposición al ruido en el trabajo (ISO 9612)](/phonometry/es/guides/occupational-exposure/)
+mide la causa. El nivel de exposición diario regulado LEX,8h se ensambla a
+partir de muestras de una jornada real por una de tres estrategias (por
+tareas, por puesto o de jornada completa), y se reporta con el presupuesto de
+incertidumbre normativo del Anexo C y su límite superior unilateral al 95 %,
+que es lo que un higienista compara realmente con los valores de acción.
+
+[Pérdida auditiva inducida por ruido (ISO 1999)](/phonometry/es/guides/noise-induced-hearing-loss/)
+predice el efecto. A partir del nivel y la duración de la exposición da el
+desplazamiento permanente del umbral inducido por ruido (NIPTS) con su
+dispersión poblacional, concentrado en la característica muesca de 4 kHz, y
+lo combina con la componente de edad de ISO 7029 en el nivel de umbral de
+audición asociado a edad y ruido (HTLAN): la magnitud con la que se estima el
+hándicap auditivo y el riesgo de compensación en una población expuesta.
+
+Lee primero la página del umbral, después ISO 9612 y después ISO 1999: línea
+base, exposición, daño. Así la cadena queda explícita: ISO 9612 produce el
+LEX,8h que ISO 1999 consume, e ISO 1999 se apoya en la estadística de
+ISO 7029. Las consecuencias perceptivas de un
+umbral desplazado, como la pérdida de inteligibilidad, las recoge el SII en
+la [sección de habla](/phonometry/es/guides/sections/speech/).
+
+## Páginas de esta sección
+
+- [Umbral de audición (edad y cero de referencia)](/phonometry/es/guides/hearing-threshold/):
+  la distribución del umbral con la edad de ISO 7029:2017 y el umbral de
+  referencia de ISO 389-7:2005.
+- [Pérdida auditiva inducida por ruido (ISO 1999)](/phonometry/es/guides/noise-induced-hearing-loss/):
+  el NIPTS y su distribución poblacional, y la combinación con la edad en el
+  HTLAN.
+- [Exposición al ruido en el trabajo (ISO 9612)](/phonometry/es/guides/occupational-exposure/):
+  las tres estrategias de medición para LEX,8h con el presupuesto de
+  incertidumbre del Anexo C.

--- a/site/src/content/docs/es/guides/sections/hearing-perception.md
+++ b/site/src/content/docs/es/guides/sections/hearing-perception.md
@@ -1,0 +1,73 @@
+---
+title: "Audición y percepción"
+description: "Cómo perciben el sonido los oyentes y qué hace el ruido a la audición: sensaciones psicoacústicas (sonoridad, agudeza, aspereza, tonalidad, molestia), inteligibilidad del habla (STI y SII), y la estadística de umbrales, daño auditivo y exposición laboral."
+---
+
+Un nivel de presión sonora dice cuánto sonido hay; esta sección trata de lo
+que un **oyente** hace con él. Sus tres subsecciones responden a tres
+preguntas distintas. La **psicoacústica** cuantifica sensaciones: cuán fuerte
+se percibe un sonido, cuán agudo, áspero o tonal resulta, y cómo esas
+sensaciones se combinan en molestia. El **habla** pregunta cómo sobreviven
+las palabras al viaje del hablante al oyente, a través de una sala, un
+sistema de megafonía o el ruido de fondo. Y **audición y exposición** cubre
+el propio oído: dónde se sitúa el umbral de audición según la edad y la
+población, cómo el ruido lo desplaza de forma permanente, y cómo se mide y
+reporta la exposición de una jornada laboral.
+
+Las tres se apoyan mutuamente en una dirección: los modelos psicoacústicos
+consumen señales calibradas o espectros de banda del
+[análisis de señal](/phonometry/es/guides/sections/core-signal-analysis/); los
+índices de habla consumen niveles de banda y, en el caso del SII, los umbrales
+de audición que cuantifican las páginas de exposición; y las métricas de
+exposición alimentan el modelo de daño auditivo de ISO 1999.
+
+Un buen punto de entrada es [Sonoridad](/phonometry/es/guides/loudness/):
+introduce la escala perceptiva (el sonio) y los modelos auditivos que la
+mayoría de las demás métricas de esta sección reutilizan o extienden.
+
+## [Psicoacústica](/phonometry/es/guides/sections/psychoacoustics/)
+
+Las sensaciones perceptivas del sonido: la sonoridad y las métricas
+construidas sobre ella.
+
+- [Sonoridad](/phonometry/es/guides/loudness/): sonoridad de Zwicker
+  (ISO 532-1), Moore-Glasberg (ISO 532-2/3) y Sottek (ECMA-418-2) en sonios,
+  más las curvas isofónicas de ISO 226:2023.
+- [Métricas de calidad sonora](/phonometry/es/guides/sound-quality/): agudeza
+  (DIN 45692) y la tonalidad y aspereza del modelo auditivo de Sottek
+  (ECMA-418-2).
+- [Tonos discretos prominentes (ECMA-418-1)](/phonometry/es/guides/tone-prominence/):
+  las razones tono-ruido y de prominencia que deciden si un tono discreto es
+  prominente.
+- [Audibilidad objetiva de tonos en ruido (ISO/PAS 20065)](/phonometry/es/guides/tone-audibility/):
+  el método de ingeniería para la audibilidad de un tono sobre el umbral de
+  enmascaramiento, que alimenta el ajuste tonal de ISO 1996-2.
+- [Molestia psicoacústica e intensidad de fluctuación](/phonometry/es/guides/psychoacoustic-annoyance/):
+  el modelo de molestia de Fastl y Zwicker, que combina sonoridad, agudeza,
+  aspereza e intensidad de fluctuación.
+
+## [Habla](/phonometry/es/guides/sections/speech/)
+
+Dos índices complementarios de inteligibilidad: el STI valora el canal de
+transmisión, el SII valora la condición de escucha.
+
+- [Índice de transmisión del habla (STI)](/phonometry/es/guides/speech-transmission/):
+  la función de transferencia de modulación de IEC 60268-16, el método
+  indirecto desde una respuesta al impulso y la medición directa STIPA.
+- [Índice de inteligibilidad del habla](/phonometry/es/guides/speech-intelligibility/):
+  el SII de ANSI S3.5-1997 en tercios de octava a partir de los espectros de
+  habla, ruido y umbral de audición.
+
+## [Audición y exposición](/phonometry/es/guides/sections/hearing-exposure/)
+
+El umbral de audición, lo que el ruido le hace y cómo se mide la exposición.
+
+- [Umbral de audición (edad y cero de referencia)](/phonometry/es/guides/hearing-threshold/):
+  la distribución del umbral con la edad de ISO 7029:2017 y el umbral de
+  referencia de ISO 389-7:2005.
+- [Pérdida auditiva inducida por ruido (ISO 1999)](/phonometry/es/guides/noise-induced-hearing-loss/):
+  el desplazamiento permanente del umbral inducido por ruido y su combinación
+  con la edad en el HTLAN.
+- [Exposición al ruido en el trabajo (ISO 9612)](/phonometry/es/guides/occupational-exposure/):
+  las estrategias por tareas, por puesto y de jornada completa para LEX,8h
+  con el presupuesto de incertidumbre del Anexo C.

--- a/site/src/content/docs/es/guides/sections/human-vibration.md
+++ b/site/src/content/docs/es/guides/sections/human-vibration.md
@@ -1,0 +1,46 @@
+---
+title: "Vibración en humanos"
+description: "La vibración transmitida a las personas: las ponderaciones de ISO 8041-1 y las métricas de cuerpo completo de ISO 2631-1, la exposición mano-brazo según ISO 5349 con los valores de acción y límite de la Directiva 2002/44/CE, y el modelo de respuesta espinal de ISO 2631-5 para choques repetidos."
+---
+
+La vibración transmitida a una persona se evalúa con una cadena de medida
+deliberadamente paralela a la de un sonómetro: la aceleración se **pondera en
+frecuencia** para reflejar cómo responde el cuerpo a cada frecuencia, se
+reduce a un valor **r.m.s. ponderado** o a una dosis, se combina entre ejes y
+se normaliza a una **exposición diaria** sobre la que la regulación puede
+actuar. Las dos páginas de esta sección cubren la cadena general y el caso
+especial que la rompe.
+
+[Vibración en humanos](/phonometry/es/guides/human-vibration/) es la cadena
+general. Cubre las ponderaciones frecuenciales de cuerpo completo y
+mano-brazo de **ISO 8041-1**, la aceleración r.m.s. ponderada y las medidas
+móviles y de dosis de **ISO 2631-1** (MTVV, VDV, MSDV, factor de cresta) que
+delatan los choques que un r.m.s. simple esconde, la vibración en edificios
+según ISO 2631-2, el valor total de vibración mano-brazo y la exposición
+diaria A(8) de **ISO 5349-1/-2**, y los valores de acción y límite de la
+**Directiva 2002/44/CE** que dan sentido legal a A(8).
+
+[Vibración con choques múltiples (ISO 2631-5)](/phonometry/es/guides/multiple-shock-vibration/)
+se ocupa de las exposiciones que la filosofía r.m.s. subestima: los choques
+mecánicos repetidos de los vehículos todoterreno, las embarcaciones rápidas o
+la maquinaria de movimiento de tierras, que cargan la columna lumbar mucho
+más de lo que sugiere su promedio energético. **ISO 2631-5:2018** modela
+explícitamente la transferencia del asiento a la columna, acumula una dosis a
+partir de los picos de respuesta y la convierte en tensión de compresión
+sobre los platillos vertebrales y en una probabilidad de lesión lumbar a lo
+largo de una vida laboral.
+
+Usa primero las métricas de ISO 2631-1; cuando el factor de cresta o el VDV
+avisen de que dominan los choques, el modelo de ISO 2631-5 es la continuación
+dedicada. El frontal de medida (filtros de ponderación, análisis en bandas)
+se comparte con la sección de
+[análisis de señal](/phonometry/es/guides/sections/core-signal-analysis/).
+
+## Páginas de esta sección
+
+- [Vibración en humanos](/phonometry/es/guides/human-vibration/):
+  ponderaciones ISO 8041-1, medidas r.m.s. y de dosis ISO 2631-1, exposición
+  diaria A(8) ISO 5349 y los valores de la Directiva 2002/44/CE.
+- [Vibración con choques múltiples (ISO 2631-5)](/phonometry/es/guides/multiple-shock-vibration/):
+  el modelo de respuesta espinal, la dosis de aceleración y la probabilidad
+  de lesión lumbar.

--- a/site/src/content/docs/es/guides/sections/levels-weighting.md
+++ b/site/src/content/docs/es/guides/sections/levels-weighting.md
@@ -1,0 +1,44 @@
+---
+title: "Niveles y ponderación"
+description: "De la señal ponderada al número reportado: las ponderaciones frecuenciales y las balísticas Fast/Slow/Impulse de IEC 61672-1, y los niveles integrados, estadísticos, de dosis y de valoración construidos sobre ellas."
+---
+
+Un sonómetro hace tres cosas a una señal calibrada, en orden: la **pondera en
+frecuencia** para imitar la sensibilidad del oído, la **suaviza en el tiempo**
+con una balística normalizada y la **integra en un nivel**. Las tres páginas
+de esta sección implementan exactamente esa cadena, una página por etapa,
+siguiendo **IEC 61672-1:2013** tan de cerca que las ponderaciones se
+verifican en CI contra las propias tablas de tolerancia de la norma.
+
+[Ponderación frecuencial (A, C, G, Z)](/phonometry/es/guides/weighting/)
+cubre la primera etapa. La curva A sigue la sensibilidad del oído a niveles
+moderados y domina la regulación; la C es casi plana y sirve para picos y
+comprobaciones de baja frecuencia; la Z no pondera por definición; y la curva
+G de **ISO 7196** extiende la idea al infrasonido, donde las ponderaciones
+convencionales son ciegas.
+
+[Ponderación temporal](/phonometry/es/guides/time-weighting/) cubre la
+segunda etapa: las balísticas exponenciales Fast (125 ms), Slow (1 s) e
+Impulse que deciden con qué rapidez el nivel mostrado sigue al sonido.
+phonometry implementa las constantes de tiempo exactas, verificadas contra
+las respuestas a ráfagas de tono de la norma.
+
+[Niveles integrados y estadísticos](/phonometry/es/guides/levels/) es la
+recompensa: el nivel continuo equivalente Leq y su versión ponderada A LAeq,
+los niveles percentiles L10/L50/L90 que describen el ruido fluctuante, LCpeak
+y SEL, la dosis de ruido de IEC 61252, el nivel día-tarde-noche Lden y los
+niveles de valoración de **ISO 1996-1** con sus ajustes, más el espectrograma
+de octava para visualizar nivel contra tiempo y banda a la vez. Es la página
+donde terminan la mayoría de las mediciones prácticas, y donde arrancan las
+secciones ambiental y laboral.
+
+## Páginas de esta sección
+
+- [Ponderación frecuencial (A, C, G, Z)](/phonometry/es/guides/weighting/):
+  las curvas A/C/Z de IEC 61672-1 y la ponderación G para infrasonido de
+  ISO 7196.
+- [Ponderación temporal](/phonometry/es/guides/time-weighting/): las
+  balísticas exponenciales Fast, Slow e Impulse.
+- [Niveles integrados y estadísticos](/phonometry/es/guides/levels/): Leq y
+  LAeq, niveles percentiles, LCpeak/SEL, dosis de ruido, Lden y niveles de
+  valoración, y espectrogramas de octava.

--- a/site/src/content/docs/es/guides/sections/materials-surfaces.md
+++ b/site/src/content/docs/es/guides/sections/materials-surfaces.md
@@ -1,0 +1,52 @@
+---
+title: "Materiales y superficies"
+description: "Caracterizar materiales y superficies acústicas: índices de absorción (ISO 11654), resistencia al flujo de aire (ISO 9053), medición en tubo de impedancia (ISO 10534, ASTM E2611), coeficientes de dispersión y difusión (ISO 17497) y absorción in situ de pavimentos (ISO 13472)."
+---
+
+Toda predicción de sala y más de un modelo de aislamiento acaban consumiendo
+un coeficiente que describe lo que un material o una superficie hace con el
+sonido. Esta sección cubre de dónde salen esos coeficientes: los instrumentos
+de laboratorio que los miden, los índices globales que los resumen y los
+métodos in situ que los recuperan fuera del laboratorio.
+
+[Materiales acústicos](/phonometry/es/guides/materials/) cubre los
+instrumentos a escala de muestra. La **cámara reverberante** produce
+coeficientes de absorción de incidencia aleatoria que ISO 11654 colapsa en el
+índice ponderado α_w con su clase por letra, la cifra que citan las hojas de
+datos de los absorbentes. El **banco de flujo** mide la resistencia y la
+resistividad al flujo de aire según ISO 9053-1/-2, el parámetro que gobierna
+el comportamiento en baja frecuencia de un absorbente poroso y ancla la
+mayoría de los modelos de material. El **tubo de impedancia** recupera, en
+incidencia normal, la impedancia superficial compleja, el factor de reflexión
+y el coeficiente de absorción de una muestra pequeña (ISO 10534-1/-2) y, con
+cuatro micrófonos, su pérdida de transmisión (ASTM E2611).
+
+[Dispersión superficial, difusión y absorción in situ](/phonometry/es/guides/surface-scattering/)
+pasa de las muestras a las *superficies*, y no pregunta cuánta energía
+absorbe una superficie sino adónde envía lo que refleja. El **coeficiente de
+dispersión** de incidencia aleatoria (ISO 17497-1) cuantifica cuánta energía
+abandona la dirección especular; el **coeficiente de difusión** (ISO 17497-2)
+cuantifica con qué uniformidad se reparte la energía reflejada; y los métodos
+de ISO 13472 miden la absorción de un pavimento in situ, por la técnica de
+sustracción sobre superficie extensa (parte 1) o con el tubo puntual
+(parte 2).
+
+Los consumidores de estos números están repartidos por el sitio: los
+coeficientes de absorción alimentan las predicciones de reverberación en
+[Acústica de salas](/phonometry/es/guides/sections/room-acoustics/), la
+rigidez dinámica (medida por un método de placa de carga emparentado)
+alimenta el modelo de suelo flotante en
+[Aislamiento acústico](/phonometry/es/guides/sections/sound-insulation/), y
+los métodos de pavimentos conectan con el interés por el ruido exterior de la
+sección de
+[Medio ambiente y transporte](/phonometry/es/guides/sections/environment-transport/).
+
+## Páginas de esta sección
+
+- [Materiales acústicos](/phonometry/es/guides/materials/): el índice
+  ponderado de absorción de ISO 11654 y su clase, la resistencia al flujo de
+  aire ISO 9053-1/-2, y la absorción, impedancia y pérdida de transmisión en
+  tubo de impedancia.
+- [Dispersión superficial, difusión y absorción in situ](/phonometry/es/guides/surface-scattering/):
+  los coeficientes de dispersión y difusión de ISO 17497-1/2, y la absorción
+  in situ de pavimentos de ISO 13472-1/-2.

--- a/site/src/content/docs/es/guides/sections/octave-filtering.md
+++ b/site/src/content/docs/es/guides/sections/octave-filtering.md
@@ -1,0 +1,48 @@
+---
+title: "Filtrado en octavas"
+description: "El análisis en bandas de octava fraccional en phonometry: los bancos de filtros ANSI S1.11 / IEC 61260-1 y sus arquitecturas, el procesado por bloques con estado para señales en streaming, y el análisis multicanal vectorizado."
+---
+
+El análisis acústico rara vez quiere una FFT en bruto: las normas, los
+índices y el propio oído trabajan en **bandas de octava fraccional**,
+intervalos de frecuencia cuya anchura crece proporcionalmente con la
+frecuencia. phonometry las implementa como bancos de filtros recursivos cuyos
+**puntos de -3 dB caen exactamente en los bordes de banda de ANSI S1.11**, de
+modo que los niveles de banda son comparables sea cual sea la arquitectura de
+filtro que los calcule, y cuyos diseños se verifican contra las tolerancias
+de clase de **IEC 61260-1:2014**.
+
+La página fundacional es
+[Bancos de filtros](/phonometry/es/guides/filter-banks/). Cubre las cinco
+arquitecturas (Butterworth, Chebyshev I/II, elíptica y Bessel), qué
+intercambian sus respuestas en frecuencia entre sí, cómo se descompone una
+señal en bandas de 1/1, 1/3 o 1/b arbitrario, y el modo de fase cero fuera de
+línea para análisis donde el retardo del filtro no debe emborronar el
+resultado. Por dentro, cada banco es una cascada de secciones de segundo
+orden con diezmado multitasa, que es lo que mantiene numéricamente estables
+las bandas de baja frecuencia.
+
+Las otras dos páginas escalan esa base por dos ejes independientes.
+[Procesado por bloques](/phonometry/es/guides/block-processing/) la escala en
+*tiempo*: las señales que no caben en memoria (grabaciones de horas,
+monitorización en vivo, registradores embebidos) se procesan búfer a búfer
+arrastrando el estado de los filtros, de modo que el resultado es idéntico
+bit a bit a procesar la señal entera de una vez.
+[Multicanal y rendimiento](/phonometry/es/guides/multichannel/) la escala en
+*canales*: los arrays de micrófonos y las grabaciones multicanal se analizan
+vectorizados, una llamada para todos los canales, con notas sobre dónde se va
+realmente el tiempo de cálculo.
+
+Léelas en ese orden. Todo lo que viene después (niveles, sonoridad,
+parámetros de sala) consume las señales o los niveles de banda que estas
+páginas producen.
+
+## Páginas de esta sección
+
+- [Bancos de filtros](/phonometry/es/guides/filter-banks/): las cinco
+  arquitecturas de filtro, respuestas en frecuencia, descomposición en bandas
+  y filtrado de fase cero.
+- [Procesado por bloques](/phonometry/es/guides/block-processing/): flujos en
+  streaming con estado de filtro arrastrado.
+- [Multicanal y rendimiento](/phonometry/es/guides/multichannel/): análisis
+  multicanal vectorizado y notas de rendimiento.

--- a/site/src/content/docs/es/guides/sections/outdoor-sound.md
+++ b/site/src/content/docs/es/guides/sections/outdoor-sound.md
@@ -1,0 +1,45 @@
+---
+title: "Sonido en exteriores"
+description: "El sonido en su camino por el aire libre y el carácter de lo que llega: el modelo de propagación en exteriores ISO 9613 con su desglose de atenuación término a término, y la prominencia y el ajuste por sonidos impulsivos de NT ACOU 112."
+---
+
+La evaluación del sonido en exteriores tiene dos mitades: predecir el nivel
+que una fuente entrega a un receptor lejano, y juzgar el carácter del sonido
+que efectivamente llega. Cada página de esta sección toma una mitad.
+
+[Propagación del sonido en exteriores](/phonometry/es/guides/outdoor-propagation/)
+es la mitad de predicción. Partiendo de la **potencia sonora** de la fuente,
+el método general de ISO 9613-2 resta, banda de octava a banda de octava,
+cada mecanismo que atenúa el sonido por el camino: la divergencia geométrica,
+la absorción atmosférica (suministrada por el coeficiente de tono puro de
+**ISO 9613-1**), el efecto del suelo y el apantallamiento por barreras, con
+una corrección meteorológica para promedios a largo plazo. La página mantiene
+visible el desglose término a término, de modo que una predicción nunca es
+una caja negra: se ve exactamente qué mecanismo compra cuántos decibelios a
+qué frecuencia.
+
+[Prominencia de sonidos impulsivos (NT ACOU 112)](/phonometry/es/guides/impulse-prominence/)
+es la mitad de evaluación. El ruido con impulsos claros (martilleo,
+remachado, hincado de pilotes) molesta más que un sonido estacionario del
+mismo LAeq, y el método Nordtest lo cuantifica: de la tasa de crecimiento y
+la diferencia de nivel del arranque de cada impulso calcula una
+**prominencia** predicha, y la convierte en el ajuste graduado KI que se suma
+al LAeq medido en un nivel de valoración.
+
+La maquinaria que lo rodea vive cerca: los niveles de valoración y el Lden en
+que terminan las evaluaciones se cubren en
+[Niveles integrados y estadísticos](/phonometry/es/guides/levels/), la
+contraparte tonal del ajuste impulsivo en
+[Audibilidad objetiva de tonos en ruido](/phonometry/es/guides/tone-audibility/),
+y las fuentes que alimentan un cálculo de propagación en
+[Potencia sonora](/phonometry/es/guides/sound-power/) y la sección de
+[Aeronaves y energía eólica](/phonometry/es/guides/sections/aircraft-wind/).
+
+## Páginas de esta sección
+
+- [Propagación del sonido en exteriores](/phonometry/es/guides/outdoor-propagation/):
+  la absorción atmosférica de ISO 9613-1 y el método general de ISO 9613-2
+  con desglose de atenuación por término y banda de octava.
+- [Prominencia de sonidos impulsivos (NT ACOU 112)](/phonometry/es/guides/impulse-prominence/):
+  la prominencia predicha de los sonidos impulsivos y el ajuste graduado KI
+  del LAeq.

--- a/site/src/content/docs/es/guides/sections/psychoacoustics.md
+++ b/site/src/content/docs/es/guides/sections/psychoacoustics.md
@@ -1,0 +1,55 @@
+---
+title: "Psicoacústica"
+description: "Las métricas perceptivas del sonido: modelos de sonoridad (ISO 532, ECMA-418-2), agudeza, tonalidad y aspereza, los dos métodos de evaluación tonal (prominencia ECMA-418-1 y audibilidad ISO/PAS 20065), y la molestia psicoacústica de Fastl y Zwicker."
+---
+
+La psicoacústica sustituye la pregunta "¿cuántos decibelios?" por "¿qué
+percibe el oyente?". Su magnitud base es la **sonoridad**: una magnitud
+perceptiva en sonios, calculada por modelos auditivos que tienen en cuenta el
+filtrado, el enmascaramiento y la compresión del oído. Sobre la sonoridad se
+asientan las sensaciones de **calidad sonora** que distinguen dos sonidos
+igual de fuertes: la agudeza (énfasis en altas frecuencias), la tonalidad
+(tonos discretos audibles) y la aspereza (modulación rápida). Y sobre ellas,
+una métrica combinada de **molestia** que las pesa en un único escalar.
+
+[Sonoridad](/phonometry/es/guides/loudness/) es la página fundacional. Cubre
+las tres familias de modelos que phonometry incluye (Zwicker según ISO 532-1,
+Moore-Glasberg según ISO 532-2/3 y el modelo auditivo de Sottek de
+ECMA-418-2) junto con las curvas isofónicas de ISO 226:2023 que anclan la
+escala perceptiva para tonos puros.
+[Métricas de calidad sonora](/phonometry/es/guides/sound-quality/) añade la
+agudeza según DIN 45692 y la tonalidad y aspereza de ECMA-418-2, que
+comparten el frontal auditivo de Sottek.
+
+Los tonos en ruido reciben dos páginas dedicadas porque se les hacen dos
+preguntas distintas.
+[Tonos discretos prominentes (ECMA-418-1)](/phonometry/es/guides/tone-prominence/)
+responde a una pregunta de ruido de producto: ¿es este tono *prominente*
+según los criterios de razón tono-ruido y razón de prominencia usados en las
+declaraciones de equipos informáticos?
+[Audibilidad objetiva de tonos en ruido (ISO/PAS 20065)](/phonometry/es/guides/tone-audibility/)
+responde a una ambiental: ¿en cuántos decibelios supera el tono su umbral de
+enmascaramiento?, la audibilidad que alimenta la penalización tonal de
+ISO 1996-2.
+
+[Molestia psicoacústica e intensidad de fluctuación](/phonometry/es/guides/psychoacoustic-annoyance/)
+cierra la cadena con el modelo de Fastl y Zwicker, que combina sonoridad,
+agudeza, aspereza y la sensación de modulación lenta de la intensidad de
+fluctuación en un único valor de molestia. Léela la última: consume todo lo
+que definen las demás páginas.
+
+## Páginas de esta sección
+
+- [Sonoridad](/phonometry/es/guides/loudness/): sonoridad de Zwicker,
+  Moore-Glasberg y Sottek en sonios, más las curvas isofónicas de
+  ISO 226:2023.
+- [Métricas de calidad sonora](/phonometry/es/guides/sound-quality/): agudeza
+  (DIN 45692) y tonalidad y aspereza de ECMA-418-2.
+- [Tonos discretos prominentes (ECMA-418-1)](/phonometry/es/guides/tone-prominence/):
+  razones tono-ruido y de prominencia con veredictos de prominencia.
+- [Audibilidad objetiva de tonos en ruido (ISO/PAS 20065)](/phonometry/es/guides/tone-audibility/):
+  la audibilidad de un tono sobre el umbral de enmascaramiento, que alimenta
+  el ajuste tonal de ISO 1996-2.
+- [Molestia psicoacústica e intensidad de fluctuación](/phonometry/es/guides/psychoacoustic-annoyance/):
+  el modelo de molestia de Fastl y Zwicker y los modelos de intensidad de
+  fluctuación que consume.

--- a/site/src/content/docs/es/guides/sections/psychoacoustics.md
+++ b/site/src/content/docs/es/guides/sections/psychoacoustics.md
@@ -35,8 +35,8 @@ ISO 1996-2.
 [Molestia psicoacústica e intensidad de fluctuación](/phonometry/es/guides/psychoacoustic-annoyance/)
 cierra la cadena con el modelo de Fastl y Zwicker, que combina sonoridad,
 agudeza, aspereza y la sensación de modulación lenta de la intensidad de
-fluctuación en un único valor de molestia. Léela la última: consume todo lo
-que definen las demás páginas.
+fluctuación en un único valor de molestia. Léela en último lugar: consume
+todo lo que definen las demás páginas.
 
 ## Páginas de esta sección
 

--- a/site/src/content/docs/es/guides/sections/room-acoustics.md
+++ b/site/src/content/docs/es/guides/sections/room-acoustics.md
@@ -1,0 +1,57 @@
+---
+title: "Acústica de salas"
+description: "El campo sonoro dentro de una sala: medición de la respuesta al impulso y los parámetros de ISO 3382, las valoraciones de ruido de sala de ANSI S12.2, y la predicción del tiempo de reverberación por las fórmulas clásicas y el modelo normativo EN 12354-6."
+---
+
+Casi todo lo que importa del campo sonoro dentro de una sala se sigue de dos
+magnitudes: su **respuesta al impulso**, que puede medirse, y su **absorción
+sonora**, que puede diseñarse. Las cuatro páginas de esta sección cubren la
+cadena de medición construida sobre la primera, la cadena de predicción
+construida sobre la segunda, y la valoración del ruido de fondo que ocupa la
+sala entre medias.
+
+La cadena de medición vive en
+[Acústica de salas](/phonometry/es/guides/room-acoustics/): adquirir la
+respuesta al impulso con las señales deterministas de ISO 18233, derivar los
+parámetros de ISO 3382 (tiempo de reverberación, EDT, claridad, tiempo
+central y las métricas de habla para oficinas abiertas de ISO 3382-3) y,
+cerrando el bucle, medir el coeficiente de absorción de un material en cámara
+reverberante según ISO 354. Ese coeficiente de absorción es precisamente lo
+que necesita la cadena de predicción.
+
+La predicción recibe dos páginas porque conviven dos tradiciones.
+[Predicción del tiempo de reverberación (Sabine, Arau)](/phonometry/es/guides/reverberation-prediction/)
+cubre las fórmulas estadísticas clásicas (Sabine, Eyring, Millington-Sette,
+Fitzroy y Arau-Puchades), incluidos los modelos que manejan una distribución
+de absorción no uniforme.
+[Absorción sonora en recintos (EN 12354-6)](/phonometry/es/guides/enclosed-space-absorption/)
+cubre la versión normativa europea de la misma física: el área de absorción
+equivalente total ensamblada desde superficies, objetos y aire, y el tiempo
+de reverberación que se sigue de ella, como norma citable en un informe de
+diseño.
+
+[Criterios de ruido de salas (NC / RC Mark II)](/phonometry/es/guides/room-noise/)
+responde a una pregunta distinta sobre la misma sala: si su ruido de fondo
+estacionario (ventilación, tráfico lejano) es aceptable para su uso, valorado
+contra las curvas de criterio de ANSI/ASA S12.2, con la etiqueta
+retumbe/siseo del RC Mark II diagnosticando *por qué* falla un espectro.
+
+Páginas relacionadas en otras secciones: la medición del aislamiento *entre*
+salas continúa en
+[Aislamiento acústico](/phonometry/es/guides/sections/sound-insulation/), y la
+inteligibilidad del habla que ofrece una sala la cuantifica el
+[índice de transmisión del habla](/phonometry/es/guides/speech-transmission/).
+
+## Páginas de esta sección
+
+- [Acústica de salas](/phonometry/es/guides/room-acoustics/): adquisición de
+  la respuesta al impulso (ISO 18233), parámetros de sala (ISO 3382-1/2),
+  métricas de oficinas abiertas (ISO 3382-3) y absorción en cámara
+  reverberante (ISO 354).
+- [Criterios de ruido de salas (NC / RC Mark II)](/phonometry/es/guides/room-noise/):
+  las valoraciones NC por tangencia y RC Mark II de ANSI/ASA S12.2-2019.
+- [Predicción del tiempo de reverberación (Sabine, Arau)](/phonometry/es/guides/reverberation-prediction/):
+  los cinco modelos estadísticos con el término de absorción del aire.
+- [Absorción sonora en recintos (EN 12354-6)](/phonometry/es/guides/enclosed-space-absorption/):
+  la predicción normativa del área de absorción equivalente y el tiempo de
+  reverberación.

--- a/site/src/content/docs/es/guides/sections/rooms-buildings.md
+++ b/site/src/content/docs/es/guides/sections/rooms-buildings.md
@@ -1,0 +1,85 @@
+---
+title: "Salas y edificación"
+description: "El sonido dentro de las salas y a través de los edificios: medición y predicción acústica de salas (ISO 3382, EN 12354-6), aislamiento acústico medido en campo y en laboratorio y predicho con EN 12354, y la caracterización de materiales y superficies acústicas."
+---
+
+Esta sección cubre el sonido en el entorno construido, y se divide por una
+línea natural: lo que ocurre **dentro** de una sala y lo que pasa **entre**
+salas. Dentro de una sala, la magnitud que gobierna es la absorción: fija el
+tiempo de reverberación y la claridad que la acústica de salas mide
+(ISO 3382) y predice (Sabine y sus refinamientos, EN 12354-6), mientras que
+el ruido de fondo en que se asienta la sala se valora contra curvas de
+criterio (ANSI/ASA S12.2). Entre salas, la magnitud que gobierna es el
+aislamiento: cuánto
+sonido aéreo y de impacto transmiten una partición y sus caminos de flancos,
+medido en campo (ISO 16283) o en laboratorio (ISO 10140) y predicho a partir
+de datos de elemento (EN 12354).
+
+Ambas mitades descansan sobre los mismos datos de material. Las páginas de
+**materiales y superficies** caracterizan lo que muros, absorbentes y
+pavimentos hacen realmente con el sonido: coeficientes de absorción y sus
+índices globales, resistencia al flujo de aire, impedancia superficial,
+dispersión y difusión. Esos coeficientes son las entradas que consumen las
+predicciones de sala, y los índices de elemento son las entradas que consumen
+las predicciones de aislamiento, así que la sección forma un bucle: medir el
+material, predecir el edificio, verificar en campo.
+
+Empieza por [Acústica de salas](/phonometry/es/guides/room-acoustics/): la
+respuesta al impulso que adquiere y los parámetros que deriva son el
+vocabulario que habla el resto de la sección. Si tu interés es el
+aislamiento, sigue con
+[Medición del aislamiento en campo e índices](/phonometry/es/guides/insulation-field/);
+si es la predicción en fase de diseño, ve a
+[Predicción del tiempo de reverberación (Sabine, Arau)](/phonometry/es/guides/reverberation-prediction/)
+y [Predicción del aislamiento acústico (EN 12354)](/phonometry/es/guides/insulation-prediction/).
+
+## [Acústica de salas](/phonometry/es/guides/sections/room-acoustics/)
+
+El campo sonoro dentro de una sala: medido desde una respuesta al impulso,
+valorado contra curvas de criterio y predicho desde el volumen y la
+absorción.
+
+- [Acústica de salas](/phonometry/es/guides/room-acoustics/): adquisición de
+  la respuesta al impulso (ISO 18233), parámetros de sala (ISO 3382-1/2),
+  métricas de oficinas abiertas (ISO 3382-3) y absorción en cámara
+  reverberante (ISO 354).
+- [Criterios de ruido de salas (NC / RC Mark II)](/phonometry/es/guides/room-noise/):
+  las valoraciones de ruido de sala de ANSI/ASA S12.2-2019 con sus etiquetas
+  espectrales.
+- [Predicción del tiempo de reverberación (Sabine, Arau)](/phonometry/es/guides/reverberation-prediction/):
+  los modelos de Sabine, Eyring, Millington-Sette, Fitzroy y Arau-Puchades
+  con el término de absorción del aire.
+- [Absorción sonora en recintos (EN 12354-6)](/phonometry/es/guides/enclosed-space-absorption/):
+  la predicción normativa del área de absorción equivalente total y el tiempo
+  de reverberación de una sala.
+
+## [Aislamiento acústico](/phonometry/es/guides/sections/sound-insulation/)
+
+Aislamiento aéreo y de impacto: medido en el edificio, caracterizado en el
+laboratorio y predicho a partir de datos de elemento.
+
+- [Medición del aislamiento en campo e índices](/phonometry/es/guides/insulation-field/):
+  medición en campo ISO 16283-1/2/3, índices ponderados ISO 717-1/2,
+  incertidumbre ISO 12999-1 y el método de inspección ISO 10052.
+- [Medición del aislamiento en laboratorio](/phonometry/es/guides/insulation-lab/):
+  caracterización en laboratorio ISO 10140, aislamiento por intensidad
+  (ISO 15186), mejora de revestimientos de suelo (ISO 16251-1) y flancos
+  (ISO 10848).
+- [Predicción del aislamiento acústico (EN 12354)](/phonometry/es/guides/insulation-prediction/):
+  transmisión por flancos aérea y de impacto (EN 12354-1/2), aislamiento de
+  fachada y radiación al exterior (EN 12354-3/4).
+- [Rigidez dinámica de materiales resilientes (EN 29052-1)](/phonometry/es/guides/dynamic-stiffness/):
+  la medición por resonancia de placa de carga detrás de toda predicción de
+  suelo flotante.
+
+## [Materiales y superficies](/phonometry/es/guides/sections/materials-surfaces/)
+
+Lo que materiales y superficies hacen con el sonido, medido en laboratorio e
+in situ.
+
+- [Materiales acústicos](/phonometry/es/guides/materials/): el índice
+  ponderado de absorción de ISO 11654, la resistencia al flujo de aire
+  (ISO 9053-1/-2) y el tubo de impedancia (ISO 10534-1/-2, ASTM E2611).
+- [Dispersión superficial, difusión y absorción in situ](/phonometry/es/guides/surface-scattering/):
+  coeficientes de dispersión (ISO 17497-1) y difusión (ISO 17497-2), y
+  absorción in situ de pavimentos (ISO 13472-1/-2).

--- a/site/src/content/docs/es/guides/sections/rooms-buildings.md
+++ b/site/src/content/docs/es/guides/sections/rooms-buildings.md
@@ -60,7 +60,7 @@ laboratorio y predicho a partir de datos de elemento.
 
 - [Medición del aislamiento en campo e índices](/phonometry/es/guides/insulation-field/):
   medición en campo ISO 16283-1/2/3, índices ponderados ISO 717-1/2,
-  incertidumbre ISO 12999-1 y el método de inspección ISO 10052.
+  incertidumbre ISO 12999-1 y el método de control ISO 10052.
 - [Medición del aislamiento en laboratorio](/phonometry/es/guides/insulation-lab/):
   caracterización en laboratorio ISO 10140, aislamiento por intensidad
   (ISO 15186), mejora de revestimientos de suelo (ISO 16251-1) y flancos

--- a/site/src/content/docs/es/guides/sections/sound-insulation.md
+++ b/site/src/content/docs/es/guides/sections/sound-insulation.md
@@ -3,15 +3,17 @@ title: "Aislamiento acústico"
 description: "El aislamiento a ruido aéreo y de impacto en todo su ciclo de vida: caracterización en laboratorio (ISO 10140 y compañeras), predicción in situ (EN 12354), verificación en campo con índices globales (ISO 16283, ISO 717), y la rigidez dinámica que alimenta el diseño de suelos flotantes."
 ---
 
-El aislamiento acústico tiene un ciclo de vida, y cada una de las cuatro
-páginas de esta sección posee una etapa. Un elemento (una solución de muro,
+El aislamiento acústico tiene un ciclo de vida con tres etapas, y una página
+de esta sección posee cada una de ellas. Un elemento (una solución de muro,
 un suelo flotante, una ventana) se caracteriza primero **en el laboratorio**,
 donde los flancos suprimidos aíslan su transmisión directa. Esos datos de
 laboratorio alimentan una **predicción** de cómo se comportará el edificio
 completo, caminos de flancos incluidos. El edificio terminado se **verifica
 en campo**, donde los valores medidos llevan los índices globales que citan
 las regulaciones. Cada etapa responde a una pregunta distinta y tiene su
-propia familia de normas.
+propia familia de normas. Una cuarta página, la de rigidez dinámica, no es
+una etapa en sí, sino la medición de material de apoyo que consume la etapa
+de predicción.
 
 [Medición del aislamiento en laboratorio](/phonometry/es/guides/insulation-lab/)
 cubre la primera etapa: el índice de reducción sonora y el nivel de impacto
@@ -31,7 +33,7 @@ de medición vive en esta sección.
 cubre la tercera: aislamiento aéreo, de impacto y de fachada en campo según
 ISO 16283-1/2/3, los índices globales ponderados y términos de adaptación
 espectral de ISO 717-1/2, la incertidumbre de ISO 12999-1 que cualifica un
-índice, y el método rápido de inspección ISO 10052.
+índice, y el método rápido de control ISO 10052.
 
 Dos secciones vecinas completan el cuadro: las magnitudes del lado de la sala
 (tiempo de reverberación, absorción) viven en
@@ -44,7 +46,7 @@ emparentada EN 12354-5, vive en
 
 - [Medición del aislamiento en campo e índices](/phonometry/es/guides/insulation-field/):
   medición ISO 16283-1/2/3, índices ISO 717-1/2, incertidumbre ISO 12999-1 y
-  el método de inspección ISO 10052.
+  el método de control ISO 10052.
 - [Medición del aislamiento en laboratorio](/phonometry/es/guides/insulation-lab/):
   caracterización ISO 10140, aislamiento por intensidad ISO 15186,
   revestimientos de suelo ISO 16251-1 y flancos ISO 10848.

--- a/site/src/content/docs/es/guides/sections/sound-insulation.md
+++ b/site/src/content/docs/es/guides/sections/sound-insulation.md
@@ -1,0 +1,56 @@
+---
+title: "Aislamiento acústico"
+description: "El aislamiento a ruido aéreo y de impacto en todo su ciclo de vida: caracterización en laboratorio (ISO 10140 y compañeras), predicción in situ (EN 12354), verificación en campo con índices globales (ISO 16283, ISO 717), y la rigidez dinámica que alimenta el diseño de suelos flotantes."
+---
+
+El aislamiento acústico tiene un ciclo de vida, y cada una de las cuatro
+páginas de esta sección posee una etapa. Un elemento (una solución de muro,
+un suelo flotante, una ventana) se caracteriza primero **en el laboratorio**,
+donde los flancos suprimidos aíslan su transmisión directa. Esos datos de
+laboratorio alimentan una **predicción** de cómo se comportará el edificio
+completo, caminos de flancos incluidos. El edificio terminado se **verifica
+en campo**, donde los valores medidos llevan los índices globales que citan
+las regulaciones. Cada etapa responde a una pregunta distinta y tiene su
+propia familia de normas.
+
+[Medición del aislamiento en laboratorio](/phonometry/es/guides/insulation-lab/)
+cubre la primera etapa: el índice de reducción sonora y el nivel de impacto
+normalizado de ISO 10140, la alternativa por intensidad sonora de ISO 15186,
+la mejora de revestimientos de suelo sobre maqueta reducida de ISO 16251-1 y
+la transmisión por flancos en laboratorio según ISO 10848.
+
+[Predicción del aislamiento acústico (EN 12354)](/phonometry/es/guides/insulation-prediction/)
+cubre la segunda: los modelos de flancos aéreo y de impacto de EN 12354-1/2
+con sus índices de reducción de vibraciones en las uniones, y el aislamiento
+de fachada y la radiación al exterior de EN 12354-3/4. Su término de mejora
+por suelo flotante consume la rigidez dinámica medida según
+[EN 29052-1](/phonometry/es/guides/dynamic-stiffness/), y por eso esa página
+de medición vive en esta sección.
+
+[Medición del aislamiento en campo e índices](/phonometry/es/guides/insulation-field/)
+cubre la tercera: aislamiento aéreo, de impacto y de fachada en campo según
+ISO 16283-1/2/3, los índices globales ponderados y términos de adaptación
+espectral de ISO 717-1/2, la incertidumbre de ISO 12999-1 que cualifica un
+índice, y el método rápido de inspección ISO 10052.
+
+Dos secciones vecinas completan el cuadro: las magnitudes del lado de la sala
+(tiempo de reverberación, absorción) viven en
+[Acústica de salas](/phonometry/es/guides/sections/room-acoustics/), y el
+ruido estructural de los *equipos* del edificio, predicho por la muy
+emparentada EN 12354-5, vive en
+[Fuentes de ruido estructural](/phonometry/es/guides/sections/structure-borne/).
+
+## Páginas de esta sección
+
+- [Medición del aislamiento en campo e índices](/phonometry/es/guides/insulation-field/):
+  medición ISO 16283-1/2/3, índices ISO 717-1/2, incertidumbre ISO 12999-1 y
+  el método de inspección ISO 10052.
+- [Medición del aislamiento en laboratorio](/phonometry/es/guides/insulation-lab/):
+  caracterización ISO 10140, aislamiento por intensidad ISO 15186,
+  revestimientos de suelo ISO 16251-1 y flancos ISO 10848.
+- [Predicción del aislamiento acústico (EN 12354)](/phonometry/es/guides/insulation-prediction/):
+  transmisión por flancos (EN 12354-1/2), aislamiento de fachada y radiación
+  al exterior (EN 12354-3/4).
+- [Rigidez dinámica de materiales resilientes (EN 29052-1)](/phonometry/es/guides/dynamic-stiffness/):
+  la medición por resonancia de placa de carga y la frecuencia natural del
+  suelo flotante.

--- a/site/src/content/docs/es/guides/sections/sources-devices.md
+++ b/site/src/content/docs/es/guides/sections/sources-devices.md
@@ -1,0 +1,51 @@
+---
+title: "Fuentes y dispositivos"
+description: "Caracterizar lo que emite el sonido: determinación de la potencia sonora por métodos de presión, cámara reverberante e intensidad (series ISO 3740 e ISO 9614), intensidad sonora con dos micrófonos (IEC 61043), y las métricas de distorsión y respuesta en frecuencia de equipos de audio de IEC 60268."
+---
+
+Toda predicción del resto de esta documentación parte de un descriptor de
+fuente, y esta sección es donde esos descriptores se miden. Su hilo conductor
+es la **emisión**: números que pertenecen al dispositivo y no a la sala ni a
+la distancia desde la que se escucha.
+
+La magnitud central es el **nivel de potencia sonora**: la energía acústica
+total por segundo que radia una fuente, la cifra que va en una hoja de datos,
+alimenta una predicción de sala o de exteriores y se compara con los límites
+de emisión de ruido. [Potencia sonora](/phonometry/es/guides/sound-power/)
+cubre las cinco rutas normalizadas para obtenerla, desde la superficie
+envolvente de presión de ISO 3744/3746 hasta la cámara reverberante de
+ISO 3741, el barrido de intensidad in situ de ISO 9614-2 y los grados de
+precisión de ISO 3745 e ISO 9614-3. Detrás de las
+rutas por intensidad está la propia **intensidad sonora**: el flujo de
+potencia con signo que puede localizar fuentes y separarlas del ruido de
+fondo, medido con una sonda de dos micrófonos según IEC 61043 y cualificado
+por los indicadores de campo de ISO 9614-1, cubierto en
+[Intensidad sonora (p-p)](/phonometry/es/guides/intensity/).
+
+[Electroacústica](/phonometry/es/guides/electroacoustics/) se vuelve hacia
+los dispositivos que *deben* producir sonido: amplificadores, altavoces y
+micrófonos. Cubre el conjunto de distorsión de IEC 60268-3 (THD, THD+N y
+SINAD, intermodulación y DIM), los estimadores de respuesta en frecuencia
+H1/H2 con la coherencia, y los convenios de sensibilidad de IEC 60268-4/-5,
+donde suelen fallar las comparaciones entre hojas de datos.
+
+Si vienes a medir una máquina, empieza por
+[Potencia sonora](/phonometry/es/guides/sound-power/) y deja que su guía de
+decisión elija la ruta; lee
+[Intensidad sonora (p-p)](/phonometry/es/guides/intensity/) cuando esa ruta
+implique una sonda de intensidad. Si vienes a caracterizar equipos de audio,
+ve directamente a
+[Electroacústica](/phonometry/es/guides/electroacoustics/).
+
+## Páginas de esta sección
+
+- [Intensidad sonora (p-p)](/phonometry/es/guides/intensity/): intensidad
+  sonora con dos micrófonos según IEC 61043 con los indicadores de campo de
+  ISO 9614-1.
+- [Potencia sonora](/phonometry/es/guides/sound-power/): el nivel de potencia
+  sonora por superficie envolvente, cámara reverberante, barrido de
+  intensidad y los métodos de precisión anecoico y de intensidad.
+- [Electroacústica: distorsión y respuesta en frecuencia](/phonometry/es/guides/electroacoustics/):
+  las métricas de distorsión de IEC 60268-3, la estimación de la respuesta en
+  frecuencia con coherencia, y los convenios de sensibilidad de micrófonos y
+  altavoces.

--- a/site/src/content/docs/es/guides/sections/sources-devices.md
+++ b/site/src/content/docs/es/guides/sections/sources-devices.md
@@ -8,10 +8,11 @@ fuente, y esta sección es donde esos descriptores se miden. Su hilo conductor
 es la **emisión**: números que pertenecen al dispositivo y no a la sala ni a
 la distancia desde la que se escucha.
 
-La magnitud central es el **nivel de potencia sonora**: la energía acústica
-total por segundo que radia una fuente, la cifra que va en una hoja de datos,
-alimenta una predicción de sala o de exteriores y se compara con los límites
-de emisión de ruido. [Potencia sonora](/phonometry/es/guides/sound-power/)
+La magnitud central es la **potencia sonora**: la energía acústica total por
+segundo que radia una fuente. Expresada en decibelios como el nivel de
+potencia sonora, es la cifra que va en una hoja de datos, alimenta una
+predicción de sala o de exteriores y se compara con los límites de emisión
+de ruido. [Potencia sonora](/phonometry/es/guides/sound-power/)
 cubre las cinco rutas normalizadas para obtenerla, desde la superficie
 envolvente de presión de ISO 3744/3746 hasta la cámara reverberante de
 ISO 3741, el barrido de intensidad in situ de ISO 9614-2 y los grados de

--- a/site/src/content/docs/es/guides/sections/speech.md
+++ b/site/src/content/docs/es/guides/sections/speech.md
@@ -1,0 +1,50 @@
+---
+title: "Habla"
+description: "Los dos índices normalizados de inteligibilidad del habla y las distintas preguntas que responden: el STI de IEC 60268-16, que valora un canal de transmisión, y el SII de ANSI S3.5, que valora una condición de escucha."
+---
+
+Las dos páginas de esta sección reducen la inteligibilidad del habla a un
+número en [0, 1], y el arte está en saber qué número responde a tu pregunta.
+El **índice de transmisión del habla** (STI) valora un *canal de
+transmisión*: una sala, un sistema de megafonía, un interfono. El **índice de
+inteligibilidad del habla** (SII) valora una *condición de escucha*: este
+espectro de habla, en este ruido, oído por este oyente. Un aula reverberante
+es un problema de STI; el ajuste de un audífono o un aviso de cabina oído
+sobre el ruido de los motores es un problema de SII.
+
+La diferencia física está en lo que modela cada índice. El STI
+(**IEC 60268-16**) trabaja sobre la *envolvente* del habla: la
+inteligibilidad se degrada cuando la reverberación y el ruido aplanan las
+modulaciones lentas de intensidad del habla, y el índice mide cuánta de esa
+modulación sobrevive al canal, mediante la función de transferencia de
+modulación. Puede calcularse indirectamente desde una respuesta al impulso
+medida o medirse directamente con la señal de ensayo STIPA.
+[Índice de transmisión del habla (STI)](/phonometry/es/guides/speech-transmission/)
+cubre la física de la modulación, ambos métodos y las bandas de calificación
+del Anexo F.
+
+El SII (**ANSI S3.5-1997**) trabaja sobre la *audibilidad*: la
+inteligibilidad se predice a partir de cuánta parte del espectro portador de
+habla supera el umbral efectivo del oyente, banda a banda, ponderada por la
+importancia de cada banda para el habla. El ruido, el autoenmascaramiento, la
+extensión ascendente del enmascaramiento y el umbral de audición del propio
+oyente entran explícitamente, y por eso el SII se extiende con naturalidad a
+la pérdida auditiva.
+[Índice de inteligibilidad del habla](/phonometry/es/guides/speech-intelligibility/)
+cubre el método en tercios de octava, incluidos los espectros normalizados de
+habla desde el esfuerzo vocal normal hasta el grito.
+
+Los dos conectan de forma natural con el resto de la biblioteca: el STI
+consume las respuestas al impulso de
+[Acústica de salas](/phonometry/es/guides/room-acoustics/), y el SII consume
+los umbrales de audición cuantificados en
+[Umbral de audición](/phonometry/es/guides/hearing-threshold/).
+
+## Páginas de esta sección
+
+- [Índice de transmisión del habla (STI)](/phonometry/es/guides/speech-transmission/):
+  la función de transferencia de modulación de IEC 60268-16, el método
+  indirecto desde una respuesta al impulso y la medición directa STIPA.
+- [Índice de inteligibilidad del habla](/phonometry/es/guides/speech-intelligibility/):
+  el método de importancia y audibilidad de banda de ANSI S3.5-1997, en ruido
+  y con pérdida auditiva.

--- a/site/src/content/docs/es/guides/sections/structure-borne.md
+++ b/site/src/content/docs/es/guides/sections/structure-borne.md
@@ -6,9 +6,11 @@ description: "La cadena desde una máquina vibrante hasta el ruido oído varias 
 Una máquina fijada a un edificio radia sonido dos veces: directamente desde
 su propia superficie vibrante, e indirectamente inyectando **potencia
 estructural** en la estructura, que la transporta y la vuelve a radiar en
-salas lejanas. Las cinco páginas de esta sección caracterizan ese segundo
-camino, el más escurridizo, de extremo a extremo: describir la vibración,
-caracterizar los aisladores, cuantificar la potencia y predecir el nivel que
+salas lejanas. Las cinco páginas de esta sección cubren ambos caminos: una
+estima la radiación directa desde la propia vibración superficial, y las
+otras cuatro caracterizan de extremo a extremo ese segundo camino
+estructural, el más escurridizo, desde describir la vibración y caracterizar
+los aisladores hasta cuantificar la potencia y predecir el nivel que
 finalmente oye un oyente.
 
 Primero el lenguaje.

--- a/site/src/content/docs/es/guides/sections/structure-borne.md
+++ b/site/src/content/docs/es/guides/sections/structure-borne.md
@@ -1,0 +1,60 @@
+---
+title: "Fuentes de ruido estructural"
+description: "La cadena desde una máquina vibrante hasta el ruido oído varias salas más allá: la familia de FRF de ISO 7626, la rigidez de transferencia de aisladores de ISO 10846, la potencia radiada desde vibración de ISO/TS 7849, la placa de recepción de EN 15657 y la predicción de instalación de EN 12354-5."
+---
+
+Una máquina fijada a un edificio radia sonido dos veces: directamente desde
+su propia superficie vibrante, e indirectamente inyectando **potencia
+estructural** en la estructura, que la transporta y la vuelve a radiar en
+salas lejanas. Las cinco páginas de esta sección caracterizan ese segundo
+camino, el más escurridizo, de extremo a extremo: describir la vibración,
+caracterizar los aisladores, cuantificar la potencia y predecir el nivel que
+finalmente oye un oyente.
+
+Primero el lenguaje.
+[Movilidad mecánica y la familia de FRF (ISO 7626-1)](/phonometry/es/guides/mechanical-mobility/)
+define las funciones de respuesta en frecuencia movimiento-por-fuerza
+(receptancia, movilidad, acelerancia y sus recíprocas) que hablan todas las
+normas posteriores, con el resonador de un grado de libertad en forma cerrada
+como referencia y los criterios de aceptación de medida de ISO 7626-2. Las
+*movilidades* de fuente y receptor son las que deciden cuánta potencia se
+acopla realmente a través de una interfaz, y por eso importa este
+vocabulario.
+
+Dos páginas caracterizan después los elementos del camino.
+[Rigidez dinámica de transferencia (ISO 10846)](/phonometry/es/guides/transfer-stiffness/)
+mide la rigidez de transferencia dinámica de los aisladores, soportes y
+mangueras que se insertan precisamente para romper el camino de transmisión,
+por los métodos directo e indirecto (transmisibilidad).
+[Potencia sonora desde vibración (ISO/TS 7849)](/phonometry/es/guides/vibration-sound-power/)
+se ocupa de la radiación directa: la potencia aérea estimada desde la
+velocidad superficial y un factor de radiación, sin medición acústica
+alguna.
+
+Las dos últimas páginas cierran la cadena sobre la fuente y el receptor.
+[Potencia sonora estructural de equipos (EN 15657)](/phonometry/es/guides/structure-borne-power/)
+mide lo que inyecta una máquina, mediante el método de la placa de recepción,
+y deriva las magnitudes de fuente independientes de la placa (fuerza
+bloqueada, nivel de potencia característico, velocidad libre).
+[Ruido estructural instalado (EN 12354-5)](/phonometry/es/guides/installed-structure-borne/)
+consume exactamente esas magnitudes, las acopla a través de las movilidades
+de fuente y receptor, y predice el nivel de presión sonora en la sala
+receptora, que es donde esta sección se encuentra con los modelos de
+[aislamiento acústico](/phonometry/es/guides/sections/sound-insulation/).
+
+## Páginas de esta sección
+
+- [Movilidad mecánica y la familia de FRF (ISO 7626-1)](/phonometry/es/guides/mechanical-mobility/):
+  la familia de FRF, las conversiones y el resonador de referencia de un
+  grado de libertad.
+- [Rigidez dinámica de transferencia (ISO 10846)](/phonometry/es/guides/transfer-stiffness/):
+  rigidez de transferencia dinámica de aisladores por los métodos directo e
+  indirecto.
+- [Potencia sonora desde vibración (ISO/TS 7849)](/phonometry/es/guides/vibration-sound-power/):
+  potencia aérea radiada desde la velocidad superficial y un factor de
+  radiación.
+- [Potencia sonora estructural de equipos (EN 15657)](/phonometry/es/guides/structure-borne-power/):
+  el método de la placa de recepción y las magnitudes de fuente
+  independientes de la placa.
+- [Ruido estructural instalado (EN 12354-5)](/phonometry/es/guides/installed-structure-borne/):
+  el nivel predicho en la sala receptora desde el equipo instalado.

--- a/site/src/content/docs/es/guides/sections/underwater.md
+++ b/site/src/content/docs/es/guides/sections/underwater.md
@@ -1,0 +1,46 @@
+---
+title: "Acústica submarina"
+description: "El sonido en el mar: los niveles de referencia de ISO 18405, el ruido radiado por buques (ISO 17208) y la exposición por hincado de pilotes (ISO 18406), y la propagación desde la pérdida de transmisión en forma cerrada y la ecuación del sonar hasta el ruido ambiente y los solvers numéricos."
+---
+
+La acústica submarina funciona con la misma física que la acústica aérea pero
+a otra escala y con otra referencia: los niveles se expresan re **1 µPa** (no
+20 µPa), la exposición re 1 µPa²·s, y el propio medio, con su velocidad del
+sonido dependiente de la profundidad, refracta el sonido en canales que lo
+transportan durante kilómetros. Esta sección cubre la disciplina en dos
+mitades que reflejan la división fuente-camino del resto de la biblioteca.
+
+La mitad de **fuente**, en
+[Acústica submarina: ruido radiado e hincado de pilotes](/phonometry/es/guides/underwater-acoustics/),
+establece la terminología de ISO 18405 (niveles SPL, SEL y de pico y sus
+referencias) y la aplica a los dos tipos de fuente regulados: el nivel de
+ruido radiado por buques y el nivel de fuente monopolar equivalente de
+ISO 17208, con la corrección de superficie del espejo de Lloyd, y la
+exposición sonora de un golpe, de pico y acumulada del hincado percusivo de
+pilotes según ISO 18406.
+
+La mitad de **camino**, en
+[Propagación submarina del sonido](/phonometry/es/guides/underwater-propagation/),
+predice lo que el mar hace con ese sonido. Se construye por capas, de las
+formas cerradas a la numérica completa: divergencia geométrica más absorción
+volumétrica (Francois-Garrison, Ainslie-McColm o Thorp), la velocidad del
+sonido en agua de mar por tres formulaciones, la ecuación del sonar pasiva y
+activa, la pérdida por reflexión en el lecho marino de Rayleigh, el espectro
+de ruido ambiente de Wenz con el tráfico marítimo JOMOPANS-ECHO, y los
+solvers numéricos de modos normales, trazado de rayos y ecuación parabólica
+para problemas dependientes de la distancia.
+
+Lee las páginas en ese orden: los niveles de referencia van primero porque
+todo resultado de propagación se expresa en ellos. Excepcionalmente en este
+sitio, la teoría de ambas páginas vive junto a las guías en lugar de en la
+referencia de teoría.
+
+## Páginas de esta sección
+
+- [Acústica submarina: ruido radiado e hincado de pilotes](/phonometry/es/guides/underwater-acoustics/):
+  niveles de referencia ISO 18405, ruido radiado por buques y nivel de fuente
+  monopolar ISO 17208, y exposición por hincado de pilotes ISO 18406.
+- [Propagación submarina del sonido](/phonometry/es/guides/underwater-propagation/):
+  pérdida de transmisión, velocidad del sonido, ecuación del sonar, reflexión
+  en el lecho, ruido ambiente oceánico y los solvers numéricos de
+  propagación.

--- a/site/src/content/docs/es/guides/sections/underwater.md
+++ b/site/src/content/docs/es/guides/sections/underwater.md
@@ -13,19 +13,19 @@ mitades que reflejan la división fuente-camino del resto de la biblioteca.
 La mitad de **fuente**, en
 [Acústica submarina: ruido radiado e hincado de pilotes](/phonometry/es/guides/underwater-acoustics/),
 establece la terminología de ISO 18405 (niveles SPL, SEL y de pico y sus
-referencias) y la aplica a los dos tipos de fuente regulados: el nivel de
-ruido radiado por buques y el nivel de fuente monopolar equivalente de
-ISO 17208, con la corrección de superficie del espejo de Lloyd, y la
-exposición sonora de un golpe, de pico y acumulada del hincado percusivo de
-pilotes según ISO 18406.
+referencias) y la aplica a dos casos de medición regulados: los buques, con
+el nivel de ruido radiado de ISO 17208-1 y el nivel de fuente monopolar
+equivalente de ISO 17208-2 mediante la corrección de superficie del espejo
+de Lloyd, y el hincado percusivo de pilotes, con la exposición sonora de un
+golpe, de pico y acumulada de ISO 18406.
 
 La mitad de **camino**, en
 [Propagación submarina del sonido](/phonometry/es/guides/underwater-propagation/),
 predice lo que el mar hace con ese sonido. Se construye por capas, de las
 formas cerradas a la numérica completa: divergencia geométrica más absorción
 volumétrica (Francois-Garrison, Ainslie-McColm o Thorp), la velocidad del
-sonido en agua de mar por tres formulaciones, la ecuación del sonar pasiva y
-activa, la pérdida por reflexión en el lecho marino de Rayleigh, el espectro
+sonido en agua de mar por tres formulaciones, las ecuaciones de sonar pasivo
+y activo, la pérdida por reflexión en el lecho marino de Rayleigh, el espectro
 de ruido ambiente de Wenz con el tráfico marítimo JOMOPANS-ECHO, y los
 solvers numéricos de modos normales, trazado de rayos y ecuación parabólica
 para problemas dependientes de la distancia.

--- a/site/src/content/docs/es/guides/sections/vibration.md
+++ b/site/src/content/docs/es/guides/sections/vibration.md
@@ -1,0 +1,70 @@
+---
+title: "Vibración y ruido estructural"
+description: "La vibración como fuente de ruido en edificios y como exposición humana: el vocabulario de FRF (ISO 7626), la rigidez de transferencia de aisladores (ISO 10846), la potencia sonora desde vibración (ISO/TS 7849), la cadena de equipos EN 15657 y EN 12354-5, y las métricas de vibración en humanos de ISO 2631 e ISO 5349."
+---
+
+La vibración importa a la acústica dos veces. Primero como **fuente de
+sonido**: una bomba o un ventilador atornillados a un edificio inyectan
+potencia estructural que viaja por muros y forjados y se vuelve a radiar como
+ruido audible varias salas más allá. Segundo como **exposición humana** por
+derecho propio: la vibración transmitida a una persona de pie, sentada o que
+empuña una herramienta se mide, pondera y limita de forma muy parecida al
+ruido, con sus propias métricas y valores legales de acción.
+
+Las páginas de **fuentes de ruido estructural** siguen la cadena de la fuente
+en orden. La familia de funciones de respuesta en frecuencia de ISO 7626
+(receptancia, movilidad, acelerancia) es el vocabulario; la rigidez de
+transferencia de ISO 10846 caracteriza los elementos resilientes que
+interrumpen el camino; ISO/TS 7849 estima la potencia aérea que una
+superficie vibrante radia directamente; EN 15657 mide la potencia estructural
+que una máquina inyecta en una placa de recepción; y EN 12354-5 lo ensambla
+todo en el nivel de presión sonora predicho en una sala receptora. Esa
+predicción final es también donde esta sección entrega el testigo a los
+modelos de [aislamiento acústico](/phonometry/es/guides/sections/sound-insulation/)
+de la sección de edificación.
+
+Las páginas de **vibración en humanos** comparten la filosofía de medida de
+un sonómetro, aplicada a la aceleración: ponderaciones frecuenciales que
+reflejan la respuesta del cuerpo, promedios móviles e integrados, y
+magnitudes de dosis comparadas con los valores de acción y límite de la
+Directiva 2002/44/CE, más el modelo dedicado de respuesta espinal para
+vibración con choques repetidos.
+
+Empieza por
+[Movilidad mecánica y la familia de FRF](/phonometry/es/guides/mechanical-mobility/)
+si te interesan las máquinas y los edificios, o por
+[Vibración en humanos](/phonometry/es/guides/human-vibration/) si te
+interesan las personas.
+
+## [Fuentes de ruido estructural](/phonometry/es/guides/sections/structure-borne/)
+
+Del vocabulario de FRF al nivel predicho en la sala receptora.
+
+- [Movilidad mecánica y la familia de FRF (ISO 7626-1)](/phonometry/es/guides/mechanical-mobility/):
+  receptancia, movilidad y acelerancia con sus recíprocas, y el resonador de
+  referencia de un grado de libertad.
+- [Rigidez dinámica de transferencia (ISO 10846)](/phonometry/es/guides/transfer-stiffness/):
+  la rigidez de transferencia dinámica de aisladores de vibración por los
+  métodos directo e indirecto.
+- [Potencia sonora desde vibración (ISO/TS 7849)](/phonometry/es/guides/vibration-sound-power/):
+  potencia aérea radiada a partir de la velocidad superficial y un factor de
+  radiación.
+- [Potencia sonora estructural de equipos (EN 15657)](/phonometry/es/guides/structure-borne-power/):
+  el método de la placa de recepción y las magnitudes de fuente
+  independientes de la placa.
+- [Ruido estructural instalado (EN 12354-5)](/phonometry/es/guides/installed-structure-borne/):
+  el nivel de presión sonora en la sala receptora predicho desde las
+  movilidades de fuente y receptor.
+
+## [Vibración en humanos](/phonometry/es/guides/sections/human-vibration/)
+
+La vibración transmitida al cuerpo humano, de la exposición diaria al riesgo
+de lesión lumbar.
+
+- [Vibración en humanos](/phonometry/es/guides/human-vibration/):
+  ponderaciones de cuerpo completo y mano-brazo (ISO 8041-1), medidas r.m.s.
+  y de dosis (ISO 2631-1), exposición diaria A(8) (ISO 5349) y los valores de
+  la Directiva 2002/44/CE.
+- [Vibración con choques múltiples (ISO 2631-5)](/phonometry/es/guides/multiple-shock-vibration/):
+  el modelo de respuesta espinal y la probabilidad de lesión lumbar para
+  vibración con múltiples choques.

--- a/site/src/content/docs/guides/sections/aircraft-wind.md
+++ b/site/src/content/docs/guides/sections/aircraft-wind.md
@@ -1,0 +1,50 @@
+---
+title: "Aircraft and wind energy"
+description: "Transport and energy sources with internationally fixed noise metrics: the ICAO Annex 16 EPNL and ECAC Doc 29 airport machinery, the ECAC Doc 32 rotorcraft hemisphere method, and the IEC 61400-11 wind-turbine emission and tonal audibility."
+---
+
+Aircraft and wind turbines are noise sources important enough to have their
+own internationally negotiated metrics, each fixed to the last decimal by a
+certification or type-testing framework. The three pages of this section
+implement those frameworks, and they share a common anatomy: a rigorously
+standardised **source descriptor**, plus standardised **propagation
+adjustments** that place the source at a receiver.
+
+[Aircraft noise: Effective Perceived Noise Level](/phonometry/guides/aircraft-noise/)
+covers fixed-wing certification. The **EPNL** of ICAO Annex 16 condenses a
+one-third-octave time history of a flyover into a single EPNdB value through
+perceived noisiness, a tone correction and a duration correction; the page
+adds the IEC 61265 measurement-system verifier, the SAE ARP 5534 atmospheric
+absorption used in the certification chain, and the ECAC Doc 29
+noise-power-distance interpolation that turns certified levels into airport
+contour inputs.
+
+[Rotorcraft noise: the hemisphere method](/phonometry/guides/rotorcraft-noise/)
+covers helicopters, whose strong directivity defeats a single-number source
+level. ECAC Doc 32 instead describes the source as a **noise hemisphere**
+(band levels on a grid of emission angles at a 60 m reference distance) and
+propagates each ray with spherical spreading, atmospheric absorption and the
+Chien-Soroka ground effect.
+
+[Wind-turbine noise: sound power and tonal audibility](/phonometry/guides/wind-turbine-noise/)
+covers IEC 61400-11 type testing: the **apparent sound power level** that
+refers the measured immission back to an equivalent point source at the rotor
+centre, and the tonal-audibility chain that decides whether a blade-passing,
+gearbox or generator tone is audible above its masking noise.
+
+The shared physics connects outward: atmospheric absorption comes from the
+same ISO 9613-1 model as
+[Outdoor Sound Propagation](/phonometry/guides/outdoor-propagation/), and the
+wind-turbine tonality test is a cousin of the tonal-audibility methods in
+[Psychoacoustics](/phonometry/guides/sections/psychoacoustics/).
+
+## Pages in this section
+
+- [Aircraft noise: Effective Perceived Noise Level](/phonometry/guides/aircraft-noise/):
+  the ICAO Annex 16 EPNL chain, IEC 61265 verifier, SAE ARP 5534 absorption
+  and ECAC Doc 29 NPD interpolation.
+- [Rotorcraft noise: the hemisphere method](/phonometry/guides/rotorcraft-noise/):
+  the ECAC Doc 32 noise-hemisphere source model and its propagation
+  adjustments.
+- [Wind-turbine noise: sound power and tonal audibility](/phonometry/guides/wind-turbine-noise/):
+  the IEC 61400-11 apparent sound power level and tonal-audibility chain.

--- a/site/src/content/docs/guides/sections/calibration-uncertainty.md
+++ b/site/src/content/docs/guides/sections/calibration-uncertainty.md
@@ -1,0 +1,42 @@
+---
+title: "Calibration and uncertainty"
+description: "The two disciplines that make a computed level a defensible measurement: physical SPL calibration versus digital dBFS analysis, and the GUM and Monte Carlo propagation of measurement uncertainty."
+---
+
+A level printed by software is not yet a measurement. Two things separate the
+one from the other: knowing what the digital samples mean **physically**, and
+knowing how much the result could reasonably be **wrong**. This section covers
+both, and they apply transversally to every other page of the documentation.
+
+[Calibration and dBFS](/phonometry/guides/calibration/) handles the first.
+phonometry works in two reference frames: physical **dB SPL**, established
+either from a recorded calibrator tone (the IEC 60942 field ritual) or from a
+known microphone sensitivity, and digital **dBFS**, levels relative to full
+scale, appropriate when no physical reference exists or when characterising
+the digital chain itself. The page explains how each mode is set up and, just
+as important, which quantities are meaningful in which frame.
+
+[Measurement uncertainty (GUM and Monte Carlo)](/phonometry/guides/gum-uncertainty/)
+handles the second, implementing the *Guide to the Expression of Uncertainty
+in Measurement* (**ISO/IEC Guide 98-3:2008**) and its Monte Carlo
+**Supplement 1**. The GUM route propagates standard uncertainties analytically
+through sensitivity coefficients into a combined and expanded uncertainty,
+with Welch-Satterthwaite effective degrees of freedom; the Monte Carlo route
+propagates whole probability distributions numerically and yields coverage
+intervals that stay honest when the model is non-linear or the inputs are far
+from Gaussian. The page shows both on the same models, including where they
+diverge and why.
+
+The two pages meet in practice: an uncertainty budget for an acoustic
+measurement almost always contains a calibration term, and several standards
+implemented elsewhere in the library (ISO 9612, ISO 12999-1) ship uncertainty
+budgets that are specialisations of the GUM machinery described here.
+
+## Pages in this section
+
+- [Calibration and dBFS](/phonometry/guides/calibration/): physical SPL
+  calibration from a calibrator tone or a known sensitivity, and the digital
+  full-scale mode.
+- [Measurement uncertainty (GUM and Monte Carlo)](/phonometry/guides/gum-uncertainty/):
+  the law of propagation of uncertainty and the Monte Carlo method, expanded
+  uncertainty and coverage intervals.

--- a/site/src/content/docs/guides/sections/core-signal-analysis.md
+++ b/site/src/content/docs/guides/sections/core-signal-analysis.md
@@ -1,0 +1,67 @@
+---
+title: "Core signal analysis"
+description: "The measurement core of phonometry: fractional octave filter banks, frequency and time weighting, integrated and statistical levels, physical calibration and measurement uncertainty, and how those pieces chain into a sound level meter in code."
+---
+
+Everything in phonometry starts here. This section covers the chain that turns
+a raw digital signal into standards-compliant acoustic numbers: split it into
+**fractional octave bands** (ANSI S1.11 / IEC 61260-1), shape it with the
+**frequency weightings** of IEC 61672-1, smooth it with the **Fast/Slow/Impulse
+time ballistics**, and integrate it into **Leq and statistical levels**. It is,
+in effect, a sound level meter decomposed into composable functions, and every
+other section of the documentation builds on it: a loudness model consumes
+calibrated band levels, a room parameter starts from a filtered impulse
+response, an environmental rating is an adjusted Leq.
+
+Two transversal concerns complete the core. **Calibration** decides what the
+digital samples mean physically: results can be referenced to a measured
+calibrator tone or a known sensitivity (dB SPL), or stay in digital full scale
+(dBFS). And **measurement uncertainty** (the GUM and its Monte Carlo
+supplement) qualifies any result computed from uncertain inputs, which is what
+makes a number defensible in a report.
+
+If you are new to the library, read
+[Filter Banks](/phonometry/guides/filter-banks/) first: it introduces the band
+decomposition every other page assumes. Then
+[Integrated and Statistical Levels](/phonometry/guides/levels/) shows the
+metrics most measurements end in, and
+[Calibration and dBFS](/phonometry/guides/calibration/) anchors them to
+physical units.
+
+## [Octave filtering](/phonometry/guides/sections/octave-filtering/)
+
+Fractional octave band decomposition and the two ways to scale it: streaming
+blocks and multichannel arrays.
+
+- [Filter Banks](/phonometry/guides/filter-banks/): the five filter
+  architectures, their frequency responses, band decomposition and zero-phase
+  offline filtering.
+- [Block Processing](/phonometry/guides/block-processing/): stateful streaming
+  analysis that carries filter state across buffers, for signals that never
+  fit in memory.
+- [Multichannel and Performance](/phonometry/guides/multichannel/): vectorized
+  analysis of many channels at once, with performance notes.
+
+## [Levels and weighting](/phonometry/guides/sections/levels-weighting/)
+
+From weighted signal to reported level: the frequency weightings, the time
+ballistics and the integrated, statistical and rating levels.
+
+- [Frequency Weighting (A, C, G, Z)](/phonometry/guides/weighting/): the
+  IEC 61672-1 ear-response curves and the ISO 7196 infrasound G-weighting.
+- [Time Weighting](/phonometry/guides/time-weighting/): Fast, Slow and Impulse
+  exponential ballistics per IEC 61672-1.
+- [Integrated and Statistical Levels](/phonometry/guides/levels/): Leq and
+  LAeq, percentile levels L10/L50/L90, LCpeak and SEL, noise dose (IEC 61252),
+  Lden and rating levels (ISO 1996-1), and octave spectrograms.
+
+## [Calibration and uncertainty](/phonometry/guides/sections/calibration-uncertainty/)
+
+What the numbers mean and how much to trust them.
+
+- [Calibration and dBFS](/phonometry/guides/calibration/): physical SPL
+  calibration from a calibrator tone (IEC 60942) or a known sensitivity, and
+  the digital dBFS mode.
+- [Measurement uncertainty (GUM and Monte Carlo)](/phonometry/guides/gum-uncertainty/):
+  the law of propagation of uncertainty and the Monte Carlo method of
+  ISO/IEC Guide 98-3, with expanded uncertainty and coverage intervals.

--- a/site/src/content/docs/guides/sections/environment-transport.md
+++ b/site/src/content/docs/guides/sections/environment-transport.md
@@ -1,0 +1,53 @@
+---
+title: "Environment and transport"
+description: "Sound outdoors and the transport sources that dominate it: the ISO 9613 propagation model, the NT ACOU 112 impulsive-sound adjustment, aircraft noise certification (EPNL, ECAC Doc 29), the rotorcraft hemisphere method and wind-turbine acoustic emission."
+---
+
+Environmental noise is a source-path-receiver problem stretched over hundreds
+of metres of open air. This section covers both ends of it. The **outdoor
+sound** pages handle the path and the assessment: ISO 9613 predicts, band by
+band, how much level survives divergence, air absorption, the ground and any
+barrier on the way to a receiver, and NT ACOU 112 quantifies when impulsive
+character makes the received sound more annoying than its LAeq suggests.
+
+The **aircraft and wind energy** pages handle transport sources that come with
+their own internationally fixed metrics. Aircraft noise certification runs on
+the Effective Perceived Noise Level of ICAO Annex 16, with the airport-contour
+machinery of ECAC Doc 29 built on top; helicopters get the directional
+noise-hemisphere source model of ECAC Doc 32; and wind turbines are rated by the
+apparent sound power and tonal audibility of IEC 61400-11. What unites them is
+the pattern: a carefully standardised source descriptor plus standardised
+propagation adjustments.
+
+This section leans on the core toolkit more than any other: the rating levels
+and Lden that environmental assessment ends in live in
+[Integrated and Statistical Levels](/phonometry/guides/levels/), and the
+atmospheric absorption that every propagation model consumes is shared with
+the room and materials pages. Start with
+[Outdoor Sound Propagation](/phonometry/guides/outdoor-propagation/); it
+introduces the source-path-receiver bookkeeping the transport pages reuse.
+
+## [Outdoor sound](/phonometry/guides/sections/outdoor-sound/)
+
+The path from an outdoor source to a receiver, and the character of what
+arrives.
+
+- [Outdoor Sound Propagation](/phonometry/guides/outdoor-propagation/):
+  atmospheric absorption (ISO 9613-1) and the ISO 9613-2 general method with
+  its per-term attenuation breakdown.
+- [Impulsive-sound prominence (NT ACOU 112)](/phonometry/guides/impulse-prominence/):
+  the predicted prominence of impulsive sounds and the graduated adjustment
+  added to LAeq.
+
+## [Aircraft and wind energy](/phonometry/guides/sections/aircraft-wind/)
+
+Transport and energy sources with their own certification metrics.
+
+- [Aircraft noise: Effective Perceived Noise Level](/phonometry/guides/aircraft-noise/):
+  the ICAO Annex 16 EPNL, the IEC 61265 measurement-system verifier, SAE
+  ARP 5534 atmospheric absorption and ECAC Doc 29 NPD interpolation.
+- [Rotorcraft noise: the hemisphere method](/phonometry/guides/rotorcraft-noise/):
+  the ECAC Doc 32 noise-hemisphere source model with its propagation
+  adjustments.
+- [Wind-turbine noise: sound power and tonal audibility](/phonometry/guides/wind-turbine-noise/):
+  the IEC 61400-11 apparent sound power level and tonal-audibility chain.

--- a/site/src/content/docs/guides/sections/hearing-exposure.md
+++ b/site/src/content/docs/guides/sections/hearing-exposure.md
@@ -1,0 +1,51 @@
+---
+title: "Hearing and exposure"
+description: "The statistics of hearing and the noise that damages it: the ISO 7029 age-related threshold distribution and ISO 389-7 reference zero, the ISO 1999 noise-induced permanent threshold shift, and the ISO 9612 occupational-exposure survey."
+---
+
+This section connects three quantities that regulation treats as one story:
+where a population's **hearing threshold** sits, how occupational **noise
+exposure** is measured, and how that exposure **shifts the threshold**
+permanently over a working life.
+
+[Hearing threshold (age and reference zero)](/phonometry/guides/hearing-threshold/)
+establishes the baseline. **ISO 7029:2017** gives the statistical distribution
+of hearing threshold with age for an otologically normal population: the slow,
+high-frequency-first loss of presbycusis, resolved by age, sex and population
+fractile. **ISO 389-7:2005** fixes the other end of the scale: the reference
+threshold of hearing, the physical sound pressure level that audiometric
+0 dB HL corresponds to under free-field and diffuse-field listening.
+
+[Occupational Noise Exposure (ISO 9612)](/phonometry/guides/occupational-exposure/)
+measures the cause. A regulated daily exposure level LEX,8h is assembled from
+samples of a real working day by one of three strategies (task-based,
+job-based or full-day), and reported with the normative Annex C uncertainty
+budget and its one-sided 95 % upper limit, which is what an occupational
+hygienist actually compares against action values.
+
+[Noise-induced hearing loss (ISO 1999)](/phonometry/guides/noise-induced-hearing-loss/)
+predicts the effect. From the exposure level and duration it gives the
+noise-induced permanent threshold shift (NIPTS) with its population spread,
+concentrated at the characteristic 4 kHz notch, and combines it with the
+ISO 7029 age component into the hearing threshold level associated with age
+and noise (HTLAN): the quantity used to estimate hearing handicap and
+compensation risk in an exposed population.
+
+Read the threshold page first, then ISO 9612, then ISO 1999: baseline,
+exposure, damage. That way the pipeline is explicit: ISO 9612 produces the
+LEX,8h that ISO 1999 consumes, and ISO 1999 builds on the ISO 7029
+statistics. The perceptual consequences of a shifted
+threshold, such as reduced speech intelligibility, are picked up by the SII in
+the [Speech section](/phonometry/guides/sections/speech/).
+
+## Pages in this section
+
+- [Hearing threshold (age and reference zero)](/phonometry/guides/hearing-threshold/):
+  the ISO 7029:2017 age-related threshold distribution and the ISO 389-7:2005
+  reference threshold of hearing.
+- [Noise-induced hearing loss (ISO 1999)](/phonometry/guides/noise-induced-hearing-loss/):
+  NIPTS and its population distribution, and the combination with age into
+  HTLAN.
+- [Occupational Noise Exposure (ISO 9612)](/phonometry/guides/occupational-exposure/):
+  the three measurement strategies for LEX,8h with the Annex C uncertainty
+  budget.

--- a/site/src/content/docs/guides/sections/hearing-perception.md
+++ b/site/src/content/docs/guides/sections/hearing-perception.md
@@ -1,0 +1,70 @@
+---
+title: "Hearing and perception"
+description: "How listeners perceive sound and what noise does to hearing: psychoacoustic sensations (loudness, sharpness, roughness, tonality, annoyance), speech intelligibility (STI and SII), and the statistics of hearing thresholds, hearing damage and occupational exposure."
+---
+
+A sound pressure level says how much sound there is; this section is about
+what a **listener** makes of it. Its three subsections answer three different
+questions. **Psychoacoustics** quantifies sensations: how loud a sound is
+perceived to be, how sharp, rough or tonal it is, and how those sensations
+combine into annoyance. **Speech** asks how well spoken words survive the trip
+from a talker to a listener, through a room, a sound system or background
+noise. And **hearing and exposure** covers the ear itself: where the hearing
+threshold sits across age and population, how noise permanently shifts it, and
+how a working day's exposure is measured and reported.
+
+The three build on each other in one direction: the psychoacoustic models
+consume calibrated signals or band spectra from the
+[core analysis](/phonometry/guides/sections/core-signal-analysis/); the speech
+indices consume band levels and, in the SII's case, the hearing thresholds
+that the exposure pages quantify; and the exposure metrics feed the
+hearing-damage model of ISO 1999.
+
+A good entry point is [Loudness](/phonometry/guides/loudness/): it introduces
+the perceptual scale (the sone) and the auditory models that most other
+metrics in this section reuse or extend.
+
+## [Psychoacoustics](/phonometry/guides/sections/psychoacoustics/)
+
+The perceptual sensations of sound: loudness and the metrics layered on it.
+
+- [Loudness](/phonometry/guides/loudness/): Zwicker (ISO 532-1),
+  Moore-Glasberg (ISO 532-2/3) and Sottek (ECMA-418-2) loudness in sones,
+  plus the ISO 226:2023 equal-loudness contours.
+- [Sound Quality Metrics](/phonometry/guides/sound-quality/): sharpness
+  (DIN 45692) and the ECMA-418-2 Sottek Hearing Model tonality and roughness.
+- [Prominent Discrete Tones (ECMA-418-1)](/phonometry/guides/tone-prominence/):
+  the tone-to-noise and prominence ratios that decide whether a discrete tone
+  is prominent.
+- [Objective audibility of tones in noise (ISO/PAS 20065)](/phonometry/guides/tone-audibility/):
+  the engineering method for the audibility of a tone above the masking
+  threshold, feeding the ISO 1996-2 tonal adjustment.
+- [Psychoacoustic annoyance and fluctuation strength](/phonometry/guides/psychoacoustic-annoyance/):
+  the Fastl & Zwicker annoyance model combining loudness, sharpness, roughness
+  and fluctuation strength.
+
+## [Speech](/phonometry/guides/sections/speech/)
+
+Two complementary indices of speech intelligibility: STI rates the
+transmission channel, SII rates the listening condition.
+
+- [Speech Transmission Index (STI)](/phonometry/guides/speech-transmission/):
+  the IEC 60268-16 modulation transfer function, the indirect method from an
+  impulse response, and direct STIPA measurement.
+- [Speech Intelligibility Index](/phonometry/guides/speech-intelligibility/):
+  the ANSI S3.5-1997 one-third-octave-band SII from speech, noise and hearing
+  threshold spectra.
+
+## [Hearing and exposure](/phonometry/guides/sections/hearing-exposure/)
+
+The hearing threshold, what noise does to it, and how exposure is measured.
+
+- [Hearing threshold (age and reference zero)](/phonometry/guides/hearing-threshold/):
+  the ISO 7029:2017 age-related threshold distribution and the ISO 389-7:2005
+  reference threshold of hearing.
+- [Noise-induced hearing loss (ISO 1999)](/phonometry/guides/noise-induced-hearing-loss/):
+  the noise-induced permanent threshold shift and its combination with age
+  into HTLAN.
+- [Occupational Noise Exposure (ISO 9612)](/phonometry/guides/occupational-exposure/):
+  the task-based, job-based and full-day strategies for LEX,8h with the
+  Annex C uncertainty budget.

--- a/site/src/content/docs/guides/sections/human-vibration.md
+++ b/site/src/content/docs/guides/sections/human-vibration.md
@@ -1,0 +1,43 @@
+---
+title: "Human vibration"
+description: "Vibration transmitted to people: the ISO 8041-1 weightings and ISO 2631-1 whole-body metrics, hand-arm exposure per ISO 5349 with the Directive 2002/44/EC action and limit values, and the ISO 2631-5 spinal-response model for repeated shocks."
+---
+
+Vibration transmitted to a person is evaluated with a measurement chain
+deliberately parallel to a sound level meter's: the acceleration is
+**frequency-weighted** to reflect how the body responds at each frequency,
+reduced to a **weighted r.m.s.** value or a dose, combined across axes, and
+normalised to a **daily exposure** that regulation can act on. The two pages
+of this section cover the general chain and the special case that breaks it.
+
+[Human Vibration](/phonometry/guides/human-vibration/) is the general chain.
+It covers the whole-body and hand-arm frequency weightings of **ISO 8041-1**,
+the weighted r.m.s. acceleration and the running and dose measures of
+**ISO 2631-1** (MTVV, VDV, MSDV, crest factor) that flag shocks a plain
+r.m.s. would hide, vibration in buildings per ISO 2631-2, the hand-arm
+vibration total value and daily exposure A(8) of **ISO 5349-1/-2**, and the
+exposure action and limit values of **Directive 2002/44/EC** that make A(8)
+legally meaningful.
+
+[Multiple-shock whole-body vibration (ISO 2631-5)](/phonometry/guides/multiple-shock-vibration/)
+handles exposures the r.m.s. philosophy underestimates: repeated mechanical
+shocks from off-road vehicles, high-speed craft or earth-moving machinery,
+which load the lumbar spine far beyond what their energy average suggests.
+**ISO 2631-5:2018** models the seat-to-spine transfer explicitly, accumulates
+a dose from the response peaks, and converts it into compressive stress on the
+vertebral endplates and a probability of lumbar injury over a working life.
+
+Use ISO 2631-1 metrics first; when the crest factor or the VDV warns that
+shocks dominate, the ISO 2631-5 model is the dedicated follow-up. The
+measurement front-end (weighting filters, band analysis) is shared with the
+[core signal analysis](/phonometry/guides/sections/core-signal-analysis/)
+section.
+
+## Pages in this section
+
+- [Human Vibration](/phonometry/guides/human-vibration/): ISO 8041-1
+  weightings, ISO 2631-1 r.m.s. and dose measures, ISO 5349 daily exposure
+  A(8) and the Directive 2002/44/EC values.
+- [Multiple-shock whole-body vibration (ISO 2631-5)](/phonometry/guides/multiple-shock-vibration/):
+  the spinal-response model, acceleration dose and probability of lumbar
+  injury.

--- a/site/src/content/docs/guides/sections/levels-weighting.md
+++ b/site/src/content/docs/guides/sections/levels-weighting.md
@@ -1,0 +1,42 @@
+---
+title: "Levels and weighting"
+description: "From weighted signal to reported number: the IEC 61672-1 frequency weightings and Fast/Slow/Impulse ballistics, and the integrated, statistical, dose and rating levels built on them."
+---
+
+A sound level meter does three things to a calibrated signal, in order: it
+**weights it in frequency** to mimic the ear's sensitivity, it **smooths it in
+time** with a standardised ballistic, and it **integrates it into a level**.
+The three pages of this section implement exactly that chain, one page per
+stage, following **IEC 61672-1:2013** closely enough that the weightings are
+verified against the standard's own tolerance tables in CI.
+
+[Frequency Weighting (A, C, G, Z)](/phonometry/guides/weighting/) covers the
+first stage. The A-curve tracks hearing sensitivity at moderate levels and
+dominates regulation; C is nearly flat and serves peaks and low-frequency
+checks; Z is unweighted by definition; and the G-curve of **ISO 7196** extends
+the idea into infrasound, where conventional weightings are blind.
+
+[Time Weighting](/phonometry/guides/time-weighting/) covers the second stage:
+the exponential Fast (125 ms), Slow (1 s) and Impulse ballistics that decide
+how quickly a displayed level follows the sound. phonometry implements the
+exact time constants, verified against the toneburst responses of the
+standard.
+
+[Integrated and Statistical Levels](/phonometry/guides/levels/) is the payoff:
+the equivalent continuous level Leq and its A-weighted LAeq, the percentile
+levels L10/L50/L90 that describe fluctuating noise, LCpeak and SEL, the noise
+dose of IEC 61252, the day-evening-night level Lden and the rating levels of
+**ISO 1996-1** with their adjustments, plus the octave spectrogram for
+visualising level against time and band at once. This is the page where most
+practical measurements end, and where the environmental and occupational
+sections pick up.
+
+## Pages in this section
+
+- [Frequency Weighting (A, C, G, Z)](/phonometry/guides/weighting/): the
+  IEC 61672-1 A/C/Z curves and the ISO 7196 infrasound G-weighting.
+- [Time Weighting](/phonometry/guides/time-weighting/): Fast, Slow and
+  Impulse exponential ballistics.
+- [Integrated and Statistical Levels](/phonometry/guides/levels/): Leq and
+  LAeq, percentile levels, LCpeak/SEL, noise dose, Lden and rating levels,
+  and octave spectrograms.

--- a/site/src/content/docs/guides/sections/materials-surfaces.md
+++ b/site/src/content/docs/guides/sections/materials-surfaces.md
@@ -1,0 +1,48 @@
+---
+title: "Materials and surfaces"
+description: "Characterising acoustic materials and surfaces: absorption ratings (ISO 11654), airflow resistance (ISO 9053), impedance-tube measurement (ISO 10534, ASTM E2611), scattering and diffusion coefficients (ISO 17497) and in-situ road-surface absorption (ISO 13472)."
+---
+
+Every room prediction and many an insulation model end up consuming a
+coefficient that describes what a material or a surface does to sound. This
+section covers where those coefficients come from: the laboratory instruments
+that measure them, the single-number ratings that summarise them, and the
+in-situ methods that recover them outside the laboratory.
+
+[Acoustic Materials](/phonometry/guides/materials/) covers the sample-scale
+instruments. The **reverberation room** yields random-incidence absorption
+coefficients that ISO 11654 collapses into the weighted rating α_w with its
+letter class, the figure absorber datasheets quote. The **flow rig** measures
+airflow resistance and resistivity per ISO 9053-1/-2, the parameter that
+governs a porous absorber's low-frequency behaviour and anchors most material
+models. The **impedance tube** recovers, at normal incidence, the complex
+surface impedance, reflection factor and absorption coefficient of a small
+sample (ISO 10534-1/-2) and, with four microphones, its transmission loss
+(ASTM E2611).
+
+[Surface Scattering, Diffusion and In-situ Absorption](/phonometry/guides/surface-scattering/)
+moves from samples to *surfaces*, asking not how much energy a surface
+absorbs but where it sends what it reflects. The random-incidence
+**scattering coefficient** (ISO 17497-1) quantifies how much energy leaves the
+specular direction; the **diffusion coefficient** (ISO 17497-2) quantifies how
+uniformly the reflected energy spreads; and the ISO 13472 methods measure the
+absorption of a road surface in situ, by the extended-surface subtraction
+technique (Part 1) or the spot tube (Part 2).
+
+The consumers of these numbers are spread across the site: absorption
+coefficients feed the reverberation predictions in
+[Room acoustics](/phonometry/guides/sections/room-acoustics/), dynamic
+stiffness (measured by a related load-plate method) feeds the floating-floor
+model in [Sound insulation](/phonometry/guides/sections/sound-insulation/),
+and the road-surface methods connect to the outdoor-noise interest of the
+[Environment and transport](/phonometry/guides/sections/environment-transport/)
+section.
+
+## Pages in this section
+
+- [Acoustic Materials](/phonometry/guides/materials/): the ISO 11654 weighted
+  absorption rating and class, ISO 9053-1/-2 airflow resistance, and
+  impedance-tube absorption, impedance and transmission loss.
+- [Surface Scattering, Diffusion and In-situ Absorption](/phonometry/guides/surface-scattering/):
+  ISO 17497-1/2 scattering and diffusion coefficients, and ISO 13472-1/-2
+  in-situ road-surface absorption.

--- a/site/src/content/docs/guides/sections/octave-filtering.md
+++ b/site/src/content/docs/guides/sections/octave-filtering.md
@@ -1,0 +1,43 @@
+---
+title: "Octave filtering"
+description: "Fractional octave band analysis in phonometry: the ANSI S1.11 / IEC 61260-1 filter banks and their architectures, stateful block processing for streaming signals, and vectorized multichannel analysis."
+---
+
+Acoustic analysis rarely wants a raw FFT: standards, ratings and human hearing
+all work in **fractional octave bands**, frequency intervals whose width grows
+proportionally with frequency. phonometry implements them as banks of
+recursive filters whose **-3 dB points sit exactly on the ANSI S1.11 band
+edges**, so band levels are comparable whichever filter architecture computes
+them, and whose designs are verified against the class tolerances of
+**IEC 61260-1:2014**.
+
+The foundation page is [Filter Banks](/phonometry/guides/filter-banks/). It
+covers the five architectures (Butterworth, Chebyshev I/II, Elliptic and
+Bessel), what their frequency responses trade against each other, how a signal
+is decomposed into 1/1, 1/3 or arbitrary 1/b octave bands, and the zero-phase
+offline mode for analysis where filter delay must not smear the result. Under
+the hood every bank is a cascade of second-order sections with multirate
+decimation, which is what keeps low-frequency bands numerically stable.
+
+The other two pages scale that foundation along two independent axes.
+[Block Processing](/phonometry/guides/block-processing/) scales it in *time*:
+signals that never fit in memory (hour-long recordings, live monitoring,
+embedded loggers) are processed buffer by buffer with carried filter state, so
+the result is bit-identical to processing the whole signal at once.
+[Multichannel and Performance](/phonometry/guides/multichannel/) scales it in
+*channels*: microphone arrays and multichannel recordings are analysed
+vectorized, one call for all channels, with notes on where the computation
+time actually goes.
+
+Read them in that order. Everything downstream (levels, loudness, room
+parameters) consumes the band signals or band levels these pages produce.
+
+## Pages in this section
+
+- [Filter Banks](/phonometry/guides/filter-banks/): the five filter
+  architectures, frequency responses, band decomposition and zero-phase
+  filtering.
+- [Block Processing](/phonometry/guides/block-processing/): stateful streaming
+  workflows with carried filter state.
+- [Multichannel and Performance](/phonometry/guides/multichannel/): vectorized
+  multichannel analysis and performance notes.

--- a/site/src/content/docs/guides/sections/outdoor-sound.md
+++ b/site/src/content/docs/guides/sections/outdoor-sound.md
@@ -1,0 +1,45 @@
+---
+title: "Outdoor sound"
+description: "Sound on its way through open air and the character of what arrives: the ISO 9613 outdoor-propagation model with its per-term attenuation breakdown, and the NT ACOU 112 prominence and adjustment for impulsive sounds."
+---
+
+Outdoor sound assessment has two halves: predicting the level a source
+delivers to a distant receiver, and judging the character of the sound that
+actually arrives. The two pages of this section take one half each.
+
+[Outdoor Sound Propagation](/phonometry/guides/outdoor-propagation/) is the
+prediction half. Starting from a source's **sound power**, the ISO 9613-2
+general method subtracts, octave band by octave band, every mechanism that
+attenuates sound on its way: geometrical divergence, atmospheric absorption
+(supplied by the pure-tone coefficient of **ISO 9613-1**), the ground effect
+and barrier screening, with a meteorological correction for long-term
+averages. The page keeps the per-term breakdown visible, so a prediction is
+never a black box: you can see exactly which mechanism buys how many decibels
+at which frequency.
+
+[Impulsive-sound prominence (NT ACOU 112)](/phonometry/guides/impulse-prominence/)
+is the assessment half. Noise containing distinct impulses (hammering,
+riveting, pile driving) annoys more than a steady sound of the same LAeq, and
+the Nordtest method quantifies that: from the onset rate and level difference
+of each impulse it computes a predicted **prominence**, and converts it into
+the graduated adjustment KI that is added to the measured LAeq in a rating
+level.
+
+The surrounding machinery lives nearby: the rating levels and Lden that
+assessments end in are covered in
+[Integrated and Statistical Levels](/phonometry/guides/levels/), the tonal
+counterpart of the impulsive adjustment in
+[Objective audibility of tones in noise](/phonometry/guides/tone-audibility/),
+and the sources that feed a propagation calculation in
+[Sound Power](/phonometry/guides/sound-power/) and the
+[Aircraft and wind energy](/phonometry/guides/sections/aircraft-wind/)
+section.
+
+## Pages in this section
+
+- [Outdoor Sound Propagation](/phonometry/guides/outdoor-propagation/):
+  ISO 9613-1 atmospheric absorption and the ISO 9613-2 general method with a
+  per-term octave-band attenuation breakdown.
+- [Impulsive-sound prominence (NT ACOU 112)](/phonometry/guides/impulse-prominence/):
+  the predicted prominence of impulsive sounds and the graduated LAeq
+  adjustment KI.

--- a/site/src/content/docs/guides/sections/psychoacoustics.md
+++ b/site/src/content/docs/guides/sections/psychoacoustics.md
@@ -1,0 +1,52 @@
+---
+title: "Psychoacoustics"
+description: "The perceptual metrics of sound: loudness models (ISO 532, ECMA-418-2), sharpness, tonality and roughness, the two tonal-assessment methods (ECMA-418-1 prominence and ISO/PAS 20065 audibility), and the Fastl & Zwicker psychoacoustic annoyance."
+---
+
+Psychoacoustics replaces the question "how many decibels?" with "what does the
+listener perceive?". Its base quantity is **loudness**: a perceptual magnitude
+in sones, computed by auditory models that account for the ear's filtering,
+masking and compression. On top of loudness sit the **sound quality**
+sensations that distinguish two equally loud sounds: sharpness (high-frequency
+emphasis), tonality (audible discrete tones) and roughness (fast modulation).
+And on top of those sits a combined **annoyance** metric that weighs them into
+a single scalar.
+
+[Loudness](/phonometry/guides/loudness/) is the foundation page. It covers the
+three model families phonometry ships (Zwicker per ISO 532-1, Moore-Glasberg
+per ISO 532-2/3, and the Sottek Hearing Model of ECMA-418-2) together with the
+ISO 226:2023 equal-loudness contours that anchor the perceptual scale for pure
+tones. [Sound Quality Metrics](/phonometry/guides/sound-quality/) adds
+sharpness per DIN 45692 and the ECMA-418-2 tonality and roughness that share
+the Sottek front-end.
+
+Tones in noise get two dedicated pages because two different questions are
+asked of them.
+[Prominent Discrete Tones (ECMA-418-1)](/phonometry/guides/tone-prominence/)
+answers a product-noise question: is this tone *prominent* by the
+tone-to-noise and prominence-ratio criteria used in IT-equipment declarations?
+[Objective audibility of tones in noise (ISO/PAS 20065)](/phonometry/guides/tone-audibility/)
+answers an environmental one: by how many decibels does the tone exceed its
+masking threshold, the audibility that feeds the tonal penalty of
+ISO 1996-2.
+
+[Psychoacoustic annoyance and fluctuation strength](/phonometry/guides/psychoacoustic-annoyance/)
+closes the chain with the Fastl & Zwicker model, which combines loudness,
+sharpness, roughness and the slow-modulation sensation of fluctuation strength
+into a single annoyance value. Read it last: it consumes everything the other
+pages define.
+
+## Pages in this section
+
+- [Loudness](/phonometry/guides/loudness/): Zwicker, Moore-Glasberg and
+  Sottek loudness in sones, plus the ISO 226:2023 equal-loudness contours.
+- [Sound Quality Metrics](/phonometry/guides/sound-quality/): sharpness
+  (DIN 45692) and ECMA-418-2 tonality and roughness.
+- [Prominent Discrete Tones (ECMA-418-1)](/phonometry/guides/tone-prominence/):
+  tone-to-noise and prominence ratios with prominence verdicts.
+- [Objective audibility of tones in noise (ISO/PAS 20065)](/phonometry/guides/tone-audibility/):
+  the audibility of a tone above the masking threshold, feeding the
+  ISO 1996-2 tonal adjustment.
+- [Psychoacoustic annoyance and fluctuation strength](/phonometry/guides/psychoacoustic-annoyance/):
+  the Fastl & Zwicker annoyance model and the fluctuation-strength models it
+  consumes.

--- a/site/src/content/docs/guides/sections/room-acoustics.md
+++ b/site/src/content/docs/guides/sections/room-acoustics.md
@@ -1,0 +1,53 @@
+---
+title: "Room acoustics"
+description: "The sound field inside a single room: impulse-response measurement and the ISO 3382 parameters, the ANSI S12.2 room-noise ratings, and reverberation-time prediction by the classical formulae and the EN 12354-6 normative model."
+---
+
+Almost everything about the sound field inside a room follows from two
+quantities: its **impulse response**, which can be measured, and its **sound
+absorption**, which can be designed. The four pages of this section cover the
+measurement chain built on the first, the prediction chain built on the
+second, and the rating of the background noise that occupies the room in
+between.
+
+The measurement chain lives in
+[Room Acoustics](/phonometry/guides/room-acoustics/): acquiring the impulse
+response with the deterministic signals of ISO 18233, deriving the ISO 3382
+parameters (reverberation time, EDT, clarity, centre time, and the open-plan
+speech metrics of ISO 3382-3), and, closing the loop, measuring a material's
+absorption coefficient in a reverberation room per ISO 354. That absorption
+coefficient is precisely what the prediction chain needs.
+
+Prediction gets two pages because two traditions coexist.
+[Reverberation-time prediction (Sabine, Eyring, Arau)](/phonometry/guides/reverberation-prediction/)
+covers the classical statistical formulae (Sabine, Eyring, Millington-Sette,
+Fitzroy and Arau-Puchades), including the models that handle a non-uniform
+absorption distribution.
+[Sound absorption in enclosed spaces (EN 12354-6)](/phonometry/guides/enclosed-space-absorption/)
+covers the normative European version of the same physics: the total
+equivalent absorption area assembled from surfaces, objects and air, and the
+reverberation time that follows from it, as a standard a design report can
+cite.
+
+[Room-noise criteria (NC / RC Mark II)](/phonometry/guides/room-noise/)
+answers a different question about the same room: whether its steady
+background noise (ventilation, distant traffic) is acceptable for its use,
+rated against the ANSI/ASA S12.2 criterion curves, with the RC Mark II
+rumble/hiss tag diagnosing *why* a spectrum fails.
+
+Related pages elsewhere: measuring insulation *between* rooms continues in
+[Sound insulation](/phonometry/guides/sections/sound-insulation/), and the
+speech intelligibility a room affords is quantified by the
+[Speech Transmission Index](/phonometry/guides/speech-transmission/).
+
+## Pages in this section
+
+- [Room Acoustics](/phonometry/guides/room-acoustics/): impulse-response
+  acquisition (ISO 18233), room parameters (ISO 3382-1/2), open-plan metrics
+  (ISO 3382-3) and reverberation-room absorption (ISO 354).
+- [Room-noise criteria (NC / RC Mark II)](/phonometry/guides/room-noise/):
+  the ANSI/ASA S12.2-2019 NC tangency and RC Mark II ratings.
+- [Reverberation-time prediction (Sabine, Eyring, Arau)](/phonometry/guides/reverberation-prediction/):
+  the five statistical models with the air-absorption term.
+- [Sound absorption in enclosed spaces (EN 12354-6)](/phonometry/guides/enclosed-space-absorption/):
+  the normative equivalent-absorption-area and reverberation-time prediction.

--- a/site/src/content/docs/guides/sections/rooms-buildings.md
+++ b/site/src/content/docs/guides/sections/rooms-buildings.md
@@ -1,0 +1,77 @@
+---
+title: "Rooms and buildings"
+description: "Sound inside rooms and through buildings: room-acoustic measurement and prediction (ISO 3382, EN 12354-6), sound insulation measured in the field and the laboratory and predicted with EN 12354, and the laboratory characterisation of acoustic materials and surfaces."
+---
+
+This section covers sound in the built environment, and it splits along a
+natural line: what happens **inside** one room, and what passes **between**
+rooms. Inside a room, the governing quantity is absorption: it sets the
+reverberation time and the clarity that room acoustics measures (ISO 3382)
+and predicts (Sabine and its refinements, EN 12354-6), while the background
+noise the room settles into is rated against criterion curves
+(ANSI/ASA S12.2). Between rooms, the governing quantity is insulation: how much
+airborne and impact sound a partition and its flanking paths transmit, measured
+in the field (ISO 16283) or the laboratory (ISO 10140) and predicted from
+element data (EN 12354).
+
+Both halves rest on the same material data. The **materials and surfaces**
+pages characterise what walls, absorbers and pavements actually do to sound:
+absorption coefficients and their single-number ratings, airflow resistance,
+surface impedance, scattering and diffusion. Those coefficients are the inputs
+the room predictions consume, and the element ratings are the inputs the
+insulation predictions consume, so the section forms a loop: measure the
+material, predict the building, verify in the field.
+
+Start with [Room Acoustics](/phonometry/guides/room-acoustics/): the impulse
+response it acquires and the parameters it derives are the vocabulary the rest
+of the section speaks. If your interest is insulation, read
+[Field Insulation Measurement and Ratings](/phonometry/guides/insulation-field/)
+next; if it is design-stage prediction, go to
+[Reverberation-time prediction (Sabine, Eyring, Arau)](/phonometry/guides/reverberation-prediction/)
+and [Predicting Sound Insulation (EN 12354)](/phonometry/guides/insulation-prediction/).
+
+## [Room acoustics](/phonometry/guides/sections/room-acoustics/)
+
+The sound field inside a single room: measured from an impulse response, rated
+against criterion curves, and predicted from volume and absorption.
+
+- [Room Acoustics](/phonometry/guides/room-acoustics/): impulse-response
+  acquisition (ISO 18233), room parameters (ISO 3382-1/2), open-plan speech
+  metrics (ISO 3382-3) and reverberation-room absorption (ISO 354).
+- [Room-noise criteria (NC / RC Mark II)](/phonometry/guides/room-noise/): the
+  ANSI/ASA S12.2-2019 room-noise ratings with their spectral tags.
+- [Reverberation-time prediction (Sabine, Eyring, Arau)](/phonometry/guides/reverberation-prediction/):
+  Sabine, Eyring, Millington-Sette, Fitzroy and Arau-Puchades models with the
+  air-absorption term.
+- [Sound absorption in enclosed spaces (EN 12354-6)](/phonometry/guides/enclosed-space-absorption/):
+  the normative prediction of a room's total equivalent absorption area and
+  reverberation time.
+
+## [Sound insulation](/phonometry/guides/sections/sound-insulation/)
+
+Airborne and impact insulation: measured in the building, characterised in the
+laboratory, and predicted from element data.
+
+- [Field Insulation Measurement and Ratings](/phonometry/guides/insulation-field/):
+  ISO 16283-1/2/3 field measurement, ISO 717-1/2 weighted ratings,
+  ISO 12999-1 uncertainty and the ISO 10052 survey method.
+- [Laboratory Insulation Measurement](/phonometry/guides/insulation-lab/):
+  ISO 10140 laboratory characterisation, insulation by intensity (ISO 15186),
+  floor-covering improvement (ISO 16251-1) and flanking (ISO 10848).
+- [Predicting Sound Insulation (EN 12354)](/phonometry/guides/insulation-prediction/):
+  airborne and impact flanking transmission (EN 12354-1/2), façade insulation
+  and outdoor radiation (EN 12354-3/4).
+- [Dynamic stiffness of resilient materials (EN 29052-1)](/phonometry/guides/dynamic-stiffness/):
+  the load-plate resonance measurement behind every floating-floor prediction.
+
+## [Materials and surfaces](/phonometry/guides/sections/materials-surfaces/)
+
+What materials and surfaces do to sound, measured in the laboratory and in
+situ.
+
+- [Acoustic Materials](/phonometry/guides/materials/): the ISO 11654 weighted
+  absorption rating, airflow resistance (ISO 9053-1/-2) and the impedance tube
+  (ISO 10534-1/-2, ASTM E2611).
+- [Surface Scattering, Diffusion and In-situ Absorption](/phonometry/guides/surface-scattering/):
+  scattering (ISO 17497-1) and diffusion (ISO 17497-2) coefficients, and
+  in-situ road-surface absorption (ISO 13472-1/-2).

--- a/site/src/content/docs/guides/sections/sound-insulation.md
+++ b/site/src/content/docs/guides/sections/sound-insulation.md
@@ -1,0 +1,55 @@
+---
+title: "Sound insulation"
+description: "Airborne and impact sound insulation across its full life cycle: laboratory characterisation (ISO 10140 and companions), in-situ prediction (EN 12354), field verification with single-number ratings (ISO 16283, ISO 717), and the dynamic stiffness that feeds floating-floor design."
+---
+
+Sound insulation has a life cycle, and the four pages of this section each own
+one stage of it. An element (a wall build-up, a floating floor, a window) is
+first characterised **in the laboratory**, where suppressed flanking isolates
+its direct transmission. That laboratory data feeds a **prediction** of how a
+whole building will perform, flanking paths included. The finished building is
+then **verified in the field**, where the measured values carry the
+single-number ratings that regulations quote. Each stage answers a different
+question, and each has its own standards family.
+
+[Laboratory Insulation Measurement](/phonometry/guides/insulation-lab/) covers
+the first stage: the ISO 10140 sound reduction index and normalized impact
+level, the sound-intensity alternative of ISO 15186, the small-mock-up
+floor-covering improvement of ISO 16251-1 and laboratory flanking transmission
+per ISO 10848.
+
+[Predicting Sound Insulation (EN 12354)](/phonometry/guides/insulation-prediction/)
+covers the second: the airborne and impact flanking models of EN 12354-1/2
+with their junction vibration reduction indices, and the façade insulation and
+outdoor radiation of EN 12354-3/4. Its floating-floor improvement term
+consumes the dynamic stiffness measured per
+[EN 29052-1](/phonometry/guides/dynamic-stiffness/), which is why that
+measurement page lives in this section.
+
+[Field Insulation Measurement and Ratings](/phonometry/guides/insulation-field/)
+covers the third: field airborne, impact and façade insulation per
+ISO 16283-1/2/3, the weighted single-number ratings and spectrum adaptation
+terms of ISO 717-1/2, the ISO 12999-1 uncertainty that qualifies a rating, and
+the quick ISO 10052 survey method.
+
+Two neighbouring sections complete the picture: the room-side quantities
+(reverberation time, absorption) live in
+[Room acoustics](/phonometry/guides/sections/room-acoustics/), and the
+structure-borne noise of building *equipment*, predicted by the closely
+related EN 12354-5, lives in
+[Structure-borne sources](/phonometry/guides/sections/structure-borne/).
+
+## Pages in this section
+
+- [Field Insulation Measurement and Ratings](/phonometry/guides/insulation-field/):
+  ISO 16283-1/2/3 measurement, ISO 717-1/2 ratings, ISO 12999-1 uncertainty
+  and the ISO 10052 survey method.
+- [Laboratory Insulation Measurement](/phonometry/guides/insulation-lab/):
+  ISO 10140 characterisation, ISO 15186 intensity insulation, ISO 16251-1
+  floor coverings and ISO 10848 flanking.
+- [Predicting Sound Insulation (EN 12354)](/phonometry/guides/insulation-prediction/):
+  flanking transmission (EN 12354-1/2), façade insulation and outdoor
+  radiation (EN 12354-3/4).
+- [Dynamic stiffness of resilient materials (EN 29052-1)](/phonometry/guides/dynamic-stiffness/):
+  the load-plate resonance measurement and the floating-floor natural
+  frequency.

--- a/site/src/content/docs/guides/sections/sound-insulation.md
+++ b/site/src/content/docs/guides/sections/sound-insulation.md
@@ -3,14 +3,16 @@ title: "Sound insulation"
 description: "Airborne and impact sound insulation across its full life cycle: laboratory characterisation (ISO 10140 and companions), in-situ prediction (EN 12354), field verification with single-number ratings (ISO 16283, ISO 717), and the dynamic stiffness that feeds floating-floor design."
 ---
 
-Sound insulation has a life cycle, and the four pages of this section each own
-one stage of it. An element (a wall build-up, a floating floor, a window) is
-first characterised **in the laboratory**, where suppressed flanking isolates
-its direct transmission. That laboratory data feeds a **prediction** of how a
-whole building will perform, flanking paths included. The finished building is
-then **verified in the field**, where the measured values carry the
-single-number ratings that regulations quote. Each stage answers a different
-question, and each has its own standards family.
+Sound insulation has a life cycle with three stages, and a page of this
+section owns each of them. An element (a wall build-up, a floating floor, a
+window) is first characterised **in the laboratory**, where suppressed
+flanking isolates its direct transmission. That laboratory data feeds a
+**prediction** of how a whole building will perform, flanking paths included.
+The finished building is then **verified in the field**, where the measured
+values carry the single-number ratings that regulations quote. Each stage
+answers a different question, and each has its own standards family. A fourth
+page, on dynamic stiffness, is not a stage of its own but the supporting
+material measurement that the prediction stage consumes.
 
 [Laboratory Insulation Measurement](/phonometry/guides/insulation-lab/) covers
 the first stage: the ISO 10140 sound reduction index and normalized impact

--- a/site/src/content/docs/guides/sections/sources-devices.md
+++ b/site/src/content/docs/guides/sections/sources-devices.md
@@ -8,9 +8,10 @@ descriptor, and this section is where those descriptors are measured. Its
 common thread is **emission**: numbers that belong to the device rather than
 to the room or the distance it is heard at.
 
-The central quantity is the **sound power level**: the total acoustic energy
-per second a source radiates, the figure that goes on a datasheet, feeds a
-room or outdoor prediction and is checked against noise-emission limits.
+The central quantity is the **sound power**: the total acoustic energy per
+second a source radiates. Expressed in decibels as the sound power level, it
+is the figure that goes on a datasheet, feeds a room or outdoor prediction
+and is checked against noise-emission limits.
 [Sound Power](/phonometry/guides/sound-power/) covers the five standardised
 routes to it, from the enveloping pressure surface of ISO 3744/3746 to the
 reverberation room of ISO 3741, the on-site intensity scanning of ISO 9614-2

--- a/site/src/content/docs/guides/sections/sources-devices.md
+++ b/site/src/content/docs/guides/sections/sources-devices.md
@@ -1,0 +1,46 @@
+---
+title: "Sources and devices"
+description: "Characterising what emits the sound: sound power determination by pressure, reverberation-room and intensity methods (ISO 3740 and ISO 9614 series), two-microphone sound intensity (IEC 61043), and the IEC 60268 distortion and frequency-response metrics of audio equipment."
+---
+
+Every prediction elsewhere in this documentation starts from a source
+descriptor, and this section is where those descriptors are measured. Its
+common thread is **emission**: numbers that belong to the device rather than
+to the room or the distance it is heard at.
+
+The central quantity is the **sound power level**: the total acoustic energy
+per second a source radiates, the figure that goes on a datasheet, feeds a
+room or outdoor prediction and is checked against noise-emission limits.
+[Sound Power](/phonometry/guides/sound-power/) covers the five standardised
+routes to it, from the enveloping pressure surface of ISO 3744/3746 to the
+reverberation room of ISO 3741, the on-site intensity scanning of ISO 9614-2
+and the precision grades of ISO 3745 and ISO 9614-3. Behind the intensity-based routes sits **sound intensity** itself:
+the signed power flux that can localise sources and separate them from
+background noise, measured with a two-microphone probe per IEC 61043 and
+qualified by the ISO 9614-1 field indicators, covered in
+[Sound Intensity (p-p)](/phonometry/guides/intensity/).
+
+[Electroacoustics](/phonometry/guides/electroacoustics/) turns to devices that
+are *supposed* to make sound: amplifiers, loudspeakers and microphones. It
+covers the IEC 60268-3 distortion set (THD, THD+N and SINAD, intermodulation
+and DIM), the H1/H2 frequency-response estimators with coherence, and the
+sensitivity conventions of IEC 60268-4/-5 where datasheet comparisons usually
+go wrong.
+
+If you are here to measure a machine, start with
+[Sound Power](/phonometry/guides/sound-power/) and let its decision guidance
+pick the route; read [Sound Intensity (p-p)](/phonometry/guides/intensity/)
+when that route involves an intensity probe. If you are here to bench-test
+audio gear, go straight to
+[Electroacoustics](/phonometry/guides/electroacoustics/).
+
+## Pages in this section
+
+- [Sound Intensity (p-p)](/phonometry/guides/intensity/): two-microphone
+  sound intensity per IEC 61043 with the ISO 9614-1 field indicators.
+- [Sound Power](/phonometry/guides/sound-power/): the sound power level by
+  enveloping surface, reverberation room, intensity scanning and the
+  precision anechoic and intensity methods.
+- [Electroacoustics: distortion and frequency response](/phonometry/guides/electroacoustics/):
+  the IEC 60268-3 distortion metrics, frequency-response estimation with
+  coherence, and microphone and loudspeaker sensitivity conventions.

--- a/site/src/content/docs/guides/sections/speech.md
+++ b/site/src/content/docs/guides/sections/speech.md
@@ -1,0 +1,46 @@
+---
+title: "Speech"
+description: "The two standard indices of speech intelligibility and the different questions they answer: the STI of IEC 60268-16, which rates a transmission channel, and the SII of ANSI S3.5, which rates a listening condition."
+---
+
+Both pages in this section reduce speech intelligibility to a number in
+[0, 1], and the art is knowing which number answers your question. The
+**Speech Transmission Index** (STI) rates a *transmission channel*: a room, a
+public-address system, an intercom. The **Speech Intelligibility Index** (SII)
+rates a *listening condition*: this speech spectrum, in this noise, heard by
+this listener. A reverberant lecture hall is an STI problem; a hearing-aid
+fitting or a cockpit warning heard over engine noise is an SII problem.
+
+The physical difference sits in what each index models. STI
+(**IEC 60268-16**) works on the speech *envelope*: intelligibility degrades
+when reverberation and noise flatten the slow intensity modulations of speech,
+and the index measures how much of that modulation survives the channel, via
+the modulation transfer function. It can be computed indirectly from a
+measured impulse response or measured directly with the STIPA test signal.
+[Speech Transmission Index (STI)](/phonometry/guides/speech-transmission/)
+covers the modulation physics, both methods and the Annex F rating bands.
+
+SII (**ANSI S3.5-1997**) works on *audibility*: intelligibility is predicted
+from how much of the speech-bearing spectrum rises above the listener's
+effective threshold, band by band, weighted by each band's importance to
+speech. Noise, self-masking, upward spread of masking and the listener's own
+hearing threshold all enter explicitly, which is why SII extends naturally to
+hearing loss.
+[Speech Intelligibility Index](/phonometry/guides/speech-intelligibility/)
+covers the one-third-octave-band method, including the standard speech spectra
+for normal to shouted vocal effort.
+
+The two connect back to the rest of the library naturally: the STI consumes
+the impulse responses of
+[Room Acoustics](/phonometry/guides/room-acoustics/), and the SII consumes the
+hearing thresholds quantified in
+[Hearing threshold](/phonometry/guides/hearing-threshold/).
+
+## Pages in this section
+
+- [Speech Transmission Index (STI)](/phonometry/guides/speech-transmission/):
+  the IEC 60268-16 modulation transfer function, the indirect method from an
+  impulse response, and direct STIPA measurement.
+- [Speech Intelligibility Index](/phonometry/guides/speech-intelligibility/):
+  the ANSI S3.5-1997 band-importance and band-audibility method, in noise and
+  in hearing loss.

--- a/site/src/content/docs/guides/sections/structure-borne.md
+++ b/site/src/content/docs/guides/sections/structure-borne.md
@@ -6,9 +6,11 @@ description: "The chain from a vibrating machine to the noise heard rooms away: 
 A machine fixed to a building radiates sound twice: directly from its own
 vibrating surface, and indirectly by injecting **structure-borne power** into
 the structure, which carries it away and re-radiates it in distant rooms. The
-five pages of this section characterise that second, sneakier path end to
-end: describe the vibration, characterise the isolators, quantify the power,
-and predict the level a listener finally hears.
+five pages of this section cover both paths: one estimates the direct
+radiation from the surface vibration itself, and the other four characterise
+the second, sneakier structure-borne path end to end, from describing the
+vibration and characterising the isolators to quantifying the power and
+predicting the level a listener finally hears.
 
 The language comes first.
 [Mechanical mobility and the FRF family (ISO 7626-1)](/phonometry/guides/mechanical-mobility/)

--- a/site/src/content/docs/guides/sections/structure-borne.md
+++ b/site/src/content/docs/guides/sections/structure-borne.md
@@ -1,0 +1,53 @@
+---
+title: "Structure-borne sources"
+description: "The chain from a vibrating machine to the noise heard rooms away: the ISO 7626 FRF family, ISO 10846 isolator transfer stiffness, ISO/TS 7849 radiated power from surface vibration, the EN 15657 reception plate and the EN 12354-5 installed prediction."
+---
+
+A machine fixed to a building radiates sound twice: directly from its own
+vibrating surface, and indirectly by injecting **structure-borne power** into
+the structure, which carries it away and re-radiates it in distant rooms. The
+five pages of this section characterise that second, sneakier path end to
+end: describe the vibration, characterise the isolators, quantify the power,
+and predict the level a listener finally hears.
+
+The language comes first.
+[Mechanical mobility and the FRF family (ISO 7626-1)](/phonometry/guides/mechanical-mobility/)
+defines the motion-per-force frequency-response functions (receptance,
+mobility, accelerance and their reciprocals) that every later standard speaks,
+with the closed-form SDOF resonator as the reference and the ISO 7626-2
+measurement acceptance criteria. Source and receiver *mobilities* are what
+decide how much power actually couples across an interface, which is why this
+vocabulary matters.
+
+Two pages then characterise the path elements.
+[Transfer stiffness of resilient elements (ISO 10846)](/phonometry/guides/transfer-stiffness/)
+measures the dynamic transfer stiffness of the isolators, mounts and hoses
+inserted precisely to break the transmission path, by the direct and indirect
+(transmissibility) methods.
+[Sound power from surface vibration (ISO/TS 7849)](/phonometry/guides/vibration-sound-power/)
+handles the direct radiation: the airborne power estimated from surface
+velocity and a radiation factor, without any acoustic measurement.
+
+The last two pages close the chain on the source and the receiver.
+[Structure-borne sound power of equipment (EN 15657)](/phonometry/guides/structure-borne-power/)
+measures what a machine injects, via the reception-plate method, and derives
+the plate-independent source quantities (blocked force, characteristic power
+level, free velocity).
+[Installed structure-borne sound (EN 12354-5)](/phonometry/guides/installed-structure-borne/)
+consumes exactly those quantities, couples them through source and receiver
+mobilities, and predicts the sound pressure level in the receiving room,
+which is where this section meets the
+[sound insulation](/phonometry/guides/sections/sound-insulation/) models.
+
+## Pages in this section
+
+- [Mechanical mobility and the FRF family (ISO 7626-1)](/phonometry/guides/mechanical-mobility/):
+  the FRF family, conversions and the SDOF reference resonator.
+- [Transfer stiffness of resilient elements (ISO 10846)](/phonometry/guides/transfer-stiffness/):
+  dynamic transfer stiffness of isolators by the direct and indirect methods.
+- [Sound power from surface vibration (ISO/TS 7849)](/phonometry/guides/vibration-sound-power/):
+  radiated airborne power from surface velocity and a radiation factor.
+- [Structure-borne sound power of equipment (EN 15657)](/phonometry/guides/structure-borne-power/):
+  the reception-plate method and plate-independent source quantities.
+- [Installed structure-borne sound (EN 12354-5)](/phonometry/guides/installed-structure-borne/):
+  the predicted receiving-room level from installed equipment.

--- a/site/src/content/docs/guides/sections/underwater.md
+++ b/site/src/content/docs/guides/sections/underwater.md
@@ -1,0 +1,43 @@
+---
+title: "Underwater acoustics"
+description: "Sound in the sea: the ISO 18405 reference levels, ship radiated noise (ISO 17208) and pile-driving exposure (ISO 18406), and propagation from closed-form transmission loss and the sonar equation to ambient noise and full numerical solvers."
+---
+
+Underwater acoustics runs on the same physics as airborne acoustics but on a
+different scale and a different reference: levels are expressed re **1 µPa**
+(not 20 µPa), exposure re 1 µPa²·s, and the medium itself, with its
+depth-dependent sound speed, refracts sound into channels that carry it for
+kilometres. This section covers the discipline in two halves that mirror the
+source-path split of the rest of the library.
+
+The **source** half, in
+[Underwater acoustics: radiated noise and pile driving](/phonometry/guides/underwater-acoustics/),
+sets up the ISO 18405 terminology (SPL, SEL and peak levels and their
+references) and applies it to the two regulated source types: the ship
+radiated noise level and equivalent monopole source level of ISO 17208, with
+the Lloyd's-mirror surface correction, and the single-strike, peak and
+cumulative sound exposure of percussive pile driving per ISO 18406.
+
+The **path** half, in
+[Underwater sound propagation](/phonometry/guides/underwater-propagation/),
+predicts what the sea does to that sound. It layers up from closed forms to
+full numerics: geometrical spreading plus volume absorption
+(Francois-Garrison, Ainslie-McColm or Thorp), the speed of sound in sea water
+by three formulations, the passive and active sonar equation, Rayleigh seabed
+reflection loss, the Wenz ambient-noise spectrum with JOMOPANS-ECHO ship
+traffic, and the normal-mode, ray-tracing and parabolic-equation numerical
+solvers for range-dependent problems.
+
+Read the pages in that order: the reference levels come first because every
+propagation result is expressed in them. Unusually for this site, the theory
+for both pages lives inline with the guides rather than in the theory
+reference.
+
+## Pages in this section
+
+- [Underwater acoustics: radiated noise and pile driving](/phonometry/guides/underwater-acoustics/):
+  ISO 18405 reference levels, ISO 17208 ship radiated noise and monopole
+  source level, and ISO 18406 pile-driving sound exposure.
+- [Underwater sound propagation](/phonometry/guides/underwater-propagation/):
+  transmission loss, sound speed, the sonar equation, seabed reflection,
+  ocean ambient noise and the numerical propagation solvers.

--- a/site/src/content/docs/guides/sections/underwater.md
+++ b/site/src/content/docs/guides/sections/underwater.md
@@ -13,10 +13,11 @@ source-path split of the rest of the library.
 The **source** half, in
 [Underwater acoustics: radiated noise and pile driving](/phonometry/guides/underwater-acoustics/),
 sets up the ISO 18405 terminology (SPL, SEL and peak levels and their
-references) and applies it to the two regulated source types: the ship
-radiated noise level and equivalent monopole source level of ISO 17208, with
-the Lloyd's-mirror surface correction, and the single-strike, peak and
-cumulative sound exposure of percussive pile driving per ISO 18406.
+references) and applies it to two regulated measurement cases: ships, with
+the radiated noise level of ISO 17208-1 and the equivalent monopole source
+level of ISO 17208-2 via the Lloyd's-mirror surface correction, and
+percussive pile driving, with the single-strike, peak and cumulative sound
+exposure of ISO 18406.
 
 The **path** half, in
 [Underwater sound propagation](/phonometry/guides/underwater-propagation/),

--- a/site/src/content/docs/guides/sections/vibration.md
+++ b/site/src/content/docs/guides/sections/vibration.md
@@ -1,0 +1,64 @@
+---
+title: "Vibration and structure-borne sound"
+description: "Vibration as a source of building noise and as a human exposure: the FRF vocabulary (ISO 7626), isolator transfer stiffness (ISO 10846), sound power from surface vibration (ISO/TS 7849), the EN 15657 and EN 12354-5 equipment chain, and the ISO 2631 and ISO 5349 human-vibration metrics."
+---
+
+Vibration matters to acoustics twice. First as a **source of sound**: a pump
+or fan bolted to a building injects structure-borne power that travels through
+walls and floors and re-radiates as audible noise rooms away. Second as a
+**human exposure** in its own right: vibration transmitted to a standing,
+seated or hand-gripping person is measured, weighted and limited much like
+noise, with its own metrics and legal action values.
+
+The **structure-borne sources** pages follow the source chain in order. The
+frequency-response-function family of ISO 7626 (receptance, mobility,
+accelerance) is the vocabulary; the transfer stiffness of ISO 10846
+characterises the resilient elements that interrupt the path; ISO/TS 7849
+estimates the airborne power a vibrating surface radiates directly; EN 15657
+measures the structure-borne power a machine injects into a reception plate;
+and EN 12354-5 assembles all of it into the sound pressure level predicted in
+a receiving room. That final prediction is also where this section hands over
+to the [sound insulation](/phonometry/guides/sections/sound-insulation/) models
+of the buildings section.
+
+The **human vibration** pages share the measurement philosophy of a sound
+level meter, applied to acceleration: frequency weightings that reflect body
+response, running and integrated averages, and dose quantities compared
+against the action and limit values of Directive 2002/44/EC, plus the
+dedicated spinal-response model for vibration containing repeated shocks.
+
+Start with
+[Mechanical mobility and the FRF family](/phonometry/guides/mechanical-mobility/)
+if you care about machines and buildings, or with
+[Human Vibration](/phonometry/guides/human-vibration/) if you care about
+people.
+
+## [Structure-borne sources](/phonometry/guides/sections/structure-borne/)
+
+From FRF vocabulary to the predicted level in a receiving room.
+
+- [Mechanical mobility and the FRF family (ISO 7626-1)](/phonometry/guides/mechanical-mobility/):
+  receptance, mobility and accelerance with their reciprocals, and the SDOF
+  reference resonator.
+- [Transfer stiffness of resilient elements (ISO 10846)](/phonometry/guides/transfer-stiffness/):
+  the dynamic transfer stiffness of vibration isolators by the direct and
+  indirect methods.
+- [Sound power from surface vibration (ISO/TS 7849)](/phonometry/guides/vibration-sound-power/):
+  radiated airborne power from surface velocity and a radiation factor.
+- [Structure-borne sound power of equipment (EN 15657)](/phonometry/guides/structure-borne-power/):
+  the reception-plate method and the plate-independent source quantities.
+- [Installed structure-borne sound (EN 12354-5)](/phonometry/guides/installed-structure-borne/):
+  the receiving-room sound pressure level predicted from source and receiver
+  mobilities.
+
+## [Human vibration](/phonometry/guides/sections/human-vibration/)
+
+Vibration transmitted to the human body, from daily exposure to spinal injury
+risk.
+
+- [Human Vibration](/phonometry/guides/human-vibration/): whole-body and
+  hand-arm weightings (ISO 8041-1), r.m.s. and dose measures (ISO 2631-1),
+  daily exposure A(8) (ISO 5349) and the Directive 2002/44/EC values.
+- [Multiple-shock whole-body vibration (ISO 2631-5)](/phonometry/guides/multiple-shock-vibration/):
+  the spinal-response model and the probability of lumbar injury for vibration
+  containing multiple shocks.


### PR DESCRIPTION
## Summary

Every sidebar group and subgroup now leads somewhere: 20 didactic landing pages (7 domain groups, 13 subgroups) in English and Spanish, wired as the Overview first item of each section.

- Group pages orient the visitor in 2 to 4 paragraphs (what the domain covers, how its pieces relate, where to start) and map every child with a one-line description; subgroup pages go deeper (key concepts, which standards live there, how the pages fit together) with the full linked page list. The Speech page, for instance, explains STI versus SII in one breath and what question each answers.
- The Overview-first-item pattern is Starlight-native (group labels themselves are not links), needs no component overrides, and reads identically in the mobile drawer; Start and Reference keep their existing entries.
- Link maps were verified programmatically against the sidebar's actual children in both languages, and every cited standard number was checked against the child pages; a misattribution of background-noise character (it belongs to the ANSI/ASA S12.2 criterion curves, not to the reverberation material) was caught and corrected in both languages.

## Test plan

i18n parity (76 pairs), site build with links validator at 0 errors (317 pages), html-validate clean, pa11y 34 of 34 URLs including the new landing pages, zero em-dashes in the new prose. A review pass produced one factual and ten wording findings, all applied.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added new Spanish guide pages and overviews for aircraft/wind energy, calibration & uncertainty, core signal analysis, hearing, speech, psychoacoustics, environmental/transport noise, room acoustics, sound insulation, vibration, underwater acoustics, and sound sources.
  * Improved section navigation with localized “Overview” entries and “pages in this section” indexes to streamline related-topic discovery.
* **Accessibility**
  * Expanded automated accessibility checks to cover additional English and Spanish guide pages.
* **SEO / Structured Data**
  * Updated breadcrumb labeling for section paths to reflect localized “Sections” wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->