### PR TITLE
fix(building): remove spurious pi from flanking critical frequency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -795,6 +795,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- `building.critical_frequency` (flanking, ISO 12354-1:2017 Formula (20)) dropped
+  a spurious factor of pi that made the thin-plate critical frequency about 3.14
+  times too low (for example roughly 670 Hz instead of about 2100 Hz for 6 mm
+  glass). The value now matches the closed-form plate coincidence frequency
+  `coincidence_frequency` to within the rounding of the 1.8 constant.
 - Reverberation-time prediction no longer rejects absorption coefficients
   at or above 1 for every model with a blanket `[0, 1)` validator; each
   model now enforces its own mathematical domain. Sabine accepts measured

--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -15,7 +15,7 @@
 
 ## Numerical conformance report
 
-&#9989; **353/353 conformance checks pass** across 44 domains and 224 standards - filters class 1 - weightings within IEC 61672-1 class 1.
+&#9989; **354/354 conformance checks pass** across 44 domains and 225 standards - filters class 1 - weightings within IEC 61672-1 class 1.
 
 <sub>Each row pins a standard clause to its expected normative value and the value the library computes. Every section below is collapsible and stays collapsed while all of its rows pass; a section with any failing row opens automatically.</sub>
 
@@ -144,7 +144,7 @@ Only **Butterworth** (the library default) and **Chebyshev-II** are class-compli
 </details>
 
 <details>
-<summary>&#9989; <b>Room &amp; building acoustics</b>: 100% (50/50)</summary>
+<summary>&#9989; <b>Room &amp; building acoustics</b>: 100% (51/51)</summary>
 
 | Standard | Quantity | Expected (norm) | Computed | &#916; | Status |
 |:---|:---|:---|:---|:---|:---:|
@@ -171,6 +171,7 @@ Only **Butterworth** (the library default) and **Chebyshev-II** are class-compli
 | ISO 10848-1:2006 Formula (14) | Flanking Kij (simplified) matches closed form | Kij = 1.9897 dB | Kij = 1.9897 dB | exact | &#9989; |
 | ISO 10848-1:2006 Formula (12) | Flanking equivalent absorption length aj at f_ref | aj = 1.2661 m | aj = 1.2661 m | exact | &#9989; |
 | ISO 10848-1:2006 Clause 7.3.1 | Flanking total loss factor η = 2,2/(f·Ts) | η = 0.0044 | η = 0.0044 | exact | &#9989; |
