### PR TITLE
feat: EN/ES language option for the aircraft/underwater/environmental plots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   terminology and a comma decimal separator, while English stays exactly as
   before. A shared `phonometry._i18n` helper module backs the locale-aware
   number formatting and tick localisation.
+- The `.plot()` methods of the aircraft, underwater and environmental result
+  objects accept a `language` keyword (`"en"`, the default, or `"es"`). Spanish
+  renders localised axis labels, titles and legends with comma decimal
+  separators; English output is unchanged.
 - IEC 61260-1 filter class compliance can now be exported as a one-page PDF
   fiche. A new `filter_class_compliance(bank, *, num_points=..., edition=...)`
   runs the same verification as `verify_filter_class` and returns a frozen

--- a/site/src/content/docs/reference/api/aeroacoustics/aircraft-noise.md
+++ b/site/src/content/docs/reference/api/aeroacoustics/aircraft-noise.md
@@ -139,7 +139,12 @@ Effective Perceived Noise Level of an aircraft flyover (ICAO Annex 16).
 ### EPNLResult.plot()
 
 ```python
-EPNLResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+EPNLResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the PNL and PNLT time histories with PNLTM and the 10 dB-down band.

--- a/site/src/content/docs/reference/api/aeroacoustics/airport-noise.md
+++ b/site/src/content/docs/reference/api/aeroacoustics/airport-noise.md
@@ -167,7 +167,12 @@ Single-event noise level of an aircraft movement at a receiver.
 ### FlyoverResult.plot()
 
 ```python
-FlyoverResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+FlyoverResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the per-segment contributions to the event level.
@@ -335,7 +340,12 @@ Single-event noise level over a ground grid (ECAC Doc 29).
 ### NoiseContourResult.plot()
 
 ```python
-NoiseContourResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+NoiseContourResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot filled noise contours over the ground plane.
@@ -435,7 +445,12 @@ NPD event level over a distance sweep at one power (ECAC Doc 29).
 ### NpdLevelResult.plot()
 
 ```python
-NpdLevelResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+NpdLevelResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the interpolated level versus slant distance (log axis).

--- a/site/src/content/docs/reference/api/aeroacoustics/atmospheric-absorption.md
+++ b/site/src/content/docs/reference/api/aeroacoustics/atmospheric-absorption.md
@@ -59,7 +59,12 @@ One-third-octave-band atmospheric attenuation over a path (SAE ARP 5534).
 ### AircraftBandAttenuation.plot()
 
 ```python
-AircraftBandAttenuation.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+AircraftBandAttenuation.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the band and pure-tone mid-band attenuation versus frequency.

--- a/site/src/content/docs/reference/api/aeroacoustics/rotorcraft-noise.md
+++ b/site/src/content/docs/reference/api/aeroacoustics/rotorcraft-noise.md
@@ -293,7 +293,12 @@ inconsistent with its use; ECAC Doc 32 Eq. 10 states the correct
 ### FlightPathKinematics.plot()
 
 ```python
-FlightPathKinematics.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+FlightPathKinematics.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the speed and angle profiles along the track.
@@ -534,7 +539,12 @@ The plane height `a·d + b` at `distance`, in metres.
 ### MeanGroundPlaneResult.plot()
 
 ```python
-MeanGroundPlaneResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+MeanGroundPlaneResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the terrain section and the fitted mean ground plane.
@@ -743,7 +753,12 @@ A rotorcraft single-event time history at a receiver (Doc 32 §6.1).
 ### RotorcraftEventResult.plot()
 
 ```python
-RotorcraftEventResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+RotorcraftEventResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the A-weighted level time history with its event metrics.
@@ -795,7 +810,12 @@ by reversing the hemisphere azimuth angle.
 ### RotorcraftHemisphere.plot()
 
 ```python
-RotorcraftHemisphere.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+RotorcraftHemisphere.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the hemisphere directivity for one band (polar section).
@@ -827,6 +847,8 @@ Rotorcraft single-event noise level over a ground grid (Doc 32 §6.3).
 ```python
 RotorcraftNoiseContourResult.plot(
     ax: Axes | None = None,
+    *,
+    language: str = 'en',
     **kwargs: Any,
 ) -> Axes
 ```
@@ -961,7 +983,12 @@ Ground and screening over a terrain section (guidance §A.4.4-A.4.5).
 ### TerrainScreeningResult.plot()
 
 ```python
-TerrainScreeningResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+TerrainScreeningResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the section geometry: terrain, line of sight and sound path.

--- a/site/src/content/docs/reference/api/aeroacoustics/wind-turbine-noise.md
+++ b/site/src/content/docs/reference/api/aeroacoustics/wind-turbine-noise.md
@@ -190,6 +190,8 @@ Tonal audibility of a narrowband spectrum (IEC 61400-11).
 ```python
 WindTurbineTonalityResult.plot(
     ax: Axes | None = None,
+    *,
+    language: str = 'en',
     **kwargs: Any,
 ) -> Axes
 ```

--- a/site/src/content/docs/reference/api/environment/atmospheric-refraction.md
+++ b/site/src/content/docs/reference/api/environment/atmospheric-refraction.md
@@ -195,7 +195,12 @@ Relative sound level versus range at the grid height nearest `height`.
 ### AtmosphericPEResult.plot()
 
 ```python
-AtmosphericPEResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+AtmosphericPEResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the relative-level field over the range-height plane.
@@ -231,7 +236,12 @@ Ray-tracing solution through an effective sound-speed profile.
 ### AtmosphericRayResult.plot()
 
 ```python
-AtmosphericRayResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+AtmosphericRayResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the curved ray paths (height on the vertical axis).
@@ -265,6 +275,8 @@ two-point profile represents an exact linear gradient.
 ```python
 EffectiveSoundSpeedProfile.plot(
     ax: Axes | None = None,
+    *,
+    language: str = 'en',
     **kwargs: Any,
 ) -> Axes
 ```

--- a/site/src/content/docs/reference/api/environment/ground-barriers.md
+++ b/site/src/content/docs/reference/api/environment/ground-barriers.md
@@ -190,7 +190,12 @@ Per-frequency barrier insertion loss (IL vs frequency).
 ### BarrierInsertionLoss.plot()
 
 ```python
-BarrierInsertionLoss.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+BarrierInsertionLoss.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the insertion loss versus frequency.
@@ -392,7 +397,12 @@ Every array is aligned with `frequencies`.
 ### SphericalGroundResult.plot()
 
 ```python
-SphericalGroundResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+SphericalGroundResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the excess attenuation `dL` versus frequency.

--- a/site/src/content/docs/reference/api/environment/impulse-prominence.md
+++ b/site/src/content/docs/reference/api/environment/impulse-prominence.md
@@ -114,7 +114,12 @@ Prominence of a set of candidate impulses (NT ACOU 112:2002).
 ### ImpulseProminenceResult.plot()
 
 ```python
-ImpulseProminenceResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+ImpulseProminenceResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the adjustment curve `KI(P)` with the impulses marked.

--- a/site/src/content/docs/reference/api/environment/measurement.md
+++ b/site/src/content/docs/reference/api/environment/measurement.md
@@ -447,7 +447,12 @@ Tonal-audibility assessment of a tone in noise (ISO 1996-2 Annex C).
 ### TonalAssessmentResult.plot()
 
 ```python
-TonalAssessmentResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+TonalAssessmentResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the `Kt(ΔLta)` adjustment curve with this tone marked.

--- a/site/src/content/docs/reference/api/environment/outdoor-propagation.md
+++ b/site/src/content/docs/reference/api/environment/outdoor-propagation.md
@@ -447,7 +447,12 @@ contributions separately.
 ### OutdoorAttenuation.plot()
 
 ```python
-OutdoorAttenuation.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+OutdoorAttenuation.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the stacked per-band attenuation terms with the total.

--- a/site/src/content/docs/reference/api/underwater/numerical-propagation.md
+++ b/site/src/content/docs/reference/api/underwater/numerical-propagation.md
@@ -118,7 +118,12 @@ Normal-mode solution of a range-independent waveguide.
 ### NormalModeResult.plot()
 
 ```python
-NormalModeResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+NormalModeResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the transmission loss versus range (loss increasing downward).
@@ -200,7 +205,12 @@ Parabolic-equation transmission-loss field.
 ### ParabolicEquationResult.plot()
 
 ```python
-ParabolicEquationResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+ParabolicEquationResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the transmission-loss field (depth increasing downward).
@@ -271,7 +281,12 @@ Ray-tracing solution through a sound-speed profile.
 ### RayTraceResult.plot()
 
 ```python
-RayTraceResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+RayTraceResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the ray paths (depth increasing downward).

--- a/site/src/content/docs/reference/api/underwater/ocean-ambient-noise.md
+++ b/site/src/content/docs/reference/api/underwater/ocean-ambient-noise.md
@@ -59,7 +59,12 @@ Composite ambient-noise spectrum (Wenz framework).
 ### AmbientNoiseResult.plot()
 
 ```python
-AmbientNoiseResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+AmbientNoiseResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the composite spectrum and its components versus frequency.

--- a/site/src/content/docs/reference/api/underwater/pile-driving-noise.md
+++ b/site/src/content/docs/reference/api/underwater/pile-driving-noise.md
@@ -129,6 +129,8 @@ Per-strike pile-driving metrics (ISO 18406).
 ```python
 PileStrikeResult.plot(
     ax: Axes | None = None,
+    *,
+    language: str = 'en',
     **kwargs: Any,
 ) -> Axes | NDArray[Any]
 ```

--- a/site/src/content/docs/reference/api/underwater/propagation.md
+++ b/site/src/content/docs/reference/api/underwater/propagation.md
@@ -172,7 +172,12 @@ Transmission loss versus range (closed-form).
 ### TransmissionLossResult.plot()
 
 ```python
-TransmissionLossResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+TransmissionLossResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the transmission loss versus range with its two contributions.

--- a/site/src/content/docs/reference/api/underwater/seabed-reflection.md
+++ b/site/src/content/docs/reference/api/underwater/seabed-reflection.md
@@ -84,7 +84,12 @@ Bottom reflection loss versus grazing angle (fluid-fluid Rayleigh model).
 ### BottomLossResult.plot()
 
 ```python
-BottomLossResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+BottomLossResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the bottom loss versus grazing angle with the critical angle.

--- a/site/src/content/docs/reference/api/underwater/ship-radiated-noise.md
+++ b/site/src/content/docs/reference/api/underwater/ship-radiated-noise.md
@@ -148,7 +148,12 @@ Equivalent monopole source level of a ship (ISO 17208-2).
 ### ShipSourceLevelResult.plot()
 
 ```python
-ShipSourceLevelResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+ShipSourceLevelResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot RNL, source level and the ΔL surface correction vs frequency.

--- a/site/src/content/docs/reference/api/underwater/ship-traffic-noise.md
+++ b/site/src/content/docs/reference/api/underwater/ship-traffic-noise.md
@@ -99,7 +99,12 @@ Predicted ship source-level spectrum.
 ### ShipTrafficSpectrum.plot()
 
 ```python
-ShipTrafficSpectrum.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+ShipTrafficSpectrum.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the predicted source spectral-density level versus frequency.

--- a/site/src/content/docs/reference/api/underwater/sonar-equation.md
+++ b/site/src/content/docs/reference/api/underwater/sonar-equation.md
@@ -137,7 +137,12 @@ Sonar-equation solution.
 ### SonarEquationResult.plot()
 
 ```python
-SonarEquationResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+SonarEquationResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot signal excess versus transmission loss with the detection limit.

