### PR TITLE
feat: EN/ES language option for the building/noise-control/emission plots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Every `.report()` fiche accepts a `language` argument (`'en'` default, `'es'`):
   Spanish strings and a comma decimal separator.
+- The `.plot()` renderers of the building, noise-control and emission result
+  objects accept a `language` keyword (`"en"` by default, or `"es"`). Spanish
+  renders the axis labels, titles and legends with building-acoustics
+  terminology and a comma decimal separator, while English stays exactly as
+  before. A shared `phonometry._i18n` helper module backs the locale-aware
+  number formatting and tick localisation.
 - IEC 61260-1 filter class compliance can now be exported as a one-page PDF
   fiche. A new `filter_class_compliance(bank, *, num_points=..., edition=...)`
   runs the same verification as `verify_filter_class` and returns a frozen

--- a/site/src/content/docs/reference/api/building/aperture-transmission.md
+++ b/site/src/content/docs/reference/api/building/aperture-transmission.md
@@ -78,6 +78,8 @@ Transmission through a slit or circular aperture (Hopkins 4.3.10).
 ```python
 ApertureTransmissionResult.plot(
     ax: Axes | None = None,
+    *,
+    language: str = 'en',
     **kwargs: Any,
 ) -> Axes
 ```

--- a/site/src/content/docs/reference/api/building/building-prediction.md
+++ b/site/src/content/docs/reference/api/building/building-prediction.md
@@ -78,7 +78,12 @@ Predicted apparent airborne insulation (EN 12354-1:2000, Formula 26).
 ### AirbornePredictionResult.plot()
 
 ```python
-AirbornePredictionResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+AirbornePredictionResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the per-path shares of the transmitted energy.
@@ -323,7 +328,12 @@ Predicted apparent impact insulation (EN 12354-2:2000, Formula 21).
 ### ImpactPredictionResult.plot()
 
 ```python
-ImpactPredictionResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+ImpactPredictionResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the Formula 21 terms and the resulting `L'n,w`.

--- a/site/src/content/docs/reference/api/building/building-uncertainty.md
+++ b/site/src/content/docs/reference/api/building/building-uncertainty.md
@@ -105,7 +105,12 @@ One-third-octave-band standard uncertainties (ISO 12999-1 Tables 2/4/6/D.1).
 ### BandUncertainty.plot()
 
 ```python
-BandUncertainty.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+BandUncertainty.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the per-band standard uncertainty spectrum.

--- a/site/src/content/docs/reference/api/building/facade-prediction.md
+++ b/site/src/content/docs/reference/api/building/facade-prediction.md
@@ -209,7 +209,12 @@ Predicted façade airborne insulation (EN 12354-3:2000).
 ### FacadePredictionResult.plot()
 
 ```python
-FacadePredictionResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+FacadePredictionResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the per-element partial indices and the façade `R'` / `D2m,nT`.
@@ -326,7 +331,12 @@ Predicted sound power radiated to the outside by a segment (EN 12354-4).
 ### RadiatedPowerResult.plot()
 
 ```python
-RadiatedPowerResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+RadiatedPowerResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the radiated sound power level `LW` per band.

--- a/site/src/content/docs/reference/api/building/flanking-transmission.md
+++ b/site/src/content/docs/reference/api/building/flanking-transmission.md
@@ -222,6 +222,8 @@ Normalized flanking impact level `Ln,f` (Formula (5)).
 ```python
 FlankingImpactLevelResult.plot(
     ax: Axes | None = None,
+    *,
+    language: str = 'en',
     **kwargs: Any,
 ) -> Axes
 ```
@@ -251,6 +253,8 @@ Normalized flanking level difference `Dn,f` (airborne, Formula (4)).
 ```python
 FlankingLevelDifferenceResult.plot(
     ax: Axes | None = None,
+    *,
+    language: str = 'en',
     **kwargs: Any,
 ) -> Axes
 ```
@@ -630,7 +634,12 @@ An octave band is bracketed when any of its one-third-octave bands is.
 ### VibrationReductionResult.plot()
 
 ```python
-VibrationReductionResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+VibrationReductionResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot `Kij` against frequency.

--- a/site/src/content/docs/reference/api/building/floor-covering-improvement.md
+++ b/site/src/content/docs/reference/api/building/floor-covering-improvement.md
@@ -140,6 +140,8 @@ Return `(octave_freqs, ΔLoct)` via Formula (5) (needs 16 1/3-oct bands).
 ```python
 FloorCoveringImprovementResult.plot(
     ax: Axes | None = None,
+    *,
+    language: str = 'en',
     **kwargs: Any,
 ) -> Axes
 ```

--- a/site/src/content/docs/reference/api/building/installed-structure-borne.md
+++ b/site/src/content/docs/reference/api/building/installed-structure-borne.md
@@ -257,7 +257,12 @@ Band-summed total level `10 lg(sum 10^(0.1 L_n,s))`, in dB.
 ### InstalledSourceResult.plot()
 
 ```python
-InstalledSourceResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+InstalledSourceResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the per-path and total normalised sound pressure levels.

--- a/site/src/content/docs/reference/api/building/insulation.md
+++ b/site/src/content/docs/reference/api/building/insulation.md
@@ -170,7 +170,12 @@ Per-band field airborne sound insulation (ISO 16283-1:2014).
 ### AirborneInsulationResult.plot()
 
 ```python
-AirborneInsulationResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+AirborneInsulationResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the per-band insulation quantities (`DnT`, `D`, `R'`).
@@ -362,7 +367,12 @@ Per-band field façade sound insulation (ISO 16283-3).
 ### FacadeInsulationResult.plot()
 
 ```python
-FacadeInsulationResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+FacadeInsulationResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the per-band façade insulation profile (ISO 16283-3).
@@ -465,7 +475,12 @@ Per-band field impact sound insulation (ISO 16283-2).
 ### ImpactInsulationResult.plot()
 
 ```python
-ImpactInsulationResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+ImpactInsulationResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the per-band impact levels (`L'nT` and, if present, `L'n`).
@@ -504,7 +519,12 @@ Single-number weighted impact rating and CI (ISO 717-2).
 ### ImpactRatingResult.plot()
 
 ```python
-ImpactRatingResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+ImpactRatingResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the measured curve vs the shifted reference (ISO 717-2).
@@ -862,7 +882,12 @@ Single-number weighted rating and adaptation terms (ISO 717-1).
 ### WeightedRatingResult.plot()
 
 ```python
-WeightedRatingResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+WeightedRatingResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the measured curve vs the shifted reference (ISO 717-1).

--- a/site/src/content/docs/reference/api/building/panel-transmission.md
+++ b/site/src/content/docs/reference/api/building/panel-transmission.md
@@ -284,7 +284,12 @@ Predicted airborne sound reduction index `R(f)` of a construction.
 ### SoundReductionResult.plot()
 
 ```python
-SoundReductionResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+SoundReductionResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the predicted sound reduction index `R(f)`.

--- a/site/src/content/docs/reference/api/building/structure-borne-power.md
+++ b/site/src/content/docs/reference/api/building/structure-borne-power.md
@@ -389,6 +389,8 @@ plate-independent source quantities with
 ```python
 StructureBornePowerResult.plot(
     ax: Axes | None = None,
+    *,
+    language: str = 'en',
     **kwargs: Any,
 ) -> Axes
 ```

--- a/site/src/content/docs/reference/api/noise_control/enclosures.md
+++ b/site/src/content/docs/reference/api/noise_control/enclosures.md
@@ -99,7 +99,12 @@ Insertion loss of a machine enclosure over frequency (Bies §7.4.2).
 ### EnclosureResult.plot()
 
 ```python
-EnclosureResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+EnclosureResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the panel `R`, correction `C` and net insertion loss.

--- a/site/src/content/docs/reference/api/noise_control/hvac.md
+++ b/site/src/content/docs/reference/api/noise_control/hvac.md
@@ -179,7 +179,12 @@ A per-frequency HVAC quantity (attenuation or regenerated power level).
 ### HvacSpectrumResult.plot()
 
 ```python
-HvacSpectrumResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+HvacSpectrumResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the quantity against a continuous log-frequency axis.

--- a/site/src/content/docs/reference/api/noise_control/silencers.md
+++ b/site/src/content/docs/reference/api/noise_control/silencers.md
@@ -235,7 +235,12 @@ Transmission and insertion loss of a reactive silencer over frequency.
 ### ReactiveSilencerResult.plot()
 
 ```python
-ReactiveSilencerResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+ReactiveSilencerResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the transmission (and insertion) loss against frequency.

--- a/site/src/content/docs/reference/api/power/intensity.md
+++ b/site/src/content/docs/reference/api/power/intensity.md
@@ -164,7 +164,12 @@ is the usable-bandwidth bound `0,1*c/spacing` (bias \< ~0,3 dB).
 ### IntensityResult.plot()
 
 ```python
-IntensityResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+IntensityResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot Lp vs LI per band with the pressure-intensity index.

--- a/site/src/content/docs/reference/api/power/sound-power-intensity.md
+++ b/site/src/content/docs/reference/api/power/sound-power-intensity.md
@@ -152,6 +152,8 @@ and more than one band).
 ```python
 SoundPowerIntensityResult.plot(
     ax: Axes | None = None,
+    *,
+    language: str = 'en',
     **kwargs: Any,
 ) -> Axes
 ```

--- a/site/src/content/docs/reference/api/power/sound-power-reverberation.md
+++ b/site/src/content/docs/reference/api/power/sound-power-reverberation.md
@@ -88,6 +88,8 @@ or `'comparison'`.
 ```python
 ReverberationSoundPowerResult.plot(
     ax: Axes | None = None,
+    *,
+    language: str = 'en',
     **kwargs: Any,
 ) -> Axes
 ```

--- a/site/src/content/docs/reference/api/power/sound-power.md
+++ b/site/src/content/docs/reference/api/power/sound-power.md
@@ -443,7 +443,12 @@ applicable bands (`NaN` without `frequencies` and more than one band).
 ### PrecisionIntensityResult.plot()
 
 ```python
-PrecisionIntensityResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+PrecisionIntensityResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the `LW` spectrum; non-applicable bands are hatched/greyed.
@@ -495,6 +500,8 @@ the A-weighted total `LWA` (Eq. C.1).
 ```python
 PrecisionSoundPowerResult.plot(
     ax: Axes | None = None,
+    *,
+    language: str = 'en',
     **kwargs: Any,
 ) -> Axes
 ```