+| ISO 12354-1:2017 Formula (20) vs Hopkins Eq. 2.201 (6 mm glass) | Flanking critical frequency (c0²/1,8·cL·h) vs plate coincidence (c0²/2π · sqrt(m''/B')) | 2107.4 Hz (+/-1%) | 2123.5 Hz | 16.156 Hz | &#9989; |
 | EN 29052-1:1992 Formula 4 | Apparent dynamic stiffness s't = 4π²·m't·fr²  (m't=200 kg/m², fr=25 Hz) | 4.934802 MN/m³ (+/-0.000001 MN/m³) | 4.934802 MN/m³ | 0 MN/m³ | &#9989; |
 | EN 29052-1:1992 clause 8.2 NOTE | Enclosed-gas stiffness s'a·d = 111 MN·mm/m³ (p₀=0,1 MPa, ε=0,9) | 5.55556 MN/m³ (+/-0.0001 MN/m³) | 5.55556 MN/m³ | 0 MN/m³ | &#9989; |
 | EN 29052-1:1992 Formula 2 | Floating-floor natural frequency f0 = (1/2π)√(s'/m')  (s'=10 MN/m³, m'=100 kg/m²) | 50.32921 Hz (+/-0 Hz) | 50.32921 Hz | 0 Hz | &#9989; |

--- a/scripts/conformance_report.py
+++ b/scripts/conformance_report.py
@@ -1713,6 +1713,25 @@ def _chk_iso10848_loss_factor() -> Outcome:
     )
 
 
+@register(
+    "Room & building acoustics",
+    "ISO 12354-1:2017 Formula (20) vs Hopkins Eq. 2.201 (6 mm glass)",
+    "Flanking critical frequency (c0²/1,8·cL·h) vs plate coincidence "
+    "(c0²/2π · sqrt(m''/B'))",
+)
+def _chk_flanking_critical_frequency() -> Outcome:
+    # The 1,8 constant rounds 2π/√12, so for a plate whose bending stiffness
+    # and mass are mutually consistent the two independent formulas must
+    # agree to within that rounding (< 1 %).
+    e, rho, nu, h, c0 = 6.2e10, 2500.0, 0.24, 0.006, 343.0
+    c_l = math.sqrt(e / (rho * (1.0 - nu**2)))
+    fc_flank = ph.critical_frequency(c_l, h, speed_of_sound=c0)
+    fc_coinc = ph.coincidence_frequency(
+        rho * h, ph.plate_bending_stiffness(e, h, nu), speed_of_sound=c0
+    )
+    return numeric(fc_coinc, fc_flank, 0.01, rel=True, unit="Hz", places=1)
+
+
 # --- Dynamic stiffness of resilient materials (EN 29052-1:1992) ---
 @register(
     "Room & building acoustics",

--- a/site/src/content/docs/reference/api/building/flanking-transmission.md
+++ b/site/src/content/docs/reference/api/building/flanking-transmission.md
@@ -113,7 +113,11 @@ critical_frequency(
 
 Thin-plate critical frequency `fc` (Part 1, Formula (20)).
 
-`fc = c0² / (1,8 · cL · h · π)` for a homogeneous isotropic element.
+`fc = c0² / (1,8 · cL · h)` for a homogeneous isotropic element. The
+constant 1,8 already carries the `2π/√12` factor of the thin-plate
+dispersion relation, so for a plate whose bending stiffness and mass are
+mutually consistent this equals [`phonometry.coincidence_frequency`](/phonometry/reference/api/vibration/radiation-efficiency/#coincidence_frequency)
+(Hopkins Eq. 2.201) to within the rounding of the constant.
 
 **Parameters**
 

--- a/src/phonometry/building/flanking_transmission.py
+++ b/src/phonometry/building/flanking_transmission.py
@@ -681,7 +681,11 @@ def critical_frequency(
 ) -> float:
     """Thin-plate critical frequency ``fc`` (Part 1, Formula (20)).
 
-    ``fc = c0² / (1,8 · cL · h · π)`` for a homogeneous isotropic element.
+    ``fc = c0² / (1,8 · cL · h)`` for a homogeneous isotropic element. The
+    constant 1,8 already carries the ``2π/√12`` factor of the thin-plate
+    dispersion relation, so for a plate whose bending stiffness and mass are
+    mutually consistent this equals :func:`phonometry.coincidence_frequency`
+    (Hopkins Eq. 2.201) to within the rounding of the constant.
 
     :param longitudinal_wave_speed: Longitudinal wave speed ``cL``, in m/s.
     :param thickness: Element thickness ``h``, in m.
@@ -692,7 +696,7 @@ def critical_frequency(
     c0 = _positive(speed_of_sound, "speed_of_sound")
     c_l = _positive(longitudinal_wave_speed, "longitudinal_wave_speed")
     h = _positive(thickness, "thickness")
-    return c0**2 / (_CRITICAL_FREQUENCY_CONSTANT * c_l * h * np.pi)
+    return c0**2 / (_CRITICAL_FREQUENCY_CONSTANT * c_l * h)
 
 
 def strong_coupling_satisfied(

--- a/tests/building/test_flanking_transmission.py
+++ b/tests/building/test_flanking_transmission.py
@@ -16,6 +16,7 @@ import pytest
 import reference_data as ref
 from phonometry import (
     band_mode_count,
+    coincidence_frequency,
     critical_frequency,
     direction_averaged_level_difference,
     equivalent_absorption_length,
@@ -23,6 +24,7 @@ from phonometry import (
     modal_overlap_factor,
     normalized_flanking_impact_level,
     normalized_flanking_level_difference,
+    plate_bending_stiffness,
     strong_coupling_satisfied,
     total_loss_factor,
     velocity_level_difference,
@@ -307,9 +309,28 @@ def test_indirect_kij_from_flanking_roundtrip() -> None:
 # Validity criteria
 # ---------------------------------------------------------------------------
 def test_critical_frequency() -> None:
-    """fc = c0²/(1.8·cL·h·π) (Formula (20))."""
-    fc = critical_frequency(5500.0, 0.2, speed_of_sound=343.0)
-    assert fc == pytest.approx(343.0**2 / (1.8 * 5500.0 * 0.2 * np.pi))
+    """fc = c0²/(1.8·cL·h) (Formula (20)), checked against two independent oracles.
+
+    (a) Hand-computed value for 6 mm float glass (cL = 5130 m/s):
+    343² / (1.8 · 5130 · 0.006) ≈ 2123.5 Hz. The lower bound guards against a
+    reintroduced spurious π factor (which would give ≈ 676 Hz).
+    (b) Cross-oracle: the constant 1.8 rounds 2π/√12, so for a plate with
+    mutually consistent bending stiffness and mass the result must match the
+    Hopkins Eq. 2.201 coincidence frequency to within that rounding (< 1 %).
+    """
+    # (a) Independent published/hand-computed value for 6 mm float glass.
+    fc = critical_frequency(5130.0, 0.006, speed_of_sound=343.0)
+    assert fc == pytest.approx(2123.5, rel=0.01)
+    assert fc > 1500.0  # a spurious π factor would give ~676 Hz
+
+    # (b) Cross-oracle against the closed-form plate coincidence frequency.
+    e, rho, nu, h = 6.2e10, 2500.0, 0.24, 0.006
+    c_l = np.sqrt(e / (rho * (1.0 - nu**2)))
+    fc_flank = critical_frequency(float(c_l), h, speed_of_sound=343.0)
+    fc_coinc = coincidence_frequency(
+        rho * h, plate_bending_stiffness(e, h, nu), speed_of_sound=343.0
+    )
+    assert fc_flank == pytest.approx(fc_coinc, rel=0.01)
 
 
 def test_strong_coupling_check() -> None:


### PR DESCRIPTION
ISO 12354-1:2017 Formula (20) for the thin-plate critical frequency is `fc = c0^2 / (1.8 cL h)`. The constant 1.8 already carries the `2*pi/sqrt(12)` factor of the plate dispersion relation, so the previous implementation multiplied by an extra pi and returned a value about 3.14 times too low (for example roughly 670 Hz instead of about 2100 Hz for 6 mm float glass).

The formula now matches the standard, and the docstring is corrected to match. The previous unit test re-derived the same wrong expression, so it could never catch the error; it is replaced by two independent oracles:

- a hand-computed value for 6 mm float glass (about 2123 Hz), with a lower bound that fails if the spurious pi is reintroduced;
- a cross-check against the closed-form plate coincidence frequency `coincidence_frequency` (Hopkins Eq. 2.201), which uses the exact `2*pi` and must agree to within the rounding of the 1.8 constant (about 0.8 %).

A conformance check covering the same cross-comparison is added under "Room & building acoustics".

https://claude.ai/code/session_01LnezkUn2wvXJ9LFKoYhdyd

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected thin-plate critical-frequency calculations by removing an erroneous factor, improving agreement with established coincidence-frequency results.

- **Documentation**
  - Updated the critical-frequency formula and clarified its calculation.
  - Added the correction to the changelog.

- **Tests**
  - Added conformance coverage for ISO 12354-1:2017.
  - Updated validation checks to confirm critical-frequency results against independent calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->