### PR TITLE
ci: collapse the conformance showcase tables in the PR comment and report

### DIFF
--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -17,7 +17,10 @@
 
 &#9989; **266/266 conformance checks pass** across 32 domains and 147 standards - filters class 1 - weightings within IEC 61672-1 class 1.
 
-### Numerical validation - filters &amp; weightings
+<sub>Each row pins a standard clause to its expected normative value and the value the library computes. Every section below is collapsible and stays collapsed while all of its rows pass; a section with any failing row opens automatically.</sub>
+
+<details>
+<summary>&#9989; <b>Numerical validation - filters &amp; weightings</b> — class showcase (IEC 61260-1 · IEC 61672-1 · ISO 7196)</summary>
 
 **IEC 61260-1:2014 class per filter architecture** (order 6, one-third-octave, 100 Hz-10 kHz, fs = 48 kHz). For each architecture the table shows, at its *binding* band, the measured relative attenuation and the class-1 limit it must clear, so the number and the range it must sit in are both visible. A positive margin means the acceptance limits are met with that much room.
 
@@ -39,6 +42,8 @@ Only **Butterworth** (the library default) and **Chebyshev-II** are class-compli
 | A | 96 kHz | -0.482 dB @ 19953 Hz | 1000 Hz | +0.000 dB | [-0.70, +0.70] dB | +0.700 dB |
 | C | 48 kHz | -0.900 dB @ 19953 Hz | 1000 Hz | +0.000 dB | [-0.70, +0.70] dB | +0.700 dB |
 | G | 48 kHz | +0.047 dB @ 1 Hz | 1 Hz | +0.047 dB | [-1.00, +1.00] dB | +0.953 dB |
+
+</details>
 
 <details>
 <summary>&#9989; <b>Filters &amp; weightings</b> — 100% (7/7)</summary>

--- a/scripts/conformance_report.py
+++ b/scripts/conformance_report.py
@@ -11,10 +11,13 @@ A maintainable registry of numerical conformance checks. Each entry pins one
 * the tolerance.
 
 Running the harness emits Markdown for a GitHub PR comment: a headline
-summary, a "Numerical validation - filters & weightings" section (per
-filter architecture IEC 61260-1 class margins and A/C/G weighting worst-case
-deviation vs the analytic/normative curve), and one conformance table per
-domain (Standard | Quantity | Expected | Computed | Delta | Status).
+summary followed only by collapsible sections, so the comment stays compact
+by default. First a "Numerical validation - filters & weightings" showcase
+(per filter architecture IEC 61260-1 class margins and A/C/G weighting
+worst-case deviation vs the analytic/normative curve), then one conformance
+table per domain (Standard | Quantity | Expected | Computed | Delta |
+Status). Every section stays collapsed while all of its rows pass and opens
+automatically when any row fails.
 
 Expected values are pulled from a single source of truth wherever the tests
 already encode them: the shared ``tests/reference_data`` tables and the
@@ -4663,9 +4666,19 @@ def _filter_verdict(arch: str, fc: FilterClass) -> str:
     return f"By design ({reason})" if reason else "not compliant"
 
 
-def _numerical_validation_section() -> str:
+def _numerical_validation_section(filters_ok: bool) -> str:
+    # Collapsed like the per-domain groups so the report stays compact by
+    # default; it springs open whenever the filters/weightings domain has a
+    # failing row, exactly like those groups do.
+    emoji = "&#9989;" if filters_ok else "&#10060;"
+    opened = "" if filters_ok else " open"
     lines: list[str] = []
-    lines.append("### Numerical validation - filters &amp; weightings")
+    lines.append(f"<details{opened}>")
+    lines.append(
+        f"<summary>{emoji} <b>Numerical validation - filters &amp; "
+        "weightings</b> — class showcase (IEC 61260-1 · IEC 61672-1 · "
+        "ISO 7196)</summary>"
+    )
     lines.append("")
     lines.append(
         "**IEC 61260-1:2014 class per filter architecture** (order 6, "
@@ -4725,6 +4738,8 @@ def _numerical_validation_section() -> str:
             f"| {wd.bind_freq:.0f} Hz | {_snap(wd.bind_dev):+.3f} dB | {band} "
             f"| {wd.min_headroom:+.3f} dB |"
         )
+    lines.append("")
+    lines.append("</details>")
     return "\n".join(lines)
 
 
@@ -4750,7 +4765,14 @@ def render_markdown() -> tuple[str, int, int]:
         summary += " - filters class 1 - weightings within IEC 61672-1 class 1"
     out.append(f"{headline_emoji} {summary}.")
     out.append("")
-    out.append(_numerical_validation_section())
+    out.append(
+        "<sub>Each row pins a standard clause to its expected normative value "
+        "and the value the library computes. Every section below is "
+        "collapsible and stays collapsed while all of its rows pass; a "
+        "section with any failing row opens automatically.</sub>"
+    )
+    out.append("")
+    out.append(_numerical_validation_section(filters_ok))
     out.append("")
 
     for domain in _domains():

--- a/tests/test_conformance_report.py
+++ b/tests/test_conformance_report.py
@@ -202,6 +202,11 @@ def test_render_markdown_is_well_formed() -> None:
     assert "## Numerical conformance report" in markdown
     assert "Numerical validation - filters &amp; weightings" in markdown
     assert f"{passed}/{total} conformance checks pass" in markdown
+    # Compact by default: after the headline everything lives in collapsible
+    # sections (the showcase plus one per domain), each collapsed when green.
+    assert markdown.count("<details>") == len(cr._domains()) + 1
+    assert markdown.count("<details open>") == 0
+    assert markdown.count("</details>") == len(cr._domains()) + 1
     # One table header per domain plus the two numerical-validation tables.
     assert markdown.count("|:---") >= len(cr._domains())
     # The redesigned filters table labels non-compliant architectures as


### PR DESCRIPTION
## Summary

The sticky conformance comment and docs/CONFORMANCE.md now show only the headline by default. The numerical-validation showcase (per-architecture IEC 61260-1 filter classes and A/C/G weighting compliance) moves into its own collapsible section, matching the per-domain tables that were already collapsible, and a short line under the headline explains how to read the report. Any section with a failing row still opens automatically, so regressions stay visible without expanding anything.

This PR also serves as the live rendering check: the sticky comment below is produced by the redesigned generator.

## Checks

Conformance regenerated byte-exact (266 checks), generator tests extended to assert the new structure (all sections collapsed when green), ruff and mypy clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reformatted numerical validation guidance into collapsible sections for easier navigation.
  * Added explanatory text to clarify the validation content.

* **New Features**
  * Conformance reports now group numerical validation results into collapsible sections.
  * Sections with filter or weighting failures open automatically, making issues easier to spot.
  * Reports include clearer status summaries and improved presentation.

* **Tests**
  * Added checks to ensure collapsible sections are correctly rendered and closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->