@@ -701,7 +708,12 @@ uncertainty
 ### SoundPowerResult.plot()
 
 ```python
-SoundPowerResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+SoundPowerResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the LW spectrum with the A-weighted total annotated.

--- a/site/src/content/docs/reference/api/power/vibration-sound-power.md
+++ b/site/src/content/docs/reference/api/power/vibration-sound-power.md
@@ -297,6 +297,8 @@ Sound power radiated by surface vibration (ISO/TS 7849).
 ```python
 VibrationSoundPowerResult.plot(
     ax: Axes | None = None,
+    *,
+    language: str = 'en',
     **kwargs: Any,
 ) -> Axes
 ```

--- a/src/phonometry/_i18n.py
+++ b/src/phonometry/_i18n.py
@@ -77,18 +77,28 @@ def localize_axes(ax: Any, language: str = "en") -> None:
     """
     if language != "es":
         return
-    from matplotlib.ticker import FuncFormatter, NullFormatter
+    from matplotlib.ticker import ScalarFormatter
 
-    def _comma(x: float, _pos: int) -> str:
-        # Match matplotlib's default compact formatting, then swap the point.
-        text = f"{x:g}"
-        return text.replace(".", ",")
+    class _CommaScalarFormatter(ScalarFormatter):
+        """Matplotlib's default numeric formatter with a comma separator.
+
+        Installed as the axis formatter (not wrapped around a detached one, which
+        renders blank labels), so matplotlib keeps its tick locations in sync and
+        the decimal precision stays consistent, e.g. ``1,0`` and ``1,5`` rather
+        than the ``1`` and ``1,5`` a bare ``{x:g}`` would produce.
+        """
+
+        def __call__(self, x: float, pos: Any = None) -> str:
+            return super().__call__(x, pos).replace(".", ",")
 
     for axis in (ax.xaxis, ax.yaxis):
-        # Leave axes whose labels are not plain numbers (log/symlog with the
-        # default LogFormatter, or fixed category labels) untouched.
+        # Only reformat axes still using matplotlib's default auto numeric
+        # formatter. Skip logarithmic / symlog axes (a LogFormatter) and category
+        # axes whose text labels were installed by ``set_xticklabels`` (a
+        # FuncFormatter that maps tick positions to fixed strings), which the
+        # comma formatter would otherwise overwrite with bare positions.
         if axis.get_scale() != "linear":
             continue
-        if isinstance(axis.get_major_formatter(), NullFormatter):
+        if not isinstance(axis.get_major_formatter(), ScalarFormatter):
             continue
-        axis.set_major_formatter(FuncFormatter(_comma))
+        axis.set_major_formatter(_CommaScalarFormatter())

--- a/src/phonometry/_plot/building.py
+++ b/src/phonometry/_plot/building.py
@@ -48,94 +48,254 @@ if TYPE_CHECKING:
 #: Shared x-axis label for the frequency-domain building plots.
 _FREQ_LABEL = "Frequency [Hz]"
 
+#: English -> {language: string} lookup for the fixed labels/titles/legends of
+#: the building-domain renderers. English ids map to themselves so ``_t(key,
+#: "en")`` returns the verbatim original string.
+_STRINGS: dict[str, dict[str, str]] = {
+    "Frequency [Hz]": {"en": "Frequency [Hz]", "es": "Frecuencia [Hz]"},
+    "Band": {"en": "Band", "es": "Banda"},
+    "Band index": {"en": "Band index", "es": "Índice de banda"},
+    "predicted $R$": {"en": "predicted $R$", "es": "$R$ previsto"},
+    "Sound reduction index $R$ [dB]": {
+        "en": "Sound reduction index $R$ [dB]",
+        "es": "Índice de reducción acústica $R$ [dB]",
+    },
+    "Predicted sound insulation": {
+        "en": "Predicted sound insulation",
+        "es": "Aislamiento acústico previsto",
+    },
+    "aperture $R$": {"en": "aperture $R$", "es": "$R$ de abertura"},
+    "Aperture sound transmission (Gomperts / Wilson-Soroka)": {
+        "en": "Aperture sound transmission (Gomperts / Wilson-Soroka)",
+        "es": "Transmisión sonora por abertura (Gomperts / Wilson-Soroka)",
+    },
+    "Sound reduction index [dB]": {
+        "en": "Sound reduction index [dB]",
+        "es": "Índice de reducción acústica [dB]",
+    },
+    "Sigma unfav.": {"en": "Sigma unfav.", "es": "Σ desfav."},
+    "impact rating": {"en": "impact rating", "es": "índice de impacto"},
+    "Impact sound pressure level [dB]": {
+        "en": "Impact sound pressure level [dB]",
+        "es": "Nivel de presión sonora de impacto [dB]",
+    },
+    "Level difference / reduction index [dB]": {
+        "en": "Level difference / reduction index [dB]",
+        "es": "Diferencia de nivel / índice de reducción [dB]",
+    },
+    "Façade sound insulation (ISO 16283-3)": {
+        "en": "Façade sound insulation (ISO 16283-3)",
+        "es": "Aislamiento acústico de fachada (ISO 16283-3)",
+    },
+    "Reduction index / level difference [dB]": {
+        "en": "Reduction index / level difference [dB]",
+        "es": "Índice de reducción / diferencia de nivel [dB]",
+    },
+    "Façade insulation prediction (EN 12354-3)": {
+        "en": "Façade insulation prediction (EN 12354-3)",
+        "es": "Predicción del aislamiento de fachada (EN 12354-3)",
+    },
+    "Radiated sound power level [dB]": {
+        "en": "Radiated sound power level [dB]",
+        "es": "Nivel de potencia acústica radiada [dB]",
+    },
+    "Radiated sound power (EN 12354-4)": {
+        "en": "Radiated sound power (EN 12354-4)",
+        "es": "Potencia sonora radiada (EN 12354-4)",
+    },
+    "Vibration reduction index $K_{ij}$ [dB]": {
+        "en": "Vibration reduction index $K_{ij}$ [dB]",
+        "es": "Índice de reducción de vibraciones $K_{ij}$ [dB]",
+    },
+    "Vibration reduction index (ISO 10848)": {
+        "en": "Vibration reduction index (ISO 10848)",
+        "es": "Índice de reducción de vibraciones (ISO 10848)",
+    },
+    r"Structure-borne power level $L_{Ws}$ [dB re 1 pW]": {
+        "en": r"Structure-borne power level $L_{Ws}$ [dB re 1 pW]",
+        "es": r"Nivel de potencia estructural $L_{Ws}$ [dB re 1 pW]",
+    },
+    "EN 15657 characteristic structure-borne sound power": {
+        "en": "EN 15657 characteristic structure-borne sound power",
+        "es": "Potencia sonora estructural característica EN 15657",
+    },
+    "paths": {"en": "paths", "es": "trayectos"},
+    r"total $L_{n,s}$": {"en": r"total $L_{n,s}$", "es": r"total $L_{n,s}$"},
+    r"Normalised SPL $L_{n,s}$ [dB]": {
+        "en": r"Normalised SPL $L_{n,s}$ [dB]",
+        "es": r"NPS normalizado $L_{n,s}$ [dB]",
+    },
+    "EN 12354-5 installed structure-borne sound": {
+        "en": "EN 12354-5 installed structure-borne sound",
+        "es": "Ruido estructural instalado EN 12354-5",
+    },
+    "Transmission path": {
+        "en": "Transmission path",
+        "es": "Trayecto de transmisión",
+    },
+    "Share of transmitted energy [%]": {
+        "en": "Share of transmitted energy [%]",
+        "es": "Fracción de energía transmitida [%]",
+    },
+    "flanking prediction": {
+        "en": "flanking prediction",
+        "es": "predicción de transmisión por flancos",
+    },
+    "Level / correction [dB]": {
+        "en": "Level / correction [dB]",
+        "es": "Nivel / corrección [dB]",
+    },
+    "impact prediction": {
+        "en": "impact prediction",
+        "es": "predicción de impacto",
+    },
+    "Airborne sound insulation (ISO 16283-1)": {
+        "en": "Airborne sound insulation (ISO 16283-1)",
+        "es": "Aislamiento a ruido aéreo (ISO 16283-1)",
+    },
+    "Impact sound insulation (ISO 16283-2)": {
+        "en": "Impact sound insulation (ISO 16283-2)",
+        "es": "Aislamiento a ruido de impacto (ISO 16283-2)",
+    },
+    "Standard uncertainty u [dB]": {
+        "en": "Standard uncertainty u [dB]",
+        "es": "Incertidumbre típica u [dB]",
+    },
+    "band uncertainty": {"en": "band uncertainty", "es": "incertidumbre por banda"},
+    "situation": {"en": "situation", "es": "situación"},
+    "sigma_R95 upper limit": {
+        "en": "sigma_R95 upper limit",
+        "es": "límite superior sigma_R95",
+    },
+    "limit of measurement (> delta-L)": {
+        "en": "limit of measurement (> delta-L)",
+        "es": "límite de medición (> delta-L)",
+    },
+    "Improvement of impact sound insulation delta-L [dB]": {
+        "en": "Improvement of impact sound insulation delta-L [dB]",
+        "es": "Mejora del aislamiento a ruido de impacto delta-L [dB]",
+    },
+    "ISO 16251-1 Floor-Covering Impact Sound Improvement": {
+        "en": "ISO 16251-1 Floor-Covering Impact Sound Improvement",
+        "es": "Mejora del aislamiento a ruido de impacto de revestimiento de suelo ISO 16251-1",
+    },
+}
+
+
+def _t(key: str, language: str) -> str:
+    """Look up the localised string for ``key`` (falls back to ``key``)."""
+    return _STRINGS.get(key, {}).get(language, key)
+
+
 def plot_sound_reduction(
-    result: "SoundReductionResult", ax: Axes | None = None, **kwargs: Any
+    result: "SoundReductionResult", ax: Axes | None = None, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Predicted sound reduction index ``R(f)`` (Bies 7.2).
 
     :param result: A
         :class:`~phonometry.building.panel_transmission.SoundReductionResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the ``R(f)`` curve ``plot``.
     :return: The axes.
     """
+    from .._i18n import format_number, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     freq = np.asarray(result.frequencies, dtype=np.float64)
     r = np.asarray(result.transmission_loss, dtype=np.float64)
     kwargs.setdefault("color", _C_PRIMARY)
     kwargs.setdefault("marker", "o")
     kwargs.setdefault("markersize", 3)
-    ax.semilogx(freq, r, label="predicted $R$", **kwargs)
+    ax.semilogx(freq, r, label=_t("predicted $R$", language), **kwargs)
     if result.critical_frequency is not None:
         ax.axvline(
             result.critical_frequency, color=_C_REFERENCE, ls="--", lw=1.0,
-            label=f"$f_c$ = {result.critical_frequency:.0f} Hz",
+            label=f"$f_c$ = {format_number(result.critical_frequency, language, decimals=0)} Hz",
         )
     if result.resonance_frequency is not None:
         ax.axvline(
             result.resonance_frequency, color=_C_SECONDARY, ls="--", lw=1.0,
-            label=f"$f_0$ = {result.resonance_frequency:.0f} Hz",
+            label=f"$f_0$ = {format_number(result.resonance_frequency, language, decimals=0)} Hz",
         )
     format_frequency_axis(ax, float(freq.min()), float(freq.max()))
-    ax.set_xlabel(_FREQ_LABEL)
-    ax.set_ylabel("Sound reduction index $R$ [dB]")
-    ax.set_title(f"Predicted sound insulation ({result.model})")
+    ax.set_xlabel(_t(_FREQ_LABEL, language))
+    ax.set_ylabel(_t("Sound reduction index $R$ [dB]", language))
+    ax.set_title(f"{_t('Predicted sound insulation', language)} ({result.model})")
     ax.legend(loc="best", fontsize="small")
     ax.grid(True, which="both", alpha=0.3)
+    localize_axes(ax, language)
     return ax
 
+
 def plot_aperture_transmission(
-    result: "ApertureTransmissionResult", ax: Axes | None = None, **kwargs: Any
+    result: "ApertureTransmissionResult", ax: Axes | None = None,
+    language: str = "en", **kwargs: Any
 ) -> Axes:
     """Aperture sound reduction index ``R(f) = -10 lg(tau)`` (Hopkins 4.3.10).
 
     :param result: An
         :class:`~phonometry.building.aperture_transmission.ApertureTransmissionResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the ``R(f)`` curve ``plot``.
     :return: The axes.
     """
+    from .._i18n import localize_axes
+
     ax = ax if ax is not None else _new_axes()
     freq = np.asarray(result.frequencies, dtype=np.float64)
     r = np.asarray(result.transmission_loss, dtype=np.float64)
     kwargs.setdefault("color", _C_PRIMARY)
-    ax.semilogx(freq, r, label=f"{result.kind} aperture $R$", **kwargs)
+    ax.semilogx(freq, r, label=f"{result.kind} {_t('aperture $R$', language)}", **kwargs)
     ax.axhline(0.0, color=_C_MUTED, ls=":", lw=0.9)
     format_frequency_axis(ax, float(freq.min()), float(freq.max()))
-    ax.set_xlabel(_FREQ_LABEL)
-    ax.set_ylabel("Sound reduction index $R$ [dB]")
-    ax.set_title("Aperture sound transmission (Gomperts / Wilson-Soroka)")
+    ax.set_xlabel(_t(_FREQ_LABEL, language))
+    ax.set_ylabel(_t("Sound reduction index $R$ [dB]", language))
+    ax.set_title(_t("Aperture sound transmission (Gomperts / Wilson-Soroka)", language))
     ax.legend(loc="best", fontsize="small")
     ax.grid(True, which="both", alpha=0.3)
+    localize_axes(ax, language)
     return ax
 
+
 def plot_weighted_rating(
-    result: "WeightedRatingResult", ax: Axes | None = None, **kwargs: Any
+    result: "WeightedRatingResult", ax: Axes | None = None, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Airborne rating curve vs shifted reference (ISO 717-1).
 
     :param result: A :class:`~phonometry.insulation.WeightedRatingResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the measured-curve ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import format_number, localize_axes
