### PR TITLE
test(broadcast): document the EBU-derived loudness series and drop the CI audio fetch

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -187,37 +187,13 @@ jobs:
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
         pip install -e .
-    # The authentic-programme loudness oracle (EBU Tech 3341 cases 7-8 and
-    # Tech 3342 cases 5-6) needs the official EBU loudness test set. Its
-    # licence only covers technical testing, so the audio is never committed:
-    # one matrix cell fetches it from the EBU (cached between runs) and the
-    # tests skip gracefully anywhere the set is absent.
-    - name: Cache the EBU loudness test set
-      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
-      id: ebu-cache
-      uses: actions/cache@v5
-      with:
-        path: ebu-loudness-test-set
-        key: ebu-loudness-test-set-v04-1
-    - name: Download the EBU loudness test set
-      if: >-
-        matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' &&
-        steps.ebu-cache.outputs.cache-hit != 'true'
-      continue-on-error: true
-      run: |
-        # The EBU site rejects the default curl agent; a sentinel file is
-        # checked (and the directory dropped on failure) so a bad download
-        # is never cached and the oracle tests skip instead of failing.
-        curl -sfL --retry 3 --retry-all-errors \
-          -A "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0" \
-          -o ebu-set.zip \
-          "https://tech.ebu.ch/files/live/sites/tech/files/shared/testmaterial/ebu-loudness-test-setv04.zip"
-        mkdir -p ebu-loudness-test-set
-        unzip -q ebu-set.zip -d ebu-loudness-test-set
-        rm ebu-set.zip
-        test -f "ebu-loudness-test-set/seq-3341-7_seq-3342-5-24bit.wav" \
-          -a -f "ebu-loudness-test-set/seq-3341-2011-8_seq-3342-6-24bit-v02.wav" \
-          || { rm -rf ebu-loudness-test-set; exit 1; }
+    # The EBU authentic-programme loudness oracle is not fetched in CI: its
+    # audio cannot be redistributed (technical-testing licence, third-party
+    # programme content), so the full-chain test in test_ebu_material_oracle.py
+    # is local-only and skips here. CI still validates the gating and
+    # loudness-range stages against the committed per-block loudness series in
+    # tests/data/broadcast/ (see its README.md), and the K-weighting front end
+    # against the synthesizable EBU cases in test_program_loudness.py.
     - name: Run tests
       # -n auto fans the suite out across the runner's cores via pytest-xdist;
       # pytest-cov combines the per-worker coverage into a single coverage.xml.
@@ -229,7 +205,6 @@ jobs:
         OPENBLAS_NUM_THREADS: "1"
         NUMEXPR_NUM_THREADS: "1"
         VECLIB_MAXIMUM_THREADS: "1"
-        EBU_LOUDNESS_TEST_SET: ${{ github.workspace }}/ebu-loudness-test-set
       run: |
         pytest -n auto --junitxml=test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml --cov=src --cov-report=xml
     - name: Upload Test Results

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,13 @@ To check coverage locally:
 ```bash
 pytest --cov=src/phonometry --cov-report=term-missing tests/
 ```
