### PR TITLE
docs: document the vertical-axis scope of the ISO 2631-5 multiple-shock model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -300,6 +300,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- The multiple-shock whole-body vibration module (ISO 2631-5:2018) now
+  documents its axis scope: the spinal-response model is vertical-axis only by
+  design (clause 4a neglects the horizontal contributions to spinal
+  compression), and horizontal whole-body exposure should be assessed with the
+  ISO 2631-1 weighted r.m.s. and VDV metrics already in the vibration domain.
+  Docstrings and the guide (EN + ES) gain the clarification; no behaviour
+  change.
 - Dependency refresh across the toolchains: the development tools move to
   ruff >=0.15.21, mypy >=2.3.0 and types-setuptools >=83.0.0.20260716; the
   docs site moves to Astro 7.0.9 and html-validate 11.5.6; the docs deploy

--- a/docs/multiple-shock-vibration.md
+++ b/docs/multiple-shock-vibration.md
@@ -151,7 +151,10 @@ plt.show()
 The `MultipleShockResult` carries the dose ``Dz``, the daily dose ``Dzd``, the
 compressive stress ``Sd``, the stress variable ``R``, the injury probability and
 the response peaks, and its `.plot()` draws the injury-probability curve with the
-10/50/90 % risk thresholds of Table C.2. This complements the r.m.s.,
+10/50/90 % risk thresholds of Table C.2. The model is vertical-axis only:
+clause 4 neglects the horizontal contributions to spinal compression by design,
+and the horizontal spinal model of the withdrawn 2004 edition is not reinstated,
+so horizontal whole-body exposure is assessed instead with the r.m.s.,
 running-r.m.s./MTVV and VDV metrics of [Human Vibration](human-vibration.md)
 (ISO 2631-1).
 

--- a/site/src/content/docs/es/guides/multiple-shock-vibration.md
+++ b/site/src/content/docs/es/guides/multiple-shock-vibration.md
@@ -157,8 +157,11 @@ plt.show()
 El `MultipleShockResult` lleva la dosis `Dz`, la dosis diaria `Dzd`, la tensión
 compresiva `Sd`, la variable de tensión `R`, la probabilidad de lesión y los
 picos de respuesta, y su `.plot()` dibuja la curva de probabilidad de lesión con
-los umbrales de riesgo del 10/50/90 % de la Tabla C.2. Complementa las métricas
-eficaz, eficaz móvil/MTVV y VDV de
+los umbrales de riesgo del 10/50/90 % de la Tabla C.2. El modelo es solo para el
+eje vertical: la cláusula 4 desprecia por diseño las contribuciones horizontales
+a la compresión espinal, y el modelo espinal horizontal de la edición de 2004,
+retirada, no se restablece, de modo que la exposición horizontal de cuerpo
+completo se evalúa con las métricas eficaz, eficaz móvil/MTVV y VDV de
 [Vibración en humanos](/phonometry/es/guides/human-vibration/) (ISO 2631-1).
 
 ## Referencias

--- a/site/src/content/docs/guides/multiple-shock-vibration.md
+++ b/site/src/content/docs/guides/multiple-shock-vibration.md
@@ -152,7 +152,10 @@ plt.show()
 The `MultipleShockResult` carries the dose `Dz`, the daily dose `Dzd`, the
 compressive stress `Sd`, the stress variable `R`, the injury probability and the
 response peaks, and its `.plot()` draws the injury-probability curve with the
-10/50/90 % risk thresholds of Table C.2. This complements the r.m.s.,
+10/50/90 % risk thresholds of Table C.2. The model is vertical-axis only:
+clause 4 neglects the horizontal contributions to spinal compression by design,
+and the horizontal spinal model of the withdrawn 2004 edition is not reinstated,
+so horizontal whole-body exposure is assessed instead with the r.m.s.,
 running-r.m.s./MTVV and VDV metrics of
 [Human Vibration](/phonometry/guides/human-vibration/) (ISO 2631-1).
 

--- a/site/src/content/docs/reference/api/vibration/multiple-shock-vibration.md
+++ b/site/src/content/docs/reference/api/vibration/multiple-shock-vibration.md
@@ -12,6 +12,16 @@ Whole-body vibration containing multiple shocks (ISO 2631-5:2018).
 Implements the normative Clause 5 spinal-response model and the Annex C
 assessment of adverse health effects for the vertical (`z`) axis.
 