--- a/site/src/content/docs/reference/api/underwater/sound-speed.md
+++ b/site/src/content/docs/reference/api/underwater/sound-speed.md
@@ -155,7 +155,12 @@ Sound-speed profile `c(z)` over a column of water.
 ### SoundSpeedProfile.plot()
 
 ```python
-SoundSpeedProfile.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+SoundSpeedProfile.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the sound-speed profile (speed vs depth, depth increasing down).

--- a/src/phonometry/_plot/aircraft.py
+++ b/src/phonometry/_plot/aircraft.py
@@ -32,7 +32,101 @@ if TYPE_CHECKING:
         TerrainScreeningResult,
     )
 
-def plot_epnl(result: "EPNLResult", ax: Axes | None = None, **kwargs: Any) -> Axes:
+#: English and Spanish text for every fixed label/title/legend drawn by this
+#: module's renderers.  English entries are byte-for-byte the original strings.
+_STRINGS: dict[str, dict[str, str]] = {
+    "en": {
+        "win_10db": "10 dB-down window",
+        "time_s": "Time [s]",
+        "level_pndb": "Level [PNdB]",
+        "sae_band": "SAE band",
+        "puretone_midband": "Pure-tone mid-band (ISO 9613-1)",
+        "freq_hz": "Frequency [Hz]",
+        "atten_db": "Attenuation [dB]",
+        "aircraft_abs_title": "Aircraft atmospheric absorption (SAE ARP 5534)",
+        "tabulated": "Tabulated",
+        "slant_distance": "Slant distance [m]",
+        "event_level": "Event level [dB]",
+        "npd_title": "Noise-power-distance curve (ECAC Doc 29)",
+        "segment_index": "Segment index",
+        "segment_metric": "Segment {metric} [dB]",
+        "flyover_title": "Single-event segment contributions (ECAC Doc 29)",
+        "polar_angle": "Polar angle θ [°]  (0° forward → 180° rearward)",
+        "source_level_60m": "Source level at 60 m [dB]",
+        "hemisphere_title": "Rotorcraft noise hemisphere directivity (ECAC Doc 32)",
+        "contour_title": "Aircraft noise contour (ECAC Doc 29)",
+        "airspeed": "Airspeed $V_A$",
+        "ground_speed": "Ground speed $V_g$",
+        "speed_ms": "Speed [m/s]",
+        "path_angle": "Path angle $\\gamma$",
+        "bank_angle": "Bank angle $\\Phi$",
+        "angle_deg": "Angle [°]",
+        "kinematics_title": "Rotorcraft flight-path kinematics (ECAC Doc 32)",
+        "recorded_time": "Recorded time [s]",
+        "a_level": "A-weighted level [dB(A)]",
+        "rotor_event_title": "Rotorcraft flyover time history (ECAC Doc 32)",
+        "rotor_contour_title": "Rotorcraft noise contour (ECAC Doc 32)",
+        "terrain_profile": "Terrain profile",
+        "mean_ground_plane": "Mean ground plane",
+        "section_distance": "Section distance [m]",
+        "height_m": "Height [m]",
+        "mgp_title": "Mean ground plane (NORAH2 guidance Eq. 36-40)",
+        "line_of_sight": "Line of sight",
+        "diffracted_path": "Diffracted path",
+        "diffraction_edges": "Diffraction edges",
+        "screening_title": "Terrain screening (ECAC Doc 32 / NORAH2 guidance)",
+    },
+    "es": {
+        "win_10db": "Ventana 10 dB por debajo",
+        "time_s": "Tiempo [s]",
+        "level_pndb": "Nivel [PNdB]",
+        "sae_band": "Banda SAE",
+        "puretone_midband": "Banda media de tono puro (ISO 9613-1)",
+        "freq_hz": "Frecuencia [Hz]",
+        "atten_db": "Atenuación [dB]",
+        "aircraft_abs_title": "Absorción atmosférica de aeronaves (SAE ARP 5534)",
+        "tabulated": "Tabulados",
+        "slant_distance": "Distancia oblicua [m]",
+        "event_level": "Nivel del evento [dB]",
+        "npd_title": "Curva ruido-potencia-distancia (ECAC Doc 29)",
+        "segment_index": "Índice de segmento",
+        "segment_metric": "{metric} por segmento [dB]",
+        "flyover_title": "Contribuciones por segmento de un evento único (ECAC Doc 29)",
+        "polar_angle": "Ángulo polar θ [°]  (0° adelante → 180° atrás)",
+        "source_level_60m": "Nivel de fuente a 60 m [dB]",
+        "hemisphere_title": "Directividad del hemisferio de ruido de rotorcraft (ECAC Doc 32)",
+        "contour_title": "Curvas de ruido de aeronaves (ECAC Doc 29)",
+        "airspeed": "Velocidad del aire $V_A$",
+        "ground_speed": "Velocidad respecto al suelo $V_g$",
+        "speed_ms": "Velocidad [m/s]",
+        "path_angle": "Ángulo de trayectoria $\\gamma$",
+        "bank_angle": "Ángulo de alabeo $\\Phi$",
+        "angle_deg": "Ángulo [°]",
+        "kinematics_title": "Cinemática de la trayectoria de rotorcraft (ECAC Doc 32)",
+        "recorded_time": "Tiempo registrado [s]",
+        "a_level": "Nivel ponderado A [dB(A)]",
+        "rotor_event_title": "Historia temporal de sobrevuelo de rotorcraft (ECAC Doc 32)",
+        "rotor_contour_title": "Curvas de ruido de rotorcraft (ECAC Doc 32)",
+        "terrain_profile": "Perfil del terreno",
+        "mean_ground_plane": "Plano medio del suelo",
+        "section_distance": "Distancia de la sección [m]",
+        "height_m": "Altura [m]",
+        "mgp_title": "Plano medio del suelo (guía NORAH2 Ec. 36-40)",
+        "line_of_sight": "Línea de visión",
+        "diffracted_path": "Trayectoria difractada",
+        "diffraction_edges": "Bordes de difracción",
+        "screening_title": "Apantallamiento por terreno (ECAC Doc 32 / guía NORAH2)",
+    },
+}
+
+
+def _t(key: str, language: str) -> str:
+    """Localised fixed string for ``key`` (English is the byte-identical default)."""
+    return _STRINGS[language][key]
+
+
+def plot_epnl(result: "EPNLResult", ax: Axes | None = None, *, language: str = "en",
+              **kwargs: Any) -> Axes:
     """PNL and PNLT time histories with PNLTM and the 10 dB-down window.
 
     The perceived noise level and its tone-corrected counterpart are drawn
@@ -41,9 +135,12 @@ def plot_epnl(result: "EPNLResult", ax: Axes | None = None, **kwargs: Any) -> Ax
 
     :param result: An :class:`~phonometry.aircraft_noise.EPNLResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the PNLT ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import decimal_comma, format_number, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     t = np.asarray(result.times, dtype=np.float64)
     kf, kl = result.band_limits
@@ -52,71 +149,86 @@ def plot_epnl(result: "EPNLResult", ax: Axes | None = None, **kwargs: Any) -> Ax
     # (svglib) does not preserve alpha, so a translucent fill would render solid
     # and hide the PNL/PNLT traces. A light face keeps both curves readable.
     ax.axvspan(t[kf], t[kl], facecolor="#d7eccb", edgecolor="none", zorder=0,
-               label="10 dB-down window")
+               label=_t("win_10db", language))
     ax.plot(t, np.asarray(result.pnl), color=_C_MUTED, lw=1.0, ls="--", label="PNL")
     ax.plot(t, np.asarray(result.pnlt), **{"color": _C_PRIMARY, "lw": 1.4, "label": "PNLT", **kwargs})
     km = int(np.argmax(np.asarray(result.pnlt)))
     ax.plot([t[km]], [result.pnltm], "o", color=_C_REFERENCE,
-            label=f"PNLTM = {result.pnltm:.1f} PNdB")
-    ax.set_xlabel("Time [s]")
-    ax.set_ylabel("Level [PNdB]")
-    ax.set_title(f"ICAO EPNL = {result.epnl:.1f} EPNdB (D = {result.duration_correction:+.1f} dB)")
+            label=f"PNLTM = {format_number(result.pnltm, language)} PNdB")
+    ax.set_xlabel(_t("time_s", language))
+    ax.set_ylabel(_t("level_pndb", language))
+    ax.set_title(
+        f"ICAO EPNL = {format_number(result.epnl, language)} EPNdB "
+        f"(D = {decimal_comma(f'{result.duration_correction:+.1f}', language)} dB)"
+    )
     ax.grid(True, alpha=0.3)
     ax.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