+A few tests need reference material that is not committed (its licence forbids
+redistribution) and skip when it is absent. The EBU programme-loudness
+full-chain oracle (`tests/broadcast/test_ebu_material_oracle.py`) needs the free
+[EBU loudness test set](https://tech.ebu.ch/publications/ebu_loudness_test_set):
+drop it under `plan/dsp-sources/ebu-loudness-test-set/` or point
+`EBU_LOUDNESS_TEST_SET` at your copy. CI does not fetch it; the committed
+per-block series in `tests/data/broadcast/` cover the same cases without audio.
 
 ### 4. Documentation Images (auto-generated)
 Every image under `.github/images/` is generated with the library itself by

--- a/tests/data/broadcast/README.md
+++ b/tests/data/broadcast/README.md
@@ -1,0 +1,66 @@
+# EBU programme-loudness — derived validation data
+
+## What this folder contains
+
+`ebu_programme_block_loudness.npz` holds **block-loudness series** measured from
+the authentic-programme cases of the *EBU loudness test set* (v04). They are used
+by the test suite to validate the gating and loudness-range stages of
+`phonometry.broadcast.program_loudness` against the EBU Tech 3341/3342 targets
+without any network access.
+
+| Array | Blocks | Source case | Content |
+| :--- | :--- | :--- | :--- |
+| `nlr_momentary` | 400 ms / 100 ms hop | Tech 3341 case 7 (NLR narration) | Momentary loudness series, LUFS (the BS.1770-5 integrated-loudness gate input) |
+| `nlr_short_term` | 3 s / 100 ms hop | Tech 3342 case 5 (NLR) | Short-term loudness series, LUFS (the loudness-range input) |
+| `wlr_momentary` | 400 ms / 100 ms hop | Tech 3341 case 8 (WLR movie/drama) | Momentary loudness series, LUFS |
+| `wlr_short_term` | 3 s / 100 ms hop | Tech 3342 case 6 (WLR) | Short-term loudness series, LUFS |
+
+The series were measured with `phonometry.broadcast.program_loudness` from
+`seq-3341-7_seq-3342-5-24bit.wav` (NLR) and
+`seq-3341-2011-8_seq-3342-6-24bit-v02.wav` (WLR), then stored rounded to
+0.0001 LU (three orders of magnitude below the official tolerances). They pin
+the integrated loudness to `-23.0 LUFS` and the loudness range to `5 LU` (NLR)
+and `15 LU` (WLR), the EBU-published targets for those cases.
+
+## Why only the derived series, not the audio
+
+These are **measurement data, not audio**: a per-block loudness envelope at a
+100 ms hop cannot reconstruct the programme signal. The authentic-programme WAVs
+themselves are **not** committed. The EBU loudness test set is distributed free
+for technical testing, but its cases 7/8 and 5/6 use real programme material
+(narration and a movie/drama segment) that carries its own third-party rights,
+so redistributing the audio in this repository is out of scope. The committed
+series carry none of that content and are safe to version.
+
+## Source and authorship
+
+- Derived from the **EBU loudness test set** (v04), © EBU (European Broadcasting
+  Union), distributed for technical testing at
+  <https://tech.ebu.ch/publications/ebu-loudness-test-set>.
+- The target values reproduced by these series are defined in **EBU Tech 3341**
+  (loudness metering) and **EBU Tech 3342** (loudness range), which in turn build
+  on ITU-R BS.1770.
+- The `.npz` itself is an original transcription of numeric measurements, not an
+  EBU file.
+
+## Purpose and scope of use
+
+The series are consumed by `tests/broadcast/test_ebu_material_series.py` to
+demonstrate that this library's independent gating and loudness-range
+implementation reproduces the EBU authentic-programme targets, everywhere
+including CI cells without network access. They are **not** part of the
+`phonometry` package and are not installed with it.
+
+The full signal chain (the K-weighting front end included) is exercised against
+the original audio in `tests/broadcast/test_ebu_material_oracle.py`, which runs
+only where the EBU set is present locally (point `EBU_LOUDNESS_TEST_SET` at it,
+or drop it under `plan/dsp-sources/ebu-loudness-test-set/`); that test skips
+otherwise. The synthesizable EBU cases are covered with generated signals in
+`tests/broadcast/test_program_loudness.py`.
+
+## Removal policy
+
+If you represent the EBU and consider that publishing these derived series
+exceeds the intended use of the test set, please open an issue or contact the
+maintainer (see `CITATION.cff`) and they will be removed promptly, together
+with the `tests/broadcast/test_ebu_material_series.py` tests that read them.


### PR DESCRIPTION
The only external download the CI performed was the EBU loudness test set (about 76 MB of authentic-programme audio). That audio cannot be redistributed: the EBU set is licensed for technical testing only and its cases 7/8 and 5/6 carry third-party programme rights, so it was never committed.

What runs where is now made explicit and network-free in CI:

- `tests/data/broadcast/README.md` documents the committed per-block loudness series (`ebu_programme_block_loudness.npz`): their EBU Tech 3341/3342 origin, that they are derived measurement data (a 100 ms-hop loudness envelope cannot reconstruct the signal), the EBU source and licence, and a removal policy.
- The CI download step is removed. The gating and loudness-range stages are validated against the committed series, and the K-weighting front end against the synthesizable EBU cases in `test_program_loudness.py`, so CI needs no audio.
- The full signal chain against the original audio stays in `test_ebu_material_oracle.py`, which runs only where the set is present locally and skips otherwise.

https://claude.ai/code/session_01LnezkUn2wvXJ9LFKoYhdyd

## Summary by Sourcery

Document the EBU-derived loudness validation data and make the broadcast loudness tests in CI run without fetching external audio.

CI:
- Remove the CI step that caches and downloads the EBU loudness test set and rely solely on committed derived loudness series and synthesizable cases for CI validation.

Documentation:
- Add README documenting the EBU-derived per-block loudness series, their provenance, licensing context, and removal policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated CI loudness checks to rely on committed per-block measurement fixtures, so validation runs reliably offline without downloading or redistributing restricted audio assets.
* **Documentation**
  * Added documentation for the broadcast loudness derived fixture data, including sources, coverage, and how it’s used for validation.
  * Refreshed the testing guidance to explain when external reference material is required and why it’s not included in CI.
* **Chores**
  * Removed the workflow’s loudness test-set download/caching setup and related configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->