+The 2018 edition is vertical-axis only by design: clause 4 (delineation,
+item a) neglects the `x` and `y` contributions to spinal compression, the
+seat-to-spine transfer function of clause 5.2 is the vertical seat-to-lumbar
+response, and the Annex C stress conversion `mz` is the vertical one. The
+horizontal spinal model of the withdrawn 2004 edition is not reproduced.
+Assess horizontal whole-body exposure with the ISO 2631-1 metrics in this
+domain instead: the weighted r.m.s. acceleration
+([`weighted_acceleration`](/phonometry/reference/api/vibration/human-vibration/#weighted_acceleration)) and the vibration dose
+value ([`vibration_dose_value`](/phonometry/reference/api/vibration/human-vibration/#vibration_dose_value)).
+
 A seat-to-spine transfer function `H(w)` (clause 5.2, Formula 1) maps the
 measured seat acceleration `az(t)` to the spinal response acceleration
 `Az(t) = F^-1[H(w) * F[az(t)]]` (Formula 2). The standard assumes a
@@ -214,6 +224,11 @@ Chains the Clause 5 dose and the Annex C risk: spinal response (Formula 2),
 acceleration dose (Formula 3), daily dose (Formula 4), compressive stress
 (C.1), stress variable `R` (C.3) and injury probability (C.5). The input
 must be conditioned (DC-removed); see [`spinal_response`](/phonometry/reference/api/vibration/multiple-shock-vibration/#spinal_response).
+
+The model is vertical-axis only (clause 4a of the 2018 edition); for
+horizontal whole-body exposure use the ISO 2631-1 metrics in this domain
+([`weighted_acceleration`](/phonometry/reference/api/vibration/human-vibration/#weighted_acceleration),
+[`vibration_dose_value`](/phonometry/reference/api/vibration/human-vibration/#vibration_dose_value)).
 
 **Parameters**
 

--- a/src/phonometry/vibration/multiple_shock_vibration.py
+++ b/src/phonometry/vibration/multiple_shock_vibration.py
@@ -5,6 +5,16 @@ Whole-body vibration containing multiple shocks (ISO 2631-5:2018).
 Implements the normative Clause 5 spinal-response model and the Annex C
 assessment of adverse health effects for the vertical (``z``) axis.
 
+The 2018 edition is vertical-axis only by design: clause 4 (delineation,
+item a) neglects the ``x`` and ``y`` contributions to spinal compression, the
+seat-to-spine transfer function of clause 5.2 is the vertical seat-to-lumbar
+response, and the Annex C stress conversion ``mz`` is the vertical one. The
+horizontal spinal model of the withdrawn 2004 edition is not reproduced.
+Assess horizontal whole-body exposure with the ISO 2631-1 metrics in this
+domain instead: the weighted r.m.s. acceleration
+(:func:`~phonometry.vibration.weighted_acceleration`) and the vibration dose
+value (:func:`~phonometry.vibration.vibration_dose_value`).
+
 A seat-to-spine transfer function ``H(w)`` (clause 5.2, Formula 1) maps the
 measured seat acceleration ``az(t)`` to the spinal response acceleration
 ``Az(t) = F^-1[H(w) * F[az(t)]]`` (Formula 2). The standard assumes a
@@ -399,6 +409,11 @@ def multiple_shock_assessment(
     acceleration dose (Formula 3), daily dose (Formula 4), compressive stress
     (C.1), stress variable ``R`` (C.3) and injury probability (C.5). The input
     must be conditioned (DC-removed); see :func:`spinal_response`.
+
+    The model is vertical-axis only (clause 4a of the 2018 edition); for
+    horizontal whole-body exposure use the ISO 2631-1 metrics in this domain
+    (:func:`~phonometry.vibration.weighted_acceleration`,
+    :func:`~phonometry.vibration.vibration_dose_value`).
 
     :param acceleration: Measured, conditioned (zero-mean) vertical seat
         acceleration ``az(t)``, m/s2.


### PR DESCRIPTION
## Summary

The multiple-shock whole-body vibration module now documents its axis scope explicitly. ISO 2631-5:2018 defines the spinal-response model for the vertical axis only, by design: clause 4 (delineation, item a) neglects the x and y contributions to the compressive forces in the spine, the clause 5.2 transfer function is the vertical seat-to-lumbar response, and the Annex C stress conversion factor is the vertical one. The horizontal spinal model existed only in the withdrawn 2004 edition and is not reproduced.

The module and function docstrings and the guide (EN and ES) now state this and point horizontal whole-body exposure to the ISO 2631-1 metrics already in the vibration domain (weighted r.m.s. acceleration and VDV). No behaviour change.

## Checks

ruff, mypy, full pytest, api-docs regenerated with no drift, site i18n parity and full build clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