+
     _require_rating_curve(result)
-    return _plot_rating(
+    ax = _plot_rating(
         np.asarray(result.band_centers, dtype=np.float64),
         np.asarray(result.measured, dtype=np.float64),
         np.asarray(result.shifted_reference, dtype=np.float64),
         impact=False,
         title=(
             f"ISO 717-1 Rw (C={result.c:+d}; Ctr={result.ctr:+d}) = "
-            f"{result.rating} dB  (Sigma unfav. = {result.unfavourable_sum:.1f} dB)"
+            f"{result.rating} dB  ({_t('Sigma unfav.', language)} = "
+            f"{format_number(result.unfavourable_sum, language, decimals=1)} dB)"
         ),
-        ylabel="Sound reduction index [dB]",
+        ylabel=_t("Sound reduction index [dB]", language),
         ax=ax,
         **kwargs,
     )
+    localize_axes(ax, language)
+    return ax
+
 
 def plot_impact_rating(
-    result: "ImpactRatingResult", ax: Axes | None = None, **kwargs: Any
+    result: "ImpactRatingResult", ax: Axes | None = None, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Impact rating curve vs shifted reference (ISO 717-2).
 
@@ -147,9 +307,12 @@ def plot_impact_rating(
 
     :param result: An :class:`~phonometry.insulation.ImpactRatingResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the measured-curve ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import format_number, localize_axes
+
     _require_rating_curve(result)
     band_centers = np.asarray(result.band_centers, dtype=np.float64)
     reference = np.asarray(result.shifted_reference, dtype=np.float64)
@@ -162,18 +325,22 @@ def plot_impact_rating(
         # the dataclass does not carry which, so the figure uses the neutral
         # "impact rating" label rather than hard-coding one specific symbol.
         title=(
-            f"ISO 717-2 impact rating (CI={result.ci:+d}) = {result.rating} dB"
-            f"  (Sigma unfav. = {result.unfavourable_sum:.1f} dB)"
+            f"ISO 717-2 {_t('impact rating', language)} (CI={result.ci:+d}) = "
+            f"{result.rating} dB  ({_t('Sigma unfav.', language)} = "
+            f"{format_number(result.unfavourable_sum, language, decimals=1)} dB)"
         ),
-        ylabel="Impact sound pressure level [dB]",
+        ylabel=_t("Impact sound pressure level [dB]", language),
         ax=ax,
         **kwargs,
     )
     _annotate_impact_500(ax, band_centers, reference, int(result.rating))
+    localize_axes(ax, language)
     return ax
 
+
 def plot_facade_insulation(
-    result: "FacadeInsulationResult", ax: Axes | None = None, **kwargs: Any
+    result: "FacadeInsulationResult", ax: Axes | None = None, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Per-band façade sound-insulation profile (ISO 16283-3).
 
@@ -185,9 +352,12 @@ def plot_facade_insulation(
     :param result: A façade result exposing ``d_2m``, ``d_2m_nt``,
         ``d_2m_n``, ``r_prime`` and (optionally) ``frequencies``.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the primary ``D2m,nT`` curve ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import localize_axes
+
     ax = ax if ax is not None else _new_axes()
     dnt = np.asarray(result.d_2m_nt, dtype=np.float64)
     n = dnt.size
@@ -209,14 +379,17 @@ def plot_facade_insulation(
             opts.update(kwargs)
         ax.plot(x, y, "o-", **opts)
 
-    ax.set_ylabel("Level difference / reduction index [dB]")
-    ax.set_title("Façade sound insulation (ISO 16283-3)")
+    ax.set_ylabel(_t("Level difference / reduction index [dB]", language))
+    ax.set_title(_t("Façade sound insulation (ISO 16283-3)", language))
     ax.legend(loc="best", fontsize="small")
     ax.grid(True, alpha=0.3)
+    localize_axes(ax, language)
     return ax
 
+
 def plot_facade_prediction(
-    result: "FacadePredictionResult", ax: Axes | None = None, **kwargs: Any
+    result: "FacadePredictionResult", ax: Axes | None = None, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Predicted façade insulation profile (EN 12354-3:2000).
 
@@ -228,9 +401,12 @@ def plot_facade_prediction(
     :param result: A façade prediction result exposing ``r_prime``,
         ``d_2m_nt``, ``element_r`` and (optionally) ``frequencies``.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the primary ``R'`` curve ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import localize_axes
+
     ax = ax if ax is not None else _new_axes()
     r_prime = np.asarray(result.r_prime, dtype=np.float64)
     n = r_prime.size
@@ -251,14 +427,17 @@ def plot_facade_prediction(
         label="$D_{2m,nT}$",
     )
 
-    ax.set_ylabel("Reduction index / level difference [dB]")
-    ax.set_title("Façade insulation prediction (EN 12354-3)")
+    ax.set_ylabel(_t("Reduction index / level difference [dB]", language))
+    ax.set_title(_t("Façade insulation prediction (EN 12354-3)", language))
     ax.legend(loc="best", fontsize="small", ncol=2)
     ax.grid(True, alpha=0.3)
+    localize_axes(ax, language)
     return ax
 
+
 def plot_radiated_power(
-    result: "RadiatedPowerResult", ax: Axes | None = None, **kwargs: Any
+    result: "RadiatedPowerResult", ax: Axes | None = None, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Radiated sound power level ``LW`` per band (EN 12354-4:2000).
 
@@ -268,22 +447,25 @@ def plot_radiated_power(
 
     :param result: A :class:`~phonometry.facade_prediction.RadiatedPowerResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the ``bar`` call.
     :return: The axes.
     """
+    from .._i18n import format_number, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     l_w = np.asarray(result.l_w, dtype=np.float64)
     n = l_w.size
     positions = np.arange(n, dtype=np.float64)
     if result.frequencies is None:
-        labels = [f"Band {i + 1}" for i in range(n)]
+        labels = [f"{_t('Band', language)} {i + 1}" for i in range(n)]
     else:
         labels = [_format_freq(f) for f in np.asarray(result.frequencies, dtype=np.float64)]
 
     opts: dict[str, Any] = {"color": "tab:red", "alpha": 0.8, "label": "$L_W$"}
     opts.update(kwargs)
     ax.bar(positions, l_w, **opts)
-    _band_axis(ax, labels, xlabel=_FREQ_LABEL)
+    _band_axis(ax, labels, xlabel=_t(_FREQ_LABEL, language))
 
     if result.l_w_dba is not None:
         ax.axhline(
@@ -291,16 +473,19 @@ def plot_radiated_power(
             color="black",
             ls="--",
             lw=1.2,
-            label=f"$L_{{WA}}$ = {result.l_w_dba:.1f} dB(A)",
+            label=f"$L_{{WA}}$ = {format_number(result.l_w_dba, language, decimals=1)} dB(A)",
         )
-    ax.set_ylabel("Radiated sound power level [dB]")
-    ax.set_title("Radiated sound power (EN 12354-4)")
+    ax.set_ylabel(_t("Radiated sound power level [dB]", language))
+    ax.set_title(_t("Radiated sound power (EN 12354-4)", language))
     ax.legend(loc="best", fontsize="small")
     ax.grid(True, axis="y", alpha=0.3)
+    localize_axes(ax, language)
     return ax
 
+
 def plot_vibration_reduction(
-    result: "VibrationReductionResult", ax: Axes | None = None, **kwargs: Any
+    result: "VibrationReductionResult", ax: Axes | None = None, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Vibration reduction index ``Kij`` versus frequency (ISO 10848).
 
@@ -311,9 +496,12 @@ def plot_vibration_reduction(
     :param result: A
         :class:`~phonometry.flanking_transmission.VibrationReductionResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the ``Kij`` curve ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import format_number, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     k_ij = np.asarray(result.k_ij, dtype=np.float64)
     kwargs.setdefault("marker", "o")
@@ -325,47 +513,61 @@ def plot_vibration_reduction(
         _freq_axis(ax, freqs)
     else:
         ax.plot(np.arange(k_ij.size), k_ij, **kwargs)
-        ax.set_xlabel("Band index")
+        ax.set_xlabel(_t("Band index", language))
     if result.single_number is not None:
         ax.axhline(
             result.single_number,
             color=_C_REFERENCE,
             ls="--",
             lw=1.0,
-            label=rf"$\overline{{K}}_{{ij}}$ = {result.single_number:.1f} dB",
+            label=rf"$\overline{{K}}_{{ij}}$ = {format_number(result.single_number, language, decimals=1)} dB",
         )
-    ax.set_ylabel("Vibration reduction index $K_{ij}$ [dB]")
-    ax.set_title("Vibration reduction index (ISO 10848)")
+    ax.set_ylabel(_t("Vibration reduction index $K_{ij}$ [dB]", language))
+    ax.set_title(_t("Vibration reduction index (ISO 10848)", language))
     ax.grid(True, alpha=0.3)
     ax.legend()
+    localize_axes(ax, language)
     return ax
 
+
 def plot_structure_borne_power(
-    result: "StructureBornePowerResult", ax: Axes | None = None, **kwargs: Any
+    result: "StructureBornePowerResult", ax: Axes | None = None, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Characteristic structure-borne sound power level per band (EN 15657).
 
     :param result: A :class:`~phonometry.structure_borne_power.StructureBornePowerResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the bar ``plot``.
     :return: The axes.
     """
-    return _plot_band_level_bars(
+    from .._i18n import localize_axes
+
+    ax = _plot_band_level_bars(
         ax, result.power_level, result.frequencies, result.total_level,
-        ylabel=r"Structure-borne power level $L_{Ws}$ [dB re 1 pW]",
-        title="EN 15657 characteristic structure-borne sound power", **kwargs,
+        ylabel=_t(r"Structure-borne power level $L_{Ws}$ [dB re 1 pW]", language),
+        title=_t("EN 15657 characteristic structure-borne sound power", language),
+        **kwargs,
     )
+    localize_axes(ax, language)
+    return ax
+
 
 def plot_installed_structure_borne(
-    result: "InstalledSourceResult", ax: Axes | None = None, **kwargs: Any
+    result: "InstalledSourceResult", ax: Axes | None = None, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Per-path and total normalised structure-borne SPL (EN 12354-5).
 
     :param result: An :class:`~phonometry.installed_structure_borne.InstalledSourceResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the total-level ``plot``.
     :return: The axes.
     """
+    from .._i18n import localize_axes
+
     ax = ax if ax is not None else _new_axes()
     paths = np.atleast_2d(np.asarray(result.path_levels, dtype=np.float64))
     total = np.atleast_1d(np.asarray(result.total_level, dtype=np.float64))
@@ -373,26 +575,29 @@ def plot_installed_structure_borne(
     if result.frequencies is not None:
         x = np.asarray(result.frequencies, dtype=np.float64)
         ax.set_xscale("log")
-        ax.set_xlabel(_FREQ_LABEL)
+        ax.set_xlabel(_t(_FREQ_LABEL, language))
     else:
         x = np.arange(1, n_bands + 1, dtype=np.float64)
-        ax.set_xlabel("Band")
+        ax.set_xlabel(_t("Band", language))
     for k, path in enumerate(paths):
         ax.plot(x, path, color=_C_MUTED, lw=1.0, ls=":", marker=".",
-                label="paths" if k == 0 else None)
+                label=_t("paths", language) if k == 0 else None)
     kwargs.setdefault("color", _C_PRIMARY)
     kwargs.setdefault("lw", 2.2)
-    ax.plot(x, total, label=r"total $L_{n,s}$", **kwargs)
-    ax.set_ylabel(r"Normalised SPL $L_{n,s}$ [dB]")
-    ax.set_title("EN 12354-5 installed structure-borne sound")
+    ax.plot(x, total, label=_t(r"total $L_{n,s}$", language), **kwargs)
+    ax.set_ylabel(_t(r"Normalised SPL $L_{n,s}$ [dB]", language))
+    ax.set_title(_t("EN 12354-5 installed structure-borne sound", language))
     ax.legend(loc="best", fontsize="small")
     ax.grid(True, which="both", alpha=0.3)
     if result.frequencies is not None:
         format_frequency_axis(ax, float(x.min()), float(x.max()))
+    localize_axes(ax, language)
     return ax
 
+
 def plot_airborne_prediction(
-    result: "AirbornePredictionResult", ax: Axes | None = None, **kwargs: Any
+    result: "AirbornePredictionResult", ax: Axes | None = None, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Per-path shares of the transmitted energy (EN 12354-1).
 
@@ -402,9 +607,12 @@ def plot_airborne_prediction(
     :param result: An
         :class:`~phonometry.building_prediction.AirbornePredictionResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the path :meth:`~matplotlib.axes.Axes.bar`.
     :return: The axes.
     """
+    from .._i18n import format_number, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     contribs = sorted(result.paths, key=lambda c: c.fraction, reverse=True)
     shares = [100.0 * c.fraction for c in contribs]
@@ -415,17 +623,21 @@ def plot_airborne_prediction(
     ax.bar(positions, shares, **kwargs)
     ax.set_xticks(positions)
     ax.set_xticklabels([c.label for c in contribs], rotation=45, ha="right")
-    ax.set_xlabel("Transmission path")
-    ax.set_ylabel("Share of transmitted energy [%]")
+    ax.set_xlabel(_t("Transmission path", language))
+    ax.set_ylabel(_t("Share of transmitted energy [%]", language))
     ax.set_title(
-        f"EN 12354-1 flanking prediction — R'w = {result.r_prime_w:.1f} dB "
-        f"(RDd,w = {result.r_direct_w:.1f} dB)"
+        f"EN 12354-1 {_t('flanking prediction', language)} — R'w = "
+        f"{format_number(result.r_prime_w, language, decimals=1)} dB "
+        f"(RDd,w = {format_number(result.r_direct_w, language, decimals=1)} dB)"
     )
     ax.grid(True, axis="y", alpha=0.3)
+    localize_axes(ax, language)
     return ax
 
+
 def plot_impact_prediction(
-    result: "ImpactPredictionResult", ax: Axes | None = None, **kwargs: Any
+    result: "ImpactPredictionResult", ax: Axes | None = None, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Terms of the apparent impact-level prediction (EN 12354-2).
 
@@ -436,9 +648,12 @@ def plot_impact_prediction(
     :param result: An
         :class:`~phonometry.building_prediction.ImpactPredictionResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the term :meth:`~matplotlib.axes.Axes.bar`.
     :return: The axes.
     """
+    from .._i18n import format_number, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     labels = ("$L_{n,w,eq}$", r"$-\Delta L_w$", "$+K$", "$L'_{n,w}$")
     values = (
@@ -453,15 +668,19 @@ def plot_impact_prediction(
     ax.axhline(0.0, color=_C_MUTED, lw=0.8)
     ax.set_xticks(positions)
     ax.set_xticklabels(labels)
-    ax.set_ylabel("Level / correction [dB]")
+    ax.set_ylabel(_t("Level / correction [dB]", language))
     ax.set_title(
-        f"EN 12354-2 impact prediction — L'n,w = {result.l_prime_n_w:.1f} dB"
+        f"EN 12354-2 {_t('impact prediction', language)} — L'n,w = "
+        f"{format_number(result.l_prime_n_w, language, decimals=1)} dB"
     )
     ax.grid(True, axis="y", alpha=0.3)
+    localize_axes(ax, language)
     return ax
 
+
 def plot_airborne_insulation(
-    result: "AirborneInsulationResult", ax: Axes | None = None, **kwargs: Any
+    result: "AirborneInsulationResult", ax: Axes | None = None, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Per-band airborne insulation quantities (ISO 16283-1).
 
@@ -471,25 +690,32 @@ def plot_airborne_insulation(
 
     :param result: An :class:`~phonometry.insulation.AirborneInsulationResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the primary ``DnT`` curve ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import localize_axes
+
     curves = [
         ("$D_{nT}$", np.asarray(result.dnt, dtype=np.float64)),
         ("$D$", np.asarray(result.d, dtype=np.float64)),
     ]
     if result.r_prime is not None:
         curves.append(("$R'$", np.asarray(result.r_prime, dtype=np.float64)))
-    return _plot_insulation_bands(
+    ax = _plot_insulation_bands(
         curves,
-        ylabel="Level difference / reduction index [dB]",
-        title="Airborne sound insulation (ISO 16283-1)",
+        ylabel=_t("Level difference / reduction index [dB]", language),
+        title=_t("Airborne sound insulation (ISO 16283-1)", language),
         ax=ax,
         **kwargs,
     )
+    localize_axes(ax, language)
+    return ax
+
 
 def plot_impact_insulation(
-    result: "ImpactInsulationResult", ax: Axes | None = None, **kwargs: Any
+    result: "ImpactInsulationResult", ax: Axes | None = None, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Per-band impact sound pressure levels (ISO 16283-2).
 
@@ -498,58 +724,74 @@ def plot_impact_insulation(
 
     :param result: An :class:`~phonometry.insulation.ImpactInsulationResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the primary ``L'nT`` curve ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import localize_axes
+
     curves = [("$L'_{nT}$", np.asarray(result.l_n_t, dtype=np.float64))]
     if result.l_n is not None:
         curves.append(("$L'_n$", np.asarray(result.l_n, dtype=np.float64)))
-    return _plot_insulation_bands(
+    ax = _plot_insulation_bands(
         curves,
-        ylabel="Impact sound pressure level [dB]",
-        title="Impact sound insulation (ISO 16283-2)",
+        ylabel=_t("Impact sound pressure level [dB]", language),
+        title=_t("Impact sound insulation (ISO 16283-2)", language),
         ax=ax,
         **kwargs,
     )
+    localize_axes(ax, language)
+    return ax
+
 
 def plot_band_uncertainty(
-    result: "BandUncertainty", ax: Axes | None = None, **kwargs: Any
+    result: "BandUncertainty", ax: Axes | None = None, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Per-band standard uncertainty of an insulation quantity (ISO 12999-1).
 
     :param result: A
         :class:`~phonometry.building_uncertainty.BandUncertainty`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the uncertainty curve ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import localize_axes
+
     ax = ax if ax is not None else _new_axes()
     freqs, u = result.to_arrays()
     kwargs.setdefault("color", _C_PRIMARY)
     kwargs.setdefault("marker", "o")
     ax.plot(freqs, u, **kwargs)
     _freq_axis(ax, freqs)
-    ax.set_ylabel("Standard uncertainty u [dB]")
+    ax.set_ylabel(_t("Standard uncertainty u [dB]", language))
     ax.set_ylim(bottom=0.0)
-    quantity = "sigma_R95 upper limit" if result.upper_limit else "u"
+    quantity = _t("sigma_R95 upper limit", language) if result.upper_limit else "u"
     ax.set_title(
-        f"ISO 12999-1 band uncertainty ({quantity}) — "
-        f"{result.measurand}, situation {result.situation}"
+        f"ISO 12999-1 {_t('band uncertainty', language)} ({quantity}) — "
+        f"{result.measurand}, {_t('situation', language)} {result.situation}"
     )
     ax.grid(True, which="both", alpha=0.3)
+    localize_axes(ax, language)
     return ax
 
+
 def plot_floor_covering_improvement(
-    result: "FloorCoveringImprovementResult", ax: Axes | None = None, **kwargs: Any
+    result: "FloorCoveringImprovementResult", ax: Axes | None = None,
+    language: str = "en", **kwargs: Any
 ) -> Axes:
     """Impact-sound improvement spectrum ΔL of a floor covering (ISO 16251-1).
 
     :param result: A
         :class:`~phonometry.floor_covering_improvement.FloorCoveringImprovementResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the improvement-curve ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import decimal_comma, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     freqs, dl = result.frequencies, result.improvement
     kwargs.setdefault("color", _C_PRIMARY)
@@ -560,16 +802,17 @@ def plot_floor_covering_improvement(
         ax.plot(
             freqs[result.limited], dl[result.limited], ls="", marker="v",
             color=_C_SECONDARY, ms=9, mfc="none", mew=1.6, zorder=5,
-            label="limit of measurement (> delta-L)",
+            label=_t("limit of measurement (> delta-L)", language),
         )
     _freq_axis(ax, freqs)
-    ax.set_ylabel("Improvement of impact sound insulation delta-L [dB]")
+    ax.set_ylabel(_t("Improvement of impact sound insulation delta-L [dB]", language))
     ax.set_ylim(bottom=0.0)
-    title = "ISO 16251-1 Floor-Covering Impact Sound Improvement"
+    title = _t("ISO 16251-1 Floor-Covering Impact Sound Improvement", language)
     if result.delta_lw is not None:
-        title += f"  (delta-Lw = {result.delta_lw} dB)"
+        title += f"  (delta-Lw = {decimal_comma(str(result.delta_lw), language)} dB)"
     ax.set_title(title)
     ax.grid(True, which="both", alpha=0.3)
     if ax.get_legend_handles_labels()[0]:
         ax.legend()
+    localize_axes(ax, language)
     return ax

--- a/src/phonometry/_plot/emission.py
+++ b/src/phonometry/_plot/emission.py
@@ -29,12 +29,53 @@ if TYPE_CHECKING:
     from ..emission.sound_power_intensity import SoundPowerIntensityResult
     from ..emission.sound_power_reverberation import ReverberationSoundPowerResult
 
+#: English -> {language: string} lookup for the fixed labels/titles/legends of
+#: the emission-domain renderers. English ids map to themselves so ``_t(key,
+#: "en")`` returns the verbatim original string.
+_STRINGS: dict[str, dict[str, str]] = {
+    "Band": {"en": "Band", "es": "Banda"},
+    "Sound power level LW [dB]": {
+        "en": "Sound power level LW [dB]",
+        "es": "Nivel de potencia acústica LW [dB]",
+    },
+    "sound power spectrum": {
+        "en": "sound power spectrum",
+        "es": "espectro de potencia acústica",
+    },
+    "Non-positive band": {"en": "Non-positive band", "es": "Banda no positiva"},
+    "Pressure level Lp": {"en": "Pressure level Lp", "es": "Nivel de presión Lp"},
+    "Intensity level LI": {
+        "en": "Intensity level LI",
+        "es": "Nivel de intensidad LI",
+    },
+    "Level [dB]": {"en": "Level [dB]", "es": "Nivel [dB]"},
+    "Pressure-intensity index δpI [dB]": {
+        "en": "Pressure-intensity index δpI [dB]",
+        "es": "Índice presión-intensidad δpI [dB]",
+    },
+    r"Sound power level $L_W$ [dB re 1 pW]": {
+        "en": r"Sound power level $L_W$ [dB re 1 pW]",
+        "es": r"Nivel de potencia acústica $L_W$ [dB re 1 pW]",
+    },
+    "ISO/TS 7849 sound power from surface vibration": {
+        "en": "ISO/TS 7849 sound power from surface vibration",
+        "es": "Potencia sonora por vibración superficial ISO/TS 7849",
+    },
+}
+
+
+def _t(key: str, language: str) -> str:
+    """Look up the localised string for ``key`` (falls back to ``key``)."""
+    return _STRINGS.get(key, {}).get(language, key)
+
+
 def plot_sound_power(
     result: (
         "SoundPowerResult | ReverberationSoundPowerResult"
         " | SoundPowerIntensityResult | Any"
     ),
     ax: Axes | None = None,
+    language: str = "en",
     **kwargs: Any,
 ) -> Axes:
     """Sound power level spectrum with the A-weighted total annotated.
@@ -49,16 +90,20 @@ def plot_sound_power(
         ``sound_power_level``, ``sound_power_level_a`` and (optionally)
         ``frequencies`` and ``negative_band``.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the band :meth:`~matplotlib.axes.Axes.bar`.
     :return: The axes.
     """
+    from .._i18n import format_number, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     lw = np.asarray(result.sound_power_level, dtype=np.float64)
     n = lw.size
     freqs = getattr(result, "frequencies", None)
     if freqs is None:
         positions = _band_axis(
-            ax, [f"Band {i + 1}" for i in range(n)], xlabel="Band"
+            ax, [f"{_t('Band', language)} {i + 1}" for i in range(n)],
+            xlabel=_t("Band", language)
         )
     else:
         positions = _band_axis(ax, np.asarray(freqs, dtype=np.float64))
@@ -78,22 +123,29 @@ def plot_sound_power(
     bars = ax.bar(positions, np.nan_to_num(lw), **kwargs)
     _hatch_invalid(bars, neg)
 
-    ax.set_ylabel("Sound power level LW [dB]")
+    ax.set_ylabel(_t("Sound power level LW [dB]", language))
     designation = _sound_power_designation(result)
     lwa = float(result.sound_power_level_a)
     if np.isfinite(lwa):
-        ax.set_title(f"{designation} sound power spectrum  (LWA = {lwa:.1f} dB(A))")
+        ax.set_title(
+            f"{designation} {_t('sound power spectrum', language)}  "
+            f"(LWA = {format_number(lwa, language, decimals=1)} dB(A))"
+        )
     else:
-        ax.set_title(f"{designation} sound power spectrum")
+        ax.set_title(f"{designation} {_t('sound power spectrum', language)}")
     if np.any(neg):
-        ax.plot([], [], color=_C_MUTED, marker="s", ls="", label="Non-positive band")
+        ax.plot([], [], color=_C_MUTED, marker="s", ls="",
+                label=_t("Non-positive band", language))
     if np.any(neg) or "label" in kwargs:
         ax.legend(loc="best", fontsize="small")
     ax.grid(True, axis="y", alpha=0.3)
+    localize_axes(ax, language)
     return ax
 
+
 def plot_intensity(
-    result: IntensityResult, ax: Axes | None = None, **kwargs: Any
+    result: IntensityResult, ax: Axes | None = None, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Pressure vs intensity level per band with the pressure-intensity index.
 
@@ -104,10 +156,13 @@ def plot_intensity(
     :param result: An :class:`~phonometry.intensity.IntensityResult` with
         per-band data (obtained by requesting a band ``fraction``).
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the pressure-level curve ``plot`` call.
     :return: The axes.
     :raises ValueError: If the result carries no per-band data.
     """
+    from .._i18n import format_number, localize_axes
+
     if result.frequency is None:
         raise ValueError(
             "plot() needs per-band intensity data; call sound_intensity(...) "
@@ -120,11 +175,11 @@ def plot_intensity(
     index = np.asarray(result.pressure_intensity_index, dtype=np.float64)
 
     kwargs.setdefault("color", _C_PRIMARY)
-    kwargs.setdefault("label", "Pressure level Lp")
+    kwargs.setdefault("label", _t("Pressure level Lp", language))
     ax.plot(freqs, lp, "o-", **kwargs)
-    ax.plot(freqs, li, "s--", color=_C_REFERENCE, label="Intensity level LI")
+    ax.plot(freqs, li, "s--", color=_C_REFERENCE, label=_t("Intensity level LI", language))
     _freq_axis(ax, freqs)
-    ax.set_ylabel("Level [dB]")
+    ax.set_ylabel(_t("Level [dB]", language))
     ax.grid(True, which="both", alpha=0.3)
 
     twin = ax.twinx()
@@ -136,29 +191,38 @@ def plot_intensity(
         alpha=0.25,
         label="δpI = Lp - LI",
     )
-    twin.set_ylabel("Pressure-intensity index δpI [dB]")
+    twin.set_ylabel(_t("Pressure-intensity index δpI [dB]", language))
 
     lines, labels = ax.get_legend_handles_labels()
     tlines, tlabels = twin.get_legend_handles_labels()
     ax.legend(lines + tlines, labels + tlabels, loc="best", fontsize="small")
     ax.set_title(
         "ISO 9614 Lp vs LI  "
-        f"(total δpI = {result.total_pressure_intensity_index:.1f} dB)"
+        f"(total δpI = {format_number(result.total_pressure_intensity_index, language, decimals=1)} dB)"
     )
+    localize_axes(ax, language)
     return ax
 
+
 def plot_vibration_sound_power(
-    result: "VibrationSoundPowerResult", ax: Axes | None = None, **kwargs: Any
+    result: "VibrationSoundPowerResult", ax: Axes | None = None,
+    language: str = "en", **kwargs: Any
 ) -> Axes:
     """Radiated sound power level per band (ISO/TS 7849).
 
     :param result: A :class:`~phonometry.vibration_sound_power.VibrationSoundPowerResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the bar ``plot``.
     :return: The axes.
     """
-    return _plot_band_level_bars(
+    from .._i18n import localize_axes
+
+    ax = _plot_band_level_bars(
         ax, result.sound_power_level, result.frequencies, result.total_level,
-        ylabel=r"Sound power level $L_W$ [dB re 1 pW]",
-        title="ISO/TS 7849 sound power from surface vibration", **kwargs,
+        ylabel=_t(r"Sound power level $L_W$ [dB re 1 pW]", language),
+        title=_t("ISO/TS 7849 sound power from surface vibration", language),
+        **kwargs,
     )
+    localize_axes(ax, language)
+    return ax

--- a/src/phonometry/_plot/noise_control.py
+++ b/src/phonometry/_plot/noise_control.py
@@ -25,53 +25,99 @@ if TYPE_CHECKING:
 
 _FREQ_LABEL = "Frequency [Hz]"
 
+#: English -> {language: string} lookup for the fixed labels/titles/legends of
+#: the noise-control renderers. English ids map to themselves so ``_t(key,
+#: "en")`` returns the verbatim original string.
+_STRINGS: dict[str, dict[str, str]] = {
+    "Frequency [Hz]": {"en": "Frequency [Hz]", "es": "Frecuencia [Hz]"},
+    "Band": {"en": "Band", "es": "Banda"},
+    "Transmission loss": {"en": "Transmission loss", "es": "Pérdida por transmisión"},
+    "Insertion loss": {"en": "Insertion loss", "es": "Pérdida por inserción"},
+    "Resonance": {"en": "Resonance", "es": "Resonancia"},
+    "Loss [dB]": {"en": "Loss [dB]", "es": "Pérdida [dB]"},
+    "Reactive silencer": {"en": "Reactive silencer", "es": "Silenciador reactivo"},
+    "Sound power level [dB re 1 pW]": {
+        "en": "Sound power level [dB re 1 pW]",
+        "es": "Nivel de potencia acústica [dB re 1 pW]",
+    },
+    "Attenuation [dB]": {"en": "Attenuation [dB]", "es": "Atenuación [dB]"},
+    "Panel R": {"en": "Panel R", "es": "R del panel"},
+    "Interior correction C": {
+        "en": "Interior correction C",
+        "es": "Corrección interior C",
+    },
+    "Insertion loss (R - C)": {
+        "en": "Insertion loss (R - C)",
+        "es": "Pérdida por inserción (R - C)",
+    },
+    "Level [dB]": {"en": "Level [dB]", "es": "Nivel [dB]"},
+    "Machine enclosure insertion loss": {
+        "en": "Machine enclosure insertion loss",
+        "es": "Pérdida por inserción de encapsulado de máquina",
+    },
+}
+
+
+def _t(key: str, language: str) -> str:
+    """Look up the localised string for ``key`` (falls back to ``key``)."""
+    return _STRINGS.get(key, {}).get(language, key)
+
 
 def plot_reactive_silencer(
-    result: "ReactiveSilencerResult", ax: "Axes | None" = None, **kwargs: Any
+    result: "ReactiveSilencerResult", ax: "Axes | None" = None,
+    language: str = "en", **kwargs: Any
 ) -> "Axes":
     """Transmission (and insertion) loss of a reactive silencer over frequency.
 
     :param result: A
         :class:`~phonometry.noise_control.silencers.ReactiveSilencerResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the transmission-loss ``Axes.plot``.
     :return: The axes.
     """
+    from .._i18n import localize_axes
+
     ax = ax if ax is not None else _new_axes()
     f = np.asarray(result.frequencies, dtype=np.float64)
     kwargs.setdefault("color", _C_PRIMARY)
-    kwargs.setdefault("label", "Transmission loss")
+    kwargs.setdefault("label", _t("Transmission loss", language))
     kwargs.setdefault("lw", 1.8)
     ax.plot(f, np.asarray(result.transmission_loss), **kwargs)
     if result.insertion_loss is not None:
         ax.plot(f, np.asarray(result.insertion_loss), color=_C_SECONDARY,
-                lw=1.4, ls="--", label="Insertion loss")
+                lw=1.4, ls="--", label=_t("Insertion loss", language))
     if result.resonances is not None:
         labeled = False
         for fr in np.atleast_1d(np.asarray(result.resonances)):
             if f.min() <= fr <= f.max():
                 ax.axvline(fr, color=_C_TERTIARY, ls=":", lw=1.0,
-                           label="Resonance" if not labeled else None)
+                           label=_t("Resonance", language) if not labeled else None)
                 labeled = True
-    ax.set_xlabel(_FREQ_LABEL)
-    ax.set_ylabel("Loss [dB]")
-    ax.set_title(f"Reactive silencer: {result.kind}")
+    ax.set_xlabel(_t(_FREQ_LABEL, language))
+    ax.set_ylabel(_t("Loss [dB]", language))
+    ax.set_title(f"{_t('Reactive silencer', language)}: {result.kind}")
     ax.grid(True, which="both", alpha=0.3)
     format_frequency_axis(ax)
     ax.legend(loc="best", fontsize="small")
+    localize_axes(ax, language)
     return ax
 
 
 def plot_hvac_spectrum(
-    result: "HvacSpectrumResult", ax: "Axes | None" = None, **kwargs: Any
+    result: "HvacSpectrumResult", ax: "Axes | None" = None, language: str = "en",
+    **kwargs: Any
 ) -> "Axes":
     """Per-frequency HVAC attenuation or regenerated sound power level.
 
     :param result: A :class:`~phonometry.noise_control.hvac.HvacSpectrumResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to ``Axes.plot``.
     :return: The axes.
     """
+    from .._i18n import localize_axes
+
     ax = ax if ax is not None else _new_axes()
     f = np.asarray(result.frequencies, dtype=np.float64)
     is_power = result.quantity == "sound_power_level"
@@ -81,28 +127,34 @@ def plot_hvac_spectrum(
     kwargs.setdefault("marker", "o")
     kwargs.setdefault("ms", 3)
     ax.plot(f, np.asarray(result.values), **kwargs)
-    ax.set_xlabel(_FREQ_LABEL)
+    ax.set_xlabel(_t(_FREQ_LABEL, language))
     ax.set_ylabel(
-        "Sound power level [dB re 1 pW]" if is_power else "Attenuation [dB]"
+        _t("Sound power level [dB re 1 pW]", language) if is_power
+        else _t("Attenuation [dB]", language)
     )
     ax.set_title(result.label)
     ax.grid(True, which="both", alpha=0.3)
     format_frequency_axis(ax)
     ax.legend(loc="best", fontsize="small")
+    localize_axes(ax, language)
     return ax
 
 
 def plot_enclosure(
-    result: "EnclosureResult", ax: "Axes | None" = None, **kwargs: Any
+    result: "EnclosureResult", ax: "Axes | None" = None, language: str = "en",
+    **kwargs: Any
 ) -> "Axes":
     """Panel R, interior correction C and net insertion loss of an enclosure.
 
     :param result: An
         :class:`~phonometry.noise_control.enclosures.EnclosureResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the insertion-loss ``Axes.plot``.
     :return: The axes.
     """
+    from .._i18n import localize_axes
+
     ax = ax if ax is not None else _new_axes()
     n = np.asarray(result.insertion_loss).size
     if result.frequencies is not None:
@@ -112,23 +164,24 @@ def plot_enclosure(
         x = np.arange(n, dtype=np.float64)
         continuous = False
     ax.plot(x, np.asarray(result.panel_transmission_loss), color=_C_REFERENCE,
-            lw=1.3, ls="--", marker="s", ms=3, label="Panel R")
+            lw=1.3, ls="--", marker="s", ms=3, label=_t("Panel R", language))
     ax.plot(x, np.asarray(result.correction), color=_C_TERTIARY, lw=1.3,
-            ls=":", marker="^", ms=3, label="Interior correction C")
+            ls=":", marker="^", ms=3, label=_t("Interior correction C", language))
     kwargs.setdefault("color", _C_PRIMARY)
-    kwargs.setdefault("label", "Insertion loss (R - C)")
+    kwargs.setdefault("label", _t("Insertion loss (R - C)", language))
     kwargs.setdefault("lw", 1.9)
     kwargs.setdefault("marker", "o")
     kwargs.setdefault("ms", 3)
     ax.plot(x, np.asarray(result.insertion_loss), **kwargs)
-    ax.set_ylabel("Level [dB]")
-    ax.set_title("Machine enclosure insertion loss")
+    ax.set_ylabel(_t("Level [dB]", language))
+    ax.set_title(_t("Machine enclosure insertion loss", language))
     ax.grid(True, which="both", alpha=0.3)
     if continuous:
-        ax.set_xlabel(_FREQ_LABEL)
+        ax.set_xlabel(_t(_FREQ_LABEL, language))
         format_frequency_axis(ax)
     else:
-        ax.set_xlabel("Band")
+        ax.set_xlabel(_t("Band", language))
         ax.set_xticks(x)
     ax.legend(loc="best", fontsize="small")
+    localize_axes(ax, language)
     return ax

--- a/src/phonometry/building/aperture_transmission.py
+++ b/src/phonometry/building/aperture_transmission.py
@@ -107,15 +107,17 @@ class ApertureTransmissionResult:
         """Aperture sound reduction index ``R = -10 lg(tau)`` per band, dB."""
         return transmission_loss_from_coefficient(self.transmission_coefficient)
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the aperture sound reduction index ``R(f)``.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.building import plot_aperture_transmission
 
-        return plot_aperture_transmission(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_aperture_transmission(self, ax=ax, language=language, **kwargs)
 
 
 def _slit_end_correction(k_big: np.ndarray) -> np.ndarray:

--- a/src/phonometry/building/building_prediction.py
+++ b/src/phonometry/building/building_prediction.py
@@ -175,15 +175,17 @@ class AirbornePredictionResult:
     paths: tuple[PathContribution, ...]
     dominant: PathContribution
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the per-path shares of the transmitted energy.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.building import plot_airborne_prediction
 
-        return plot_airborne_prediction(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_airborne_prediction(self, ax=ax, language=language, **kwargs)
 
 
 @dataclass(frozen=True)
@@ -202,15 +204,17 @@ class ImpactPredictionResult:
     delta_l_w: float
     k_correction: float
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the Formula 21 terms and the resulting ``L'n,w``.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.building import plot_impact_prediction
 
-        return plot_impact_prediction(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_impact_prediction(self, ax=ax, language=language, **kwargs)
 
 
 def _check_finite(value: float, name: str) -> float:

--- a/src/phonometry/building/building_uncertainty.py
+++ b/src/phonometry/building/building_uncertainty.py
@@ -215,15 +215,17 @@ class BandUncertainty:
             np.asarray(self.uncertainties, dtype=float),
         )
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the per-band standard uncertainty spectrum.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.building import plot_band_uncertainty
 
-        return plot_band_uncertainty(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_band_uncertainty(self, ax=ax, language=language, **kwargs)
 
 
 @dataclass(frozen=True)

--- a/src/phonometry/building/facade_prediction.py
+++ b/src/phonometry/building/facade_prediction.py
@@ -169,11 +169,13 @@ class FacadePredictionResult:
     c_tr: int | None = None
     frequencies: np.ndarray | None = None
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the per-element partial indices and the façade ``R'`` / ``D2m,nT``."""
+        from .._i18n import check_language
         from .._plot.building import plot_facade_prediction
 
-        return plot_facade_prediction(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_facade_prediction(self, ax=ax, language=language, **kwargs)
 
 
 @dataclass(frozen=True)
@@ -195,11 +197,13 @@ class RadiatedPowerResult:
     l_w_dba: float | None = None
     frequencies: np.ndarray | None = None
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the radiated sound power level ``LW`` per band."""
+        from .._i18n import check_language
         from .._plot.building import plot_radiated_power
 
-        return plot_radiated_power(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_radiated_power(self, ax=ax, language=language, **kwargs)
 
 
 # A-weighting at octave-band centres 63 Hz .. 8 kHz (IEC 61672-1), for the

--- a/src/phonometry/building/flanking_transmission.py
+++ b/src/phonometry/building/flanking_transmission.py
@@ -320,15 +320,17 @@ class VibrationReductionResult:
             bracketed=oct_bracketed,
         )
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot ``Kij`` against frequency.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.building import plot_vibration_reduction
 
-        return plot_vibration_reduction(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_vibration_reduction(self, ax=ax, language=language, **kwargs)
 
 
 def _validate_octave_triples(freq_groups: np.ndarray) -> None:
@@ -558,14 +560,14 @@ class FlankingLevelDifferenceResult:
     d_n_f: np.ndarray
     rating: WeightedRatingResult | None
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot ``Dn,f`` against the shifted ISO 717-1 reference curve."""
         if self.rating is None:
             raise ValueError(
                 "No single-number rating is available to plot (need 16 "
                 "one-third-octave or 5 octave bands)."
             )
-        return self.rating.plot(ax=ax, **kwargs)
+        return self.rating.plot(ax=ax, language=language, **kwargs)
 
 
 @dataclass(frozen=True)
@@ -580,14 +582,14 @@ class FlankingImpactLevelResult:
     l_n_f: np.ndarray
     rating: ImpactRatingResult | None
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot ``Ln,f`` against the shifted ISO 717-2 reference curve."""
         if self.rating is None:
             raise ValueError(
                 "No single-number rating is available to plot (need 16 "
                 "one-third-octave or 5 octave bands)."
             )
-        return self.rating.plot(ax=ax, **kwargs)
+        return self.rating.plot(ax=ax, language=language, **kwargs)
 
 
 def normalized_flanking_level_difference(

--- a/src/phonometry/building/floor_covering_improvement.py
+++ b/src/phonometry/building/floor_covering_improvement.py
@@ -168,15 +168,17 @@ class FloorCoveringImprovementResult:
         """Return ``(octave_freqs, ΔLoct)`` via Formula (5) (needs 16 1/3-oct bands)."""
         return improvement_octave_bands(self.improvement, self.frequencies)
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the improvement spectrum ``ΔL`` (with ``ΔLw`` when available).
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.building import plot_floor_covering_improvement
 
-        return plot_floor_covering_improvement(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_floor_covering_improvement(self, ax=ax, language=language, **kwargs)
 
 
 def _rating_slice(frequencies: np.ndarray) -> np.ndarray | None:

--- a/src/phonometry/building/installed_structure_borne.py
+++ b/src/phonometry/building/installed_structure_borne.py
@@ -284,15 +284,17 @@ class InstalledSourceResult:
         lt = np.atleast_1d(np.asarray(self.total_level, dtype=np.float64))
         return float(10.0 * np.log10(np.sum(10.0 ** (0.1 * lt))))
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the per-path and total normalised sound pressure levels.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.building import plot_installed_structure_borne
 
-        return plot_installed_structure_borne(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_installed_structure_borne(self, ax=ax, language=language, **kwargs)
 
 
 def installed_source_prediction(

--- a/src/phonometry/building/insulation.py
+++ b/src/phonometry/building/insulation.py
@@ -254,15 +254,17 @@ class AirborneInsulationResult:
     dnt: np.ndarray
     r_prime: np.ndarray | None
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the per-band insulation quantities (``DnT``, ``D``, ``R'``).
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.building import plot_airborne_insulation
 
-        return plot_airborne_insulation(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_airborne_insulation(self, ax=ax, language=language, **kwargs)
 
 
 @dataclass(frozen=True)
@@ -299,7 +301,7 @@ class WeightedRatingResult:
     shifted_reference: np.ndarray | None = None
     quantity: str = "airborne"
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the measured curve vs the shifted reference (ISO 717-1).
 
         Unfavourable deviations (reference above measurement) are shaded and
@@ -307,9 +309,11 @@ class WeightedRatingResult:
         (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.building import plot_weighted_rating
 
-        return plot_weighted_rating(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_weighted_rating(self, ax=ax, language=language, **kwargs)
 
     def report(
         self,
@@ -368,15 +372,17 @@ class ImpactInsulationResult:
     l_n_t: np.ndarray
     l_n: np.ndarray | None
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the per-band impact levels (``L'nT`` and, if present, ``L'n``).
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.building import plot_impact_insulation
 
-        return plot_impact_insulation(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_impact_insulation(self, ax=ax, language=language, **kwargs)
 
 
 @dataclass(frozen=True)
@@ -411,7 +417,7 @@ class ImpactRatingResult:
     shifted_reference: np.ndarray | None = None
     quantity: str = "impact"
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the measured curve vs the shifted reference (ISO 717-2).
 
         Unfavourable deviations (measurement above the reference, the sign
@@ -419,9 +425,11 @@ class ImpactRatingResult:
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.building import plot_impact_rating
 
-        return plot_impact_rating(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_impact_rating(self, ax=ax, language=language, **kwargs)
 
     def report(
         self,
@@ -489,7 +497,7 @@ class FacadeInsulationResult:
     r_prime: np.ndarray | None
     frequencies: np.ndarray | None = None
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the per-band façade insulation profile (ISO 16283-3).
 
         Draws the standardized level difference and any other available
@@ -497,9 +505,11 @@ class FacadeInsulationResult:
         matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.building import plot_facade_insulation
 
-        return plot_facade_insulation(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_facade_insulation(self, ax=ax, language=language, **kwargs)
 
 
 def _render_iso717(

--- a/src/phonometry/building/panel_transmission.py
+++ b/src/phonometry/building/panel_transmission.py
@@ -193,15 +193,17 @@ class SoundReductionResult:
         """
         return self.rating().report(path, **kwargs)
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the predicted sound reduction index ``R(f)``.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.building import plot_sound_reduction
 
-        return plot_sound_reduction(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_sound_reduction(self, ax=ax, language=language, **kwargs)
 
 
 def single_panel_transmission_loss(

--- a/src/phonometry/building/structure_borne_power.py
+++ b/src/phonometry/building/structure_borne_power.py
@@ -203,15 +203,17 @@ class StructureBornePowerResult:
         lw = np.asarray(self.power_level, dtype=np.float64)
         return float(10.0 * np.log10(np.sum(10.0 ** (0.1 * lw))))
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the characteristic structure-borne power level per band.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.building import plot_structure_borne_power
 
-        return plot_structure_borne_power(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_structure_borne_power(self, ax=ax, language=language, **kwargs)
 
 
 def reception_plate_power(

--- a/src/phonometry/emission/intensity.py
+++ b/src/phonometry/emission/intensity.py
@@ -115,16 +115,18 @@ class IntensityResult:
     total_direction: int
     max_valid_frequency: float
 
-    def plot(self, ax: Axes | None = None, **kwargs: Any) -> Axes:
+    def plot(self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any) -> Axes:
         """Plot Lp vs LI per band with the pressure-intensity index.
 
         Requires per-band data (call ``sound_intensity(..., fraction=...)``)
         and matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.emission import plot_intensity
 
-        return plot_intensity(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_intensity(self, ax=ax, language=language, **kwargs)
 
 
 @dataclass(frozen=True)

--- a/src/phonometry/emission/sound_power.py
+++ b/src/phonometry/emission/sound_power.py
@@ -168,15 +168,17 @@ class SoundPowerResult:
     uncertainty: float
     grade: str
 
-    def plot(self, ax: Axes | None = None, **kwargs: Any) -> Axes:
+    def plot(self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any) -> Axes:
         """Plot the LW spectrum with the A-weighted total annotated.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.emission import plot_sound_power
 
-        return plot_sound_power(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_sound_power(self, ax=ax, language=language, **kwargs)
 
 
 def background_noise_correction(
@@ -752,15 +754,17 @@ class PrecisionSoundPowerResult:
     uncertainty_bands: np.ndarray
     coverage_factor: float
 
-    def plot(self, ax: Axes | None = None, **kwargs: Any) -> Axes:
+    def plot(self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any) -> Axes:
         """Plot the precision ``LW`` spectrum with the A-weighted total.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.emission import plot_sound_power
 
-        return plot_sound_power(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_sound_power(self, ax=ax, language=language, **kwargs)
 
 
 def _precision_table(surface: PrecisionSurface, array: PrecisionArray) -> np.ndarray:
@@ -1207,15 +1211,17 @@ class PrecisionIntensityResult:
     surface_area: float
     sound_power_level_a: float
 
-    def plot(self, ax: Axes | None = None, **kwargs: Any) -> Axes:
+    def plot(self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any) -> Axes:
         """Plot the ``LW`` spectrum; non-applicable bands are hatched/greyed.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.emission import plot_sound_power
 
-        return plot_sound_power(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_sound_power(self, ax=ax, language=language, **kwargs)
 
 
 def precision_field_indicators(

--- a/src/phonometry/emission/sound_power_intensity.py
+++ b/src/phonometry/emission/sound_power_intensity.py
@@ -140,15 +140,17 @@ class SoundPowerIntensityResult:
     sound_power_level_a: float
     grade: str
 
-    def plot(self, ax: Axes | None = None, **kwargs: Any) -> Axes:
+    def plot(self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any) -> Axes:
         """Plot the LW spectrum; non-positive bands are hatched as unusable.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.emission import plot_sound_power
 
-        return plot_sound_power(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_sound_power(self, ax=ax, language=language, **kwargs)
 
 
 def _level_magnitude(values: np.ndarray) -> np.ndarray:

--- a/src/phonometry/emission/sound_power_reverberation.py
+++ b/src/phonometry/emission/sound_power_reverberation.py
@@ -90,15 +90,17 @@ class ReverberationSoundPowerResult:
     sound_power_level_a: float
     method: str
 
-    def plot(self, ax: Axes | None = None, **kwargs: Any) -> Axes:
+    def plot(self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any) -> Axes:
         """Plot the LW spectrum with the A-weighted total annotated.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.emission import plot_sound_power
 
-        return plot_sound_power(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_sound_power(self, ax=ax, language=language, **kwargs)
 
 
 def _validate_meteorology(temperature: float, static_pressure: float) -> None:

--- a/src/phonometry/emission/vibration_sound_power.py
+++ b/src/phonometry/emission/vibration_sound_power.py
@@ -249,15 +249,17 @@ class VibrationSoundPowerResult:
         lw = np.asarray(self.sound_power_level, dtype=np.float64)
         return float(10.0 * np.log10(np.sum(10.0 ** (0.1 * lw))))
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the radiated sound power level per band.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.emission import plot_vibration_sound_power
 
-        return plot_vibration_sound_power(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_vibration_sound_power(self, ax=ax, language=language, **kwargs)
 
 
 def sound_power_from_vibration(

--- a/src/phonometry/noise_control/enclosures.py
+++ b/src/phonometry/noise_control/enclosures.py
@@ -71,15 +71,17 @@ class EnclosureResult:
     internal_area: float
     room_constant: np.ndarray
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the panel ``R``, correction ``C`` and net insertion loss.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.noise_control import plot_enclosure
 
-        return plot_enclosure(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_enclosure(self, ax=ax, language=language, **kwargs)
 
 
 class PanelTransmissionResult(Protocol):

--- a/src/phonometry/noise_control/hvac.py
+++ b/src/phonometry/noise_control/hvac.py
@@ -133,14 +133,16 @@ class HvacSpectrumResult:
     quantity: str
     label: str
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the quantity against a continuous log-frequency axis.
 
         Requires matplotlib (``pip install phonometry[plot]``).
         """
+        from .._i18n import check_language
         from .._plot.noise_control import plot_hvac_spectrum
 
-        return plot_hvac_spectrum(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_hvac_spectrum(self, ax=ax, language=language, **kwargs)
 
 
 def end_reflection_loss(

--- a/src/phonometry/noise_control/silencers.py
+++ b/src/phonometry/noise_control/silencers.py
@@ -327,15 +327,17 @@ class ReactiveSilencerResult:
     kind: str
     resonances: np.ndarray | None = None
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the transmission (and insertion) loss against frequency.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.noise_control import plot_reactive_silencer
 
-        return plot_reactive_silencer(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_reactive_silencer(self, ax=ax, language=language, **kwargs)
 
 
 def _result(

--- a/tests/building/test_panel_transmission.py
+++ b/tests/building/test_panel_transmission.py
@@ -203,3 +203,23 @@ def test_double_wall_degenerate_f0_above_fl_is_partitioned() -> None:
 def test_double_wall_rejects_bad_input() -> None:
     with pytest.raises(ValueError, match="gap"):
         double_wall_transmission_loss(BANDS, 10.0, 10.0, -0.1)
+
+
+def test_plot_language_spanish_and_validation() -> None:
+    # The .plot() renderer accepts a language option: Spanish localises the
+    # axis labels and title, and an unknown code is rejected up front.
+    m = 15.0
+    bp = plate_bending_stiffness(6.2e10, 0.006, 0.24)
+    fc = coincidence_frequency(m, bp)
+    res = single_panel_transmission_loss(BANDS, m, critical_frequency=fc,
+                                         loss_factor=0.024)
+    ax = res.plot(language="es")
+    assert "Frecuencia" in ax.get_xlabel()
+    assert "reducción acústica" in ax.get_ylabel()
+    assert "Aislamiento" in ax.get_title()
+    # English (the default) stays byte-for-byte the original text.
+    ax_en = res.plot()
+    assert ax_en.get_xlabel() == "Frequency [Hz]"
+    assert ax_en.get_ylabel() == "Sound reduction index $R$ [dB]"
+    with pytest.raises(ValueError, match="Unknown language"):
+        res.plot(language="xx")

--- a/tests/emission/test_sound_power.py
+++ b/tests/emission/test_sound_power.py
@@ -433,3 +433,17 @@ def test_k2_over_validity_limit_warns() -> None:
         sound_power_pressure(
             np.full((10, 1), 60.0), "hemisphere", radius=r, absorption_area=10.0
         )
+
+
+def test_plot_language_spanish_and_validation() -> None:
+    # The sound-power .plot() renderer localises to Spanish and rejects an
+    # unknown language code; English remains the unchanged default.
+    levels = np.full((10, 1), 70.0)
+    res = sound_power_pressure(levels, "hemisphere", radius=2.0)
+    ax = res.plot(language="es")
+    assert "potencia acústica" in ax.get_ylabel()
+    assert "espectro de potencia acústica" in ax.get_title()
+    ax_en = res.plot()
+    assert ax_en.get_ylabel() == "Sound power level LW [dB]"
+    with pytest.raises(ValueError, match="Unknown language"):
+        res.plot(language="xx")

--- a/tests/noise_control/test_silencers.py
+++ b/tests/noise_control/test_silencers.py
@@ -159,3 +159,19 @@ def test_validation() -> None:
         sl.expansion_chamber([100.0], 0.3, -0.04, 0.01)
     with pytest.raises(ValueError, match="must exceed"):
         sl.extended_tube_chamber([100.0], 0.3, 0.01, 0.02)
+
+
+def test_plot_language_spanish_and_validation() -> None:
+    # The reactive-silencer .plot() renderer localises to Spanish and rejects
+    # an unknown language code; English remains the unchanged default.
+    f = np.linspace(20.0, 2000.0, 500)
+    res = sl.expansion_chamber(f, 0.3, 0.04, 0.01)
+    ax = res.plot(language="es")
+    assert "Frecuencia" in ax.get_xlabel()
+    assert "Pérdida" in ax.get_ylabel()
+    assert "Silenciador reactivo" in ax.get_title()
+    ax_en = res.plot()
+    assert ax_en.get_xlabel() == "Frequency [Hz]"
+    assert ax_en.get_ylabel() == "Loss [dB]"
+    with pytest.raises(ValueError, match="Unknown language"):
+        res.plot(language="xx")


### PR DESCRIPTION
## Summary

The `.plot()` renderers of the building, noise-control and emission result objects now accept a `language` keyword. It defaults to `"en"`, which keeps the current English output byte-for-byte unchanged, and `"es"` renders the axis labels, titles and legends with the usual Spanish building-acoustics terminology and a comma decimal separator.

## What changed

- New shared `phonometry._i18n` helper module: language validation (`check_language`), locale-aware number formatting (`format_number`, `decimal_comma`) and linear-axis tick localisation (`localize_axes`).
- Each of `_plot/building.py`, `_plot/noise_control.py` and `_plot/emission.py` gains an English-to-Spanish string table plus a small `_t` lookup, and every renderer threads `language` through to its labels, titles, legends and embedded numbers.
- The 28 `.plot()` methods on the affected result dataclasses expose `*, language="en"`, validate the code up front and forward it to the renderer. The `_i18n` imports live inside the functions so the rendering leaves keep no module-level domain imports.
- A representative Spanish-rendering test per domain (building, noise-control, emission) covering the localised labels and the `ValueError` on an unknown code.
- Regenerated the committed API reference for the updated public `.plot()` signatures.

## Verification

- English is byte-for-byte identical: an old-versus-new comparison of every one of the 22 renderers, driven with the same data, produces the same set of text artists. `_t(key, "en")` returns the verbatim original, `format_number(x, "en", ...)` matches the original format specs, and `localize_axes(ax, "en")` is a no-op.
- The committed docs figures for these domains regenerate with zero change under `.github/images/`.
- Gates: `ruff check .` clean, `mypy src scripts` clean (169 files), and `pytest tests/building tests/noise_control tests/emission tests/test_package_architecture.py` passes (743 tests).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plot renderers now support English and Spanish labels, titles, legends, and localized number formatting.
  * Added an optional `language` setting, defaulting to English, across building, noise-control, and emission plots.
  * Unsupported language codes now provide clear validation errors.

* **Documentation**
  * Updated API references and changelog with the new plotting language option.

* **Tests**
  * Added coverage for Spanish localization, English defaults, and invalid language handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->