+    localize_axes(ax, language)
     return ax
 
 def plot_aircraft_band_attenuation(
-    result: "AircraftBandAttenuation", ax: Axes | None = None, **kwargs: Any
+    result: "AircraftBandAttenuation", ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """One-third-octave-band and pure-tone mid-band attenuation versus frequency.
 
     :param result: An
         :class:`~phonometry.aircraft_atmospheric_absorption.AircraftBandAttenuation`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the band-attenuation ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import format_number, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     f = np.asarray(result.frequency, dtype=np.float64)
-    label = f"SAE band ({result.path_length:.0f} m)"
+    label = f"{_t('sae_band', language)} ({format_number(result.path_length, language, decimals=0)} m)"
     ax.plot(f, np.asarray(result.band_attenuation),
             **{"color": _C_PRIMARY, "lw": 1.6, "marker": "o", "ms": 3, "label": label, **kwargs})
     ax.plot(f, np.asarray(result.midband_attenuation), color=_C_SECONDARY, lw=1.0, ls="--",
-            label="Pure-tone mid-band (ISO 9613-1)")
+            label=_t("puretone_midband", language))
     ax.set_xscale("log")
-    ax.set_xlabel("Frequency [Hz]")
-    ax.set_ylabel("Attenuation [dB]")
-    ax.set_title("Aircraft atmospheric absorption (SAE ARP 5534)")
+    ax.set_xlabel(_t("freq_hz", language))
+    ax.set_ylabel(_t("atten_db", language))
+    ax.set_title(_t("aircraft_abs_title", language))
     ax.grid(True, which="both", alpha=0.3)
     ax.legend(loc="upper left", fontsize="small")
     format_frequency_axis(ax, float(f.min()), float(f.max()))
+    localize_axes(ax, language)
     return ax
 
-def plot_npd_level(result: "NpdLevelResult", ax: Axes | None = None, **kwargs: Any) -> Axes:
+def plot_npd_level(result: "NpdLevelResult", ax: Axes | None = None, *, language: str = "en",
+                   **kwargs: Any) -> Axes:
     """NPD event level versus slant distance (log axis), with the tabulated nodes.
 
     :param result: An :class:`~phonometry.airport_noise.NpdLevelResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the interpolated-curve ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import decimal_comma, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     d = np.asarray(result.distance, dtype=np.float64)
     lvl = np.asarray(result.level, dtype=np.float64)
     td = np.asarray(result.table_distances, dtype=np.float64)
     tl = np.asarray(result.table_levels, dtype=np.float64)
-    label = f"NPD (P = {result.power:g})"
+    label = f"NPD (P = {decimal_comma(f'{result.power:g}', language)})"
     ax.plot(d, lvl, **{"color": _C_PRIMARY, "lw": 1.6, "label": label, **kwargs})
-    ax.plot(td, tl, "o", color=_C_REFERENCE, ms=4, label="Tabulated")
+    ax.plot(td, tl, "o", color=_C_REFERENCE, ms=4, label=_t("tabulated", language))
     ax.set_xscale("log")
-    ax.set_xlabel("Slant distance [m]")
-    ax.set_ylabel("Event level [dB]")
-    ax.set_title("Noise-power-distance curve (ECAC Doc 29)")
+    ax.set_xlabel(_t("slant_distance", language))
+    ax.set_ylabel(_t("event_level", language))
+    ax.set_title(_t("npd_title", language))
     ax.grid(True, which="both", alpha=0.3)
     ax.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
+    localize_axes(ax, language)
     return ax
 
-def plot_flyover(result: "FlyoverResult", ax: Axes | None = None, **kwargs: Any) -> Axes:
+def plot_flyover(result: "FlyoverResult", ax: Axes | None = None, *, language: str = "en",
+                 **kwargs: Any) -> Axes:
     """Per-segment contributions to a single-event level (ECAC Doc 29).
 
     Bars show each flight-path segment's event level; the dashed line marks the
@@ -124,9 +236,12 @@ def plot_flyover(result: "FlyoverResult", ax: Axes | None = None, **kwargs: Any)
 
     :param result: A :class:`~phonometry.airport_noise.FlyoverResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the bar call.
     :return: The axes.
     """
+    from .._i18n import format_number, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     seg = np.asarray(result.segment_levels, dtype=np.float64)
     # Non-finite segment contributions (e.g. a fully-attenuated segment) are
@@ -137,18 +252,19 @@ def plot_flyover(result: "FlyoverResult", ax: Axes | None = None, **kwargs: Any)
     ax.bar(idx, seg, **{"color": _C_PRIMARY, "alpha": 0.85, **kwargs})
     if np.isfinite(result.level):
         ax.axhline(result.level, color=_C_REFERENCE, ls="--", lw=1.2,
-                   label=f"Total {metric} = {result.level:.1f} dB")
-    ax.set_xlabel("Segment index")
-    ax.set_ylabel(f"Segment {metric} [dB]")
-    ax.set_title("Single-event segment contributions (ECAC Doc 29)")
+                   label=f"Total {metric} = {format_number(result.level, language)} dB")
+    ax.set_xlabel(_t("segment_index", language))
+    ax.set_ylabel(_t("segment_metric", language).format(metric=metric))
+    ax.set_title(_t("flyover_title", language))
     ax.grid(True, axis="y", alpha=0.3)
     if np.isfinite(result.level):
         ax.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
+    localize_axes(ax, language)
     return ax
 
 def plot_rotorcraft_hemisphere(
     result: "RotorcraftHemisphere", ax: Axes | None = None, *, band: float | None = None,
-    **kwargs: Any) -> Axes:
+    language: str = "en", **kwargs: Any) -> Axes:
     """Fore-aft directivity section of a rotorcraft noise hemisphere (ECAC Doc 32).
 
     Plots the source level versus polar angle θ (0° forward → 180° rearward) in the
@@ -157,9 +273,11 @@ def plot_rotorcraft_hemisphere(
     :param result: A :class:`~phonometry.aircraft.rotorcraft_noise.RotorcraftHemisphere`.
     :param ax: Existing axes, or ``None`` to create a figure.
     :param band: Band centre frequency to plot, in Hz (default: the loudest band).
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to ``plot``.
     :return: The axes.
     """
+    from .._i18n import format_number, localize_axes
     from ..aircraft.rotorcraft_noise import hemisphere_source_level
 
     ax = ax if ax is not None else _new_axes()
@@ -169,22 +287,27 @@ def plot_rotorcraft_hemisphere(
     idx = int(np.argmin(np.abs(freqs - band))) if band is not None else int(
         np.nanargmax(np.nansum(10.0 ** (grid / 10.0), axis=0)))
     ax.plot(theta, grid[:, idx], **{"color": _C_PRIMARY, "lw": 1.8,
-            "label": f"{freqs[idx]:.0f} Hz (φ = 0°)", **kwargs})
-    ax.set_xlabel("Polar angle θ [°]  (0° forward → 180° rearward)")
-    ax.set_ylabel("Source level at 60 m [dB]")
-    ax.set_title("Rotorcraft noise hemisphere directivity (ECAC Doc 32)")
+            "label": f"{format_number(freqs[idx], language, decimals=0)} Hz (φ = 0°)", **kwargs})
+    ax.set_xlabel(_t("polar_angle", language))
+    ax.set_ylabel(_t("source_level_60m", language))
+    ax.set_title(_t("hemisphere_title", language))
     ax.grid(True, alpha=0.3)
     ax.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
+    localize_axes(ax, language)
     return ax
 
-def plot_noise_contour(result: "NoiseContourResult", ax: Axes | None = None, **kwargs: Any) -> Axes:
+def plot_noise_contour(result: "NoiseContourResult", ax: Axes | None = None, *,
+                       language: str = "en", **kwargs: Any) -> Axes:
     """Filled single-event noise contours over the ground plane (ECAC Doc 29).
 
     :param result: A :class:`~phonometry.airport_noise.NoiseContourResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to ``contourf``.
     :return: The axes.
     """
+    from .._i18n import localize_axes
+
     ax = ax if ax is not None else _new_axes()
     x = np.asarray(result.x, dtype=np.float64) / 1000.0
     y = np.asarray(result.y, dtype=np.float64) / 1000.0
@@ -199,13 +322,15 @@ def plot_noise_contour(result: "NoiseContourResult", ax: Axes | None = None, **k
     ax.figure.colorbar(cf, ax=ax, label=f"{'SEL' if result.metric == 'exposure' else 'LAmax'} [dB]")
     ax.set_xlabel("x [km]")
     ax.set_ylabel("y [km]")
-    ax.set_title("Aircraft noise contour (ECAC Doc 29)")
+    ax.set_title(_t("contour_title", language))
     ax.set_aspect("equal", adjustable="box")
+    localize_axes(ax, language)
     return ax
 
 
 def plot_flight_path_kinematics(
-    result: "FlightPathKinematics", ax: Axes | None = None, **kwargs: Any) -> Axes:
+    result: "FlightPathKinematics", ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any) -> Axes:
     """Speed and angle profiles of a rotorcraft track (ECAC Doc 32).
 
     The ground speed and airspeed share the left axis; the path and bank
@@ -214,33 +339,38 @@ def plot_flight_path_kinematics(
     :param result: A
         :class:`~phonometry.aircraft.rotorcraft_noise.FlightPathKinematics`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the speed ``plot`` calls.
     :return: The (left) axes.
     """
+    from .._i18n import localize_axes
+
     ax = ax if ax is not None else _new_axes()
     t = np.asarray(result.times, dtype=np.float64)
     ax.plot(t, result.airspeed, **{"color": _C_PRIMARY, "lw": 1.8,
-            "label": "Airspeed $V_A$", **kwargs})
+            "label": _t("airspeed", language), **kwargs})
     ax.plot(t, result.ground_speed, **{"color": _C_SECONDARY, "lw": 1.4,
-            "ls": "--", "label": "Ground speed $V_g$", **kwargs})
-    ax.set_xlabel("Time [s]")
-    ax.set_ylabel("Speed [m/s]")
+            "ls": "--", "label": _t("ground_speed", language), **kwargs})
+    ax.set_xlabel(_t("time_s", language))
+    ax.set_ylabel(_t("speed_ms", language))
     ax2 = ax.twinx()
     ax2.plot(t, result.path_angle, color=_C_TERTIARY, lw=1.4,
-             label="Path angle $\\gamma$")
+             label=_t("path_angle", language))
     ax2.plot(t, result.bank_angle, color=_C_MUTED, lw=1.4, ls=":",
-             label="Bank angle $\\Phi$")
-    ax2.set_ylabel("Angle [°]")
+             label=_t("bank_angle", language))
+    ax2.set_ylabel(_t("angle_deg", language))
     lines = [*ax.get_lines(), *ax2.get_lines()]
     ax.legend(lines, [str(ln.get_label()) for ln in lines],
               loc=_LEGEND_UPPER_RIGHT, fontsize="small")
-    ax.set_title("Rotorcraft flight-path kinematics (ECAC Doc 32)")
+    ax.set_title(_t("kinematics_title", language))
     ax.grid(True, alpha=0.3)
+    localize_axes(ax, language)
     return ax
 
 
 def plot_rotorcraft_event(
-    result: "RotorcraftEventResult", ax: Axes | None = None, **kwargs: Any) -> Axes:
+    result: "RotorcraftEventResult", ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any) -> Axes:
     """A-weighted level time history of a rotorcraft event (ECAC Doc 32).
 
     Draws ``L_A(t)`` at recorded time, marks ``LASmax``, shades the 10 dB-down
@@ -249,43 +379,51 @@ def plot_rotorcraft_event(
     :param result: A
         :class:`~phonometry.aircraft.rotorcraft_noise.RotorcraftEventResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to ``plot``.
     :return: The axes.
     """
+    from .._i18n import format_number, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     t = np.asarray(result.times, dtype=np.float64)
     la = np.asarray(result.a_levels, dtype=np.float64)
-    label = f"$L_A(t)$  (SEL {result.sel:.1f} dB(A)"
+    label = f"$L_A(t)$  (SEL {format_number(result.sel, language)} dB(A)"
     if np.isfinite(result.epnl):
-        label += f", EPNL {result.epnl:.1f} EPNdB"
+        label += f", EPNL {format_number(result.epnl, language)} EPNdB"
     label += ")"
     ax.plot(t, la, **{"color": _C_PRIMARY, "lw": 1.6, "label": label, **kwargs})
     k = int(np.argmax(la))
     ax.plot(t[k], la[k], "o", color=_C_SECONDARY, ms=5,
-            label=f"$L_{{ASmax}}$ = {result.la_max:.1f} dB(A)")
+            label=f"$L_{{ASmax}}$ = {format_number(result.la_max, language)} dB(A)")
     window = la >= result.la_max - 10.0
     if np.any(window):
         idx = np.nonzero(window)[0]
         ax.axvspan(t[idx[0]], t[idx[-1]], color=_C_PRIMARY, alpha=0.08,
-                   label="10 dB-down window")
-    ax.set_xlabel("Recorded time [s]")
-    ax.set_ylabel("A-weighted level [dB(A)]")
-    ax.set_title("Rotorcraft flyover time history (ECAC Doc 32)")
+                   label=_t("win_10db", language))
+    ax.set_xlabel(_t("recorded_time", language))
+    ax.set_ylabel(_t("a_level", language))
+    ax.set_title(_t("rotor_event_title", language))
     ax.grid(True, alpha=0.3)
     ax.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
+    localize_axes(ax, language)
     return ax
 
 
 def plot_rotorcraft_noise_contour(
-    result: "RotorcraftNoiseContourResult", ax: Axes | None = None, **kwargs: Any) -> Axes:
+    result: "RotorcraftNoiseContourResult", ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any) -> Axes:
     """Filled rotorcraft single-event noise contours over the ground plane.
 
     :param result: A
         :class:`~phonometry.aircraft.rotorcraft_noise.RotorcraftNoiseContourResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to ``contourf``.
     :return: The axes.
     """
+    from .._i18n import localize_axes
+
     ax = ax if ax is not None else _new_axes()
     x = np.asarray(result.x, dtype=np.float64) / 1000.0
     y = np.asarray(result.y, dtype=np.float64) / 1000.0
@@ -301,74 +439,85 @@ def plot_rotorcraft_noise_contour(
     ax.figure.colorbar(cf, ax=ax, label=f"{metric} [dB(A)]")
     ax.set_xlabel("x [km]")
     ax.set_ylabel("y [km]")
-    ax.set_title("Rotorcraft noise contour (ECAC Doc 32)")
+    ax.set_title(_t("rotor_contour_title", language))
     ax.set_aspect("equal", adjustable="box")
+    localize_axes(ax, language)
     return ax
 
 
 def plot_mean_ground_plane(
-    result: "MeanGroundPlaneResult", ax: Axes | None = None, **kwargs: Any) -> Axes:
+    result: "MeanGroundPlaneResult", ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any) -> Axes:
     """Terrain section with its fitted mean ground plane (ECAC Doc 32 guidance).
 
     :param result: A
         :class:`~phonometry.aircraft.rotorcraft_noise.MeanGroundPlaneResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the terrain ``plot``.
     :return: The axes.
     """
+    from .._i18n import format_number, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     d = np.asarray(result.distances, dtype=np.float64)
     z = np.asarray(result.heights, dtype=np.float64)
-    ax.plot(d, z, **{"color": _C_PRIMARY, "lw": 1.8, "label": "Terrain profile",
+    ax.plot(d, z, **{"color": _C_PRIMARY, "lw": 1.8, "label": _t("terrain_profile", language),
             **kwargs})
     ax.fill_between(d, z, z.min() - 0.05 * np.ptp(z) - 0.5, color=_C_PRIMARY,
                     alpha=0.08)
     ax.plot(d, result.height(d), color=_C_SECONDARY, lw=1.6, ls="--",
-            label=f"Mean ground plane (a = {result.slope:.3f})")
-    ax.set_xlabel("Section distance [m]")
-    ax.set_ylabel("Height [m]")
-    ax.set_title("Mean ground plane (NORAH2 guidance Eq. 36-40)")
+            label=f"{_t('mean_ground_plane', language)} (a = {format_number(result.slope, language, decimals=3)})")
+    ax.set_xlabel(_t("section_distance", language))
+    ax.set_ylabel(_t("height_m", language))
+    ax.set_title(_t("mgp_title", language))
     ax.grid(True, alpha=0.3)
     ax.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
+    localize_axes(ax, language)
     return ax
 
 
 def plot_terrain_screening(
-    result: "TerrainScreeningResult", ax: Axes | None = None, **kwargs: Any) -> Axes:
+    result: "TerrainScreeningResult", ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any) -> Axes:
     """Terrain screening section: profile, line of sight and diffracted path.
 
     :param result: A
         :class:`~phonometry.aircraft.rotorcraft_noise.TerrainScreeningResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the terrain ``plot``.
     :return: The axes.
     """
+    from .._i18n import format_number, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     d = np.asarray(result.distances, dtype=np.float64)
     z = np.asarray(result.heights, dtype=np.float64)
     src, rcv = result.source, result.receiver
-    ax.plot(d, z, **{"color": _C_MUTED, "lw": 1.8, "label": "Terrain profile",
+    ax.plot(d, z, **{"color": _C_MUTED, "lw": 1.8, "label": _t("terrain_profile", language),
             **kwargs})
     floor = min(z.min(), src[1], rcv[1]) - 0.05 * max(np.ptp(z), 1.0) - 0.5
     ax.fill_between(d, z, floor, color=_C_MUTED, alpha=0.12)
     ax.plot([src[0], rcv[0]], [src[1], rcv[1]], color=_C_REFERENCE, lw=1.2,
-            ls=":", label="Line of sight")
+            ls=":", label=_t("line_of_sight", language))
     if result.screened and result.diffraction_points.size:
         pts = np.vstack([[src[0], src[1]], result.diffraction_points,
                          [rcv[0], rcv[1]]])
         ax.plot(pts[:, 0], pts[:, 1], color=_C_PRIMARY, lw=1.8,
-                label=f"Diffracted path (δ = {result.path_difference:.2f} m)")
+                label=f"{_t('diffracted_path', language)} (δ = {format_number(result.path_difference, language, decimals=2)} m)")
         ax.plot(result.diffraction_points[:, 0], result.diffraction_points[:, 1],
-                "v", color=_C_SECONDARY, ms=6, label="Diffraction edges")
+                "v", color=_C_SECONDARY, ms=6, label=_t("diffraction_edges", language))
     ax.plot(*src, "o", color=_C_PRIMARY, ms=7)
     ax.annotate("S", src, textcoords="offset points", xytext=(0, 8),
                 ha="center", fontsize=10)
     ax.plot(*rcv, "s", color=_C_SECONDARY, ms=6)
     ax.annotate("R", rcv, textcoords="offset points", xytext=(0, 8),
                 ha="center", fontsize=10)
-    ax.set_xlabel("Section distance [m]")
-    ax.set_ylabel("Height [m]")
-    ax.set_title("Terrain screening (ECAC Doc 32 / NORAH2 guidance)")
+    ax.set_xlabel(_t("section_distance", language))
+    ax.set_ylabel(_t("height_m", language))
+    ax.set_title(_t("screening_title", language))
     ax.grid(True, alpha=0.3)
     ax.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
+    localize_axes(ax, language)
     return ax

--- a/src/phonometry/_plot/environmental.py
+++ b/src/phonometry/_plot/environmental.py
@@ -37,22 +37,116 @@ if TYPE_CHECKING:
     from ..environmental.impulse_prominence import ImpulseProminenceResult
     from ..environmental.wind_turbine_noise import WindTurbineTonalityResult
 
-#: Axis labels shared by the atmospheric-refraction figures (height on the
-#: vertical axis, horizontal range on the x-axis).
-_LABEL_HEIGHT_M = "Height [m]"
-_LABEL_RANGE_M = "Range [m]"
+#: English and Spanish text for every fixed label/title/legend drawn by this
+#: module's renderers.  English entries are byte-for-byte the original strings.
+_STRINGS: dict[str, dict[str, str]] = {
+    "en": {
+        "narrowband": "Narrowband spectrum",
+        "critical_band": "Critical band",
+        "masking_level": "Masking level",
+        "tone": "Tone",
+        "freq_hz": "Frequency [Hz]",
+        "level_db": "Level [dB]",
+        "wt_prefix": "IEC 61400-11 tonal audibility",
+        "threshold": "threshold",
+        "impulses": "Impulses",
+        "governing": "Governing",
+        "predicted_prominence": "Predicted prominence $P$",
+        "adjustment_ki": "Adjustment $K_I$ [dB]",
+        "impulse_title": "NT ACOU 112 — impulse adjustment to $L_{Aeq}$",
+        "knees": "knees $\\Delta L_{ta}=4,\\,10$ dB",
+        "tonal_audibility_x": "Tonal audibility $\\Delta L_{ta}$ [dB]",
+        "tonal_adjustment_y": "Tonal adjustment $K_t$ [dB]",
+        "tonal_title": "ISO 1996-2 tonal adjustment",
+        "a_div": "$A_{div}$ — divergence",
+        "a_atm": "$A_{atm}$ — atmospheric",
+        "a_gr": "$A_{gr}$ — ground",
+        "a_bar": "$A_{bar}$ — barrier",
+        "a_total": "$A$ — total",
+        "atten_a": "Attenuation A [dB]",
+        "outdoor_title": "ISO 9613-2 attenuation breakdown",
+        "excess_atten": "Excess attenuation $\\Delta L$",
+        "free_field": "Free field (0 dB)",
+        "hard_ground": "Hard-ground limit (+6 dB)",
+        "level_re_ff": "Level re free field [dB]",
+        "spherical_title": "Spherical-wave ground effect (Weyl-Van der Pol)",
+        "insertion_loss": "Insertion loss",
+        "ground_word": "ground",
+        "grazing_limit": "Grazing limit (5 dB)",
+        "insertion_loss_db": "Insertion loss [dB]",
+        "barrier_title": "Barrier insertion loss",
+        "eff_sound_speed": "Effective sound speed [m/s]",
+        "height_m": "Height [m]",
+        "range_m": "Range [m]",
+        "eff_profile_title": "Effective sound-speed profile",
+        "source": "Source",
+        "rays_title": "Atmospheric ray paths",
+        "gfpe_prefix": "GFPE relative sound level",
+    },
+    "es": {
+        "narrowband": "Espectro de banda estrecha",
+        "critical_band": "Banda crítica",
+        "masking_level": "Nivel de enmascaramiento",
+        "tone": "Tono",
+        "freq_hz": "Frecuencia [Hz]",
+        "level_db": "Nivel [dB]",
+        "wt_prefix": "Audibilidad tonal IEC 61400-11",
+        "threshold": "umbral",
+        "impulses": "Impulsos",
+        "governing": "Determinante",
+        "predicted_prominence": "Prominencia prevista $P$",
+        "adjustment_ki": "Ajuste $K_I$ [dB]",
+        "impulse_title": "NT ACOU 112 — ajuste por impulsos a $L_{Aeq}$",
+        "knees": "codos $\\Delta L_{ta}=4,\\,10$ dB",
+        "tonal_audibility_x": "Audibilidad tonal $\\Delta L_{ta}$ [dB]",
+        "tonal_adjustment_y": "Ajuste tonal $K_t$ [dB]",
+        "tonal_title": "Ajuste tonal ISO 1996-2",
+        "a_div": "$A_{div}$ — divergencia",
+        "a_atm": "$A_{atm}$ — atmosférica",
+        "a_gr": "$A_{gr}$ — suelo",
+        "a_bar": "$A_{bar}$ — barrera",
+        "a_total": "$A$ — total",
+        "atten_a": "Atenuación A [dB]",
+        "outdoor_title": "Desglose de atenuación ISO 9613-2",
+        "excess_atten": "Atenuación en exceso $\\Delta L$",
+        "free_field": "Campo libre (0 dB)",
+        "hard_ground": "Límite de suelo duro (+6 dB)",
+        "level_re_ff": "Nivel re campo libre [dB]",
+        "spherical_title": "Efecto de suelo de onda esférica (Weyl-Van der Pol)",
+        "insertion_loss": "Pérdida por inserción",
+        "ground_word": "suelo",
+        "grazing_limit": "Límite rasante (5 dB)",
+        "insertion_loss_db": "Pérdida por inserción [dB]",
+        "barrier_title": "Pérdida por inserción de barrera",
+        "eff_sound_speed": "Velocidad efectiva del sonido [m/s]",
+        "height_m": "Altura [m]",
+        "range_m": "Distancia [m]",
+        "eff_profile_title": "Perfil de velocidad efectiva del sonido",
+        "source": "Fuente",
+        "rays_title": "Trayectorias de rayos atmosféricos",
+        "gfpe_prefix": "Nivel sonoro relativo GFPE",
+    },
+}
+
+
+def _t(key: str, language: str) -> str:
+    """Localised fixed string for ``key`` (English is the byte-identical default)."""
+    return _STRINGS[language][key]
 
 
 def plot_wind_turbine_tonality(
-    result: "WindTurbineTonalityResult", ax: Axes | None = None, **kwargs: Any
+    result: "WindTurbineTonalityResult", ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Narrowband spectrum with the critical band, masking level and the tone.
 
     :param result: A :class:`~phonometry.wind_turbine_noise.WindTurbineTonalityResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the spectrum ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import format_number, localize_axes
     from ..environmental.wind_turbine_noise import _critical_band_edges
 
     ax = ax if ax is not None else _new_axes()
@@ -60,29 +154,33 @@ def plot_wind_turbine_tonality(
     levels = np.asarray(result.levels, dtype=np.float64)
     fc = result.tone_frequency
     lo, hi = _critical_band_edges(fc)
-    ax.plot(freqs, levels, **{"color": _C_PRIMARY, "lw": 1.0, "label": "Narrowband spectrum", **kwargs})
-    ax.axvspan(lo, hi, color=_C_TERTIARY, alpha=0.12, label="Critical band")
+    ax.plot(freqs, levels, **{"color": _C_PRIMARY, "lw": 1.0, "label": _t("narrowband", language), **kwargs})
+    ax.axvspan(lo, hi, color=_C_TERTIARY, alpha=0.12, label=_t("critical_band", language))
     ax.axhline(result.masking_level, color=_C_MUTED, ls="--", lw=1.0,
-               label=f"Masking level ({result.masking_level:.1f} dB)")
+               label=f"{_t('masking_level', language)} ({format_number(result.masking_level, language)} dB)")
     ax.plot([fc], [result.tone_level], "o", color=_C_REFERENCE,
-            label=f"Tone ({result.tone_level:.1f} dB)")
-    ax.set_xlabel("Frequency [Hz]")
-    ax.set_ylabel("Level [dB]")
-    ax.set_title(f"IEC 61400-11 tonal audibility ΔLₐ = {result.tonal_audibility:.1f} dB")
+            label=f"{_t('tone', language)} ({format_number(result.tone_level, language)} dB)")
+    ax.set_xlabel(_t("freq_hz", language))
+    ax.set_ylabel(_t("level_db", language))
+    ax.set_title(f"{_t('wt_prefix', language)} ΔLₐ = {format_number(result.tonal_audibility, language)} dB")
     ax.grid(True, alpha=0.3)
     ax.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
+    localize_axes(ax, language)
     return ax
 
 def plot_impulse_prominence(
-    result: "ImpulseProminenceResult", ax: Axes | None = None, **kwargs: Any
+    result: "ImpulseProminenceResult", ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Adjustment curve ``KI(P)`` with the candidate impulses marked.
 
     :param result: An :class:`~phonometry.impulse_prominence.ImpulseProminenceResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the impulses ``scatter``.
     :return: The axes.
     """
+    from .._i18n import decimal_comma, format_number, localize_axes
     from ..environmental.impulse_prominence import ADJUSTMENT_THRESHOLD, impulse_adjustment
 
     ax = ax if ax is not None else _new_axes()
@@ -93,34 +191,38 @@ def plot_impulse_prominence(
     ax.plot(grid, impulse_adjustment(grid), color=_C_PRIMARY,
             label=r"$K_I = 1.8\,(P-5)$")
     ax.axvline(ADJUSTMENT_THRESHOLD, color=_C_MUTED, ls=":",
-               label=f"threshold $P = {ADJUSTMENT_THRESHOLD:g}$")
+               label=f"{_t('threshold', language)} $P = {decimal_comma(f'{ADJUSTMENT_THRESHOLD:g}', language)}$")
 
     kwargs.setdefault("color", _C_PRIMARY_LIGHT)
     kwargs.setdefault("zorder", 3)
-    ax.scatter(per, impulse_adjustment(per), label="Impulses", **kwargs)
+    ax.scatter(per, impulse_adjustment(per), label=_t("impulses", language), **kwargs)
     ax.scatter([result.prominence], [result.adjustment], color=_C_REFERENCE,
                zorder=4, s=90, marker="*",
-               label=f"Governing  P = {result.prominence:.2f},  "
-                     f"$K_I$ = {result.adjustment:.1f} dB")
-    ax.set_xlabel("Predicted prominence $P$")
-    ax.set_ylabel("Adjustment $K_I$ [dB]")
-    ax.set_title("NT ACOU 112 — impulse adjustment to $L_{Aeq}$")
+               label=f"{_t('governing', language)}  P = {format_number(result.prominence, language, decimals=2)},  "
+                     f"$K_I$ = {format_number(result.adjustment, language)} dB")
+    ax.set_xlabel(_t("predicted_prominence", language))
+    ax.set_ylabel(_t("adjustment_ki", language))
+    ax.set_title(_t("impulse_title", language))
     ax.set_ylim(bottom=0.0)
     ax.legend(loc="upper left", fontsize="small")
     ax.grid(True, alpha=0.3)
+    localize_axes(ax, language)
     return ax
 
 def plot_tonal_adjustment(
-    result: "TonalAssessmentResult", ax: Axes | None = None, **kwargs: Any
+    result: "TonalAssessmentResult", ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Tonal adjustment curve ``Kt(ΔLta)`` with the assessed tone marked.
 
     :param result: A
         :class:`~phonometry.environmental_measurement.TonalAssessmentResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the assessed-tone ``scatter``.
     :return: The axes.
     """
+    from .._i18n import format_number, localize_axes
     from ..environmental.measurement import tonal_adjustment
 
     ax = ax if ax is not None else _new_axes()
@@ -128,7 +230,7 @@ def plot_tonal_adjustment(
     grid = np.linspace(0.0, top, 200)
     curve = np.array([tonal_adjustment(d) for d in grid], dtype=np.float64)
     ax.plot(grid, curve, color=_C_PRIMARY, label=r"$K_t(\Delta L_{ta})$")
-    ax.axvline(4.0, color=_C_MUTED, ls=":", label=r"knees $\Delta L_{ta}=4,\,10$ dB")
+    ax.axvline(4.0, color=_C_MUTED, ls=":", label=_t("knees", language))
     ax.axvline(10.0, color=_C_MUTED, ls=":")
 
     kwargs.setdefault("color", _C_REFERENCE)
@@ -136,18 +238,20 @@ def plot_tonal_adjustment(
     kwargs.setdefault("s", 90)
     kwargs.setdefault("marker", "*")
     ax.scatter([result.audibility], [result.adjustment],
-               label=rf"$\Delta L_{{ta}}$ = {result.audibility:.1f} dB,  "
-                     rf"$K_t$ = {result.adjustment:.1f} dB", **kwargs)
-    ax.set_xlabel(r"Tonal audibility $\Delta L_{ta}$ [dB]")
-    ax.set_ylabel("Tonal adjustment $K_t$ [dB]")
-    ax.set_title("ISO 1996-2 tonal adjustment")
+               label=rf"$\Delta L_{{ta}}$ = {format_number(result.audibility, language)} dB,  "
+                     rf"$K_t$ = {format_number(result.adjustment, language)} dB", **kwargs)
+    ax.set_xlabel(_t("tonal_audibility_x", language))
+    ax.set_ylabel(_t("tonal_adjustment_y", language))
+    ax.set_title(_t("tonal_title", language))
     ax.set_ylim(bottom=0.0)
     ax.legend(loc="upper left", fontsize="small")
     ax.grid(True, alpha=0.3)
+    localize_axes(ax, language)
     return ax
 
 def plot_outdoor_attenuation(
-    result: "OutdoorAttenuation", ax: Axes | None = None, **kwargs: Any
+    result: "OutdoorAttenuation", ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Stacked per-band attenuation terms with the total overlaid (ISO 9613-2).
 
@@ -159,9 +263,12 @@ def plot_outdoor_attenuation(
     :param result: An
         :class:`~phonometry.outdoor_propagation.OutdoorAttenuation`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the total-attenuation ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import localize_axes
+
     ax = ax if ax is not None else _new_axes()
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     positions = _band_axis(ax, freqs)
@@ -173,10 +280,10 @@ def plot_outdoor_attenuation(
     pos_bottom = np.zeros(n)
     neg_bottom = np.zeros(n)
     terms = (
-        (result.a_div, _C_PRIMARY, "$A_{div}$ — divergence"),
-        (result.a_atm, _C_TERTIARY, "$A_{atm}$ — atmospheric"),
-        (result.a_gr, _C_QUATERNARY, "$A_{gr}$ — ground"),
-        (result.a_bar, _C_SECONDARY, "$A_{bar}$ — barrier"),
+        (result.a_div, _C_PRIMARY, _t("a_div", language)),
+        (result.a_atm, _C_TERTIARY, _t("a_atm", language)),
+        (result.a_gr, _C_QUATERNARY, _t("a_gr", language)),
+        (result.a_bar, _C_SECONDARY, _t("a_bar", language)),
     )
     for values, color, label in terms:
         term = np.asarray(values, dtype=np.float64)
@@ -187,19 +294,21 @@ def plot_outdoor_attenuation(
 
     kwargs.setdefault("color", _C_REFERENCE)
     kwargs.setdefault("marker", "D")
-    kwargs.setdefault("label", "$A$ — total")
+    kwargs.setdefault("label", _t("a_total", language))
     ax.plot(positions, np.asarray(result.a_total, dtype=np.float64),
             zorder=4, **kwargs)
     ax.axhline(0.0, color=_C_MUTED, lw=0.8)
-    ax.set_ylabel("Attenuation A [dB]")
-    ax.set_title("ISO 9613-2 attenuation breakdown")
+    ax.set_ylabel(_t("atten_a", language))
+    ax.set_title(_t("outdoor_title", language))
     ax.legend(loc="best", fontsize="small")
     ax.grid(True, axis="y", alpha=0.3)
+    localize_axes(ax, language)
     return ax
 
 
 def plot_spherical_ground(
-    result: "SphericalGroundResult", ax: Axes | None = None, **kwargs: Any
+    result: "SphericalGroundResult", ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Excess attenuation (level re free field) of the spherical-wave ground effect.
 
@@ -210,107 +319,128 @@ def plot_spherical_ground(
     :param result: A
         :class:`~phonometry.environmental.ground_barriers.SphericalGroundResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the ``dL`` ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import localize_axes
+
     ax = ax if ax is not None else _new_axes()
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     d_l = np.asarray(result.excess_attenuation, dtype=np.float64)
     ax.plot(freqs, d_l, **{"color": _C_PRIMARY, "lw": 1.4, "marker": "o",
-                           "ms": 3.0, "label": "Excess attenuation $\\Delta L$",
+                           "ms": 3.0, "label": _t("excess_atten", language),
                            **kwargs})
-    ax.axhline(0.0, color=_C_MUTED, lw=0.8, label="Free field (0 dB)")
+    ax.axhline(0.0, color=_C_MUTED, lw=0.8, label=_t("free_field", language))
     ax.axhline(6.0, color=_C_REFERENCE, ls="--", lw=0.9,
-               label="Hard-ground limit (+6 dB)")
+               label=_t("hard_ground", language))
     _freq_axis(ax, freqs)
-    ax.set_ylabel("Level re free field [dB]")
-    ax.set_title("Spherical-wave ground effect (Weyl-Van der Pol)")
+    ax.set_ylabel(_t("level_re_ff", language))
+    ax.set_title(_t("spherical_title", language))
     ax.legend(loc="best", fontsize="small")
     ax.grid(True, which="both", alpha=0.3)
+    localize_axes(ax, language)
     return ax
 
 
 def plot_barrier_insertion_loss(
-    result: "BarrierInsertionLoss", ax: Axes | None = None, **kwargs: Any
+    result: "BarrierInsertionLoss", ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Barrier insertion loss versus frequency.
 
     :param result: A
         :class:`~phonometry.environmental.ground_barriers.BarrierInsertionLoss`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the insertion-loss ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import localize_axes
+
     ax = ax if ax is not None else _new_axes()
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     il = np.asarray(result.insertion_loss, dtype=np.float64)
-    label = f"Insertion loss ({result.method}{', ground' if result.ground else ''})"
+    ground_frag = f", {_t('ground_word', language)}" if result.ground else ""
+    label = f"{_t('insertion_loss', language)} ({result.method}{ground_frag})"
     ax.plot(freqs, il, **{"color": _C_SECONDARY, "lw": 1.4, "marker": "s",
                           "ms": 3.0, "label": label, **kwargs})
     ax.axhline(0.0, color=_C_MUTED, lw=0.8)
     ax.axhline(5.0, color=_C_MUTED, ls=":", lw=0.9,
-               label="Grazing limit (5 dB)")
+               label=_t("grazing_limit", language))
     _freq_axis(ax, freqs)
-    ax.set_ylabel("Insertion loss [dB]")
-    ax.set_title("Barrier insertion loss")
+    ax.set_ylabel(_t("insertion_loss_db", language))
+    ax.set_title(_t("barrier_title", language))
     ax.legend(loc="best", fontsize="small")
     ax.grid(True, which="both", alpha=0.3)
+    localize_axes(ax, language)
     return ax
 
 
 def plot_sound_speed_profile(
-    profile: "EffectiveSoundSpeedProfile", ax: Axes | None = None, **kwargs: Any
+    profile: "EffectiveSoundSpeedProfile", ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Effective sound-speed profile ``c_eff(z)`` (height on the vertical axis).
 
     :param profile: An
         :class:`~phonometry.environmental.atmospheric_refraction.EffectiveSoundSpeedProfile`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the profile ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import localize_axes
+
     ax = ax if ax is not None else _new_axes()
     z = np.asarray(profile.heights, dtype=np.float64)
     c = np.asarray(profile.sound_speeds, dtype=np.float64)
     label = profile.description or "c_eff(z)"
     ax.plot(c, z, **{"color": _C_PRIMARY, "lw": 1.4, "label": label, **kwargs})
-    ax.set_xlabel("Effective sound speed [m/s]")
-    ax.set_ylabel(_LABEL_HEIGHT_M)
-    ax.set_title("Effective sound-speed profile")
+    ax.set_xlabel(_t("eff_sound_speed", language))
+    ax.set_ylabel(_t("height_m", language))
+    ax.set_title(_t("eff_profile_title", language))
     ax.grid(True, alpha=0.3)
     ax.legend(loc="best", fontsize="small")
+    localize_axes(ax, language)
     return ax
 
 
 def plot_atmospheric_rays(
-    result: "AtmosphericRayResult", ax: Axes | None = None, **kwargs: Any
+    result: "AtmosphericRayResult", ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Curved sound-ray paths over the ground (height on the vertical axis).
 
     :param result: An
         :class:`~phonometry.environmental.atmospheric_refraction.AtmosphericRayResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to each ray ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import localize_axes
+
     ax = ax if ax is not None else _new_axes()
     r = np.asarray(result.ranges, dtype=np.float64)
     z = np.asarray(result.heights, dtype=np.float64)
     for i in range(r.shape[0]):
         ax.plot(r[i], z[i], **{"color": _C_PRIMARY, "lw": 0.7, "alpha": 0.7, **kwargs})
-    ax.plot([0.0], [result.source_height], "o", color=_C_REFERENCE, label="Source")
+    ax.plot([0.0], [result.source_height], "o", color=_C_REFERENCE, label=_t("source", language))
     ax.axhline(0.0, color=_C_MUTED, lw=1.0)
-    ax.set_xlabel(_LABEL_RANGE_M)
-    ax.set_ylabel(_LABEL_HEIGHT_M)
+    ax.set_xlabel(_t("range_m", language))
+    ax.set_ylabel(_t("height_m", language))
     ax.set_ylim(bottom=0.0)
-    ax.set_title("Atmospheric ray paths")
+    ax.set_title(_t("rays_title", language))
     ax.grid(True, alpha=0.3)
     ax.legend(loc="upper right", fontsize="small")
+    localize_axes(ax, language)
     return ax
 
 
 def plot_atmospheric_pe(
-    result: "AtmosphericPEResult", ax: Axes | None = None, **kwargs: Any
+    result: "AtmosphericPEResult", ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Parabolic-equation relative-level field over the range-height plane.
 
@@ -321,9 +451,12 @@ def plot_atmospheric_pe(
     :param result: An
         :class:`~phonometry.environmental.atmospheric_refraction.AtmosphericPEResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to ``imshow``.
     :return: The axes.
     """
+    from .._i18n import format_number, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     r = np.asarray(result.ranges, dtype=np.float64)
     z = np.asarray(result.heights, dtype=np.float64)
@@ -345,10 +478,11 @@ def plot_atmospheric_pe(
             **kwargs,
         },
     )
-    ax.figure.colorbar(img, ax=ax, label="Level re free field [dB]")
-    ax.plot([0.0], [result.source_height], "o", color="k", ms=4.0, label="Source")
-    ax.set_xlabel(_LABEL_RANGE_M)
-    ax.set_ylabel(_LABEL_HEIGHT_M)
-    ax.set_title(f"GFPE relative sound level ({result.frequency:.0f} Hz)")
+    ax.figure.colorbar(img, ax=ax, label=_t("level_re_ff", language))
+    ax.plot([0.0], [result.source_height], "o", color="k", ms=4.0, label=_t("source", language))
+    ax.set_xlabel(_t("range_m", language))
+    ax.set_ylabel(_t("height_m", language))
+    ax.set_title(f"{_t('gfpe_prefix', language)} ({format_number(result.frequency, language, decimals=0)} Hz)")
     ax.legend(loc="upper right", fontsize="small")
+    localize_axes(ax, language)
     return ax

--- a/src/phonometry/_plot/underwater.py
+++ b/src/phonometry/_plot/underwater.py
@@ -13,9 +13,6 @@ from .common import (
     _C_REFERENCE,
     _C_SECONDARY,
     _C_TERTIARY,
-    _LABEL_DEPTH_M,
-    _LABEL_RANGE_KM,
-    _LABEL_TL_DB,
     _LEGEND_UPPER_RIGHT,
     _new_axes,
     _new_axes_column,
@@ -38,8 +35,118 @@ if TYPE_CHECKING:
     from ..underwater.ocean_ambient_noise import AmbientNoiseResult
     from ..underwater.ship_traffic_noise import ShipTrafficSpectrum
 
+#: English and Spanish text for every fixed label/title/legend drawn by this
+#: module's renderers.  English entries are byte-for-byte the original strings.
+_STRINGS: dict[str, dict[str, str]] = {
+    "en": {
+        "source_level_ls": "Source level Ls",
+        "radiated_noise": "Radiated noise level",
+        "freq_hz": "Frequency [Hz]",
+        "level_upam": "Level [dB re 1 µPa·m]",
+        "surface_corr_legend": "Surface correction ΔL",
+        "surface_corr_ylabel": "Surface correction ΔL [dB]",
+        "source_level_title": "ISO 17208-2 equivalent monopole source level",
+        "peak": "Peak",
+        "pressure_pa": "Pressure [Pa]",
+        "time_s": "Time [s]",
+        "pile_title": "ISO 18406 pile strike",
+        "cumulative_energy": "Cumulative energy",
+        "cumulative_energy_norm": "Cumulative energy (norm.)",
+        "pulse_duration": "90 % pulse duration",
+        "sound_speed_ms": "Sound speed [m/s]",
+        "depth_m": "Depth [m]",
+        "sound_speed_title": "Sea-water sound-speed profile",
+        "total_tl": "Total TL",
+        "spreading": "Spreading",
+        "absorption": "Absorption",
+        "range_m": "Range [m]",
+        "tl_db": "Transmission loss [dB]",
+        "underwater_tl_title": "Underwater transmission loss",
+        "signal_excess": "Signal excess",
+        "detection_limit": "Detection limit (SE = 0)",
+        "figure_of_merit": "Figure of merit",
+        "signal_excess_db": "Signal excess [dB]",
+        "sonar_title": "Sonar equation",
+        "bottom_loss": "Bottom loss",
+        "critical_angle": "Critical angle",
+        "grazing_angle": "Grazing angle [°]",
+        "bottom_loss_db": "Bottom loss [dB]",
+        "seabed_title": "Seabed reflection loss",
+        "total": "Total",
+        "wind": "Wind",
+        "thermal": "Thermal",
+        "shipping": "Shipping",
+        "spectrum_level": "Spectrum level [dB re 1 µPa²/Hz]",
+        "ambient_title": "Ocean ambient noise",
+        "source_psd_ylabel": "Source spectral density [dB re 1 µPa²/Hz at 1 m]",
+        "traffic_title": "Ship traffic source level",
+        "modes_word": "modes",
+        "range_km": "Range [km]",
+        "modes_title": "Normal-mode transmission loss",
+        "source": "Source",
+        "raytrace_title": "Ray trace",
+        "pe_title": "Parabolic-equation transmission loss",
+    },
+    "es": {
+        "source_level_ls": "Nivel de fuente Ls",
+        "radiated_noise": "Nivel de ruido radiado",
+        "freq_hz": "Frecuencia [Hz]",
+        "level_upam": "Nivel [dB re 1 µPa·m]",
+        "surface_corr_legend": "Corrección de superficie ΔL",
+        "surface_corr_ylabel": "Corrección de superficie ΔL [dB]",
+        "source_level_title": "Nivel de fuente monopolar equivalente ISO 17208-2",
+        "peak": "Pico",
+        "pressure_pa": "Presión [Pa]",
+        "time_s": "Tiempo [s]",
+        "pile_title": "Golpe de pilote ISO 18406",
+        "cumulative_energy": "Energía acumulada",
+        "cumulative_energy_norm": "Energía acumulada (norm.)",
+        "pulse_duration": "Duración del pulso al 90 %",
+        "sound_speed_ms": "Velocidad del sonido [m/s]",
+        "depth_m": "Profundidad [m]",
+        "sound_speed_title": "Perfil de velocidad del sonido en agua de mar",
+        "total_tl": "TL total",
+        "spreading": "Divergencia",
+        "absorption": "Absorción",
+        "range_m": "Distancia [m]",
+        "tl_db": "Pérdida por transmisión [dB]",
+        "underwater_tl_title": "Pérdida por transmisión submarina",
+        "signal_excess": "Exceso de señal",
+        "detection_limit": "Límite de detección (SE = 0)",
+        "figure_of_merit": "Cifra de mérito",
+        "signal_excess_db": "Exceso de señal [dB]",
+        "sonar_title": "Ecuación del sonar",
+        "bottom_loss": "Pérdida en el fondo",
+        "critical_angle": "Ángulo crítico",
+        "grazing_angle": "Ángulo rasante [°]",
+        "bottom_loss_db": "Pérdida en el fondo [dB]",
+        "seabed_title": "Pérdida por reflexión en el fondo marino",
+        "total": "Total",
+        "wind": "Viento",
+        "thermal": "Térmico",
+        "shipping": "Tráfico marítimo",
+        "spectrum_level": "Nivel espectral [dB re 1 µPa²/Hz]",
+        "ambient_title": "Ruido ambiental oceánico",
+        "source_psd_ylabel": "Densidad espectral de la fuente [dB re 1 µPa²/Hz a 1 m]",
+        "traffic_title": "Nivel de fuente del tráfico marítimo",
+        "modes_word": "modos",
+        "range_km": "Distancia [km]",
+        "modes_title": "Pérdida por transmisión por modos normales",
+        "source": "Fuente",
+        "raytrace_title": "Trazado de rayos",
+        "pe_title": "Pérdida por transmisión por ecuación parabólica",
+    },
+}
+
+
+def _t(key: str, language: str) -> str:
+    """Localised fixed string for ``key`` (English is the byte-identical default)."""
+    return _STRINGS[language][key]
+
+
 def plot_ship_source_level(
-    result: "ShipSourceLevelResult", ax: Axes | None = None, **kwargs: Any
+    result: "ShipSourceLevelResult", ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Radiated noise level, source level and the ΔL surface correction.
 
@@ -49,9 +156,12 @@ def plot_ship_source_level(
     :param result: A
         :class:`~phonometry.ship_radiated_noise.ShipSourceLevelResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the source-level ``semilogx`` call.
     :return: The axes.
     """
+    from .._i18n import format_number, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     rnl = np.asarray(result.radiated_noise_level, dtype=np.float64)
@@ -59,17 +169,17 @@ def plot_ship_source_level(
     dl = np.asarray(result.surface_correction, dtype=np.float64)
 
     kwargs.setdefault("color", _C_PRIMARY)
-    kwargs.setdefault("label", "Source level Ls")
+    kwargs.setdefault("label", _t("source_level_ls", language))
     ax.semilogx(freqs, ls, "o-", **kwargs)
-    ax.semilogx(freqs, rnl, "s--", color=_C_REFERENCE, label="Radiated noise level")
-    ax.set_xlabel("Frequency [Hz]")
-    ax.set_ylabel("Level [dB re 1 µPa·m]")
+    ax.semilogx(freqs, rnl, "s--", color=_C_REFERENCE, label=_t("radiated_noise", language))
+    ax.set_xlabel(_t("freq_hz", language))
+    ax.set_ylabel(_t("level_upam", language))
     ax.grid(True, which="both", alpha=0.3)
     ax.set_axisbelow(True)
 
     twin = ax.twinx()
-    twin.semilogx(freqs, dl, ":", color=_C_TERTIARY, label="Surface correction ΔL")
-    twin.set_ylabel("Surface correction ΔL [dB]")
+    twin.semilogx(freqs, dl, ":", color=_C_TERTIARY, label=_t("surface_corr_legend", language))
+    twin.set_ylabel(_t("surface_corr_ylabel", language))
     # After twinx() (it re-initialises the shared x-axis with the default log
     # locator) so the octave-band labelling is not reset back to 10^n ticks.
     format_frequency_axis(ax, float(freqs.min()), float(freqs.max()))
@@ -78,13 +188,16 @@ def plot_ship_source_level(
     tlines, tlabels = twin.get_legend_handles_labels()
     ax.legend(lines + tlines, labels + tlabels, loc="best", fontsize="small")
     ax.set_title(
-        "ISO 17208-2 equivalent monopole source level "
-        f"(d_s = {result.source_depth:.1f} m, c = {result.sound_speed:.0f} m/s)"
+        f"{_t('source_level_title', language)} "
+        f"(d_s = {format_number(result.source_depth, language)} m, "
+        f"c = {format_number(result.sound_speed, language, decimals=0)} m/s)"
     )
+    localize_axes(ax, language)
     return ax
 
 def plot_pile_strike(
-    result: "PileStrikeResult", ax: Axes | None = None, **kwargs: Any
+    result: "PileStrikeResult", ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any
 ) -> Axes | np.ndarray:
     """Pile-strike pressure waveform and its cumulative energy.
 
@@ -95,9 +208,12 @@ def plot_pile_strike(
     :param result: A :class:`~phonometry.pile_driving_noise.PileStrikeResult`.
     :param ax: Existing axes for the waveform panel, or ``None`` for a fresh
         two-panel figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the waveform ``plot`` call.
     :return: The waveform axes (``ax`` given) or the array of two axes.
     """
+    from .._i18n import format_number, localize_axes
+
     pressure = np.asarray(result.pressure, dtype=np.float64)
     fs = float(result.fs)
     t = np.arange(pressure.size) / fs
@@ -110,41 +226,48 @@ def plot_pile_strike(
     def _waveform(axw: Axes) -> None:
         axw.plot(t, pressure, color=color, lw=0.8, **kwargs)
         axw.plot([t[peak_idx]], [pressure[peak_idx]], "o", color=_C_REFERENCE,
-                 label=f"Peak ({result.peak_spl:.0f} dB re 1 µPa)")
-        axw.set_ylabel("Pressure [Pa]")
+                 label=f"{_t('peak', language)} ({format_number(result.peak_spl, language, decimals=0)} dB re 1 µPa)")
+        axw.set_ylabel(_t("pressure_pa", language))
         axw.grid(True, alpha=0.3)
         axw.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
 
     if ax is not None:
         _waveform(ax)
-        ax.set_xlabel("Time [s]")
-        ax.set_title(f"ISO 18406 pile strike (SEL_ss = {result.single_strike_sel:.0f} dB)")
+        ax.set_xlabel(_t("time_s", language))
+        ax.set_title(f"{_t('pile_title', language)} (SEL_ss = {format_number(result.single_strike_sel, language, decimals=0)} dB)")
+        localize_axes(ax, language)
         return ax
 
     axes = _new_axes_column(2, sharex=True, figsize=(8.0, 6.0))
     _waveform(axes[0])
     axes[0].set_title(
-        f"ISO 18406 pile strike (SEL_ss = {result.single_strike_sel:.0f} dB re 1 µPa²·s)"
+        f"{_t('pile_title', language)} (SEL_ss = {format_number(result.single_strike_sel, language, decimals=0)} dB re 1 µPa²·s)"
     )
-    axes[1].plot(t, cum, color=_C_TERTIARY, label="Cumulative energy")
+    axes[1].plot(t, cum, color=_C_TERTIARY, label=_t("cumulative_energy", language))
     for frac in (0.05, 0.95):
         axes[1].axhline(frac, color=_C_MUTED, ls="--", lw=0.8)
-    axes[1].set_ylabel("Cumulative energy (norm.)")
-    axes[1].set_xlabel("Time [s]")
-    axes[1].set_title(f"90 % pulse duration = {result.pulse_duration * 1e3:.0f} ms")
+    axes[1].set_ylabel(_t("cumulative_energy_norm", language))
+    axes[1].set_xlabel(_t("time_s", language))
+    axes[1].set_title(f"{_t('pulse_duration', language)} = {format_number(result.pulse_duration * 1e3, language, decimals=0)} ms")
     axes[1].grid(True, alpha=0.3)
+    localize_axes(axes[0], language)
+    localize_axes(axes[1], language)
     return axes
 
 def plot_sound_speed_profile(
-    result: "SoundSpeedProfile", ax: Axes | None = None, **kwargs: Any
+    result: "SoundSpeedProfile", ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Sound-speed profile: speed vs depth, with depth increasing downward.
 
     :param result: A :class:`~phonometry.underwater_sound_speed.SoundSpeedProfile`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the profile ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import localize_axes
+
     ax = ax if ax is not None else _new_axes()
     depth = np.asarray(result.depth, dtype=np.float64)
     speed = np.asarray(result.sound_speed, dtype=np.float64)
@@ -152,15 +275,17 @@ def plot_sound_speed_profile(
     ax.plot(speed, depth, **{"color": _C_PRIMARY, "lw": 1.4, "label": label, **kwargs})
     if not ax.yaxis_inverted():
         ax.invert_yaxis()
-    ax.set_xlabel("Sound speed [m/s]")
-    ax.set_ylabel(_LABEL_DEPTH_M)
-    ax.set_title("Sea-water sound-speed profile")
+    ax.set_xlabel(_t("sound_speed_ms", language))
+    ax.set_ylabel(_t("depth_m", language))
+    ax.set_title(_t("sound_speed_title", language))
     ax.grid(True, alpha=0.3)
     ax.legend(loc="lower left", fontsize="small")
+    localize_axes(ax, language)
     return ax
 
 def plot_transmission_loss(
-    result: "TransmissionLossResult", ax: Axes | None = None, **kwargs: Any
+    result: "TransmissionLossResult", ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Transmission loss versus range, with spreading and absorption split out.
 
@@ -168,115 +293,138 @@ def plot_transmission_loss(
 
     :param result: A :class:`~phonometry.underwater_propagation.TransmissionLossResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the total-TL ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import decimal_comma, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     r = np.asarray(result.range_m, dtype=np.float64)
-    label = f"Total TL ({result.frequency / 1000.0:.3g} kHz)"
+    label = f"{_t('total_tl', language)} ({decimal_comma(f'{result.frequency / 1000.0:.3g}', language)} kHz)"
     ax.plot(r, np.asarray(result.tl), **{"color": _C_PRIMARY, "lw": 1.6, "label": label, **kwargs})
     ax.plot(r, np.asarray(result.spreading), color=_C_MUTED, lw=1.0, ls="--",
-            label=f"Spreading ({result.law})")
+            label=f"{_t('spreading', language)} ({result.law})")
     ax.plot(r, np.asarray(result.absorption), color=_C_SECONDARY, lw=1.0, ls=":",
-            label=f"Absorption ({result.absorption_coefficient:.3g} dB/km)")
-    ax.set_xlabel("Range [m]")
-    ax.set_ylabel(_LABEL_TL_DB)
-    ax.set_title(f"Underwater transmission loss ({result.model})")
+            label=f"{_t('absorption', language)} ({decimal_comma(f'{result.absorption_coefficient:.3g}', language)} dB/km)")
+    ax.set_xlabel(_t("range_m", language))
+    ax.set_ylabel(_t("tl_db", language))
+    ax.set_title(f"{_t('underwater_tl_title', language)} ({result.model})")
     if not ax.yaxis_inverted():
         ax.invert_yaxis()
     ax.grid(True, alpha=0.3)
     ax.legend(loc="lower right", fontsize="small")
+    localize_axes(ax, language)
     return ax
 
 def plot_sonar_equation(
-    result: "SonarEquationResult", ax: Axes | None = None, **kwargs: Any
+    result: "SonarEquationResult", ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Signal excess versus transmission loss, with the detection limit (SE = 0).
 
     :param result: A :class:`~phonometry.sonar_equation.SonarEquationResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the signal-excess ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import format_number, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     tl = np.asarray(result.transmission_loss, dtype=np.float64)
     se = np.asarray(result.signal_excess, dtype=np.float64)
     order = np.argsort(tl)
-    label = f"Signal excess ({result.mode})"
+    label = f"{_t('signal_excess', language)} ({result.mode})"
     ax.plot(tl[order], se[order], **{"color": _C_PRIMARY, "lw": 1.6, "label": label, **kwargs})
-    ax.axhline(0.0, color=_C_REFERENCE, ls="--", lw=1.0, label="Detection limit (SE = 0)")
+    ax.axhline(0.0, color=_C_REFERENCE, ls="--", lw=1.0, label=_t("detection_limit", language))
     ax.axvline(result.figure_of_merit, color=_C_MUTED, ls=":", lw=1.0,
-               label=f"Figure of merit = {result.figure_of_merit:.1f} dB")
-    ax.set_xlabel(_LABEL_TL_DB)
-    ax.set_ylabel("Signal excess [dB]")
-    ax.set_title("Sonar equation")
+               label=f"{_t('figure_of_merit', language)} = {format_number(result.figure_of_merit, language)} dB")
+    ax.set_xlabel(_t("tl_db", language))
+    ax.set_ylabel(_t("signal_excess_db", language))
+    ax.set_title(_t("sonar_title", language))
     ax.grid(True, alpha=0.3)
     ax.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
+    localize_axes(ax, language)
     return ax
 
 def plot_bottom_loss(
-    result: "BottomLossResult", ax: Axes | None = None, **kwargs: Any
+    result: "BottomLossResult", ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Bottom reflection loss versus grazing angle, marking the critical angle.
 
     :param result: A :class:`~phonometry.seabed_reflection.BottomLossResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the bottom-loss ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import format_number, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     phi = np.asarray(result.grazing_angle, dtype=np.float64)
     loss = np.asarray(result.reflection_loss, dtype=np.float64)
-    ax.plot(phi, loss, **{"color": _C_PRIMARY, "lw": 1.6, "label": "Bottom loss", **kwargs})
+    ax.plot(phi, loss, **{"color": _C_PRIMARY, "lw": 1.6, "label": _t("bottom_loss", language), **kwargs})
     if result.critical_angle is not None:
         ax.axvline(result.critical_angle, color=_C_REFERENCE, ls="--", lw=1.0,
-                   label=f"Critical angle = {result.critical_angle:.1f}°")
-    ax.set_xlabel("Grazing angle [°]")
-    ax.set_ylabel("Bottom loss [dB]")
-    ax.set_title("Seabed reflection loss")
+                   label=f"{_t('critical_angle', language)} = {format_number(result.critical_angle, language)}°")
+    ax.set_xlabel(_t("grazing_angle", language))
+    ax.set_ylabel(_t("bottom_loss_db", language))
+    ax.set_title(_t("seabed_title", language))
     ax.grid(True, alpha=0.3)
     ax.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
+    localize_axes(ax, language)
     return ax
 
 def plot_ambient_noise(
-    result: "AmbientNoiseResult", ax: Axes | None = None, **kwargs: Any
+    result: "AmbientNoiseResult", ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Composite ambient-noise spectrum and its components versus frequency.
 
     :param result: An :class:`~phonometry.ocean_ambient_noise.AmbientNoiseResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the composite-level ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import format_number, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     f = np.asarray(result.frequency, dtype=np.float64)
-    label = f"Total ({result.wind_speed_knots:.1f} kn)"
+    label = f"{_t('total', language)} ({format_number(result.wind_speed_knots, language)} kn)"
     ax.plot(f, np.asarray(result.spectrum_level),
             **{"color": _C_PRIMARY, "lw": 1.8, "label": label, **kwargs})
-    ax.plot(f, np.asarray(result.wind), color=_C_SECONDARY, lw=1.0, ls="--", label="Wind")
-    ax.plot(f, np.asarray(result.thermal), color=_C_TERTIARY, lw=1.0, ls=":", label="Thermal")
+    ax.plot(f, np.asarray(result.wind), color=_C_SECONDARY, lw=1.0, ls="--", label=_t("wind", language))
+    ax.plot(f, np.asarray(result.thermal), color=_C_TERTIARY, lw=1.0, ls=":", label=_t("thermal", language))
     if result.shipping is not None:
         ax.plot(f, np.asarray(result.shipping), color=_C_REFERENCE, lw=1.0, ls="-.",
-                label="Shipping")
+                label=_t("shipping", language))
     ax.set_xscale("log")
-    ax.set_xlabel("Frequency [Hz]")
-    ax.set_ylabel("Spectrum level [dB re 1 µPa²/Hz]")
-    ax.set_title("Ocean ambient noise")
+    ax.set_xlabel(_t("freq_hz", language))
+    ax.set_ylabel(_t("spectrum_level", language))
+    ax.set_title(_t("ambient_title", language))
     ax.grid(True, which="both", alpha=0.3)
     ax.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
     format_frequency_axis(ax, float(f.min()), float(f.max()))
+    localize_axes(ax, language)
     return ax
 
 def plot_ship_traffic_spectrum(
-    result: "ShipTrafficSpectrum", ax: Axes | None = None, **kwargs: Any
+    result: "ShipTrafficSpectrum", ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Predicted ship source spectral-density level versus frequency.
 
     :param result: A :class:`~phonometry.ship_traffic_noise.ShipTrafficSpectrum`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the source-PSD ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import localize_axes
+
     ax = ax if ax is not None else _new_axes()
     f = np.asarray(result.frequency, dtype=np.float64)
     psd = np.asarray(result.source_psd, dtype=np.float64)
@@ -286,72 +434,87 @@ def plot_ship_traffic_spectrum(
         label = result.model
     ax.plot(f, psd, **{"color": _C_PRIMARY, "lw": 1.6, "label": label, **kwargs})
     ax.set_xscale("log")
-    ax.set_xlabel("Frequency [Hz]")
-    ax.set_ylabel("Source spectral density [dB re 1 µPa²/Hz at 1 m]")
-    ax.set_title("Ship traffic source level")
+    ax.set_xlabel(_t("freq_hz", language))
+    ax.set_ylabel(_t("source_psd_ylabel", language))
+    ax.set_title(_t("traffic_title", language))
     ax.grid(True, which="both", alpha=0.3)
     ax.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
     format_frequency_axis(ax, float(f.min()), float(f.max()))
+    localize_axes(ax, language)
     return ax
 
 def plot_normal_modes(
-    result: "NormalModeResult", ax: Axes | None = None, **kwargs: Any
+    result: "NormalModeResult", ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Normal-mode transmission loss versus range (loss increasing downward).
 
     :param result: A :class:`~phonometry.numerical_propagation.NormalModeResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the transmission-loss ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import format_number, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     r = np.asarray(result.ranges, dtype=np.float64)
     tl = np.asarray(result.transmission_loss, dtype=np.float64)
-    label = f"{result.wavenumbers.size} modes ({result.frequency:.0f} Hz)"
+    label = f"{result.wavenumbers.size} {_t('modes_word', language)} ({format_number(result.frequency, language, decimals=0)} Hz)"
     ax.plot(r / 1000.0, tl, **{"color": _C_PRIMARY, "lw": 1.2, "label": label, **kwargs})
-    ax.set_xlabel(_LABEL_RANGE_KM)
-    ax.set_ylabel(_LABEL_TL_DB)
-    ax.set_title("Normal-mode transmission loss")
+    ax.set_xlabel(_t("range_km", language))
+    ax.set_ylabel(_t("tl_db", language))
+    ax.set_title(_t("modes_title", language))
     if not ax.yaxis_inverted():
         ax.invert_yaxis()
     ax.grid(True, alpha=0.3)
     ax.legend(loc="lower right", fontsize="small")
+    localize_axes(ax, language)
     return ax
 
-def plot_ray_trace(result: "RayTraceResult", ax: Axes | None = None, **kwargs: Any) -> Axes:
+def plot_ray_trace(result: "RayTraceResult", ax: Axes | None = None, *, language: str = "en",
+                   **kwargs: Any) -> Axes:
     """Ray paths through the water column (depth increasing downward).
 
     :param result: A :class:`~phonometry.numerical_propagation.RayTraceResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to each ray ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import localize_axes
+
     ax = ax if ax is not None else _new_axes()
     r = np.asarray(result.ranges, dtype=np.float64)
     z = np.asarray(result.depths, dtype=np.float64)
     for i in range(r.shape[0]):
         ax.plot(r[i] / 1000.0, z[i], **{"color": _C_PRIMARY, "lw": 0.7, "alpha": 0.7, **kwargs})
-    ax.plot([0.0], [result.source_depth], "o", color=_C_REFERENCE, label="Source")
-    ax.set_xlabel(_LABEL_RANGE_KM)
-    ax.set_ylabel(_LABEL_DEPTH_M)
-    ax.set_title("Ray trace")
+    ax.plot([0.0], [result.source_depth], "o", color=_C_REFERENCE, label=_t("source", language))
+    ax.set_xlabel(_t("range_km", language))
+    ax.set_ylabel(_t("depth_m", language))
+    ax.set_title(_t("raytrace_title", language))
     if not ax.yaxis_inverted():
         ax.invert_yaxis()
     ax.grid(True, alpha=0.3)
     ax.legend(loc="lower right", fontsize="small")
+    localize_axes(ax, language)
     return ax
 
 def plot_parabolic_equation(
-    result: "ParabolicEquationResult", ax: Axes | None = None, **kwargs: Any
+    result: "ParabolicEquationResult", ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Parabolic-equation transmission-loss field (range x depth).
 
     :param result: A
         :class:`~phonometry.numerical_propagation.ParabolicEquationResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to ``imshow``.
     :return: The axes.
     """
+    from .._i18n import localize_axes
+
     ax = ax if ax is not None else _new_axes()
     r = np.asarray(result.ranges, dtype=np.float64) / 1000.0
     z = np.asarray(result.depths, dtype=np.float64)
@@ -376,8 +539,9 @@ def plot_parabolic_equation(
             **kwargs,
         },
     )
-    ax.figure.colorbar(img, ax=ax, label=_LABEL_TL_DB)
-    ax.set_xlabel(_LABEL_RANGE_KM)
-    ax.set_ylabel(_LABEL_DEPTH_M)
-    ax.set_title("Parabolic-equation transmission loss")
+    ax.figure.colorbar(img, ax=ax, label=_t("tl_db", language))
+    ax.set_xlabel(_t("range_km", language))
+    ax.set_ylabel(_t("depth_m", language))
+    ax.set_title(_t("pe_title", language))
+    localize_axes(ax, language)
     return ax

--- a/src/phonometry/aircraft/aircraft_noise.py
+++ b/src/phonometry/aircraft/aircraft_noise.py
@@ -386,11 +386,12 @@ class EPNLResult:
     epnl: float
     band_limits: "tuple[int, int]"
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the PNL and PNLT time histories with PNLTM and the 10 dB-down band."""
+        from .._i18n import check_language
         from .._plot.aircraft import plot_epnl
 
-        return plot_epnl(self, ax=ax, **kwargs)
+        return plot_epnl(self, ax=ax, language=check_language(language), **kwargs)
 
     def report(
         self,

--- a/src/phonometry/aircraft/airport_noise.py
+++ b/src/phonometry/aircraft/airport_noise.py
@@ -276,11 +276,12 @@ class NpdLevelResult:
     table_distances: "NDArray[np.float64]"
     table_levels: "NDArray[np.float64]"
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the interpolated level versus slant distance (log axis)."""
+        from .._i18n import check_language
         from .._plot.aircraft import plot_npd_level
 
-        return plot_npd_level(self, ax=ax, **kwargs)
+        return plot_npd_level(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def npd_level(
@@ -463,11 +464,12 @@ class FlyoverResult:
     segment_levels: "NDArray[np.float64]"
     observer: "NDArray[np.float64]"
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the per-segment contributions to the event level."""
+        from .._i18n import check_language
         from .._plot.aircraft import plot_flyover
 
-        return plot_flyover(self, ax=ax, **kwargs)
+        return plot_flyover(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def _validate_path(path: "NDArray[np.float64] | list[list[float]]") -> "NDArray[np.float64]":
@@ -986,11 +988,12 @@ class NoiseContourResult:
     level: "NDArray[np.float64]"
     metric: str
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot filled noise contours over the ground plane."""
+        from .._i18n import check_language
         from .._plot.aircraft import plot_noise_contour
 
-        return plot_noise_contour(self, ax=ax, **kwargs)
+        return plot_noise_contour(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def noise_contour(

--- a/src/phonometry/aircraft/atmospheric_absorption.py
+++ b/src/phonometry/aircraft/atmospheric_absorption.py
@@ -82,11 +82,12 @@ class AircraftBandAttenuation:
     relative_humidity: float
     pressure: float
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the band and pure-tone mid-band attenuation versus frequency."""
+        from .._i18n import check_language
         from .._plot.aircraft import plot_aircraft_band_attenuation
 
-        return plot_aircraft_band_attenuation(self, ax=ax, **kwargs)
+        return plot_aircraft_band_attenuation(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def sae_band_attenuation(

--- a/src/phonometry/aircraft/rotorcraft_noise.py
+++ b/src/phonometry/aircraft/rotorcraft_noise.py
@@ -308,11 +308,12 @@ class RotorcraftHemisphere:
     levels: "NDArray[np.float64]"
     distance: float = _RH
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the hemisphere directivity for one band (polar section)."""
+        from .._i18n import check_language
         from .._plot.aircraft import plot_rotorcraft_hemisphere
 
-        return plot_rotorcraft_hemisphere(self, ax=ax, **kwargs)
+        return plot_rotorcraft_hemisphere(self, ax=ax, language=check_language(language), **kwargs)
 
     def mirrored(self) -> "RotorcraftHemisphere":
         """The hemisphere with the azimuth axis reversed (``φ → −φ``).
@@ -504,11 +505,12 @@ class MeanGroundPlaneResult:
         return float((height - self.slope * distance - self.intercept)
                      / math.hypot(1.0, self.slope))
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the terrain section and the fitted mean ground plane."""
+        from .._i18n import check_language
         from .._plot.aircraft import plot_mean_ground_plane
 
-        return plot_mean_ground_plane(self, ax=ax, **kwargs)
+        return plot_mean_ground_plane(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def mean_ground_plane(
@@ -676,11 +678,12 @@ class TerrainScreeningResult:
     distances: "NDArray[np.float64]"
     heights: "NDArray[np.float64]"
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the section geometry: terrain, line of sight and sound path."""
+        from .._i18n import check_language
         from .._plot.aircraft import plot_terrain_screening
 
-        return plot_terrain_screening(self, ax=ax, **kwargs)
+        return plot_terrain_screening(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def terrain_screening_adjustment(
@@ -1156,11 +1159,12 @@ class FlightPathKinematics:
     bank_angle: "NDArray[np.float64]"
     path_angle: "NDArray[np.float64]"
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the speed and angle profiles along the track."""
+        from .._i18n import check_language
         from .._plot.aircraft import plot_flight_path_kinematics
 
-        return plot_flight_path_kinematics(self, ax=ax, **kwargs)
+        return plot_flight_path_kinematics(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def flight_path_kinematics(
@@ -1317,11 +1321,12 @@ class RotorcraftEventResult:
     pnltm: float
     epnl: float
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the A-weighted level time history with its event metrics."""
+        from .._i18n import check_language
         from .._plot.aircraft import plot_rotorcraft_event
 
-        return plot_rotorcraft_event(self, ax=ax, **kwargs)
+        return plot_rotorcraft_event(self, ax=ax, language=check_language(language), **kwargs)
 
 
 @dataclass(frozen=True)
@@ -1339,11 +1344,12 @@ class RotorcraftNoiseContourResult:
     level: "NDArray[np.float64]"
     metric: str
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot filled noise contours over the ground plane."""
+        from .._i18n import check_language
         from .._plot.aircraft import plot_rotorcraft_noise_contour
 
-        return plot_rotorcraft_noise_contour(self, ax=ax, **kwargs)
+        return plot_rotorcraft_noise_contour(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def _per_point(

--- a/src/phonometry/environmental/atmospheric_refraction.py
+++ b/src/phonometry/environmental/atmospheric_refraction.py
@@ -89,11 +89,12 @@ class EffectiveSoundSpeedProfile:
         return np.asarray(np.interp(z, self.heights, self.sound_speeds),
                           dtype=np.float64)
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the effective sound-speed profile (height on the vertical axis)."""
+        from .._i18n import check_language
         from .._plot.environmental import plot_sound_speed_profile
 
-        return plot_sound_speed_profile(self, ax=ax, **kwargs)
+        return plot_sound_speed_profile(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def linear_sound_speed_profile(
@@ -303,11 +304,12 @@ class AtmosphericRayResult:
     ground_reflections: "NDArray[np.int_]"
     source_height: float
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the curved ray paths (height on the vertical axis)."""
+        from .._i18n import check_language
         from .._plot.environmental import plot_atmospheric_rays
 
-        return plot_atmospheric_rays(self, ax=ax, **kwargs)
+        return plot_atmospheric_rays(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def atmospheric_ray_paths(
@@ -451,11 +453,12 @@ class AtmosphericPEResult:
         i = int(np.argmin(np.abs(self.heights - float(height))))
         return np.asarray(self.relative_level[i], dtype=np.float64)
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the relative-level field over the range-height plane."""
+        from .._i18n import check_language
         from .._plot.environmental import plot_atmospheric_pe
 
-        return plot_atmospheric_pe(self, ax=ax, **kwargs)
+        return plot_atmospheric_pe(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def _resolve_pe_impedance(

--- a/src/phonometry/environmental/ground_barriers.py
+++ b/src/phonometry/environmental/ground_barriers.py
@@ -203,15 +203,16 @@ class SphericalGroundResult:
     r_direct: float
     r_reflected: float
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the excess attenuation ``dL`` versus frequency.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.environmental import plot_spherical_ground
 
-        return plot_spherical_ground(self, ax=ax, **kwargs)
+        return plot_spherical_ground(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def spherical_reflection_coefficient(
@@ -509,15 +510,16 @@ class BarrierInsertionLoss:
     method: str
     ground: bool
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the insertion loss versus frequency.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.environmental import plot_barrier_insertion_loss
 
-        return plot_barrier_insertion_loss(self, ax=ax, **kwargs)
+        return plot_barrier_insertion_loss(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def _validate_barrier_geometry(

--- a/src/phonometry/environmental/impulse_prominence.py
+++ b/src/phonometry/environmental/impulse_prominence.py
@@ -82,15 +82,16 @@ class ImpulseProminenceResult:
     prominence: float
     adjustment: float
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the adjustment curve ``KI(P)`` with the impulses marked.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.environmental import plot_impulse_prominence
 
-        return plot_impulse_prominence(self, ax=ax, **kwargs)
+        return plot_impulse_prominence(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def predicted_prominence(

--- a/src/phonometry/environmental/measurement.py
+++ b/src/phonometry/environmental/measurement.py
@@ -179,11 +179,12 @@ class TonalAssessmentResult:
     audibility: float
     adjustment: float
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the ``Kt(ΔLta)`` adjustment curve with this tone marked."""
+        from .._i18n import check_language
         from .._plot.environmental import plot_tonal_adjustment
 
-        return plot_tonal_adjustment(self, ax=ax, **kwargs)
+        return plot_tonal_adjustment(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def assess_tonal_audibility(

--- a/src/phonometry/environmental/outdoor_propagation.py
+++ b/src/phonometry/environmental/outdoor_propagation.py
@@ -152,15 +152,16 @@ class OutdoorAttenuation:
     a_total: NDArray[np.float64]
     d_omega: NDArray[np.float64]
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the stacked per-band attenuation terms with the total.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.environmental import plot_outdoor_attenuation
 
-        return plot_outdoor_attenuation(self, ax=ax, **kwargs)
+        return plot_outdoor_attenuation(self, ax=ax, language=check_language(language), **kwargs)
 
 
 # --------------------------------------------------------------------------- #

--- a/src/phonometry/environmental/wind_turbine_noise.py
+++ b/src/phonometry/environmental/wind_turbine_noise.py
@@ -204,11 +204,12 @@ class WindTurbineTonalityResult:
     frequencies: "NDArray[np.float64]"
     levels: "NDArray[np.float64]"
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the narrowband spectrum with the critical band and masking level."""
+        from .._i18n import check_language
         from .._plot.environmental import plot_wind_turbine_tonality
 
-        return plot_wind_turbine_tonality(self, ax=ax, **kwargs)
+        return plot_wind_turbine_tonality(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def _validate_narrowband(

--- a/src/phonometry/underwater/numerical_propagation.py
+++ b/src/phonometry/underwater/numerical_propagation.py
@@ -94,11 +94,12 @@ class NormalModeResult:
     receiver_depth: float
     source_depth: float
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the transmission loss versus range (loss increasing downward)."""
+        from .._i18n import check_language
         from .._plot.underwater import plot_normal_modes
 
-        return plot_normal_modes(self, ax=ax, **kwargs)
+        return plot_normal_modes(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def _propagating_band(
@@ -301,11 +302,12 @@ class RayTraceResult:
     source_depth: float
     water_depth: float
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the ray paths (depth increasing downward)."""
+        from .._i18n import check_language
         from .._plot.underwater import plot_ray_trace
 
-        return plot_ray_trace(self, ax=ax, **kwargs)
+        return plot_ray_trace(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def ray_trace(
@@ -425,11 +427,12 @@ class ParabolicEquationResult:
     transmission_loss: "NDArray[np.float64]"
     source_depth: float
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the transmission-loss field (depth increasing downward)."""
+        from .._i18n import check_language
         from .._plot.underwater import plot_parabolic_equation
 
-        return plot_parabolic_equation(self, ax=ax, **kwargs)
+        return plot_parabolic_equation(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def parabolic_equation(

--- a/src/phonometry/underwater/ocean_ambient_noise.py
+++ b/src/phonometry/underwater/ocean_ambient_noise.py
@@ -128,11 +128,12 @@ class AmbientNoiseResult:
     shipping: "NDArray[np.float64] | None"
     wind_speed_knots: float
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the composite spectrum and its components versus frequency."""
+        from .._i18n import check_language
         from .._plot.underwater import plot_ambient_noise
 
-        return plot_ambient_noise(self, ax=ax, **kwargs)
+        return plot_ambient_noise(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def ocean_ambient_noise(

--- a/src/phonometry/underwater/pile_driving_noise.py
+++ b/src/phonometry/underwater/pile_driving_noise.py
@@ -121,11 +121,12 @@ class PileStrikeResult:
     pressure: "NDArray[np.float64]"
     fs: float
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes | NDArray[Any]":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes | NDArray[Any]":
         """Plot the strike waveform and its cumulative energy."""
+        from .._i18n import check_language
         from .._plot.underwater import plot_pile_strike
 
-        return plot_pile_strike(self, ax=ax, **kwargs)
+        return plot_pile_strike(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def pile_strike_metrics(

--- a/src/phonometry/underwater/propagation.py
+++ b/src/phonometry/underwater/propagation.py
@@ -196,11 +196,12 @@ class TransmissionLossResult:
     law: str
     model: str
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the transmission loss versus range with its two contributions."""
+        from .._i18n import check_language
         from .._plot.underwater import plot_transmission_loss
 
-        return plot_transmission_loss(self, ax=ax, **kwargs)
+        return plot_transmission_loss(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def transmission_loss(

--- a/src/phonometry/underwater/seabed_reflection.py
+++ b/src/phonometry/underwater/seabed_reflection.py
@@ -113,11 +113,12 @@ class BottomLossResult:
     reflection_coefficient: "NDArray[np.complex128]"
     critical_angle: "float | None"
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the bottom loss versus grazing angle with the critical angle."""
+        from .._i18n import check_language
         from .._plot.underwater import plot_bottom_loss
 
-        return plot_bottom_loss(self, ax=ax, **kwargs)
+        return plot_bottom_loss(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def bottom_reflection_loss(

--- a/src/phonometry/underwater/ship_radiated_noise.py
+++ b/src/phonometry/underwater/ship_radiated_noise.py
@@ -148,11 +148,12 @@ class ShipSourceLevelResult:
     source_depth: float
     sound_speed: float
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot RNL, source level and the ΔL surface correction vs frequency."""
+        from .._i18n import check_language
         from .._plot.underwater import plot_ship_source_level
 
-        return plot_ship_source_level(self, ax=ax, **kwargs)
+        return plot_ship_source_level(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def monopole_source_level(

--- a/src/phonometry/underwater/ship_traffic_noise.py
+++ b/src/phonometry/underwater/ship_traffic_noise.py
@@ -152,11 +152,12 @@ class ShipTrafficSpectrum:
     speed_knots: "float | None"
     length_m: "float | None"
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the predicted source spectral-density level versus frequency."""
+        from .._i18n import check_language
         from .._plot.underwater import plot_ship_traffic_spectrum
 
-        return plot_ship_traffic_spectrum(self, ax=ax, **kwargs)
+        return plot_ship_traffic_spectrum(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def ship_source_spectrum(

--- a/src/phonometry/underwater/sonar_equation.py
+++ b/src/phonometry/underwater/sonar_equation.py
@@ -78,11 +78,12 @@ class SonarEquationResult:
     target_strength: "float | None"
     reverberation_limited: bool
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot signal excess versus transmission loss with the detection limit."""
+        from .._i18n import check_language
         from .._plot.underwater import plot_sonar_equation
 
-        return plot_sonar_equation(self, ax=ax, **kwargs)
+        return plot_sonar_equation(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def passive_sonar_equation(

--- a/src/phonometry/underwater/sound_speed.py
+++ b/src/phonometry/underwater/sound_speed.py
@@ -241,11 +241,12 @@ class SoundSpeedProfile:
     gradient: "NDArray[np.float64]"
     model: str
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the sound-speed profile (speed vs depth, depth increasing down)."""
+        from .._i18n import check_language
         from .._plot.underwater import plot_sound_speed_profile
 
-        return plot_sound_speed_profile(self, ax=ax, **kwargs)
+        return plot_sound_speed_profile(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def sound_speed_profile(

--- a/tests/aircraft/test_aircraft_plot_i18n.py
+++ b/tests/aircraft/test_aircraft_plot_i18n.py
@@ -1,0 +1,40 @@
+#  Copyright (c) 2026. Jose M. Requena-Plens
+"""EN/ES language option for the aircraft ``.plot()`` renderers."""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+from phonometry.aircraft.atmospheric_absorption import sae_band_attenuation
+
+
+def _result() -> object:
+    f = np.array([100.0, 1000.0, 4000.0, 8000.0])
+    return sae_band_attenuation(f, 2000.0, temperature=25.0, relative_humidity=70.0)
+
+
+def test_plot_default_is_english() -> None:
+    ax = _result().plot()
+    assert ax.get_xlabel() == "Frequency [Hz]"
+    assert ax.get_ylabel() == "Attenuation [dB]"
+    assert ax.get_title() == "Aircraft atmospheric absorption (SAE ARP 5534)"
+    plt.close("all")
+
+
+def test_plot_spanish_labels() -> None:
+    ax = _result().plot(language="es")
+    assert ax.get_ylabel() == "Atenuación [dB]"
+    assert ax.get_title() == "Absorción atmosférica de aeronaves (SAE ARP 5534)"
+    plt.close("all")
+
+
+def test_plot_unknown_language_raises() -> None:
+    result = _result()
+    with pytest.raises(ValueError, match="Unknown language"):
+        result.plot(language="xx")
+    plt.close("all")

--- a/tests/environmental/test_environmental_plot_i18n.py
+++ b/tests/environmental/test_environmental_plot_i18n.py
@@ -1,0 +1,42 @@
+#  Copyright (c) 2026. Jose M. Requena-Plens
+"""EN/ES language option for the environmental ``.plot()`` renderers."""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+from phonometry.environmental.wind_turbine_noise import wind_turbine_tonality
+
+
+def _result() -> object:
+    df = 2.0
+    freqs = np.arange(440.0, 560.0 + df, df)
+    levels = np.full(freqs.size, 30.0)
+    levels[int(np.argmin(np.abs(freqs - 500.0)))] = 60.0
+    return wind_turbine_tonality(levels, freqs)
+
+
+def test_plot_default_is_english() -> None:
+    ax = _result().plot()
+    assert ax.get_xlabel() == "Frequency [Hz]"
+    assert ax.get_ylabel() == "Level [dB]"
+    plt.close("all")
+
+
+def test_plot_spanish_labels() -> None:
+    ax = _result().plot(language="es")
+    assert ax.get_xlabel() == "Frecuencia [Hz]"
+    assert ax.get_ylabel() == "Nivel [dB]"
+    plt.close("all")
+
+
+def test_plot_unknown_language_raises() -> None:
+    result = _result()
+    with pytest.raises(ValueError, match="Unknown language"):
+        result.plot(language="xx")
+    plt.close("all")

--- a/tests/underwater/test_underwater_plot_i18n.py
+++ b/tests/underwater/test_underwater_plot_i18n.py
@@ -1,0 +1,54 @@
+#  Copyright (c) 2026. Jose M. Requena-Plens
+"""EN/ES language option for the underwater ``.plot()`` renderers."""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import pytest
+
+from phonometry.underwater.ocean_ambient_noise import ocean_ambient_noise
+from phonometry.underwater.sonar_equation import passive_sonar_equation
+
+
+def _result() -> object:
+    return passive_sonar_equation(140.0, 80.0, 60.0, directivity_index=10.0,
+                                  detection_threshold=5.0)
+
+
+def test_plot_default_is_english() -> None:
+    ax = _result().plot()
+    assert ax.get_title() == "Sonar equation"
+    assert ax.get_xlabel() == "Transmission loss [dB]"
+    assert ax.get_ylabel() == "Signal excess [dB]"
+    plt.close("all")
+
+
+def test_plot_spanish_labels() -> None:
+    ax = _result().plot(language="es")
+    assert ax.get_title() == "Ecuación del sonar"
+    assert ax.get_ylabel() == "Exceso de señal [dB]"
+    plt.close("all")
+
+
+def test_plot_unknown_language_raises() -> None:
+    result = _result()
+    with pytest.raises(ValueError, match="Unknown language"):
+        result.plot(language="xx")
+    plt.close("all")
+
+
+def test_ambient_noise_legend_localized() -> None:
+    # A legend-heavy renderer: the composite curve plus its wind/thermal
+    # components. Guards that every legend entry is localized (the composite
+    # "Total"/"wind"/"thermal" labels), not only the axis titles.
+    result = ocean_ambient_noise([100.0, 1000.0, 10000.0], wind_speed_knots=15.0)
+    ax = result.plot(language="es")
+    labels = [t.get_text() for t in ax.get_legend().get_texts()]
+    assert any(text.startswith("Total") for text in labels)
+    assert "Viento" in labels
+    assert "Térmico" in labels
+    assert not any("Wind" in text or "Thermal" in text for text in labels)
+    plt.close("all")


### PR DESCRIPTION
## Summary

Every `.plot()` on the aircraft, underwater and environmental result objects now takes a `language` keyword. `"en"` stays the default and renders exactly as before; `"es"` renders localised axis labels, titles and legends and switches the decimal separator to a comma.

## What changed

- New private `phonometry._i18n` module with the shared helpers `check_language`, `format_number`, `decimal_comma` and `localize_axes`.
- The three `_plot` renderer modules (`aircraft.py`, `underwater.py`, `environmental.py`) gain a per-module `_STRINGS` translation table and a small `_t` lookup. Every fixed label, title, legend entry and annotation is now localised, keeping unit symbols and standard acronyms intact.
- The 31 delegating `.plot()` methods accept `*, language="en"`, validate it via `check_language` and forward it to the renderer.
- The `_i18n` import is done inside the functions so the plot modules keep no module-level cross-imports.
- Per-domain tests assert that `.plot(language="es")` yields Spanish labels and that an unknown language raises `ValueError`.

## English is unchanged

English strings are byte-for-byte identical to before. The two committed figures that actually exercise these renderers (`airport_contour`, `rotorcraft_terrain_screening`) were regenerated with zero diff to the committed SV/PNG assets.

## Checks

- `ruff check .`, `mypy src scripts` and the scoped test suite (`tests/aircraft tests/underwater tests/environmental tests/test_package_architecture.py`) all pass.
- API reference and `llms.txt` regeneration produced no drift.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plot methods across aircraft, underwater, and environmental results now support English and Spanish localization.
  * Spanish plots include translated labels, titles, legends, annotations, and comma-based decimal formatting; English remains the default.
  * Unsupported language values are rejected with a clear error.

* **Documentation**
  * Updated API references and changelog entries to describe the new language option.

* **Tests**
  * Added coverage for English defaults, Spanish localization, localized legends, and invalid language handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->