### PR TITLE
feat(site): link sidebar group labels to their section landing pages

### DIFF
--- a/scripts/generate_api_docs.py
+++ b/scripts/generate_api_docs.py
@@ -1108,7 +1108,7 @@ def render_sidebar(pages: list[ModuleDoc]) -> str:
         "  label: 'API reference',",
         "  translations: { es: 'Referencia de la API' },",
         "  items: [",
-        "    { slug: 'reference/api' },",
+        "    { slug: 'reference/api', attrs: { 'data-group-link': true } },",
     ]
     by_section: dict[str, list[ModuleDoc]] = {}
     for page in pages:

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -237,6 +237,8 @@ export default defineConfig({
         Footer: './src/components/Footer.astro',
         // Default header plus a mobile-visible language selector.
         Header: './src/components/Header.astro',
+        // Linked group labels + non-collapsible sidebar.
+        Sidebar: './src/components/Sidebar.astro',
       },
       customCss: [
         './src/styles/katex.css',
@@ -296,6 +298,11 @@ export default defineConfig({
         // JSON-LD structured data
         { tag: 'script', attrs: { type: 'application/ld+json' }, content: jsonLd },
       ],
+      // Overview-first convention: when a group's first item is a link with
+      // `attrs: { 'data-group-link': true }`, the custom Sidebar override
+      // consumes it and renders the group label itself as a link to that page
+      // instead of a separate Overview row. Groups are never collapsible, so
+      // `collapsed` has no effect.
       sidebar: [
         {
           label: 'Start',
@@ -309,12 +316,12 @@ export default defineConfig({
           label: 'Core signal analysis',
           translations: { es: 'Análisis de señal' },
           items: [
-            { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/core-signal-analysis' },
+            { slug: 'guides/sections/core-signal-analysis', attrs: { 'data-group-link': true } },
             {
               label: 'Octave filtering',
               translations: { es: 'Filtrado en octavas' },
               items: [
-                { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/octave-filtering' },
+                { slug: 'guides/sections/octave-filtering', attrs: { 'data-group-link': true } },
                 'guides/filter-banks',
                 'guides/block-processing',
                 'guides/multichannel',
@@ -324,7 +331,7 @@ export default defineConfig({
               label: 'Levels and weighting',
               translations: { es: 'Niveles y ponderación' },
               items: [
-                { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/levels-weighting' },
+                { slug: 'guides/sections/levels-weighting', attrs: { 'data-group-link': true } },
                 'guides/weighting',
                 'guides/time-weighting',
                 'guides/levels',
@@ -334,7 +341,7 @@ export default defineConfig({
               label: 'Calibration and uncertainty',
               translations: { es: 'Calibración e incertidumbre' },
               items: [
-                { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/calibration-uncertainty' },
+                { slug: 'guides/sections/calibration-uncertainty', attrs: { 'data-group-link': true } },
                 'guides/calibration',
                 'guides/gum-uncertainty',
               ],
@@ -345,12 +352,12 @@ export default defineConfig({
           label: 'Hearing and perception',
           translations: { es: 'Audición y percepción' },
           items: [
-            { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/hearing-perception' },
+            { slug: 'guides/sections/hearing-perception', attrs: { 'data-group-link': true } },
             {
               label: 'Psychoacoustics',
               translations: { es: 'Psicoacústica' },
               items: [
-                { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/psychoacoustics' },
+                { slug: 'guides/sections/psychoacoustics', attrs: { 'data-group-link': true } },
                 'guides/loudness',
                 'guides/sound-quality',
                 'guides/tone-prominence',
@@ -362,7 +369,7 @@ export default defineConfig({
               label: 'Speech',
               translations: { es: 'Habla' },
               items: [
-                { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/speech' },
+                { slug: 'guides/sections/speech', attrs: { 'data-group-link': true } },
                 'guides/speech-transmission',
                 'guides/speech-intelligibility',
               ],
@@ -371,7 +378,7 @@ export default defineConfig({
               label: 'Hearing and exposure',
               translations: { es: 'Audición y exposición' },
               items: [
-                { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/hearing-exposure' },
+                { slug: 'guides/sections/hearing-exposure', attrs: { 'data-group-link': true } },
                 'guides/hearing-threshold',
                 'guides/noise-induced-hearing-loss',
                 'guides/occupational-exposure',
@@ -383,12 +390,12 @@ export default defineConfig({
           label: 'Rooms and buildings',
           translations: { es: 'Salas y edificación' },
           items: [
-            { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/rooms-buildings' },
+            { slug: 'guides/sections/rooms-buildings', attrs: { 'data-group-link': true } },
             {
               label: 'Room acoustics',
               translations: { es: 'Acústica de salas' },
               items: [
-                { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/room-acoustics' },
+                { slug: 'guides/sections/room-acoustics', attrs: { 'data-group-link': true } },
                 'guides/room-acoustics',
                 'guides/room-noise',
                 'guides/reverberation-prediction',
@@ -399,7 +406,7 @@ export default defineConfig({
               label: 'Sound insulation',
               translations: { es: 'Aislamiento acústico' },
               items: [
-                { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/sound-insulation' },
+                { slug: 'guides/sections/sound-insulation', attrs: { 'data-group-link': true } },
                 'guides/insulation-field',
                 'guides/insulation-lab',
                 'guides/insulation-prediction',
@@ -410,7 +417,7 @@ export default defineConfig({
               label: 'Materials and surfaces',
               translations: { es: 'Materiales y superficies' },
               items: [
-                { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/materials-surfaces' },
+                { slug: 'guides/sections/materials-surfaces', attrs: { 'data-group-link': true } },
                 'guides/materials',
                 'guides/surface-scattering',
               ],
@@ -421,12 +428,12 @@ export default defineConfig({
           label: 'Vibration and structure-borne sound',
           translations: { es: 'Vibración y ruido estructural' },
           items: [
-            { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/vibration' },
+            { slug: 'guides/sections/vibration', attrs: { 'data-group-link': true } },
             {
               label: 'Structure-borne sources',
               translations: { es: 'Fuentes de ruido estructural' },
               items: [
-                { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/structure-borne' },
+                { slug: 'guides/sections/structure-borne', attrs: { 'data-group-link': true } },
                 'guides/mechanical-mobility',
                 'guides/transfer-stiffness',
                 'guides/vibration-sound-power',
@@ -438,7 +445,7 @@ export default defineConfig({
               label: 'Human vibration',
               translations: { es: 'Vibración en humanos' },
               items: [
-                { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/human-vibration' },
+                { slug: 'guides/sections/human-vibration', attrs: { 'data-group-link': true } },
                 'guides/human-vibration',
                 'guides/multiple-shock-vibration',
               ],
@@ -449,12 +456,12 @@ export default defineConfig({
           label: 'Environment and transport',
           translations: { es: 'Medio ambiente y transporte' },
           items: [
-            { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/environment-transport' },
+            { slug: 'guides/sections/environment-transport', attrs: { 'data-group-link': true } },
             {
               label: 'Outdoor sound',
               translations: { es: 'Sonido en exteriores' },
               items: [
-                { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/outdoor-sound' },
+                { slug: 'guides/sections/outdoor-sound', attrs: { 'data-group-link': true } },
                 'guides/outdoor-propagation',
                 'guides/impulse-prominence',
               ],
@@ -463,7 +470,7 @@ export default defineConfig({
               label: 'Aircraft and wind energy',
               translations: { es: 'Aeronaves y energía eólica' },
               items: [
-                { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/aircraft-wind' },
+                { slug: 'guides/sections/aircraft-wind', attrs: { 'data-group-link': true } },
                 'guides/aircraft-noise',
                 'guides/rotorcraft-noise',
                 'guides/wind-turbine-noise',
@@ -475,7 +482,7 @@ export default defineConfig({
           label: 'Underwater acoustics',
           translations: { es: 'Acústica submarina' },
           items: [
-            { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/underwater' },
+            { slug: 'guides/sections/underwater', attrs: { 'data-group-link': true } },
             'guides/underwater-acoustics',
             'guides/underwater-propagation',
           ],
@@ -484,7 +491,7 @@ export default defineConfig({
           label: 'Sources and devices',
           translations: { es: 'Fuentes y dispositivos' },
           items: [
-            { label: 'Overview', translations: { es: 'Visión general' }, slug: 'guides/sections/sources-devices' },
+            { slug: 'guides/sections/sources-devices', attrs: { 'data-group-link': true } },
             'guides/intensity',
             'guides/sound-power',
             'guides/electroacoustics',
@@ -499,7 +506,7 @@ export default defineConfig({
               label: 'Theory',
               translations: { es: 'Teoría' },
               items: [
-                'reference/theory',
+                { slug: 'reference/theory', attrs: { 'data-group-link': true } },
                 'reference/theory/signal-analysis',
                 'reference/theory/perception',
                 'reference/theory/rooms-buildings',

--- a/site/src/components/Sidebar.astro
+++ b/site/src/components/Sidebar.astro
@@ -1,0 +1,26 @@
+---
+/*
+  Component override for Starlight's `Sidebar`.
+
+  Identical to the upstream `Sidebar.astro` except that it renders the tree
+  with the local `SidebarSublist.astro`, which turns group labels into links
+  to their landing page (Overview-first convention) and removes the
+  collapsible <details>/<summary> behavior. One further difference: the
+  imports below use the public `@astrojs/starlight/components/*` paths
+  instead of upstream's `virtual:starlight/*` modules, so a future component
+  override of `MobileMenuFooter` would not be picked up here.
+*/
+import MobileMenuFooter from '@astrojs/starlight/components/MobileMenuFooter.astro';
+import SidebarPersister from '@astrojs/starlight/components/SidebarPersister.astro';
+import SidebarSublist from './SidebarSublist.astro';
+
+const { sidebar } = Astro.locals.starlightRoute;
+---
+
+<SidebarPersister>
+	<SidebarSublist sublist={sidebar} />
+</SidebarPersister>
+
+<div class="md:sl-hidden">
+	<MobileMenuFooter />
+</div>

--- a/site/src/components/SidebarSublist.astro
+++ b/site/src/components/SidebarSublist.astro
@@ -1,0 +1,191 @@
+---
+/*
+  Replacement for Starlight's internal `SidebarSublist.astro`.
+
+  Differences from upstream (0.41.3):
+
+  - Groups are not collapsible: no <details>/<summary>, no caret. Children
+    are always visible, matching the fully-expanded design in sidebar.css.
+  - Overview-first convention: when a group's first entry is a link whose
+    sidebar-config `attrs` carry `data-group-link`, that entry is consumed
+    and the group label itself becomes the link (no separate Overview row).
+    Groups without a marked landing page render as a static heading.
+  - `aria-current="page"` moves to the label link when the landing page is
+    the current page, so highlighting keeps working.
+*/
+import type { StarlightRouteData } from '@astrojs/starlight/route-data';
+import { Badge } from '@astrojs/starlight/components';
+
+type SidebarEntry = StarlightRouteData['sidebar'][number];
+type SidebarLink = Extract<SidebarEntry, { type: 'link' }>;
+type SidebarGroup = Extract<SidebarEntry, { type: 'group' }>;
+
+interface Props {
+	sublist: SidebarEntry[];
+	nested?: boolean;
+}
+
+const { sublist, nested } = Astro.props;
+
+interface GroupModel {
+	group: SidebarGroup;
+	/** Marked landing link consumed from the group's first entry, if any. */
+	landing: SidebarLink | undefined;
+	/** Children to render below the label (landing entry removed). */
+	children: SidebarEntry[];
+}
+
+function toModel(entry: SidebarGroup): GroupModel {
+	const [first, ...rest] = entry.entries;
+	const isLanding =
+		first?.type === 'link' && first.attrs != null && 'data-group-link' in first.attrs;
+	return isLanding
+		? { group: entry, landing: first, children: rest }
+		: { group: entry, landing: undefined, children: entry.entries };
+}
+---
+
+<ul class:list={{ 'top-level': !nested }}>
+	{
+		sublist.map((entry) => (
+			<li>
+				{entry.type === 'link' ? (
+					<a
+						href={entry.href}
+						aria-current={entry.isCurrent ? 'page' : undefined}
+						class:list={[{ large: !nested }, entry.attrs.class]}
+						{...entry.attrs}
+					>
+						<span>{entry.label}</span>
+						{entry.badge && (
+							<Badge
+								variant={entry.badge.variant}
+								class={entry.badge.class}
+								text={entry.badge.text}
+							/>
+						)}
+					</a>
+				) : (
+					[toModel(entry)].map(({ group, landing, children }) => (
+						<>
+							{landing ? (
+								<a
+									class="group-label"
+									href={landing.href}
+									aria-current={landing.isCurrent ? 'page' : undefined}
+								>
+									<span class="large">{group.label}</span>
+									{group.badge && (
+										<Badge
+											variant={group.badge.variant}
+											class={group.badge.class}
+											text={group.badge.text}
+										/>
+									)}
+								</a>
+							) : (
+								<span class="group-label">
+									<span class="large">{group.label}</span>
+									{group.badge && (
+										<Badge
+											variant={group.badge.variant}
+											class={group.badge.class}
+											text={group.badge.text}
+										/>
+									)}
+								</span>
+							)}
+							<Astro.self sublist={children} nested />
+						</>
+					))
+				)}
+			</li>
+		))
+	}
+</ul>
+
+<style>
+	@layer starlight.core {
+		ul {
+			--sl-sidebar-item-padding-inline: 0.5rem;
+			list-style: none;
+			padding: 0;
+		}
+
+		li {
+			overflow-wrap: anywhere;
+		}
+
+		ul ul li {
+			margin-inline-start: var(--sl-sidebar-item-padding-inline);
+			border-inline-start: 1px solid var(--sl-color-hairline-light);
+			padding-inline-start: var(--sl-sidebar-item-padding-inline);
+		}
+
+		.large {
+			font-size: var(--sl-text-lg);
+			font-weight: 600;
+			color: var(--sl-color-white);
+		}
+
+		.top-level > li + li {
+			margin-top: 0.75rem;
+		}
+
+		.group-label {
+			display: block;
+			padding: 0.2em var(--sl-sidebar-item-padding-inline);
+			line-height: 1.4;
+		}
+
+		a {
+			display: block;
+			border-radius: 0.25rem;
+			text-decoration: none;
+			color: var(--sl-color-gray-2);
+			padding: 0.3em var(--sl-sidebar-item-padding-inline);
+			line-height: 1.4;
+		}
+
+		a:hover,
+		a:focus {
+			color: var(--sl-color-white);
+		}
+
+		a:hover .large,
+		a:focus .large {
+			color: var(--sl-color-accent-high);
+		}
+
+		[aria-current='page'],
+		[aria-current='page']:hover,
+		[aria-current='page']:focus {
+			font-weight: 600;
+			color: var(--sl-color-text-invert);
+			background-color: var(--sl-color-text-accent);
+		}
+
+		a[aria-current='page'] .large,
+		a[aria-current='page']:hover .large,
+		a[aria-current='page']:focus .large {
+			color: var(--sl-color-text-invert);
+		}
+
+		a > *:not(:last-child),
+		.group-label > *:not(:last-child) {
+			margin-inline-end: 0.25em;
+		}
+
+		@media (min-width: 50rem) {
+			.top-level > li + li {
+				margin-top: 0.5rem;
+			}
+			.large {
+				font-size: var(--sl-text-base);
+			}
+			a {
+				font-size: var(--sl-text-sm);
+			}
+		}
+	}
+</style>

--- a/site/src/components/SidebarSublist.astro
+++ b/site/src/components/SidebarSublist.astro
@@ -47,60 +47,70 @@ function toModel(entry: SidebarGroup): GroupModel {
 
 <ul class:list={{ 'top-level': !nested }}>
 	{
-		sublist.map((entry) => (
-			<li>
-				{entry.type === 'link' ? (
-					<a
-						href={entry.href}
-						aria-current={entry.isCurrent ? 'page' : undefined}
-						class:list={[{ large: !nested }, entry.attrs.class]}
-						{...entry.attrs}
-					>
-						<span>{entry.label}</span>
-						{entry.badge && (
-							<Badge
-								variant={entry.badge.variant}
-								class={entry.badge.class}
-								text={entry.badge.text}
-							/>
-						)}
-					</a>
-				) : (
-					[toModel(entry)].map(({ group, landing, children }) => (
-						<>
-							{landing ? (
-								<a
-									class="group-label"
-									href={landing.href}
-									aria-current={landing.isCurrent ? 'page' : undefined}
-								>
-									<span class="large">{group.label}</span>
-									{group.badge && (
-										<Badge
-											variant={group.badge.variant}
-											class={group.badge.class}
-											text={group.badge.text}
-										/>
-									)}
-								</a>
-							) : (
-								<span class="group-label">
-									<span class="large">{group.label}</span>
-									{group.badge && (
-										<Badge
-											variant={group.badge.variant}
-											class={group.badge.class}
-											text={group.badge.text}
-										/>
-									)}
-								</span>
+		sublist.map((entry) => {
+			if (entry.type === 'link') {
+				return (
+					<li>
+						<a
+							href={entry.href}
+							aria-current={entry.isCurrent ? 'page' : undefined}
+							class:list={[{ large: !nested }, entry.attrs.class]}
+							{...entry.attrs}
+						>
+							<span>{entry.label}</span>
+							{entry.badge && (
+								<Badge
+									variant={entry.badge.variant}
+									class={entry.badge.class}
+									text={entry.badge.text}
+								/>
 							)}
-							<Astro.self sublist={children} nested />
-						</>
-					))
-				)}
-			</li>
-		))
+						</a>
+					</li>
+				);
+			}
+			const { group, landing, children } = toModel(entry);
+			// Forward any custom link attributes from the consumed landing entry,
+			// except the internal `data-group-link` marker itself.
+			const {
+				'data-group-link': _marker,
+				class: landingClass,
+				...landingAttrs
+			} = landing?.attrs ?? {};
+			return (
+				<li>
+					{landing ? (
+						<a
+							class:list={['group-label', landingClass]}
+							href={landing.href}
+							aria-current={landing.isCurrent ? 'page' : undefined}
+							{...landingAttrs}
+						>
+							<span class="large">{group.label}</span>
+							{group.badge && (
+								<Badge
+									variant={group.badge.variant}
+									class={group.badge.class}
+									text={group.badge.text}
+								/>
+							)}
+						</a>
+					) : (
+						<span class="group-label">
+							<span class="large">{group.label}</span>
+							{group.badge && (
+								<Badge
+									variant={group.badge.variant}
+									class={group.badge.class}
+									text={group.badge.text}
+								/>
+							)}
+						</span>
+					)}
+					<Astro.self sublist={children} nested />
+				</li>
+			);
+		})
 	}
 </ul>
 

--- a/site/src/generated/api-sidebar.mjs
+++ b/site/src/generated/api-sidebar.mjs
@@ -4,7 +4,7 @@ export const apiSidebar = {
   label: 'API reference',
   translations: { es: 'Referencia de la API' },
   items: [
-    { slug: 'reference/api' },
+    { slug: 'reference/api', attrs: { 'data-group-link': true } },
     {
       label: 'Filters and frequencies',
       translations: { es: 'Filtros y frecuencias' },

--- a/site/src/styles/sidebar.css
+++ b/site/src/styles/sidebar.css
@@ -1,11 +1,15 @@
 /* Fully-expanded sidebar hierarchy.
 
-   Every sidebar group ships uncollapsed (no `collapsed: true` in
-   astro.config.mjs or the generated api-sidebar.mjs), so the whole map of
-   the docs — about 150 entries — is visible at once, including on the
-   mobile drawer. Starlight styles every group label with the same `.large`
-   token regardless of depth, which reads as a wall of equally-heavy rows
-   once nothing is folded. These rules restore the visual hierarchy:
+   The custom Sidebar override (src/components/Sidebar.astro plus
+   SidebarSublist.astro) renders every group permanently expanded, with no
+   <details>/<summary> toggles or carets, so the whole map of the docs --
+   about 150 entries -- is visible at once, including on the mobile drawer.
+   Group labels whose group carries a landing page (the Overview-first
+   convention in astro.config.mjs) are links and can carry
+   `aria-current="page"`; the rest are static headings. Starlight styles
+   every group label with the same `.large` token regardless of depth, which
+   reads as a wall of equally-heavy rows once nothing is folded. These rules
+   restore the visual hierarchy:
 
    - top-level groups (Start, Core signal analysis, ..., Reference) become
      small uppercase "eyebrow" headers with a hairline separator above each
@@ -17,14 +21,17 @@
      line-height) so the API reference's ~100 module entries stay compact.
 
    Only Starlight custom properties are used for color, so light and dark
-   themes are both covered, and nothing here touches focus styles or the
-   summary/caret toggles, which stay keyboard-operable. */
+   themes are both covered. Color rules guard on
+   `:not([aria-current='page'])` so the accent pill on an active label link
+   keeps its inverted text, and nothing here touches focus styles. */
 
 /* Top-level group labels: uppercase eyebrow headers. */
-#starlight__sidebar .top-level > li > details > summary .group-label > .large {
+#starlight__sidebar .top-level > li > .group-label > .large {
   font-size: var(--sl-text-xs);
   text-transform: uppercase;
   letter-spacing: 0.08em;
+}
+#starlight__sidebar .top-level > li > .group-label:not([aria-current='page']) > .large {
   color: var(--sl-color-gray-1);
 }
 
@@ -40,7 +47,17 @@
    and the links. */
 #starlight__sidebar ul ul .group-label > .large {
   font-size: var(--sl-text-sm);
+}
+#starlight__sidebar ul ul .group-label:not([aria-current='page']) > .large {
   color: var(--sl-color-white);
+}
+
+/* Linked group labels: hover/focus feedback. The color rules above are
+   unlayered, so they beat the component's layered `a:hover .large` rule;
+   restore the same accent highlight here for label links only (static
+   heading labels are <span>s and keep their fixed color). */
+#starlight__sidebar a.group-label:not([aria-current='page']):is(:hover, :focus) > .large {
+  color: var(--sl-color-accent-high);
 }
 
 /* Deep links (inside a nested group): compact rows for the long lists. */

--- a/tests/test_api_docs_generator.py
+++ b/tests/test_api_docs_generator.py
@@ -233,7 +233,7 @@ def test_xref_anchors_point_to_emitted_headings(
 def test_sidebar_fragment_lists_every_page(generated: pathlib.Path) -> None:
     sidebar = (generated / "api-sidebar.mjs").read_text(encoding="utf-8")
     pages, _, _ = gad.build_model()
-    assert "{ slug: 'reference/api' }" in sidebar
+    assert "{ slug: 'reference/api', attrs: { 'data-group-link': true } }" in sidebar
     for page in pages:
         assert f"'reference/api/{page.section.key}/{page.slug}'" in sidebar
 


### PR DESCRIPTION
## Summary

Every sidebar group and subgroup with a landing page is now itself the link to that page: the Overview rows disappear and the group label carries the navigation, with no collapsible sections. This matches how the section landings were meant to be reached and removes a full row per group from the sidebar.

Starlight 0.41 has no native support for linked group labels (the sidebar schema rejects any extra field on groups and the renderer always emits a static `<details><summary>` label; the historical upstream discussions remain open), and `starlight-sidebar-topics` only links the first level while hiding the other topics' items. The supported mechanism is a component override.

## Changes

- New `site/src/components/Sidebar.astro` and `SidebarSublist.astro`: an override of the upstream sublist without `<details>`. Convention: when a group's first child is a link marked `attrs: { 'data-group-link': true }`, that child is consumed and the group label renders as `<a>` with `aria-current` when it is the current page; groups without a landing stay as static headings.
- `site/astro.config.mjs`: registers the override and converts the 20 Overview rows plus `reference/theory` into marked entries (same slugs; the pages themselves are untouched and remain in search, sitemap and prev/next, now under their real titles).
- `scripts/generate_api_docs.py` + regenerated `api-sidebar.mjs`: the API reference index becomes the linked label of its group. The 16 API sections stay as static headings, since anchor links could not carry `aria-current` and would give inconsistent affordance.
- `site/src/styles/sidebar.css`: typography and colour split with `:not([aria-current='page'])` guards so the site CSS no longer overrides the active pill's inverted text (this fixed a real WCAG AA contrast failure flagged by pa11y), plus an explicit hover/focus accent for the linked labels.

## Verification

- `pnpm build` with starlight-links-validator: 317 pages, all links valid.
- `html-validate` over the whole `dist/`: 0 errors.
- `pa11y-ci` WCAG2AA: 34/34 URLs passing.
- `check:i18n`: EN/ES parity intact; Spanish labels link to localized hrefs.
- Grep over the built site: zero Overview rows left, exactly 22 linked labels per language, zero `<details>` in sidebars.
- Interactive check: clicking a label navigates to its landing, the active pill highlights the label itself, keyboard tab order and Enter work, and the mobile drawer renders identically.
- `ruff`, `mypy src scripts` and the api-docs drift gate all clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added linked group labels to the API reference and documentation sidebar.
  * Sidebar groups now display their overview pages directly through the group labels.
  * Expanded sidebar sections improve navigation across nested documentation topics.
  * Added responsive sidebar behavior for mobile and desktop layouts.

* **Style**
  * Updated sidebar hierarchy, spacing, colors, hover states, and active-page highlighting for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->