### PR TITLE
feat: EN/ES language option for the .report() fiches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Every `.report()` fiche accepts a `language` argument (`'en'` default, `'es'`):
+  Spanish strings and a comma decimal separator.
 - IEC 61260-1 filter class compliance can now be exported as a one-page PDF
   fiche. A new `filter_class_compliance(bank, *, num_points=..., edition=...)`
   runs the same verification as `verify_filter_class` and returns a frozen

--- a/docs/aircraft-noise.md
+++ b/docs/aircraft-noise.md
@@ -119,8 +119,11 @@ engine as the ISO 717 insulation fiche; a supplied `requirement` is read as the
 certification EPNL limit in EPNdB (the EPNL passes at or below it), and
 `metadata=None` produces a lightweight prediction fiche with no verdict row.
 Rendering needs reportlab (`pip install phonometry[report]`); only
-`engine="reportlab"` is supported. The fiche is a computational EPNL result and
-is not an official State noise certificate; it does not reproduce any TCDSN.
+`engine="reportlab"` is supported. The fiche renders in English by default;
+pass `language="es"` for a Spanish fiche (translated fixed strings and a comma
+decimal separator), e.g. `res.report("epnl_fiche_es.pdf", language="es")`. The
+fiche is a computational EPNL result and is not an official State noise
+certificate; it does not reproduce any TCDSN.
 
 ```python
 from phonometry import effective_perceived_noise_level, ReportMetadata

--- a/docs/filter-banks.md
+++ b/docs/filter-banks.md
@@ -593,7 +593,9 @@ worst-margin band's measured relative attenuation overlaid on the class
 corridor, and the boxed overall class-compliance result. Pass a `required_class`
 on the `ReportMetadata` to add a PASS/FAIL verdict row (a bank "meets class N"
 when its achieved class is at least as strict, i.e. a class index of N or
-lower).
+lower). The fiche renders in English by default; pass `language="es"` for a
+Spanish fiche (translated fixed strings and a comma decimal separator), e.g.
+`result.report("iec61260_es.pdf", language="es")`.
 
 ```python
 from phonometry import OctaveFilterBank, ReportMetadata, filter_class_compliance

--- a/docs/insulation-field.md
+++ b/docs/insulation-field.md
@@ -346,7 +346,10 @@ Rendering needs reportlab, kept out of the runtime dependencies as the optional
 `phonometry[report]` extra (`pip install phonometry[report]`); a missing
 reportlab raises a clear `ImportError` with the install command, and the plot
 still needs matplotlib (`phonometry[plot]`). Only `engine="reportlab"` is
-supported; any other engine raises `ValueError`.
+supported; any other engine raises `ValueError`. The fiche renders in English by
+default; pass `language="es"` for a Spanish fiche (translated fixed strings and
+a comma decimal separator), e.g.
+`building.weighted_rating(R).report("Rw_fiche_es.pdf", language="es")`.
 
 ```python
 from phonometry import building, ReportMetadata

--- a/docs/loudness.md
+++ b/docs/loudness.md
@@ -132,7 +132,9 @@ footer with the fixed disclaimer. It uses the same `ReportMetadata` container
 and rendering engine as the ISO 717 insulation fiche; a supplied `requirement`
 is read as the maximum permitted loudness in sone (a lower loudness passes).
 Rendering needs reportlab (`pip install phonometry[report]`); only
-`engine="reportlab"` is supported.
+`engine="reportlab"` is supported. The fiche renders in English by default;
+pass `language="es"` for a Spanish fiche (translated fixed strings and a comma
+decimal separator), e.g. `res.report("loudness_fiche_es.pdf", language="es")`.
 
 ```python
 from phonometry import psychoacoustics, ReportMetadata

--- a/docs/materials.md
+++ b/docs/materials.md
@@ -129,7 +129,9 @@ and rendering engine as the ISO 717 insulation fiche; passing
 Setting `verbose=True` swaps the two-column table for the ISO 11654 evaluation
 columns (practical coefficient, shifted reference, unfavourable deviation).
 Rendering needs reportlab (`pip install phonometry[report]`); only
-`engine="reportlab"` is supported.
+`engine="reportlab"` is supported. The fiche renders in English by default;
+pass `language="es"` for a Spanish fiche (translated fixed strings and a comma
+decimal separator), e.g. `result.report("alpha_w_fiche_es.pdf", language="es")`.
 
 ```python
 from phonometry import materials, ReportMetadata

--- a/docs/program-loudness.md
+++ b/docs/program-loudness.md
@@ -257,7 +257,9 @@ a supplied `requirement` is read as the target programme loudness in LUFS
 (defaulting to the EBU R 128 −23.0 LUFS), and the fiche passes when the
 integrated loudness is within ±0.5 LU of it and the true peak is at or below
 −1.0 dBTP. Rendering needs reportlab (`pip install phonometry[report]`); only
-`engine="reportlab"` is supported.
+`engine="reportlab"` is supported. The fiche renders in English by default;
+pass `language="es"` for a Spanish fiche (translated fixed strings and a comma
+decimal separator), e.g. `res.report("loudness_fiche_es.pdf", language="es")`.
 
 ```python
 from phonometry import broadcast, ReportMetadata

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -809,7 +809,9 @@ worst-margin band's measured relative attenuation overlaid on the class
 corridor, and the boxed overall class-compliance result. Pass a `required_class`
 on the `ReportMetadata` to add a PASS/FAIL verdict row (a bank "meets class N"
 when its achieved class is at least as strict, i.e. a class index of N or
-lower).
+lower). The fiche renders in English by default; pass `language="es"` for a
+Spanish fiche (translated fixed strings and a comma decimal separator), e.g.
+`result.report("iec61260_es.pdf", language="es")`.
 
 ```python
 from phonometry import OctaveFilterBank, ReportMetadata, filter_class_compliance
@@ -2781,7 +2783,9 @@ footer with the fixed disclaimer. It uses the same `ReportMetadata` container
 and rendering engine as the ISO 717 insulation fiche; a supplied `requirement`
 is read as the maximum permitted loudness in sone (a lower loudness passes).
 Rendering needs reportlab (`pip install phonometry[report]`); only
-`engine="reportlab"` is supported.
+`engine="reportlab"` is supported. The fiche renders in English by default;
+pass `language="es"` for a Spanish fiche (translated fixed strings and a comma
+decimal separator), e.g. `res.report("loudness_fiche_es.pdf", language="es")`.
 
 ```python
 from phonometry import psychoacoustics, ReportMetadata
@@ -5647,7 +5651,10 @@ Rendering needs reportlab, kept out of the runtime dependencies as the optional
 `phonometry[report]` extra (`pip install phonometry[report]`); a missing
 reportlab raises a clear `ImportError` with the install command, and the plot
 still needs matplotlib (`phonometry[plot]`). Only `engine="reportlab"` is
-supported; any other engine raises `ValueError`.
+supported; any other engine raises `ValueError`. The fiche renders in English by
+default; pass `language="es"` for a Spanish fiche (translated fixed strings and
+a comma decimal separator), e.g.
+`building.weighted_rating(R).report("Rw_fiche_es.pdf", language="es")`.
 
 ```python
 from phonometry import building, ReportMetadata

--- a/site/src/content/docs/es/guides/aircraft-noise.mdx
+++ b/site/src/content/docs/es/guides/aircraft-noise.mdx
@@ -165,9 +165,12 @@ contenedor `ReportMetadata` y el mismo motor de renderizado que la
 un `requirement` aportado se lee como el límite de certificación EPNL en EPNdB
 (el EPNL cumple si es igual o inferior), y `metadata=None` produce una ficha de
 predicción ligera sin fila de veredicto. El renderizado necesita reportlab
-(`pip install phonometry[report]`); solo se admite `engine="reportlab"`. La ficha
-es un resultado EPNL calculado y no es un certificado oficial de ruido de un
-Estado; no reproduce ningún TCDSN.
+(`pip install phonometry[report]`); solo se admite `engine="reportlab"`. La
+ficha se genera en inglés por defecto; pasa `language="es"` para una ficha en
+español (cadenas fijas traducidas y coma como separador decimal), p. ej.
+`res.report("epnl_fiche_es.pdf", language="es")`. La ficha es un resultado EPNL
+calculado y no es un certificado oficial de ruido de un Estado; no reproduce
+ningún TCDSN.
 
 ```python
 from phonometry import effective_perceived_noise_level, ReportMetadata

--- a/site/src/content/docs/es/guides/filter-banks.mdx
+++ b/site/src/content/docs/es/guides/filter-banks.mdx
@@ -661,7 +661,10 @@ la atenuación relativa medida de la banda de peor margen sobre el corredor de l
 clase y encuadra el resultado global de conformidad. Pasa un `required_class` en
 el `ReportMetadata` para añadir una fila de veredicto PASS/FAIL (un banco
 "cumple la clase N" cuando su clase alcanzada es al menos igual de estricta, es
-decir, un índice de clase N o inferior).
+decir, un índice de clase N o inferior). La ficha se genera en inglés por
+defecto; pasa `language="es"` para una ficha en español (cadenas fijas
+traducidas y coma como separador decimal), p. ej.
+`result.report("iec61260_es.pdf", language="es")`.
 
 ```python
 from phonometry import (

--- a/site/src/content/docs/es/guides/insulation-field.mdx
+++ b/site/src/content/docs/es/guides/insulation-field.mdx
@@ -423,7 +423,10 @@ ejecución como el extra opcional `phonometry[report]`
 (`pip install phonometry[report]`); si falta reportlab se lanza un `ImportError`
 claro con el comando de instalación, y la gráfica sigue necesitando matplotlib
 (`phonometry[plot]`). Solo se admite `engine="reportlab"`; cualquier otro motor
-lanza `ValueError`.
+lanza `ValueError`. La ficha se genera en inglés por defecto; pasa
+`language="es"` para una ficha en español (cadenas fijas traducidas y coma como
+separador decimal), p. ej.
+`building.weighted_rating(R).report("Rw_fiche_es.pdf", language="es")`.
 
 ```python
 from phonometry import building, ReportMetadata

--- a/site/src/content/docs/es/guides/loudness.mdx
+++ b/site/src/content/docs/es/guides/loudness.mdx
@@ -203,7 +203,10 @@ veredicto y un pie con el descargo fijo. Usa el mismo contenedor
 [ficha de aislamiento de ISO 717](/phonometry/es/guides/insulation-field/#informe-de-iso-717-report);
 un `requirement` aportado se lee como la sonoridad máxima admisible en sonos
 (una sonoridad menor cumple). El renderizado necesita reportlab
-(`pip install phonometry[report]`); solo se admite `engine="reportlab"`.
+(`pip install phonometry[report]`); solo se admite `engine="reportlab"`. La
+ficha se genera en inglés por defecto; pasa `language="es"` para una ficha en
+español (cadenas fijas traducidas y coma como separador decimal), p. ej.
+`res.report("loudness_fiche_es.pdf", language="es")`.
 
 ```python
 from phonometry import psychoacoustics, ReportMetadata

--- a/site/src/content/docs/es/guides/materials.mdx
+++ b/site/src/content/docs/es/guides/materials.mdx
@@ -211,7 +211,9 @@ aportado se lee como el $\alpha_w$ mínimo para el veredicto CUMPLE/NO CUMPLE.
 Con `verbose=True` la tabla cambia a las columnas de evaluación de ISO 11654
 (coeficiente práctico, referencia desplazada, desviación desfavorable). El
 renderizado necesita reportlab (`pip install phonometry[report]`); solo se
-admite `engine="reportlab"`.
+admite `engine="reportlab"`. La ficha se genera en inglés por defecto; pasa
+`language="es"` para una ficha en español (cadenas fijas traducidas y coma como
+separador decimal), p. ej. `result.report("alpha_w_fiche_es.pdf", language="es")`.
 
 ```python
 from phonometry import materials, ReportMetadata

--- a/site/src/content/docs/es/guides/program-loudness.mdx
+++ b/site/src/content/docs/es/guides/program-loudness.mdx
@@ -318,7 +318,10 @@ un `requirement` proporcionado se interpreta como la sonoridad de programa
 objetivo en LUFS (por defecto los −23,0 LUFS de EBU R 128), y la ficha cumple
 cuando la sonoridad integrada está dentro de ±0,5 LU de él y el pico verdadero
 es igual o inferior a −1,0 dBTP. El renderizado necesita reportlab
-(`pip install phonometry[report]`); solo se admite `engine="reportlab"`.
+(`pip install phonometry[report]`); solo se admite `engine="reportlab"`. La
+ficha se genera en inglés por defecto; pasa `language="es"` para una ficha en
+español (cadenas fijas traducidas y coma como separador decimal), p. ej.
+`res.report("loudness_fiche_es.pdf", language="es")`.
 
 ```python
 from phonometry import broadcast, ReportMetadata

--- a/site/src/content/docs/guides/aircraft-noise.mdx
+++ b/site/src/content/docs/guides/aircraft-noise.mdx
@@ -162,8 +162,11 @@ fiche](/phonometry/guides/insulation-field/#iso-717-report-report); a supplied
 `requirement` is read as the certification EPNL limit in EPNdB (the EPNL passes
 at or below it), and `metadata=None` produces a lightweight prediction fiche with
 no verdict row. Rendering needs reportlab (`pip install phonometry[report]`);
-only `engine="reportlab"` is supported. The fiche is a computational EPNL result
-and is not an official State noise certificate; it does not reproduce any TCDSN.
+only `engine="reportlab"` is supported. The fiche renders in English by default;
+pass `language="es"` for a Spanish fiche (translated fixed strings and a comma
+decimal separator), e.g. `res.report("epnl_fiche_es.pdf", language="es")`. The
+fiche is a computational EPNL result and is not an official State noise
+certificate; it does not reproduce any TCDSN.
 
 ```python
 from phonometry import effective_perceived_noise_level, ReportMetadata

--- a/site/src/content/docs/guides/filter-banks.mdx
+++ b/site/src/content/docs/guides/filter-banks.mdx
@@ -641,7 +641,10 @@ its binding margin, overlays the worst-margin band's measured relative
 attenuation on the class corridor, and boxes the overall class-compliance
 result. Pass a `required_class` on the `ReportMetadata` to add a PASS/FAIL
 verdict row (a bank "meets class N" when its achieved class is at least as
-strict, i.e. a class index of N or lower).
+strict, i.e. a class index of N or lower). The fiche renders in English by
+default; pass `language="es"` for a Spanish fiche (translated fixed strings and
+a comma decimal separator), e.g.
+`result.report("iec61260_es.pdf", language="es")`.
 
 ```python
 from phonometry import (

--- a/site/src/content/docs/guides/insulation-field.mdx
+++ b/site/src/content/docs/guides/insulation-field.mdx
@@ -415,7 +415,10 @@ Rendering needs reportlab, kept out of the runtime dependencies as the optional
 `phonometry[report]` extra (`pip install phonometry[report]`); a missing
 reportlab raises a clear `ImportError` with the install command, and the plot
 still needs matplotlib (`phonometry[plot]`). Only `engine="reportlab"` is
-supported; any other engine raises `ValueError`.
+supported; any other engine raises `ValueError`. The fiche renders in English by
+default; pass `language="es"` for a Spanish fiche (translated fixed strings and
+a comma decimal separator), e.g.
+`building.weighted_rating(R).report("Rw_fiche_es.pdf", language="es")`.
 
 ```python
 from phonometry import building, ReportMetadata

--- a/site/src/content/docs/guides/loudness.mdx
+++ b/site/src/content/docs/guides/loudness.mdx
@@ -194,7 +194,10 @@ footer with the fixed disclaimer. It uses the same `ReportMetadata` container
 and rendering engine as the [ISO 717 insulation fiche](/phonometry/guides/insulation-field/#iso-717-report-report);
 a supplied `requirement` is read as the maximum permitted loudness in sone (a
 lower loudness passes). Rendering needs reportlab
-(`pip install phonometry[report]`); only `engine="reportlab"` is supported.
+(`pip install phonometry[report]`); only `engine="reportlab"` is supported. The
+fiche renders in English by default; pass `language="es"` for a Spanish fiche
+(translated fixed strings and a comma decimal separator), e.g.
+`res.report("loudness_fiche_es.pdf", language="es")`.
 
 ```python
 from phonometry import psychoacoustics, ReportMetadata

--- a/site/src/content/docs/guides/materials.mdx
+++ b/site/src/content/docs/guides/materials.mdx
@@ -206,7 +206,9 @@ passing `metadata=None` produces a lightweight prediction fiche, and a supplied
 Setting `verbose=True` swaps the two-column table for the ISO 11654 evaluation
 columns (practical coefficient, shifted reference, unfavourable deviation).
 Rendering needs reportlab (`pip install phonometry[report]`); only
-`engine="reportlab"` is supported.
+`engine="reportlab"` is supported. The fiche renders in English by default; pass
+`language="es"` for a Spanish fiche (translated fixed strings and a comma
+decimal separator), e.g. `result.report("alpha_w_fiche_es.pdf", language="es")`.
 
 ```python
 from phonometry import materials, ReportMetadata

--- a/site/src/content/docs/guides/program-loudness.mdx
+++ b/site/src/content/docs/guides/program-loudness.mdx
@@ -310,7 +310,9 @@ a supplied `requirement` is read as the target programme loudness in LUFS
 (defaulting to the EBU R 128 −23.0 LUFS), and the fiche passes when the
 integrated loudness is within ±0.5 LU of it and the true peak is at or below
 −1.0 dBTP. Rendering needs reportlab (`pip install phonometry[report]`); only
-`engine="reportlab"` is supported.
+`engine="reportlab"` is supported. The fiche renders in English by default; pass
+`language="es"` for a Spanish fiche (translated fixed strings and a comma
+decimal separator), e.g. `res.report("loudness_fiche_es.pdf", language="es")`.
 
 ```python
 from phonometry import broadcast, ReportMetadata

--- a/site/src/content/docs/reference/api/aeroacoustics/aircraft-noise.md
+++ b/site/src/content/docs/reference/api/aeroacoustics/aircraft-noise.md
@@ -153,6 +153,7 @@ EPNLResult.report(
     metadata: ReportMetadata | None = None,
     engine: str = 'reportlab',
     verbose: bool = False,
+    language: str = 'en',
 ) -> str
 ```
 
@@ -177,6 +178,7 @@ strip and a footer with the fixed disclaimer.
 | `metadata` | Optional [`ReportMetadata`](/phonometry/reference/api/building/insulation/#reportmetadata); `None` produces a prediction fiche (metrics, plot and result only, no verdict). A supplied `requirement` is read as the certification EPNL limit in EPNdB (the EPNL passes at or below it). |
 | `engine` | Rendering back end; only `"reportlab"` is supported. |
 | `verbose` | Accepted for a uniform signature; it has no effect on the single-layout EPNL fiche. |
+| `language` | Fiche language: `"en"` (default, English) or `"es"` (Spanish, with a comma decimal separator). |
 
 **Returns:** The written `path` as a `str`.
 

--- a/site/src/content/docs/reference/api/broadcast/program-loudness.md
+++ b/site/src/content/docs/reference/api/broadcast/program-loudness.md
@@ -286,6 +286,7 @@ ProgramLoudnessResult.report(
     metadata: ReportMetadata | None = None,
     engine: str = 'reportlab',
     verbose: bool = False,
+    language: str = 'en',
 ) -> str
 ```
 
@@ -307,6 +308,7 @@ PASS/FAIL verdict row and a footer with the fixed disclaimer.
 | `metadata` | Optional [`ReportMetadata`](/phonometry/reference/api/building/insulation/#reportmetadata); `None` produces a measurement fiche (compliance table, plot and verdict only). A supplied `requirement` is read as the target programme loudness in LUFS (defaulting to the EBU R 128 -23.0 LUFS). |
 | `engine` | Rendering back end; only `"reportlab"` is supported. |
 | `verbose` | Accepted for a uniform signature; it has no effect on the single-layout programme-loudness fiche. |
+| `language` | Fiche language: `"en"` (default, English) or `"es"` (Spanish, with a comma decimal separator). |
 
 **Returns:** The written `path` as a `str`.
 

--- a/site/src/content/docs/reference/api/building/insulation.md
+++ b/site/src/content/docs/reference/api/building/insulation.md
@@ -523,6 +523,7 @@ ImpactRatingResult.report(
     metadata: ReportMetadata | None = None,
     engine: str = 'reportlab',
     verbose: bool = False,
+    language: str = 'en',
 ) -> str
 ```
 
@@ -542,6 +543,7 @@ an optional verdict row and a footer with the fixed disclaimer.
 | `metadata` | Optional [`ReportMetadata`](/phonometry/reference/api/building/insulation/#reportmetadata); `None` produces a prediction fiche (body, result and disclaimer only). |
 | `engine` | Rendering back end; only `"reportlab"` is supported. |
 | `verbose` | When `True`, the table uses the ISO 717 Annex C columns (frequency, measured value, shifted reference, unfavourable deviation) instead of the two-column `f \| value` table. |
+| `language` | Fiche language: `"en"` (default, English) or `"es"` (Spanish, with a comma decimal separator). |
 
 **Returns:** The written `path` as a `str`.
 
@@ -879,6 +881,7 @@ WeightedRatingResult.report(
     metadata: ReportMetadata | None = None,
     engine: str = 'reportlab',
     verbose: bool = False,
+    language: str = 'en',
 ) -> str
 ```
 
@@ -898,6 +901,7 @@ row and a footer with the fixed disclaimer.
 | `metadata` | Optional [`ReportMetadata`](/phonometry/reference/api/building/insulation/#reportmetadata); `None` produces a prediction fiche (body, result and disclaimer only). |
 | `engine` | Rendering back end; only `"reportlab"` is supported. |
 | `verbose` | When `True`, the table uses the ISO 717 Annex C columns (frequency, measured value, shifted reference, unfavourable deviation) instead of the two-column `f \| value` table. |
+| `language` | Fiche language: `"en"` (default, English) or `"es"` (Spanish, with a comma decimal separator). |
 
 **Returns:** The written `path` as a `str`.
 

--- a/site/src/content/docs/reference/api/filters/compliance.md
+++ b/site/src/content/docs/reference/api/filters/compliance.md
@@ -191,6 +191,7 @@ FilterComplianceResult.report(
     metadata: ReportMetadata | None = None,
     engine: str = 'reportlab',
     verbose: bool = False,
+    language: str = 'en',
 ) -> str
 ```
 
@@ -210,6 +211,7 @@ class-compliance result, an optional verdict row against a supplied
 | `metadata` | Optional [`ReportMetadata`](/phonometry/reference/api/building/insulation/#reportmetadata); `None` produces a prediction fiche (body, result and disclaimer only). A supplied `required_class` drives the verdict row. |
 | `engine` | Rendering back end; only `"reportlab"` is supported. |
 | `verbose` | Accepted for a uniform signature; it has no effect on the single-layout filter-compliance fiche. |
+| `language` | Fiche language: `"en"` (default, English) or `"es"` (Spanish, with a comma decimal separator). |
 
 **Returns:** The written `path` as a `str`.
 

--- a/site/src/content/docs/reference/api/materials/absorption-rating.md
+++ b/site/src/content/docs/reference/api/materials/absorption-rating.md
@@ -131,6 +131,7 @@ AbsorptionRatingResult.report(
     metadata: ReportMetadata | None = None,
     engine: str = 'reportlab',
     verbose: bool = False,
+    language: str = 'en',
 ) -> str
 ```
 
@@ -153,6 +154,7 @@ full ISO 354 one-third-octave `alpha_s` table with the octave
 | `metadata` | Optional [`ReportMetadata`](/phonometry/reference/api/building/insulation/#reportmetadata); `None` produces a prediction fiche (body, result and disclaimer only). A supplied `requirement` is read as the minimum `alpha_w`. |
 | `engine` | Rendering back end; only `"reportlab"` is supported. |
 | `verbose` | When `True`, the table adds the ISO 11654 evaluation columns (practical coefficient, shifted reference, unfavourable deviation) instead of the two-column `f \| alpha_p` table. |
+| `language` | Fiche language: `"en"` (default, English) or `"es"` (Spanish, with a comma decimal separator). |
 
 **Returns:** The written `path` as a `str`.
 

--- a/site/src/content/docs/reference/api/psychoacoustics/loudness-zwicker.md
+++ b/site/src/content/docs/reference/api/psychoacoustics/loudness-zwicker.md
@@ -147,6 +147,7 @@ ZwickerLoudness.report(
     metadata: ReportMetadata | None = None,
     engine: str = 'reportlab',
     verbose: bool = False,
+    language: str = 'en',
 ) -> str
 ```
 
@@ -167,6 +168,7 @@ and a footer with the fixed disclaimer.
 | `metadata` | Optional [`ReportMetadata`](/phonometry/reference/api/building/insulation/#reportmetadata); `None` produces a prediction fiche (body, result and disclaimer only). A supplied `requirement` is read as the maximum permitted loudness in sone. |
 | `engine` | Rendering back end; only `"reportlab"` is supported. |
 | `verbose` | Accepted for a uniform signature; it has no effect on the single-layout loudness fiche. |
+| `language` | Fiche language: `"en"` (default, English) or `"es"` (Spanish, with a comma decimal separator). |
 
 **Returns:** The written `path` as a `str`.
 

--- a/src/phonometry/_i18n.py
+++ b/src/phonometry/_i18n.py
@@ -1,0 +1,94 @@
+#  Copyright (c) 2026. Jose M. Requena-Plens
+"""Small internationalisation helpers shared by the ``.plot()`` and ``.report()``
+renderers.
+
+The library renders English by default. Passing ``language="es"`` to a result's
+``plot`` or ``report`` method switches the fixed strings (titles, axis labels,
+table headers, prose) to Spanish and the decimal separator to a comma, the way a
+Spanish-language figure or report writes numbers. Only two things live here: the
+:data:`Language` type and locale-aware number/axis formatting; the actual
+translated strings live next to the renderers that use them (``_plot`` and
+``_report`` each carry their own string tables).
+
+Nothing here is a runtime dependency: :func:`localize_axes` imports matplotlib
+lazily and is a no-op for English, so English plots are byte-for-byte unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+#: Supported rendering languages. English is the default everywhere.
+Language = Literal["en", "es"]
+
+_VALID_LANGUAGES = ("en", "es")
+
+
+def check_language(language: str) -> Language:
+    """Return ``language`` if supported, else raise a clear :class:`ValueError`."""
+    if language not in _VALID_LANGUAGES:
+        raise ValueError(
+            f"Unknown language {language!r}; supported languages are "
+            f"{_VALID_LANGUAGES}."
+        )
+    return language  # type: ignore[return-value]
+
+
+def format_number(
+    value: float,
+    language: str = "en",
+    *,
+    decimals: int = 1,
+    trim: bool = False,
+) -> str:
+    """Format ``value`` with a locale-aware decimal separator.
+
+    :param value: The number to format.
+    :param language: ``"en"`` (period) or ``"es"`` (comma).
+    :param decimals: Digits after the decimal separator.
+    :param trim: Drop a trailing ``.0`` / ``,0`` (and the separator) for a
+        whole number, e.g. ``90.0 -> "90"``.
+    :return: The formatted string.
+    """
+    text = f"{float(value):.{decimals}f}"
+    if trim and decimals > 0:
+        text = text.rstrip("0").rstrip(".")
+    if language == "es":
+        text = text.replace(".", ",")
+    return text
+
+
+def decimal_comma(value: str, language: str = "en") -> str:
+    """Swap the decimal point of an already-formatted number for the locale.
+
+    Useful when a number was produced by an ``f"{x:.2f}"`` literal and only its
+    separator needs localising. English is returned unchanged.
+    """
+    return value.replace(".", ",") if language == "es" else value
+
+
+def localize_axes(ax: Any, language: str = "en") -> None:
+    """Localise the tick-label decimal separator of ``ax`` for the language.
+
+    For Spanish, both axes' major tick labels are reformatted so decimals use a
+    comma (e.g. ``2.5 -> 2,5``); logarithmic and category axes that already emit
+    plain labels are left alone. English is a no-op, so English figures are
+    unchanged. Call it at the end of a plot function, after the data is drawn.
+    """
+    if language != "es":
+        return
+    from matplotlib.ticker import FuncFormatter, NullFormatter
+
+    def _comma(x: float, _pos: int) -> str:
+        # Match matplotlib's default compact formatting, then swap the point.
+        text = f"{x:g}"
+        return text.replace(".", ",")
+
+    for axis in (ax.xaxis, ax.yaxis):
+        # Leave axes whose labels are not plain numbers (log/symlog with the
+        # default LogFormatter, or fixed category labels) untouched.
+        if axis.get_scale() != "linear":
+            continue
+        if isinstance(axis.get_major_formatter(), NullFormatter):
+            continue
+        axis.set_major_formatter(FuncFormatter(_comma))

--- a/src/phonometry/_report/_i18n.py
+++ b/src/phonometry/_report/_i18n.py
@@ -1,0 +1,447 @@
+#  Copyright (c) 2026. Jose M. Requena-Plens
+"""Translated fixed strings for the accredited ``.report()`` fiches.
+
+Every fixed English string the six report renderers emit (titles, standard-basis
+line templates, table headers, metadata-grid labels, metric-row labels, verdict
+prose and the footer identity/disclaimer block) is keyed here by a stable
+English string-id and mapped to its English and Spanish forms. English is the
+default and is byte-for-byte unchanged; passing ``language="es"`` to a result's
+``report`` method renders these strings in Spanish (the decimal separator is
+switched to a comma by :func:`phonometry._i18n.format_number`).
+
+Unit symbols (Hz, dB, LUFS, LU, dBTP, sone, phon, EPNdB, PNdB, kPa, m2, m3, C,
+%), single-letter quantity symbols (R, alpha, N ...) and published standard
+designations (ISO 717-1, EBU R 128 ...) are never translated; only the natural
+language around them is. Templates carry ``{}``-style placeholders the renderer
+fills after translation.
+
+The user's own free-text metadata *values* (specimen, client, notes ...) are
+never translated: only the fixed *labels* live here.
+"""
+
+from __future__ import annotations
+
+#: Fixed report strings keyed by a stable English string-id. Each value maps a
+#: language code to its rendering. Templates use ``{}``/``{name}`` placeholders.
+REPORT_STRINGS: dict[str, dict[str, str]] = {
+    # --- titles ----------------------------------------------------------
+    "title.airborne": {
+        "en": "Airborne sound insulation rating",
+        "es": "Índice de aislamiento acústico a ruido aéreo",
+    },
+    "title.impact": {
+        "en": "Impact sound insulation rating",
+        "es": "Índice de aislamiento acústico a ruido de impactos",
+    },
+    "title.absorption": {
+        "en": "Sound absorption rating",
+        "es": "Índice de absorción acústica",
+    },
+    "title.loudness": {
+        "en": "Loudness rating",
+        "es": "Índice de sonoridad",
+    },
+    "title.program_loudness": {
+        "en": "Programme loudness compliance",
+        "es": "Conformidad de sonoridad de programa",
+    },
+    "title.epnl": {
+        "en": "Aircraft noise certification - EPNL result",
+        "es": "Certificación de ruido de aeronaves - resultado EPNL",
+    },
+    "title.filter_class": {
+        "en": "Filter class compliance",
+        "es": "Conformidad de clase de filtro",
+    },
+    # --- standard-basis line templates -----------------------------------
+    "basis.iso717.with_standard": {
+        "en": "{standard} laboratory measurement of sound insulation. "
+              "Rating per {part}:2020.",
+        "es": "{standard} medición en laboratorio del aislamiento acústico. "
+              "Índice según {part}:2020.",
+    },
+    "basis.iso717.plain": {
+        "en": "Sound insulation rating per {part}:2020.",
+        "es": "Índice de aislamiento acústico según {part}:2020.",
+    },
+    "basis.iso11654.with_standard": {
+        "en": "{standard} laboratory measurement of sound absorption. "
+              "Rating per ISO 11654:1997.",
+        "es": "{standard} medición en laboratorio de la absorción acústica. "
+              "Índice según ISO 11654:1997.",
+    },
+    "basis.iso11654.plain": {
+        "en": "Sound absorption rating per ISO 11654:1997.",
+        "es": "Índice de absorción acústica según ISO 11654:1997.",
+    },
+    "basis.iso532.with_standard": {
+        "en": "{standard} loudness. Rating per ISO 532-1:2017 (Zwicker method).",
+        "es": "{standard} sonoridad. Índice según ISO 532-1:2017 "
+              "(método de Zwicker).",
+    },
+    "basis.iso532.plain": {
+        "en": "Loudness rating per ISO 532-1:2017 (Zwicker method).",
+        "es": "Índice de sonoridad según ISO 532-1:2017 (método de Zwicker).",
+    },
+    "basis.broadcast.with_standard": {
+        "en": "{standard} programme loudness. Rating per EBU R 128 / "
+              "ITU-R BS.1770-5 (K-weighting, gated).",
+        "es": "{standard} sonoridad de programa. Índice según EBU R 128 / "
+              "ITU-R BS.1770-5 (ponderación K, con puerta).",
+    },
+    "basis.broadcast.plain": {
+        "en": "Programme loudness per EBU R 128 / ITU-R BS.1770-5 "
+              "(K-weighting, gated).",
+        "es": "Sonoridad de programa según EBU R 128 / ITU-R BS.1770-5 "
+              "(ponderación K, con puerta).",
+    },
+    "basis.epnl.with_standard": {
+        "en": "{standard}. Effective Perceived Noise Level per ICAO Annex 16, "
+              "Volume I, Appendix 2.",
+        "es": "{standard}. Nivel efectivo de ruido percibido según OACI Anexo 16, "
+              "Volumen I, Apéndice 2.",
+    },
+    "basis.epnl.plain": {
+        "en": "Effective Perceived Noise Level (EPNL) per ICAO Annex 16, "
+              "Volume I, Appendix 2.",
+        "es": "Nivel efectivo de ruido percibido (EPNL) según OACI Anexo 16, "
+              "Volumen I, Apéndice 2.",
+    },
+    "basis.iec61260.with_standard": {
+        "en": "{standard} type test. Conformance to {table}.",
+        "es": "{standard} ensayo de tipo. Conformidad con {table}.",
+    },
+    "basis.iec61260.plain": {
+        "en": "Conformance to {table}.",
+        "es": "Conformidad con {table}.",
+    },
+    # --- metadata-grid labels --------------------------------------------
+    "meta.client": {"en": "Client", "es": "Cliente"},
+    "meta.mounted_by": {"en": "Mounted by", "es": "Montado por"},
+    "meta.manufacturer": {"en": "Manufacturer", "es": "Fabricante"},
+    "meta.manufacturer_tc": {
+        "en": "Manufacturer / TC holder",
+        "es": "Fabricante / titular del CT",
+    },
+    "meta.applicant": {"en": "Applicant", "es": "Solicitante"},
+    "meta.aircraft": {"en": "Aircraft", "es": "Aeronave"},
+    "meta.measurement_point": {"en": "Measurement point", "es": "Punto de medición"},
+    "meta.description": {"en": "Description", "es": "Descripción"},
+    "meta.signal": {"en": "Signal", "es": "Señal"},
+    "meta.programme": {"en": "Programme", "es": "Programa"},
+    "meta.filter_instrument": {
+        "en": "Filter / instrument",
+        "es": "Filtro / instrumento",
+    },
+    "meta.test_room": {"en": "Test room", "es": "Sala de ensayo"},
+    "meta.test_facility": {"en": "Test facility", "es": "Instalación de ensayo"},
+    "meta.date_of_test": {"en": "Date of test", "es": "Fecha del ensayo"},
+    "meta.mounting": {"en": "Mounting", "es": "Montaje"},
+    "meta.sample_area": {
+        "en": "Sample area S [m<super>2</super>]",
+        "es": "Área de la muestra S [m<super>2</super>]",
+    },
+    "meta.mass_per_area": {
+        "en": "Mass per unit area [kg/m<super>2</super>]",
+        "es": "Masa por unidad de superficie [kg/m<super>2</super>]",
+    },
+    "meta.source_volume": {
+        "en": "Source room volume [m<super>3</super>]",
+        "es": "Volumen del recinto emisor [m<super>3</super>]",
+    },
+    "meta.source_temp": {
+        "en": "Source room temp. [&#176;C]",
+        "es": "Temp. recinto emisor [&#176;C]",
+    },
+    "meta.source_humidity": {
+        "en": "Source room humidity [%]",
+        "es": "Humedad recinto emisor [%]",
+    },
+    "meta.receiving_volume": {
+        "en": "Receiving room volume [m<super>3</super>]",
+        "es": "Volumen del recinto receptor [m<super>3</super>]",
+    },
+    "meta.receiving_temp": {
+        "en": "Receiving room temp. [&#176;C]",
+        "es": "Temp. recinto receptor [&#176;C]",
+    },
+    "meta.receiving_humidity": {
+        "en": "Receiving room humidity [%]",
+        "es": "Humedad recinto receptor [%]",
+    },
+    "meta.temperature": {
+        "en": "Temperature [&#176;C]",
+        "es": "Temperatura [&#176;C]",
+    },
+    "meta.relative_humidity": {
+        "en": "Relative humidity [%]",
+        "es": "Humedad relativa [%]",
+    },
+    "meta.ambient_pressure": {
+        "en": "Ambient pressure [kPa]",
+        "es": "Presión ambiente [kPa]",
+    },
+    # --- table headers ----------------------------------------------------
+    "table.frequency": {"en": "Frequency f [Hz]", "es": "Frecuencia f [Hz]"},
+    "table.f_hz": {"en": "f [Hz]", "es": "f [Hz]"},
+    "table.measured_value": {
+        "en": "Measured {vh} [dB]",
+        "es": "{vh} medido [dB]",
+    },
+    "table.value_db": {"en": "{vh} [dB]", "es": "{vh} [dB]"},
+    "table.shifted_ref_db": {"en": "Shifted ref. [dB]", "es": "Ref. desplazada [dB]"},
+    "table.unfav_dev_db": {"en": "Unfav. dev. [dB]", "es": "Desv. desfav. [dB]"},
+    "table.shifted_ref": {"en": "Shifted ref.", "es": "Ref. desplazada"},
+    "table.unfav_dev": {"en": "Unfav. dev.", "es": "Desv. desfav."},
+    "table.practical_alpha_p": {
+        "en": "Practical &#945;<sub>p</sub>",
+        "es": "&#945;<sub>p</sub> práctico",
+    },
+    "table.sum": {"en": "sum", "es": "suma"},
+    # --- captions ---------------------------------------------------------
+    "caption.one_third_octave_value": {
+        "en": "One-third-octave {vh} [dB]",
+        "es": "Tercio de octava {vh} [dB]",
+    },
+    "caption.one_third_octave_alpha": {
+        "en": "One-third-octave &#945;<sub>s</sub>, octave &#945;<sub>p</sub>",
+        "es": "&#945;<sub>s</sub> en tercio de octava, "
+              "&#945;<sub>p</sub> en octava",
+    },
+    "caption.octave_alpha_p": {
+        "en": "Octave-band &#945;<sub>p</sub>",
+        "es": "&#945;<sub>p</sub> en banda de octava",
+    },
+    "caption.loudness_results": {
+        "en": "Loudness results",
+        "es": "Resultados de sonoridad",
+    },
+    "caption.compliance_summary": {
+        "en": "Compliance summary",
+        "es": "Resumen de conformidad",
+    },
+    "caption.intermediate_quantities": {
+        "en": "Intermediate quantities",
+        "es": "Cantidades intermedias",
+    },
+    "caption.per_band_classification": {
+        "en": "Per-band classification",
+        "es": "Clasificación por bandas",
+    },
+    "caption.certification_limit": {
+        "en": "Certification limit",
+        "es": "Límite de certificación",
+    },
+    # --- compliance-table headers ----------------------------------------
+    "col.metric": {"en": "Metric", "es": "Métrica"},
+    "col.measured": {"en": "Measured", "es": "Medido"},
+    "col.target_limit": {"en": "Target / Limit", "es": "Objetivo / Límite"},
+    "col.result": {"en": "Result", "es": "Resultado"},
+    # --- verdict / status -------------------------------------------------
+    "verdict.pass": {"en": "PASS", "es": "CUMPLE"},
+    "verdict.fail": {"en": "FAIL", "es": "NO CUMPLE"},
+    "verdict.result_vs_requirement": {
+        "en": "Result vs requirement",
+        "es": "Resultado frente a requisito",
+    },
+    "status.informational": {"en": "informational", "es": "informativo"},
+    "status.complies": {"en": "COMPLIES", "es": "CUMPLE"},
+    "status.does_not_comply": {"en": "Does not comply", "es": "No cumple"},
+    # --- metric-row labels ------------------------------------------------
+    "metric.total_loudness": {
+        "en": "Total loudness N [sone]",
+        "es": "Sonoridad total N [sone]",
+    },
+    "metric.loudness_level": {
+        "en": "Loudness level L<sub>N</sub> [phon]",
+        "es": "Nivel de sonoridad L<sub>N</sub> [phon]",
+    },
+    "metric.n5": {"en": "N<sub>5</sub> [sone]", "es": "N<sub>5</sub> [sone]"},
+    "metric.n10": {"en": "N<sub>10</sub> [sone]", "es": "N<sub>10</sub> [sone]"},
+    "metric.pnltm": {"en": "PNLTM [PNdB]", "es": "PNLTM [PNdB]"},
+    "metric.duration_correction": {
+        "en": "Duration correction D [dB]",
+        "es": "Corrección de duración D [dB]",
+    },
+    "metric.window_10db_down": {
+        "en": "10 dB-down window (records)",
+        "es": "Ventana 10 dB por debajo (registros)",
+    },
+    "metric.bandsharing": {
+        "en": "Bandsharing adjustment [dB]",
+        "es": "Ajuste por reparto de bandas [dB]",
+    },
+    "metric.integrated_loudness": {
+        "en": "Integrated (Programme) Loudness",
+        "es": "Sonoridad integrada (de programa)",
+    },
+    "metric.max_true_peak": {
+        "en": "Maximum True Peak",
+        "es": "Pico real máximo",
+    },
+    "metric.loudness_range": {
+        "en": "Loudness Range (LRA)",
+        "es": "Rango de sonoridad (LRA)",
+    },
+    "metric.max_momentary": {"en": "Max Momentary", "es": "Momentánea máxima"},
+    "metric.max_short_term": {"en": "Max Short-term", "es": "Corto plazo máxima"},
+    "metric.epnl": {"en": "EPNL [EPNdB]", "es": "EPNL [EPNdB]"},
+    # --- iso717 verdict ---------------------------------------------------
+    "iso717.verdict.impact": {
+        "en": "L<sub>n,w</sub> = {rating} dB, required &#8804; {req} dB",
+        "es": "L<sub>n,w</sub> = {rating} dB, exigido &#8804; {req} dB",
+    },
+    "iso717.verdict.airborne": {
+        "en": "R<sub>w</sub> = {rating} dB, required &#8805; {req} dB",
+        "es": "R<sub>w</sub> = {rating} dB, exigido &#8805; {req} dB",
+    },
+    # --- iso11654 statement / verdict ------------------------------------
+    "iso11654.absorption_class": {
+        "en": "Absorption class: {value}",
+        "es": "Clase de absorción: {value}",
+    },
+    "iso11654.shape_indicator": {
+        "en": "Shape indicator: {value}",
+        "es": "Indicador de forma: {value}",
+    },
+    "iso11654.applied_shift": {
+        "en": "Applied shift: {value}",
+        "es": "Desplazamiento aplicado: {value}",
+    },
+    "iso11654.verdict": {
+        "en": "&#945;<sub>w</sub> = {value}, required &#8805; {req}",
+        "es": "&#945;<sub>w</sub> = {value}, exigido &#8805; {req}",
+    },
+    # --- iso532 verdict ---------------------------------------------------
+    "iso532.verdict": {
+        "en": "N = {value} sone, required &#8804; {req} sone",
+        "es": "N = {value} sone, exigido &#8804; {req} sone",
+    },
+    # --- broadcast --------------------------------------------------------
+    "broadcast.limit.integrated": {
+        "en": "{target} LUFS &#177;{tol} LU (&#916; {delta} LU)",
+        "es": "{target} LUFS &#177;{tol} LU (&#916; {delta} LU)",
+    },
+    "broadcast.limit.true_peak": {
+        "en": "&#8804; {limit} dBTP",
+        "es": "&#8804; {limit} dBTP",
+    },
+    "broadcast.verdict": {
+        "en": "Compliant when I is within {target} &#177;{tol} LU and true "
+              "peak &#8804; {tp} dBTP",
+        "es": "Conforme cuando I está dentro de {target} &#177;{tol} LU y el "
+              "pico real &#8804; {tp} dBTP",
+    },
+    "broadcast.basis_strip": {
+        "en": "Gating -70 LUFS absolute / -10 LU relative (ITU-R BS.1770); "
+              "1 LU = 1 dB; true peak per EBU Tech 3341; LRA per EBU Tech 3342 "
+              "(not recommended for programmes under 60 s).",
+        "es": "Puerta -70 LUFS absoluta / -10 LU relativa (ITU-R BS.1770); "
+              "1 LU = 1 dB; pico real según EBU Tech 3341; LRA según "
+              "EBU Tech 3342 (no recomendado para programas de menos de 60 s).",
+    },
+    # --- epnl -------------------------------------------------------------
+    "epnl.limit_cell": {
+        "en": "&#8804; {limit} (margin {margin})",
+        "es": "&#8804; {limit} (margen {margin})",
+    },
+    "epnl.reference_conditions": {
+        "en": "Reference conditions: 25 &#176;C, 70% relative humidity, sea "
+              "level, zero wind, ISA (ICAO Annex 16 Vol I App. 2).",
+        "es": "Condiciones de referencia: 25 &#176;C, 70% de humedad relativa, "
+              "nivel del mar, viento nulo, ISA (OACI Anexo 16 Vol I Ap. 2).",
+    },
+    "epnl.certificate_disclaimer": {
+        "en": "This is a computational EPNL result per ICAO Annex 16 Vol I "
+              "Appendix 2; it is not an official State noise certificate "
+              "(e.g. EASA Form 45).",
+        "es": "Este es un resultado EPNL calculado según OACI Anexo 16 Vol I "
+              "Apéndice 2; no es un certificado oficial de ruido de un Estado "
+              "(p. ej. EASA Formulario 45).",
+    },
+    # --- iec61260 ---------------------------------------------------------
+    "iec61260.basis_strip": {
+        "en": "{fraction} bank, sampling rate f<sub>s</sub> = {fs} Hz; "
+              "relative attenuation referenced to the mid-band level "
+              "(IEC 61260-1 Formula 8).",
+        "es": "Banco {fraction}, frecuencia de muestreo f<sub>s</sub> = {fs} Hz; "
+              "atenuación relativa referida al nivel de banda media "
+              "(IEC 61260-1 Fórmula 8).",
+    },
+    "iec61260.class_none": {"en": "none", "es": "ninguna"},
+    "iec61260.class_n": {"en": "Class {n}", "es": "Clase {n}"},
+    "iec61260.statement.complies": {
+        "en": "Class <b>{cls}</b> - COMPLIES &nbsp; (margin {margin} dB)",
+        "es": "Clase <b>{cls}</b> - CUMPLE &nbsp; (margen {margin} dB)",
+    },
+    "iec61260.statement.does_not_comply": {
+        "en": "<b>Does not comply</b> with class {classes} &nbsp; "
+              "(closest margin {margin} dB)",
+        "es": "<b>No cumple</b> con la clase {classes} &nbsp; "
+              "(margen más próximo {margin} dB)",
+    },
+    "iec61260.verdict": {
+        "en": "Achieved class {achieved}, required class {required}",
+        "es": "Clase obtenida {achieved}, clase exigida {required}",
+    },
+    # --- footer -----------------------------------------------------------
+    "footer.laboratory": {"en": "Laboratory", "es": "Laboratorio"},
+    "footer.report_no": {"en": "Report no.", "es": "Informe n.º"},
+    "footer.date": {"en": "Date", "es": "Fecha"},
+    "footer.notes": {"en": "Notes", "es": "Notas"},
+    "footer.operator": {"en": "Operator", "es": "Operador"},
+    "footer.signature": {"en": "Signature", "es": "Firma"},
+    "footer.disclaimer": {
+        "en": "The results relate only to the tested specimen.",
+        "es": "Los resultados se refieren únicamente a la probeta ensayada.",
+    },
+    "footer.generated_by": {
+        "en": "Generated by phonometry.",
+        "es": "Generado por phonometry.",
+    },
+}
+
+
+def t(key: str, language: str = "en") -> str:
+    """Return the ``language`` rendering of the fixed string ``key``.
+
+    Falls back to the English string when the language is not translated, and
+    raises :class:`KeyError` for an unknown ``key`` (a programming error).
+
+    :param key: A stable English string-id present in :data:`REPORT_STRINGS`.
+    :param language: ``"en"`` (default) or ``"es"``.
+    :return: The translated string (English if the language has no entry).
+    """
+    forms = REPORT_STRINGS[key]
+    return forms.get(language, forms["en"])
+
+
+def format_number(
+    value: float,
+    language: str = "en",
+    *,
+    decimals: int = 1,
+    trim: bool = False,
+) -> str:
+    """Locale-aware number formatting for the renderers (level-1 re-export).
+
+    Thin wrapper around :func:`phonometry._i18n.format_number` so the report
+    renderers, which must not import the top-level ``_i18n`` at module level
+    (the package-architecture rule keeps the render leaves free of module-level
+    parent imports), reach it through a sibling module instead. The import is
+    lazy for the same reason.
+    """
+    from .._i18n import format_number as _format_number
+
+    return _format_number(value, language, decimals=decimals, trim=trim)
+
+
+def decimal_comma(value: str, language: str = "en") -> str:
+    """Locale-aware separator swap for the renderers (level-1 re-export).
+
+    Thin wrapper around :func:`phonometry._i18n.decimal_comma`; see
+    :func:`format_number` for why the renderers reach it through this module.
+    """
+    from .._i18n import decimal_comma as _decimal_comma
+
+    return _decimal_comma(value, language)

--- a/src/phonometry/_report/_layout.py
+++ b/src/phonometry/_report/_layout.py
@@ -24,6 +24,7 @@ from typing import Any, Callable, List, Tuple
 
 import numpy as np
 
+from ._i18n import format_number, t
 from .metadata import ReportMetadata
 
 #: Installation hints for the three soft dependencies of the report.
@@ -48,20 +49,16 @@ _MUTED_HEX = "#555555"
 _VERDICT_OK_HEX = "#1b6e2f"
 _VERDICT_BAD_HEX = "#a11a1a"
 
-#: Fixed disclaimer always printed in the footer of the fiche.
-_DISCLAIMER = "The results relate only to the tested specimen."
 
-
-def fmt_num(value: float) -> str:
+def fmt_num(value: float, language: str = "en") -> str:
     """Format a number with up to one decimal, dropping a trailing ``.0``.
 
-    The fiches are English, so the decimal separator is a period (matching
-    accredited English lab reports such as the Salford reference).
+    Delegates to :func:`phonometry._i18n.format_number`, so English keeps a
+    period (matching accredited English lab reports such as the Salford
+    reference) and ``language="es"`` uses a comma, as Spanish reports write
+    numbers.
     """
-    text = f"{float(value):.1f}"
-    if text.endswith(".0"):
-        text = text[:-2]
-    return text
+    return format_number(value, language, decimals=1, trim=True)
 
 
 def render_figure_drawing(
@@ -71,6 +68,7 @@ def render_figure_drawing(
     y_top: float | None,
     expand_step: float | None = None,
     figsize: Tuple[float, float] | None = None,
+    language: str = "en",
 ) -> Any:
     """Draw a result's plot as a scaled, vector reportlab ``Drawing``.
 
@@ -133,6 +131,12 @@ def render_figure_drawing(
                 bbox_to_anchor=(0.0, 1.005), ncol=len(handles),
                 frameon=False, fontsize=8, handlelength=1.6, columnspacing=1.2,
             )
+        # Localise the tick-label decimal separator for Spanish (a no-op for
+        # English, so English figures are byte-for-byte unchanged). Imported
+        # lazily like the matplotlib backend above.
+        from .._i18n import localize_axes
+
+        localize_axes(ax, language)
         fig.tight_layout()
         with matplotlib.rc_context({"svg.fonttype": "path"}):
             fig.savefig(svg_path, format="svg")
@@ -302,7 +306,10 @@ def metrics_table(rows: List[Tuple[str, str]], *, col_widths: Any = None) -> Any
 
 
 def compliance_table(
-    rows: List[Tuple[str, str, str, str]], *, col_widths: Any = None
+    rows: List[Tuple[str, str, str, str]],
+    *,
+    col_widths: Any = None,
+    language: str = "en",
 ) -> Any:
     """A full-width 4-column ``metric | measured | target/limit | result`` table.
 
@@ -345,17 +352,23 @@ def compliance_table(
 
     def _result_markup(status: str) -> str:
         if status == "pass":
-            return f"<font color='{_VERDICT_OK_HEX}'>&#9679; PASS</font>"
+            return (
+                f"<font color='{_VERDICT_OK_HEX}'>&#9679; "
+                f"{t('verdict.pass', language)}</font>"
+            )
         if status == "fail":
-            return f"<font color='{_VERDICT_BAD_HEX}'>&#9679; FAIL</font>"
+            return (
+                f"<font color='{_VERDICT_BAD_HEX}'>&#9679; "
+                f"{t('verdict.fail', language)}</font>"
+            )
         return f"<font color='{_MUTED_HEX}'>&#8211;</font>"
 
     data: List[List[Any]] = [
         [
-            Paragraph("Metric", header_style),
-            Paragraph("Measured", header_style),
-            Paragraph("Target / Limit", header_style),
-            Paragraph("Result", header_style),
+            Paragraph(t("col.metric", language), header_style),
+            Paragraph(t("col.measured", language), header_style),
+            Paragraph(t("col.target_limit", language), header_style),
+            Paragraph(t("col.result", language), header_style),
         ]
     ]
     for metric, measured, limit, status in rows:
@@ -433,7 +446,9 @@ def result_box(
     return box
 
 
-def verdict_flow(text: str, passed: bool, styles: Any) -> List[Any]:
+def verdict_flow(
+    text: str, passed: bool, styles: Any, language: str = "en"
+) -> List[Any]:
     """The PASS/FAIL verdict paragraph for a precomputed comparison.
 
     Each renderer computes ``text`` (the requirement comparison) and ``passed``
@@ -443,22 +458,25 @@ def verdict_flow(text: str, passed: bool, styles: Any) -> List[Any]:
     from reportlab.lib.styles import ParagraphStyle
     from reportlab.platypus import Paragraph
 
-    badge = "PASS" if passed else "FAIL"
+    badge = t("verdict.pass", language) if passed else t("verdict.fail", language)
     badge_hex = _VERDICT_OK_HEX if passed else _VERDICT_BAD_HEX
     verdict_style = ParagraphStyle(
         "fiche_verdict", parent=styles["Normal"], fontSize=10, leading=14,
         spaceBefore=4,
     )
+    lead = t("verdict.result_vs_requirement", language)
     return [
         Paragraph(
-            f"Result vs requirement: {text} &#8594; "
+            f"{lead}: {text} &#8594; "
             f"<b><font color='{badge_hex}'>{badge}</font></b>",
             verdict_style,
         )
     ]
 
 
-def footer_flow(metadata: ReportMetadata | None) -> List[Any]:
+def footer_flow(
+    metadata: ReportMetadata | None, language: str = "en"
+) -> List[Any]:
     """Build the footer identity block plus the always-present disclaimer.
 
     Called only after the renderer has imported reportlab.
@@ -481,17 +499,32 @@ def footer_flow(metadata: ReportMetadata | None) -> List[Any]:
         textColor=muted, leading=11,
     )
 
+    signature = t("footer.signature", language)
+    sign_blank = f"{signature}: ______________________________"
+
     flow: List[Any] = [Spacer(1, 8)]
     lines: List[str] = []
     if metadata is not None:
         if metadata.laboratory:
-            lines.append(f"<b>Laboratory:</b> {html.escape(metadata.laboratory)}")
+            lines.append(
+                f"<b>{t('footer.laboratory', language)}:</b> "
+                f"{html.escape(metadata.laboratory)}"
+            )
         if metadata.report_id:
-            lines.append(f"<b>Report no.:</b> {html.escape(metadata.report_id)}")
+            lines.append(
+                f"<b>{t('footer.report_no', language)}:</b> "
+                f"{html.escape(metadata.report_id)}"
+            )
         if metadata.test_date:
-            lines.append(f"<b>Date:</b> {html.escape(metadata.test_date)}")
+            lines.append(
+                f"<b>{t('footer.date', language)}:</b> "
+                f"{html.escape(metadata.test_date)}"
+            )
         if metadata.notes:
-            lines.append(f"<b>Notes:</b> {html.escape(metadata.notes)}")
+            lines.append(
+                f"<b>{t('footer.notes', language)}:</b> "
+                f"{html.escape(metadata.notes)}"
+            )
     for line in lines:
         flow.append(Paragraph(line, ident_style))
 
@@ -499,26 +532,26 @@ def footer_flow(metadata: ReportMetadata | None) -> List[Any]:
     if operator:
         flow.append(
             Paragraph(
-                f"Operator: {html.escape(operator)} &nbsp;&nbsp; "
-                "Signature: ______________________________",
+                f"{t('footer.operator', language)}: {html.escape(operator)} "
+                f"&nbsp;&nbsp; {sign_blank}",
                 sign_style,
             )
         )
     elif lines:
-        flow.append(
-            Paragraph("Signature: ______________________________", sign_style)
-        )
+        flow.append(Paragraph(sign_blank, sign_style))
 
     flow.append(Spacer(1, 4))
     flow.append(
         Paragraph(
-            f"<font color='{_ACCENT_HEX}'>&#9632;</font> {_DISCLAIMER}",
+            f"<font color='{_ACCENT_HEX}'>&#9632;</font> "
+            f"{t('footer.disclaimer', language)}",
             disclaimer_style,
         )
     )
     flow.append(
         Paragraph(
-            "<font size=7 color='#888888'>Generated by phonometry.</font>",
+            f"<font size=7 color='#888888'>"
+            f"{t('footer.generated_by', language)}</font>",
             disclaimer_style,
         )
     )

--- a/src/phonometry/_report/annex16_epnl.py
+++ b/src/phonometry/_report/annex16_epnl.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 import html
 from typing import TYPE_CHECKING, Any, List, Tuple
 
+from ._i18n import decimal_comma, format_number, t
 from ._layout import (
     _ACCENT_HEX,
     _MUTED_HEX,
@@ -56,22 +57,10 @@ from .metadata import ReportMetadata
 if TYPE_CHECKING:
     from ..aircraft.aircraft_noise import EPNLResult
 
-#: Static reference atmosphere of ICAO Annex 16 Vol. I Appendix 2 (the
-#: conditions the certification EPNL is referred to). This is an informational
-#: strip, never a claim of measured atmospherics.
-_REFERENCE_CONDITIONS = (
-    "Reference conditions: 25 &#176;C, 70% relative humidity, sea level, zero "
-    "wind, ISA (ICAO Annex 16 Vol I App. 2)."
-)
 
-#: Footer note distinguishing the computational result from a State certificate.
-_CERTIFICATE_DISCLAIMER = (
-    "This is a computational EPNL result per ICAO Annex 16 Vol I Appendix 2; it "
-    "is not an official State noise certificate (e.g. EASA Form 45)."
-)
-
-
-def _metadata_pairs(metadata: ReportMetadata) -> List[Tuple[str, str]]:
+def _metadata_pairs(
+    metadata: ReportMetadata, language: str = "en"
+) -> List[Tuple[str, str]]:
     """Build the ordered (label, value) pairs of the certification header grid.
 
     Only fields that are set are returned. EPNL is an aircraft-flyover metric,
@@ -80,11 +69,11 @@ def _metadata_pairs(metadata: ReportMetadata) -> List[Tuple[str, str]]:
     (aircraft, type-certificate holder, applicant, measurement point).
     """
     specs: List[Tuple[str, str | None]] = [
-        ("Aircraft", metadata.specimen),
-        ("Manufacturer / TC holder", metadata.manufacturer),
-        ("Applicant", metadata.client),
-        ("Measurement point", metadata.test_room),
-        ("Date of test", metadata.test_date),
+        (t("meta.aircraft", language), metadata.specimen),
+        (t("meta.manufacturer_tc", language), metadata.manufacturer),
+        (t("meta.applicant", language), metadata.client),
+        (t("meta.measurement_point", language), metadata.test_room),
+        (t("meta.date_of_test", language), metadata.test_date),
     ]
     return [
         (label, html.escape(str(value)))
@@ -93,7 +82,9 @@ def _metadata_pairs(metadata: ReportMetadata) -> List[Tuple[str, str]]:
     ]
 
 
-def _metric_rows(result: "EPNLResult") -> List[Tuple[str, str]]:
+def _metric_rows(
+    result: "EPNLResult", language: str = "en"
+) -> List[Tuple[str, str]]:
     """The intermediate EPNL quantities shown in the left-hand metrics table.
 
     These are informational: PNLTM, the duration correction ``D``, the 10
@@ -102,23 +93,35 @@ def _metric_rows(result: "EPNLResult") -> List[Tuple[str, str]]:
     """
     k_first, k_last = result.band_limits
     rows = [
-        ("PNLTM [PNdB]", fmt_num(result.pnltm)),
-        ("Duration correction D [dB]", fmt_num(result.duration_correction)),
-        ("10 dB-down window (records)", f"{k_first + 1}&#8211;{k_last + 1}"),
+        (t("metric.pnltm", language), fmt_num(result.pnltm, language)),
+        (
+            t("metric.duration_correction", language),
+            fmt_num(result.duration_correction, language),
+        ),
+        (
+            t("metric.window_10db_down", language),
+            f"{k_first + 1}&#8211;{k_last + 1}",
+        ),
     ]
     if abs(result.bandsharing_adjustment) > 1e-9:
         rows.append(
-            ("Bandsharing adjustment [dB]", fmt_num(result.bandsharing_adjustment))
+            (
+                t("metric.bandsharing", language),
+                fmt_num(result.bandsharing_adjustment, language),
+            )
         )
     return rows
 
 
-def _statement(result: "EPNLResult") -> str:
+def _statement(result: "EPNLResult", language: str = "en") -> str:
     """The boxed single-number statement ``EPNL = X EPNdB``."""
-    return f"EPNL = <b>{result.epnl:.1f} EPNdB</b>"
+    epnl = format_number(result.epnl, language, decimals=1)
+    return f"EPNL = <b>{epnl} EPNdB</b>"
 
 
-def _verdict_rows(result: "EPNLResult", limit: float) -> List[Tuple[str, str, str, str]]:
+def _verdict_rows(
+    result: "EPNLResult", limit: float, language: str = "en"
+) -> List[Tuple[str, str, str, str]]:
     """The Level | Limit | Margin compliance row for a supplied EPNL limit.
 
     The EPNL passes at or below the certification limit; the limit cell also
@@ -128,9 +131,12 @@ def _verdict_rows(result: "EPNLResult", limit: float) -> List[Tuple[str, str, st
     status = "pass" if float(result.epnl) <= limit else "fail"
     return [
         (
-            "EPNL [EPNdB]",
-            f"{result.epnl:.1f}",
-            f"&#8804; {fmt_num(limit)} (margin {margin:+.1f})",
+            t("metric.epnl", language),
+            format_number(result.epnl, language, decimals=1),
+            t("epnl.limit_cell", language).format(
+                limit=fmt_num(limit, language),
+                margin=decimal_comma(f"{margin:+.1f}", language),
+            ),
             status,
         )
     ]
@@ -142,6 +148,7 @@ def render_annex16_epnl_report(
     *,
     metadata: ReportMetadata | None = None,
     verbose: bool = False,
+    language: str = "en",
 ) -> str:
     """Render an ICAO Annex 16 EPNL certification fiche to a PDF at ``path``.
 
@@ -171,21 +178,17 @@ def render_annex16_epnl_report(
     accent = colors.HexColor(_ACCENT_HEX)
 
     styles, title_style, basis_style, caption_style = document_styles(accent)
-    title = "Aircraft noise certification - EPNL result"
+    title = t("title.epnl", language)
 
     measurement_standard = (
         metadata.measurement_standard if metadata is not None else None
     )
     if measurement_standard:
-        basis = (
-            f"{html.escape(measurement_standard)}. Effective Perceived Noise "
-            "Level per ICAO Annex 16, Volume I, Appendix 2."
+        basis = t("basis.epnl.with_standard", language).format(
+            standard=html.escape(measurement_standard)
         )
     else:
-        basis = (
-            "Effective Perceived Noise Level (EPNL) per ICAO Annex 16, "
-            "Volume I, Appendix 2."
-        )
+        basis = t("basis.epnl.plain", language)
 
     muted_strip_style = ParagraphStyle(
         "fiche_reference_conditions", parent=getSampleStyleSheet()["Normal"],
@@ -199,25 +202,33 @@ def render_annex16_epnl_report(
     ]
 
     if metadata is not None and not metadata.is_empty():
-        header_pairs = _metadata_pairs(metadata)
+        header_pairs = _metadata_pairs(metadata, language)
         if header_pairs:
             flow.append(Spacer(1, 3))
             flow.append(grid_table(header_pairs))
-    flow.append(Paragraph(_REFERENCE_CONDITIONS, muted_strip_style))
+    flow.append(
+        Paragraph(t("epnl.reference_conditions", language), muted_strip_style)
+    )
     flow.append(Spacer(1, 8))
 
-    flow.append(Paragraph("Intermediate quantities", caption_style))
-    flow.append(metrics_table(_metric_rows(result), col_widths=[48 * mm, 26 * mm]))
+    flow.append(
+        Paragraph(t("caption.intermediate_quantities", language), caption_style)
+    )
+    flow.append(
+        metrics_table(
+            _metric_rows(result, language), col_widths=[48 * mm, 26 * mm]
+        )
+    )
     flow.append(Spacer(1, 8))
 
     # Full-width, landscape PNLT-vs-time plot (self-scaling axis).
     plot_drawing = render_figure_drawing(
-        result.plot, 174 * mm, y_top=None, figsize=(9.2, 4.2)
+        result.plot, 174 * mm, y_top=None, figsize=(9.2, 4.2), language=language
     )
     flow.append(plot_drawing)
     flow.append(Spacer(1, 8))
 
-    flow.append(result_box(_statement(result), styles, accent))
+    flow.append(result_box(_statement(result, language), styles, accent))
 
     limit = (
         float(metadata.requirement)
@@ -226,16 +237,24 @@ def render_annex16_epnl_report(
     )
     if limit is not None:
         flow.append(Spacer(1, 6))
-        flow.append(Paragraph("Certification limit", caption_style))
-        flow.append(compliance_table(_verdict_rows(result, limit)))
+        flow.append(
+            Paragraph(t("caption.certification_limit", language), caption_style)
+        )
+        flow.append(
+            compliance_table(
+                _verdict_rows(result, limit, language), language=language
+            )
+        )
 
-    flow.extend(footer_flow(metadata))
+    flow.extend(footer_flow(metadata, language))
 
     disclaimer_style = ParagraphStyle(
         "fiche_certificate_disclaimer", parent=getSampleStyleSheet()["Normal"],
         fontSize=7.5, leading=10, textColor=colors.HexColor(_MUTED_HEX),
         spaceBefore=2,
     )
-    flow.append(Paragraph(_CERTIFICATE_DISCLAIMER, disclaimer_style))
+    flow.append(
+        Paragraph(t("epnl.certificate_disclaimer", language), disclaimer_style)
+    )
 
     return build_document(path, flow, title)

--- a/src/phonometry/_report/broadcast.py
+++ b/src/phonometry/_report/broadcast.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import html
 from typing import TYPE_CHECKING, Any, List, Tuple
 
+from ._i18n import decimal_comma, format_number, t
 from ._layout import (
     _ACCENT_HEX,
     _MUTED_HEX,
@@ -60,7 +61,9 @@ _TOLERANCE_LU = 0.5
 _MAX_TRUE_PEAK_DBTP = -1.0
 
 
-def _metadata_pairs(metadata: ReportMetadata) -> List[Tuple[str, str]]:
+def _metadata_pairs(
+    metadata: ReportMetadata, language: str = "en"
+) -> List[Tuple[str, str]]:
     """Build the ordered (label, value) pairs of the loudness header grid.
 
     Only fields that are set are returned. Programme loudness is a signal
@@ -68,11 +71,11 @@ def _metadata_pairs(metadata: ReportMetadata) -> List[Tuple[str, str]]:
     the specimen field labels the tested programme.
     """
     specs: List[Tuple[str, str | None]] = [
-        ("Client", metadata.client),
-        ("Programme", metadata.specimen),
-        ("Manufacturer", metadata.manufacturer),
-        ("Test room", metadata.test_room),
-        ("Date of test", metadata.test_date),
+        (t("meta.client", language), metadata.client),
+        (t("meta.programme", language), metadata.specimen),
+        (t("meta.manufacturer", language), metadata.manufacturer),
+        (t("meta.test_room", language), metadata.test_room),
+        (t("meta.date_of_test", language), metadata.test_date),
     ]
     return [
         (label, html.escape(str(value)))
@@ -106,7 +109,7 @@ def _status(
 
 
 def _compliance_rows(
-    result: "ProgramLoudnessResult", target: float
+    result: "ProgramLoudnessResult", target: float, language: str = "en"
 ) -> List[Tuple[str, str, str, str]]:
     """Build the compliance-table rows for the EBU R 128 fiche.
 
@@ -118,60 +121,73 @@ def _compliance_rows(
     true_peak = float(result.true_peak)
     delta = integrated - target
     i_status, tp_status, _ = _status(result, target)
+    tol = decimal_comma(f"{_TOLERANCE_LU:g}", language)
+    informational = t("status.informational", language)
     return [
         (
-            "Integrated (Programme) Loudness",
-            f"{integrated:.1f} LUFS",
-            f"{target:.1f} LUFS &#177;{_TOLERANCE_LU:g} LU "
-            f"(&#916; {delta:+.1f} LU)",
+            t("metric.integrated_loudness", language),
+            f"{format_number(integrated, language, decimals=1)} LUFS",
+            t("broadcast.limit.integrated", language).format(
+                target=format_number(target, language, decimals=1),
+                tol=tol,
+                delta=decimal_comma(f"{delta:+.1f}", language),
+            ),
             i_status,
         ),
         (
-            "Maximum True Peak",
-            f"{true_peak:.1f} dBTP",
-            f"&#8804; {_MAX_TRUE_PEAK_DBTP:.1f} dBTP",
+            t("metric.max_true_peak", language),
+            f"{format_number(true_peak, language, decimals=1)} dBTP",
+            t("broadcast.limit.true_peak", language).format(
+                limit=format_number(_MAX_TRUE_PEAK_DBTP, language, decimals=1)
+            ),
             tp_status,
         ),
         (
-            "Loudness Range (LRA)",
-            f"{float(result.loudness_range):.1f} LU",
-            "informational",
+            t("metric.loudness_range", language),
+            f"{format_number(float(result.loudness_range), language, decimals=1)} LU",
+            informational,
             "info",
         ),
         (
-            "Max Momentary",
-            f"{float(result.max_momentary):.1f} LUFS",
-            "informational",
+            t("metric.max_momentary", language),
+            f"{format_number(float(result.max_momentary), language, decimals=1)} LUFS",
+            informational,
             "info",
         ),
         (
-            "Max Short-term",
-            f"{float(result.max_short_term):.1f} LUFS",
-            "informational",
+            t("metric.max_short_term", language),
+            f"{format_number(float(result.max_short_term), language, decimals=1)} LUFS",
+            informational,
             "info",
         ),
     ]
 
 
-def _statement(result: "ProgramLoudnessResult") -> str:
+def _statement(result: "ProgramLoudnessResult", language: str = "en") -> str:
     """The boxed single-number statement ``I = X LUFS (LRA = Y, max TP = Z)``."""
+    integrated = format_number(float(result.integrated), language, decimals=1)
+    lra = format_number(float(result.loudness_range), language, decimals=1)
+    tp = format_number(float(result.true_peak), language, decimals=1)
     return (
-        f"I = <b>{float(result.integrated):.1f} LUFS</b> &nbsp; "
-        f"(LRA = {float(result.loudness_range):.1f} LU, "
-        f"max TP = {float(result.true_peak):.1f} dBTP)"
+        f"I = <b>{integrated} LUFS</b> &nbsp; "
+        f"(LRA = {lra} LU, "
+        f"max TP = {tp} dBTP)"
     )
 
 
-def _verdict(result: "ProgramLoudnessResult", target: float) -> Tuple[str, bool]:
+def _verdict(
+    result: "ProgramLoudnessResult", target: float, language: str = "en"
+) -> Tuple[str, bool]:
     """Combined verdict text and PASS flag (integrated loudness and true peak).
 
     A programme complies when the integrated loudness is within the target
     tolerance and the true peak is at or below the permitted ceiling.
     """
     _i_status, _tp_status, passed = _status(result, target)
-    text = (
-        f"Compliant when I is within {target:.1f} &#177;{_TOLERANCE_LU:g} LU "
-        f"and true peak &#8804; {_MAX_TRUE_PEAK_DBTP:.1f} dBTP"
+    text = t("broadcast.verdict", language).format(
+        target=format_number(target, language, decimals=1),
+        tol=decimal_comma(f"{_TOLERANCE_LU:g}", language),
+        tp=format_number(_MAX_TRUE_PEAK_DBTP, language, decimals=1),
     )
     return text, passed
 
@@ -182,6 +198,7 @@ def render_program_loudness_report(
     *,
     metadata: ReportMetadata | None = None,
     verbose: bool = False,
+    language: str = "en",
 ) -> str:
     """Render an EBU R 128 programme-loudness fiche to a PDF at ``path``.
 
@@ -211,21 +228,17 @@ def render_program_loudness_report(
     accent = colors.HexColor(_ACCENT_HEX)
 
     styles, title_style, basis_style, caption_style = document_styles(accent)
-    title = "Programme loudness compliance"
+    title = t("title.program_loudness", language)
 
     measurement_standard = (
         metadata.measurement_standard if metadata is not None else None
     )
     if measurement_standard:
-        basis = (
-            f"{html.escape(measurement_standard)} programme loudness. Rating "
-            "per EBU R 128 / ITU-R BS.1770-5 (K-weighting, gated)."
+        basis = t("basis.broadcast.with_standard", language).format(
+            standard=html.escape(measurement_standard)
         )
     else:
-        basis = (
-            "Programme loudness per EBU R 128 / ITU-R BS.1770-5 "
-            "(K-weighting, gated)."
-        )
+        basis = t("basis.broadcast.plain", language)
 
     target = (
         float(metadata.requirement)
@@ -239,40 +252,35 @@ def render_program_loudness_report(
     ]
 
     if metadata is not None and not metadata.is_empty():
-        header_pairs = _metadata_pairs(metadata)
+        header_pairs = _metadata_pairs(metadata, language)
         if header_pairs:
             flow.append(Spacer(1, 3))
             flow.append(grid_table(header_pairs))
     flow.append(Spacer(1, 8))
 
-    flow.append(Paragraph("Compliance summary", caption_style))
-    flow.append(compliance_table(_compliance_rows(result, target)))
+    flow.append(Paragraph(t("caption.compliance_summary", language), caption_style))
+    flow.append(
+        compliance_table(_compliance_rows(result, target, language), language=language)
+    )
     flow.append(Spacer(1, 8))
 
     # Full-width, landscape loudness-vs-time plot (self-scaling axis).
     plot_drawing = render_figure_drawing(
-        result.plot, 174 * mm, y_top=None, figsize=(9.2, 4.2)
+        result.plot, 174 * mm, y_top=None, figsize=(9.2, 4.2), language=language
     )
     flow.append(plot_drawing)
     flow.append(Spacer(1, 8))
 
-    flow.append(result_box(_statement(result), styles, accent))
-    text, passed = _verdict(result, target)
-    flow.extend(verdict_flow(text, passed, styles))
+    flow.append(result_box(_statement(result, language), styles, accent))
+    text, passed = _verdict(result, target, language)
+    flow.extend(verdict_flow(text, passed, styles, language))
 
     basis_strip_style = ParagraphStyle(
         "fiche_measurement_basis", parent=getSampleStyleSheet()["Normal"],
         fontSize=7.5, leading=10, textColor=colors.HexColor(_MUTED_HEX),
         spaceBefore=6,
     )
-    flow.append(
-        Paragraph(
-            "Gating -70 LUFS absolute / -10 LU relative (ITU-R BS.1770); "
-            "1 LU = 1 dB; true peak per EBU Tech 3341; LRA per EBU Tech 3342 "
-            "(not recommended for programmes under 60 s).",
-            basis_strip_style,
-        )
-    )
-    flow.extend(footer_flow(metadata))
+    flow.append(Paragraph(t("broadcast.basis_strip", language), basis_strip_style))
+    flow.extend(footer_flow(metadata, language))
 
     return build_document(path, flow, title)

--- a/src/phonometry/_report/iec61260.py
+++ b/src/phonometry/_report/iec61260.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import html
 from typing import TYPE_CHECKING, Any, List, Tuple
 
+from ._i18n import decimal_comma, format_number, t
 from ._layout import (
     _ACCENT_HEX,
     _MUTED_HEX,
@@ -57,7 +58,7 @@ def _binding_margin(result: "FilterComplianceResult", cls: int) -> float:
     return min(float(band[key]) for band in result.bands)
 
 
-def _basis(metadata: ReportMetadata | None, edition: str) -> str:
+def _basis(metadata: ReportMetadata | None, edition: str, language: str = "en") -> str:
     """The standard-basis line for the fiche."""
     table = (
         "IEC 61260-1:2014, Table 1"
@@ -68,14 +69,15 @@ def _basis(metadata: ReportMetadata | None, edition: str) -> str:
         metadata.measurement_standard if metadata is not None else None
     )
     if measurement_standard:
-        return (
-            f"{html.escape(measurement_standard)} type test. Conformance to "
-            f"{table}."
+        return t("basis.iec61260.with_standard", language).format(
+            standard=html.escape(measurement_standard), table=table
         )
-    return f"Conformance to {table}."
+    return t("basis.iec61260.plain", language).format(table=table)
 
 
-def _metadata_pairs(metadata: ReportMetadata) -> List[Tuple[str, str]]:
+def _metadata_pairs(
+    metadata: ReportMetadata, language: str = "en"
+) -> List[Tuple[str, str]]:
     """Build the ordered (label, value) pairs of the header grid.
 
     Only fields that are set are returned. A filter bank is an instrument, so
@@ -83,11 +85,11 @@ def _metadata_pairs(metadata: ReportMetadata) -> List[Tuple[str, str]]:
     field labels the tested filter or analyser.
     """
     specs: List[Tuple[str, str | None]] = [
-        ("Client", metadata.client),
-        ("Filter / instrument", metadata.specimen),
-        ("Manufacturer", metadata.manufacturer),
-        ("Test facility", metadata.test_room),
-        ("Date of test", metadata.test_date),
+        (t("meta.client", language), metadata.client),
+        (t("meta.filter_instrument", language), metadata.specimen),
+        (t("meta.manufacturer", language), metadata.manufacturer),
+        (t("meta.test_facility", language), metadata.test_room),
+        (t("meta.date_of_test", language), metadata.test_date),
     ]
     return [
         (label, html.escape(str(value)))
@@ -101,38 +103,46 @@ def _fraction_label(fraction: int) -> str:
     return "1/1-octave" if fraction == 1 else f"1/{fraction}-octave"
 
 
-def _metric_rows(result: "FilterComplianceResult") -> List[Tuple[str, str]]:
+def _metric_rows(
+    result: "FilterComplianceResult", language: str = "en"
+) -> List[Tuple[str, str]]:
     """Per-band rows: mid-band frequency vs achieved class and binding margin."""
     cls = result.reference_class()
     key = f"margin_class{cls}_db"
     rows: List[Tuple[str, str]] = []
     for band in result.bands:
         band_class = band["class"]
-        class_text = "none" if band_class is None else f"Class {band_class}"
-        margin = float(band[key])
-        rows.append(
-            (f"{float(band['freq']):.0f} Hz", f"{class_text} ({margin:+.2f} dB)")
+        class_text = (
+            t("iec61260.class_none", language)
+            if band_class is None
+            else t("iec61260.class_n", language).format(n=band_class)
         )
+        margin = float(band[key])
+        freq = format_number(float(band["freq"]), language, decimals=0)
+        margin_text = decimal_comma(f"{margin:+.2f}", language)
+        rows.append((f"{freq} Hz", f"{class_text} ({margin_text} dB)"))
     return rows
 
 
-def _statement(result: "FilterComplianceResult") -> str:
+def _statement(result: "FilterComplianceResult", language: str = "en") -> str:
     """The boxed class-compliance statement with the binding margin."""
     if result.overall_class is not None:
         margin = _binding_margin(result, result.overall_class)
-        return (
-            f"Class <b>{result.overall_class}</b> - COMPLIES &nbsp; "
-            f"(margin {margin:+.2f} dB)"
+        return t("iec61260.statement.complies", language).format(
+            cls=result.overall_class,
+            margin=decimal_comma(f"{margin:+.2f}", language),
         )
     classes = "/".join(str(c) for c in result.available_classes())
     margin = _binding_margin(result, result.reference_class())
-    return (
-        f"<b>Does not comply</b> with class {classes} &nbsp; "
-        f"(closest margin {margin:+.2f} dB)"
+    return t("iec61260.statement.does_not_comply", language).format(
+        classes=classes,
+        margin=decimal_comma(f"{margin:+.2f}", language),
     )
 
 
-def _verdict(result: "FilterComplianceResult", required_class: int) -> Tuple[str, bool]:
+def _verdict(
+    result: "FilterComplianceResult", required_class: int, language: str = "en"
+) -> Tuple[str, bool]:
     """Verdict text and PASS flag against a required class.
 
     A bank meets a required class ``N`` when it achieves a class at least as
@@ -142,8 +152,14 @@ def _verdict(result: "FilterComplianceResult", required_class: int) -> Tuple[str
     passed = (
         result.overall_class is not None and result.overall_class <= required_class
     )
-    achieved = "none" if result.overall_class is None else str(result.overall_class)
-    text = f"Achieved class {achieved}, required class {required_class}"
+    achieved = (
+        t("iec61260.class_none", language)
+        if result.overall_class is None
+        else str(result.overall_class)
+    )
+    text = t("iec61260.verdict", language).format(
+        achieved=achieved, required=required_class
+    )
     return text, passed
 
 
@@ -153,6 +169,7 @@ def render_iec61260_report(
     *,
     metadata: ReportMetadata | None = None,
     verbose: bool = False,
+    language: str = "en",
 ) -> str:
     """Render an IEC 61260-1 filter-class-compliance fiche to a PDF at ``path``.
 
@@ -181,15 +198,15 @@ def render_iec61260_report(
     accent = colors.HexColor(_ACCENT_HEX)
 
     styles, title_style, basis_style, caption_style = document_styles(accent)
-    title = "Filter class compliance"
+    title = t("title.filter_class", language)
 
     flow: List[Any] = [
         Paragraph(title, title_style),
-        Paragraph(_basis(metadata, result.edition), basis_style),
+        Paragraph(_basis(metadata, result.edition, language), basis_style),
     ]
 
     if metadata is not None and not metadata.is_empty():
-        header_pairs = _metadata_pairs(metadata)
+        header_pairs = _metadata_pairs(metadata, language)
         if header_pairs:
             flow.append(Spacer(1, 3))
             flow.append(grid_table(header_pairs))
@@ -203,9 +220,10 @@ def render_iec61260_report(
     )
     flow.append(
         Paragraph(
-            f"{_fraction_label(result.fraction)} bank, sampling rate "
-            f"f<sub>s</sub> = {result.fs:.0f} Hz; relative attenuation "
-            "referenced to the mid-band level (IEC 61260-1 Formula 8).",
+            t("iec61260.basis_strip", language).format(
+                fraction=_fraction_label(result.fraction),
+                fs=format_number(result.fs, language, decimals=0),
+            ),
             basis_strip_style,
         )
     )
@@ -214,17 +232,19 @@ def render_iec61260_report(
     # Two-panel body: the per-band classification table on the left, the
     # mask-overlay plot (self-scaling dB axis) on the right.
     left_cell = [
-        Paragraph("Per-band classification", caption_style),
-        metrics_table(_metric_rows(result)),
+        Paragraph(t("caption.per_band_classification", language), caption_style),
+        metrics_table(_metric_rows(result, language)),
     ]
-    plot_drawing = render_figure_drawing(result.plot, 116 * mm, y_top=None)
+    plot_drawing = render_figure_drawing(
+        result.plot, 116 * mm, y_top=None, language=language
+    )
     flow.append(two_panel_body(left_cell, plot_drawing))
     flow.append(Spacer(1, 8))
 
-    flow.append(result_box(_statement(result), styles, accent))
+    flow.append(result_box(_statement(result, language), styles, accent))
     if metadata is not None and metadata.required_class is not None:
-        text, passed = _verdict(result, metadata.required_class)
-        flow.extend(verdict_flow(text, passed, styles))
-    flow.extend(footer_flow(metadata))
+        text, passed = _verdict(result, metadata.required_class, language)
+        flow.extend(verdict_flow(text, passed, styles, language))
+    flow.extend(footer_flow(metadata, language))
 
     return build_document(path, flow, title)

--- a/src/phonometry/_report/iso11654.py
+++ b/src/phonometry/_report/iso11654.py
@@ -40,6 +40,7 @@ from typing import TYPE_CHECKING, Any, List, Tuple
 
 import numpy as np
 
+from ._i18n import format_number, t
 from ._layout import (
     _ACCENT_HEX,
     _LIGHT_HEX,
@@ -63,9 +64,9 @@ if TYPE_CHECKING:
 _DEVIATION_EPS = 0.005
 
 
-def _d2(value: float) -> str:
-    """Two decimals, period separator (English fiche), matching the 0,05 grid."""
-    return f"{value:.2f}"
+def _d2(value: float, language: str = "en") -> str:
+    """Two decimals, locale-aware separator (period for English, comma for ES)."""
+    return format_number(value, language, decimals=2)
 
 
 def _thead_style() -> Any:
@@ -101,7 +102,9 @@ def _base_table_style(accent: Any, light: Any, n_data: int) -> List[Any]:
     ]
 
 
-def _metadata_pairs(metadata: ReportMetadata) -> List[Tuple[str, str]]:
+def _metadata_pairs(
+    metadata: ReportMetadata, language: str = "en"
+) -> List[Tuple[str, str]]:
     """Build the ordered (label, value) pairs of the absorption header grid.
 
     Only fields that are set are returned, so empty rows never appear. The
@@ -111,20 +114,20 @@ def _metadata_pairs(metadata: ReportMetadata) -> List[Tuple[str, str]]:
     """
 
     def num(value: float | None) -> str | None:
-        return fmt_num(value) if value is not None else None
+        return fmt_num(value, language) if value is not None else None
 
     specs: List[Tuple[str, str | None]] = [
-        ("Client", metadata.client),
-        ("Manufacturer", metadata.manufacturer),
-        ("Description", metadata.specimen),
-        ("Sample area S [m<super>2</super>]", num(metadata.area)),
-        ("Mounted by", metadata.mounted_by),
-        ("Mounting", metadata.mounting),
-        ("Test room", metadata.test_room),
-        ("Date of test", metadata.test_date),
-        ("Temperature [&#176;C]", num(metadata.temperature)),
-        ("Relative humidity [%]", num(metadata.relative_humidity)),
-        ("Ambient pressure [kPa]", num(metadata.pressure)),
+        (t("meta.client", language), metadata.client),
+        (t("meta.manufacturer", language), metadata.manufacturer),
+        (t("meta.description", language), metadata.specimen),
+        (t("meta.sample_area", language), num(metadata.area)),
+        (t("meta.mounted_by", language), metadata.mounted_by),
+        (t("meta.mounting", language), metadata.mounting),
+        (t("meta.test_room", language), metadata.test_room),
+        (t("meta.date_of_test", language), metadata.test_date),
+        (t("meta.temperature", language), num(metadata.temperature)),
+        (t("meta.relative_humidity", language), num(metadata.relative_humidity)),
+        (t("meta.ambient_pressure", language), num(metadata.pressure)),
     ]
     # Values are user-supplied free text; escape XML specials so a '&' or '<'
     # cannot break reportlab's Paragraph parser. Labels carry intentional markup.
@@ -141,6 +144,7 @@ def _value_table(
     shifted: np.ndarray,
     deviations: np.ndarray,
     verbose: bool,
+    language: str = "en",
 ) -> Any:
     """Build the left-hand octave-band absorption table (accredited or evaluation).
 
@@ -156,15 +160,15 @@ def _value_table(
 
     if verbose:
         header = [
-            Paragraph("f [Hz]", head_style),
-            Paragraph("Practical &#945;<sub>p</sub>", head_style),
-            Paragraph("Shifted ref.", head_style),
-            Paragraph("Unfav. dev.", head_style),
+            Paragraph(t("table.f_hz", language), head_style),
+            Paragraph(t("table.practical_alpha_p", language), head_style),
+            Paragraph(t("table.shifted_ref", language), head_style),
+            Paragraph(t("table.unfav_dev", language), head_style),
         ]
         col_widths = [15 * mm, 20 * mm, 17 * mm, 18 * mm]
     else:
         header = [
-            Paragraph("Frequency f [Hz]", head_style),
+            Paragraph(t("table.frequency", language), head_style),
             Paragraph("&#945;<sub>p</sub>", head_style),
         ]
         col_widths = [28 * mm, 28 * mm]
@@ -175,17 +179,19 @@ def _value_table(
             rows.append(
                 [
                     f"{int(round(fk))}",
-                    _d2(m),
-                    _d2(r_),
-                    _d2(d) if d > _DEVIATION_EPS else "—",
+                    _d2(m, language),
+                    _d2(r_, language),
+                    _d2(d, language) if d > _DEVIATION_EPS else "—",
                 ]
             )
         else:
-            rows.append([f"{int(round(fk))}", _d2(m)])
+            rows.append([f"{int(round(fk))}", _d2(m, language)])
 
     style_cmds = _base_table_style(accent, light, len(centers))
     if verbose:
-        rows.append(["", "", "sum", _d2(float(deviations.sum()))])
+        rows.append(
+            ["", "", t("table.sum", language), _d2(float(deviations.sum()), language)]
+        )
         style_cmds += [
             ("LINEABOVE", (0, -1), (-1, -1), 0.6, accent),
             ("FONTNAME", (2, -1), (-1, -1), "Helvetica-Bold"),
@@ -201,6 +207,7 @@ def _third_octave_table(
     bands: np.ndarray,
     alpha_s: np.ndarray,
     measured: np.ndarray,
+    language: str = "en",
 ) -> Any:
     """Build the combined one-third-octave ``f | alpha_s | alpha_p`` table.
 
@@ -220,7 +227,7 @@ def _third_octave_table(
     head_style = _thead_style()
 
     header = [
-        Paragraph("Frequency f [Hz]", head_style),
+        Paragraph(t("table.frequency", language), head_style),
         Paragraph("&#945;<sub>s</sub>", head_style),
         Paragraph("&#945;<sub>p</sub>", head_style),
     ]
@@ -229,37 +236,53 @@ def _third_octave_table(
     rows: List[List[Any]] = [header]
     for j, (fk, a_s) in enumerate(zip(bands, alpha_s)):
         # The middle of each triple is the octave centre carrying alpha_p.
-        octave_cell = _d2(measured[j // 3]) if j % 3 == 1 else ""
-        rows.append([f"{int(round(fk))}", _d2(a_s), octave_cell])
+        octave_cell = _d2(measured[j // 3], language) if j % 3 == 1 else ""
+        rows.append([f"{int(round(fk))}", _d2(a_s, language), octave_cell])
 
     table = Table(rows, colWidths=col_widths, repeatRows=1)
     table.setStyle(TableStyle(_base_table_style(accent, light, len(bands))))
     return table
 
 
-def _statement(result: "AbsorptionRatingResult") -> str:
+def _statement(result: "AbsorptionRatingResult", language: str = "en") -> str:
     """The boxed single-number statement ``alpha_w = X (shape)``."""
-    value = f"{result.alpha_w:.2f}"
+    value = format_number(result.alpha_w, language, decimals=2)
     if result.shape_indicator:
         value = f"{value} ({result.shape_indicator})"
     return f"&#945;<sub>w</sub> = <b>{value}</b>"
 
 
-def _extended_terms(result: "AbsorptionRatingResult") -> List[str]:
+def _extended_terms(
+    result: "AbsorptionRatingResult", language: str = "en"
+) -> List[str]:
     """The absorption class, shape indicator and applied shift shown by the box."""
-    terms = [f"Absorption class: {html.escape(result.absorption_class)}"]
+    terms = [
+        t("iso11654.absorption_class", language).format(
+            value=html.escape(result.absorption_class)
+        )
+    ]
     if result.shape_indicator:
-        terms.append(f"Shape indicator: {result.shape_indicator}")
-    terms.append(f"Applied shift: {result.shift:.2f}")
+        terms.append(
+            t("iso11654.shape_indicator", language).format(
+                value=result.shape_indicator
+            )
+        )
+    terms.append(
+        t("iso11654.applied_shift", language).format(
+            value=format_number(result.shift, language, decimals=2)
+        )
+    )
     return terms
 
 
-def _verdict(result: "AbsorptionRatingResult", requirement: float) -> Tuple[str, bool]:
+def _verdict(
+    result: "AbsorptionRatingResult", requirement: float, language: str = "en"
+) -> Tuple[str, bool]:
     """Verdict text and PASS flag: absorption passes at or above the requirement."""
     passed = float(result.alpha_w) >= requirement
-    text = (
-        f"&#945;<sub>w</sub> = {result.alpha_w:.2f}, required &#8805; "
-        f"{requirement:.2f}"
+    text = t("iso11654.verdict", language).format(
+        value=format_number(result.alpha_w, language, decimals=2),
+        req=format_number(requirement, language, decimals=2),
     )
     return text, passed
 
@@ -270,6 +293,7 @@ def render_iso11654_report(
     *,
     metadata: ReportMetadata | None = None,
     verbose: bool = False,
+    language: str = "en",
 ) -> str:
     """Render an ISO 11654 absorption-rating fiche to a PDF at ``path``.
 
@@ -308,18 +332,17 @@ def render_iso11654_report(
     deviations = np.maximum(shifted - measured, 0.0)
 
     styles, title_style, basis_style, caption_style = document_styles(accent)
-    title = "Sound absorption rating"
+    title = t("title.absorption", language)
 
     measurement_standard = (
         metadata.measurement_standard if metadata is not None else None
     )
     if measurement_standard:
-        basis = (
-            f"{html.escape(measurement_standard)} laboratory measurement of sound "
-            "absorption. Rating per ISO 11654:1997."
+        basis = t("basis.iso11654.with_standard", language).format(
+            standard=html.escape(measurement_standard)
         )
     else:
-        basis = "Sound absorption rating per ISO 11654:1997."
+        basis = t("basis.iso11654.plain", language)
 
     flow: List[Any] = [
         Paragraph(title, title_style),
@@ -327,7 +350,7 @@ def render_iso11654_report(
     ]
 
     if metadata is not None and not metadata.is_empty():
-        header_pairs = _metadata_pairs(metadata)
+        header_pairs = _metadata_pairs(metadata, language)
         if header_pairs:
             flow.append(Spacer(1, 3))
             flow.append(grid_table(header_pairs))
@@ -344,25 +367,33 @@ def render_iso11654_report(
             np.asarray(bands, dtype=np.float64),
             np.asarray(alpha_s, dtype=np.float64),
             measured,
+            language,
         )
-        caption = "One-third-octave &#945;<sub>s</sub>, octave &#945;<sub>p</sub>"
+        caption = t("caption.one_third_octave_alpha", language)
     else:
-        value_table = _value_table(centers, measured, shifted, deviations, verbose)
-        caption = "Octave-band &#945;<sub>p</sub>"
+        value_table = _value_table(
+            centers, measured, shifted, deviations, verbose, language
+        )
+        caption = t("caption.octave_alpha_p", language)
     left_cell = [
         Paragraph(caption, caption_style),
         value_table,
     ]
     plot_drawing = render_figure_drawing(
-        result.plot, 116 * mm, y_top=1.0, expand_step=None
+        result.plot, 116 * mm, y_top=1.0, expand_step=None, language=language
     )
     flow.append(two_panel_body(left_cell, plot_drawing))
     flow.append(Spacer(1, 8))
 
-    flow.append(result_box(_statement(result), styles, accent, _extended_terms(result)))
+    flow.append(
+        result_box(
+            _statement(result, language), styles, accent,
+            _extended_terms(result, language),
+        )
+    )
     if metadata is not None and metadata.requirement is not None:
-        text, passed = _verdict(result, metadata.requirement)
-        flow.extend(verdict_flow(text, passed, styles))
-    flow.extend(footer_flow(metadata))
+        text, passed = _verdict(result, metadata.requirement, language)
+        flow.extend(verdict_flow(text, passed, styles, language))
+    flow.extend(footer_flow(metadata, language))
 
     return build_document(path, flow, title)

--- a/src/phonometry/_report/iso532.py
+++ b/src/phonometry/_report/iso532.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import html
 from typing import TYPE_CHECKING, Any, List, Tuple
 
+from ._i18n import format_number, t
 from ._layout import (
     _ACCENT_HEX,
     _REPORTLAB_HINT,
@@ -50,7 +51,9 @@ if TYPE_CHECKING:
     from ..psychoacoustics.loudness_zwicker import ZwickerLoudness
 
 
-def _metadata_pairs(metadata: ReportMetadata) -> List[Tuple[str, str]]:
+def _metadata_pairs(
+    metadata: ReportMetadata, language: str = "en"
+) -> List[Tuple[str, str]]:
     """Build the ordered (label, value) pairs of the loudness header grid.
 
     Only fields that are set are returned. Loudness is a signal metric, so the
@@ -58,11 +61,11 @@ def _metadata_pairs(metadata: ReportMetadata) -> List[Tuple[str, str]]:
     identity fields are used.
     """
     specs: List[Tuple[str, str | None]] = [
-        ("Client", metadata.client),
-        ("Signal", metadata.specimen),
-        ("Manufacturer", metadata.manufacturer),
-        ("Test room", metadata.test_room),
-        ("Date of test", metadata.test_date),
+        (t("meta.client", language), metadata.client),
+        (t("meta.signal", language), metadata.specimen),
+        (t("meta.manufacturer", language), metadata.manufacturer),
+        (t("meta.test_room", language), metadata.test_room),
+        (t("meta.date_of_test", language), metadata.test_date),
     ]
     return [
         (label, html.escape(str(value)))
@@ -71,37 +74,46 @@ def _metadata_pairs(metadata: ReportMetadata) -> List[Tuple[str, str]]:
     ]
 
 
-def _metric_rows(result: "ZwickerLoudness") -> List[Tuple[str, str]]:
+def _metric_rows(
+    result: "ZwickerLoudness", language: str = "en"
+) -> List[Tuple[str, str]]:
     """The scalar loudness results shown in the left-hand metrics table."""
     rows = [
-        ("Total loudness N [sone]", fmt_num(result.loudness)),
-        ("Loudness level L<sub>N</sub> [phon]", fmt_num(result.loudness_level)),
+        (t("metric.total_loudness", language), fmt_num(result.loudness, language)),
+        (
+            t("metric.loudness_level", language),
+            fmt_num(result.loudness_level, language),
+        ),
     ]
     if result.n5 is not None:
-        rows.append(("N<sub>5</sub> [sone]", fmt_num(result.n5)))
+        rows.append((t("metric.n5", language), fmt_num(result.n5, language)))
     if result.n10 is not None:
-        rows.append(("N<sub>10</sub> [sone]", fmt_num(result.n10)))
+        rows.append((t("metric.n10", language), fmt_num(result.n10, language)))
     return rows
 
 
-def _statement(result: "ZwickerLoudness") -> str:
+def _statement(result: "ZwickerLoudness", language: str = "en") -> str:
     """The boxed single-number statement ``N = X sone (LN = Y phon)``."""
+    loudness = format_number(result.loudness, language, decimals=1)
+    level = format_number(result.loudness_level, language, decimals=1)
     return (
-        f"N = <b>{result.loudness:.1f} sone</b> &nbsp; "
-        f"(L<sub>N</sub> = {result.loudness_level:.1f} phon)"
+        f"N = <b>{loudness} sone</b> &nbsp; "
+        f"(L<sub>N</sub> = {level} phon)"
     )
 
 
-def _verdict(result: "ZwickerLoudness", requirement: float) -> Tuple[str, bool]:
+def _verdict(
+    result: "ZwickerLoudness", requirement: float, language: str = "en"
+) -> Tuple[str, bool]:
     """Verdict text and PASS flag: loudness passes at or below the requirement.
 
     The requirement is read as a maximum permitted loudness in sone (a lower
     loudness is better), so the sign rule is the opposite of the airborne one.
     """
     passed = float(result.loudness) <= requirement
-    text = (
-        f"N = {result.loudness:.1f} sone, required &#8804; "
-        f"{fmt_num(requirement)} sone"
+    text = t("iso532.verdict", language).format(
+        value=format_number(result.loudness, language, decimals=1),
+        req=fmt_num(requirement, language),
     )
     return text, passed
 
@@ -112,6 +124,7 @@ def render_iso532_report(
     *,
     metadata: ReportMetadata | None = None,
     verbose: bool = False,
+    language: str = "en",
 ) -> str:
     """Render an ISO 532-1 Zwicker loudness fiche to a PDF at ``path``.
 
@@ -140,18 +153,17 @@ def render_iso532_report(
     accent = colors.HexColor(_ACCENT_HEX)
 
     styles, title_style, basis_style, caption_style = document_styles(accent)
-    title = "Loudness rating"
+    title = t("title.loudness", language)
 
     measurement_standard = (
         metadata.measurement_standard if metadata is not None else None
     )
     if measurement_standard:
-        basis = (
-            f"{html.escape(measurement_standard)} loudness. Rating per "
-            "ISO 532-1:2017 (Zwicker method)."
+        basis = t("basis.iso532.with_standard", language).format(
+            standard=html.escape(measurement_standard)
         )
     else:
-        basis = "Loudness rating per ISO 532-1:2017 (Zwicker method)."
+        basis = t("basis.iso532.plain", language)
 
     flow: List[Any] = [
         Paragraph(title, title_style),
@@ -159,25 +171,27 @@ def render_iso532_report(
     ]
 
     if metadata is not None and not metadata.is_empty():
-        header_pairs = _metadata_pairs(metadata)
+        header_pairs = _metadata_pairs(metadata, language)
         if header_pairs:
             flow.append(Spacer(1, 3))
             flow.append(grid_table(header_pairs))
     flow.append(Spacer(1, 8))
 
     left_cell = [
-        Paragraph("Loudness results", caption_style),
-        metrics_table(_metric_rows(result)),
+        Paragraph(t("caption.loudness_results", language), caption_style),
+        metrics_table(_metric_rows(result, language)),
     ]
     # Non-band plot (specific loudness N' over Bark): self-scaling axis.
-    plot_drawing = render_figure_drawing(result.plot, 116 * mm, y_top=None)
+    plot_drawing = render_figure_drawing(
+        result.plot, 116 * mm, y_top=None, language=language
+    )
     flow.append(two_panel_body(left_cell, plot_drawing))
     flow.append(Spacer(1, 8))
 
-    flow.append(result_box(_statement(result), styles, accent))
+    flow.append(result_box(_statement(result, language), styles, accent))
     if metadata is not None and metadata.requirement is not None:
-        text, passed = _verdict(result, metadata.requirement)
-        flow.extend(verdict_flow(text, passed, styles))
-    flow.extend(footer_flow(metadata))
+        text, passed = _verdict(result, metadata.requirement, language)
+        flow.extend(verdict_flow(text, passed, styles, language))
+    flow.extend(footer_flow(metadata, language))
 
     return build_document(path, flow, title)

--- a/src/phonometry/_report/iso717.py
+++ b/src/phonometry/_report/iso717.py
@@ -38,6 +38,7 @@ from typing import TYPE_CHECKING, Any, List, Tuple, cast
 
 import numpy as np
 
+from ._i18n import format_number, t
 from ._layout import (
     _ACCENT_HEX,
     _LIGHT_HEX,
@@ -68,11 +69,12 @@ _Y_TOP_IMPACT = 80.0
 
 def _labels(
     result: "WeightedRatingResult | ImpactRatingResult",
+    language: str = "en",
 ) -> Tuple[str, str, str, str]:
     """Return ``(title, rating_part, statement, value_header)`` for the quantity."""
     if result.quantity == "impact":
         impact = cast("ImpactRatingResult", result)
-        title = "Impact sound insulation rating"
+        title = t("title.impact", language)
         rating_part = "ISO 717-2"
         statement = (
             f"L<sub>n,w</sub> (C<sub>I</sub>) = "
@@ -81,7 +83,7 @@ def _labels(
         value_header = "L<sub>n</sub>"
     else:
         airborne = cast("WeightedRatingResult", result)
-        title = "Airborne sound insulation rating"
+        title = t("title.airborne", language)
         rating_part = "ISO 717-1"
         statement = (
             f"R<sub>w</sub> (C; C<sub>tr</sub>) = "
@@ -93,6 +95,7 @@ def _labels(
 
 def _metadata_pairs(
     metadata: ReportMetadata,
+    language: str = "en",
 ) -> Tuple[List[Tuple[str, str]], List[Tuple[str, str]]]:
     """Build the two ordered (label, value) groups of the header grid.
 
@@ -111,21 +114,22 @@ def _metadata_pairs(
 
     identity = group(
         [
-            ("Client", metadata.client),
-            ("Mounted by", metadata.mounted_by),
+            (t("meta.client", language), metadata.client),
+            (t("meta.mounted_by", language), metadata.mounted_by),
             (
-                "Sample area S [m<super>2</super>]",
-                fmt_num(metadata.area) if metadata.area is not None else None,
+                t("meta.sample_area", language),
+                fmt_num(metadata.area, language)
+                if metadata.area is not None else None,
             ),
-            ("Manufacturer", metadata.manufacturer),
-            ("Description", metadata.specimen),
-            ("Test room", metadata.test_room),
-            ("Date of test", metadata.test_date),
+            (t("meta.manufacturer", language), metadata.manufacturer),
+            (t("meta.description", language), metadata.specimen),
+            (t("meta.test_room", language), metadata.test_room),
+            (t("meta.date_of_test", language), metadata.test_date),
         ]
     )
 
     def num(value: float | None) -> str | None:
-        return fmt_num(value) if value is not None else None
+        return fmt_num(value, language) if value is not None else None
 
     # Per-room temperature/humidity when supplied; otherwise a single value.
     per_room_t = (
@@ -138,32 +142,38 @@ def _metadata_pairs(
     )
     conditions = group(
         [
-            ("Source room volume [m<super>3</super>]", num(metadata.source_volume)),
-            ("Source room temp. [&#176;C]", num(metadata.source_temperature)),
-            ("Source room humidity [%]", num(metadata.source_relative_humidity)),
+            (t("meta.source_volume", language), num(metadata.source_volume)),
+            (t("meta.source_temp", language), num(metadata.source_temperature)),
             (
-                "Receiving room volume [m<super>3</super>]",
+                t("meta.source_humidity", language),
+                num(metadata.source_relative_humidity),
+            ),
+            (
+                t("meta.receiving_volume", language),
                 num(metadata.receiving_volume),
             ),
-            ("Receiving room temp. [&#176;C]", num(metadata.receiving_temperature)),
             (
-                "Receiving room humidity [%]",
+                t("meta.receiving_temp", language),
+                num(metadata.receiving_temperature),
+            ),
+            (
+                t("meta.receiving_humidity", language),
                 num(metadata.receiving_relative_humidity),
             ),
             (
-                "Temperature [&#176;C]",
+                t("meta.temperature", language),
                 None if per_room_t else num(metadata.temperature),
             ),
             (
-                "Relative humidity [%]",
+                t("meta.relative_humidity", language),
                 None if per_room_rh else num(metadata.relative_humidity),
             ),
-            ("Ambient pressure [kPa]", num(metadata.pressure)),
+            (t("meta.ambient_pressure", language), num(metadata.pressure)),
             (
-                "Mass per unit area [kg/m<super>2</super>]",
+                t("meta.mass_per_area", language),
                 num(metadata.mass_per_area),
             ),
-            ("Mounting", metadata.mounting),
+            (t("meta.mounting", language), metadata.mounting),
         ]
     )
     return identity, conditions
@@ -176,6 +186,7 @@ def _value_table(
     deviations: np.ndarray,
     value_header: str,
     verbose: bool,
+    language: str = "en",
 ) -> Any:
     """Build the left-hand one-third-octave table (accredited or Annex C).
 
@@ -198,22 +209,28 @@ def _value_table(
 
     if verbose:
         header = [
-            Paragraph("f [Hz]", head_style),
-            Paragraph(f"Measured {value_header} [dB]", head_style),
-            Paragraph("Shifted ref. [dB]", head_style),
-            Paragraph("Unfav. dev. [dB]", head_style),
+            Paragraph(t("table.f_hz", language), head_style),
+            Paragraph(
+                t("table.measured_value", language).format(vh=value_header),
+                head_style,
+            ),
+            Paragraph(t("table.shifted_ref_db", language), head_style),
+            Paragraph(t("table.unfav_dev_db", language), head_style),
         ]
         col_widths = [15 * mm, 19 * mm, 18 * mm, 18 * mm]
     else:
         header = [
-            Paragraph("Frequency f [Hz]", head_style),
-            Paragraph(f"{value_header} [dB]", head_style),
+            Paragraph(t("table.frequency", language), head_style),
+            Paragraph(
+                t("table.value_db", language).format(vh=value_header), head_style
+            ),
         ]
         col_widths = [28 * mm, 28 * mm]
 
     def d1(value: float) -> str:
-        # One decimal, period separator (English fiche), matching fmt_num.
-        return f"{value:.1f}"
+        # One decimal, locale-aware separator (period for English, matching
+        # fmt_num; comma for Spanish).
+        return format_number(value, language, decimals=1)
 
     rows: List[List[Any]] = [header]
     for fk, m, r_, d in zip(centers, measured, shifted, deviations):
@@ -222,7 +239,7 @@ def _value_table(
                 [
                     f"{int(round(fk))}",
                     d1(m),
-                    f"{r_:.0f}",
+                    format_number(r_, language, decimals=0),
                     d1(d) if d > _DEVIATION_EPS else "—",
                 ]
             )
@@ -248,7 +265,9 @@ def _value_table(
             ("LINEBELOW", (0, triplet_end), (-1, triplet_end), 0.4, thin)
         )
     if verbose:
-        rows.append(["", "", "sum", d1(float(deviations.sum()))])
+        rows.append(
+            ["", "", t("table.sum", language), d1(float(deviations.sum()))]
+        )
         style_cmds += [
             ("LINEABOVE", (0, -1), (-1, -1), 0.6, accent),
             ("FONTNAME", (2, -1), (-1, -1), "Helvetica-Bold"),
@@ -261,7 +280,9 @@ def _value_table(
 
 
 def _verdict(
-    result: "WeightedRatingResult | ImpactRatingResult", requirement: float
+    result: "WeightedRatingResult | ImpactRatingResult",
+    requirement: float,
+    language: str = "en",
 ) -> Tuple[str, bool]:
     """Return the verdict text and a PASS flag for a supplied requirement.
 
@@ -269,18 +290,16 @@ def _verdict(
     impact ratings pass when the rating is at or below it (lower is better).
     """
     rating = float(result.rating)
-    req_text = fmt_num(requirement)
+    req_text = fmt_num(requirement, language)
     if result.quantity == "impact":
         passed = rating <= requirement
-        text = (
-            f"L<sub>n,w</sub> = {result.rating} dB, required &#8804; "
-            f"{req_text} dB"
+        text = t("iso717.verdict.impact", language).format(
+            rating=result.rating, req=req_text
         )
     else:
         passed = rating >= requirement
-        text = (
-            f"R<sub>w</sub> = {result.rating} dB, required &#8805; "
-            f"{req_text} dB"
+        text = t("iso717.verdict.airborne", language).format(
+            rating=result.rating, req=req_text
         )
     return text, passed
 
@@ -325,6 +344,7 @@ def render_iso717_report(
     *,
     metadata: ReportMetadata | None = None,
     verbose: bool = False,
+    language: str = "en",
 ) -> str:
     """Render an ISO 717 accredited-laboratory rating fiche to a PDF at ``path``.
 
@@ -376,7 +396,7 @@ def render_iso717_report(
     else:
         deviations = np.maximum(shifted - measured, 0.0)
 
-    title, rating_part, statement, value_header = _labels(result)
+    title, rating_part, statement, value_header = _labels(result, language)
 
     styles, title_style, basis_style, caption_style = document_styles(accent)
 
@@ -384,12 +404,11 @@ def render_iso717_report(
         metadata.measurement_standard if metadata is not None else None
     )
     if measurement_standard:
-        basis = (
-            f"{html.escape(measurement_standard)} laboratory measurement of sound "
-            f"insulation. Rating per {rating_part}:2020."
+        basis = t("basis.iso717.with_standard", language).format(
+            standard=html.escape(measurement_standard), part=rating_part
         )
     else:
-        basis = f"Sound insulation rating per {rating_part}:2020."
+        basis = t("basis.iso717.plain", language).format(part=rating_part)
 
     flow: List[Any] = [
         Paragraph(title, title_style),
@@ -398,7 +417,7 @@ def render_iso717_report(
 
     # Metadata header block (only the supplied fields).
     if metadata is not None and not metadata.is_empty():
-        identity, conditions = _metadata_pairs(metadata)
+        identity, conditions = _metadata_pairs(metadata, language)
         header_pairs = identity + conditions
         if header_pairs:
             flow.append(Spacer(1, 3))
@@ -408,15 +427,18 @@ def render_iso717_report(
     # Two-panel body: the one-third-octave table on the left (~70 mm), the
     # vector plot on the right filling the rest of the content width.
     value_table = _value_table(
-        centers, measured, shifted, deviations, value_header, verbose
+        centers, measured, shifted, deviations, value_header, verbose, language
     )
     left_cell = [
-        Paragraph(f"One-third-octave {value_header} [dB]", caption_style),
+        Paragraph(
+            t("caption.one_third_octave_value", language).format(vh=value_header),
+            caption_style,
+        ),
         value_table,
     ]
     y_top = _Y_TOP_IMPACT if result.quantity == "impact" else _Y_TOP_AIRBORNE
     plot_drawing = render_figure_drawing(
-        result.plot, 116 * mm, y_top=y_top, expand_step=10.0
+        result.plot, 116 * mm, y_top=y_top, expand_step=10.0, language=language
     )
     flow.append(two_panel_body(left_cell, plot_drawing))
     flow.append(Spacer(1, 8))
@@ -424,8 +446,8 @@ def render_iso717_report(
     # Boxed single-number result, optional verdict row, footer.
     flow.append(result_box(statement, styles, accent, _extended_terms(result)))
     if metadata is not None and metadata.requirement is not None:
-        text, passed = _verdict(result, metadata.requirement)
-        flow.extend(verdict_flow(text, passed, styles))
-    flow.extend(footer_flow(metadata))
+        text, passed = _verdict(result, metadata.requirement, language)
+        flow.extend(verdict_flow(text, passed, styles, language))
+    flow.extend(footer_flow(metadata, language))
 
     return build_document(path, flow, title)

--- a/src/phonometry/aircraft/aircraft_noise.py
+++ b/src/phonometry/aircraft/aircraft_noise.py
@@ -399,6 +399,7 @@ class EPNLResult:
         metadata: "ReportMetadata | None" = None,
         engine: str = "reportlab",
         verbose: bool = False,
+        language: str = "en",
     ) -> str:
         """Render an ICAO Annex 16 EPNL certification fiche to a PDF.
 
@@ -422,11 +423,16 @@ class EPNLResult:
         :param engine: Rendering back end; only ``"reportlab"`` is supported.
         :param verbose: Accepted for a uniform signature; it has no effect on
             the single-layout EPNL fiche.
+        :param language: Fiche language: ``"en"`` (default, English) or
+            ``"es"`` (Spanish, with a comma decimal separator).
         :return: The written ``path`` as a :class:`str`.
         :raises ValueError: If ``engine`` is not ``"reportlab"``.
         :raises ImportError: If reportlab is not installed
             (``pip install phonometry[report]``).
         """
+        from .._i18n import check_language
+
+        check_language(language)
         if engine != "reportlab":
             raise ValueError(
                 f"Unknown report engine {engine!r}; only 'reportlab' is supported."
@@ -434,7 +440,7 @@ class EPNLResult:
         from .._report.annex16_epnl import render_annex16_epnl_report
 
         return render_annex16_epnl_report(
-            self, path, metadata=metadata, verbose=verbose
+            self, path, metadata=metadata, verbose=verbose, language=language
         )
 
 

--- a/src/phonometry/broadcast/program_loudness.py
+++ b/src/phonometry/broadcast/program_loudness.py
@@ -556,6 +556,7 @@ class ProgramLoudnessResult:
         metadata: "ReportMetadata | None" = None,
         engine: str = "reportlab",
         verbose: bool = False,
+        language: str = "en",
     ) -> str:
         """Render an EBU R 128 programme-loudness compliance fiche to a PDF.
 
@@ -576,11 +577,16 @@ class ProgramLoudnessResult:
         :param engine: Rendering back end; only ``"reportlab"`` is supported.
         :param verbose: Accepted for a uniform signature; it has no effect on
             the single-layout programme-loudness fiche.
+        :param language: Fiche language: ``"en"`` (default, English) or
+            ``"es"`` (Spanish, with a comma decimal separator).
         :return: The written ``path`` as a :class:`str`.
         :raises ValueError: If ``engine`` is not ``"reportlab"``.
         :raises ImportError: If reportlab is not installed
             (``pip install phonometry[report]``).
         """
+        from .._i18n import check_language
+
+        check_language(language)
         if engine != "reportlab":
             raise ValueError(
                 f"Unknown report engine {engine!r}; only 'reportlab' is supported."
@@ -588,7 +594,7 @@ class ProgramLoudnessResult:
         from .._report.broadcast import render_program_loudness_report
 
         return render_program_loudness_report(
-            self, path, metadata=metadata, verbose=verbose
+            self, path, metadata=metadata, verbose=verbose, language=language
         )
 
 

--- a/src/phonometry/building/insulation.py
+++ b/src/phonometry/building/insulation.py
@@ -318,6 +318,7 @@ class WeightedRatingResult:
         metadata: "ReportMetadata | None" = None,
         engine: str = "reportlab",
         verbose: bool = False,
+        language: str = "en",
     ) -> str:
         """Render an ISO 717-1 airborne sound-insulation fiche to a PDF.
 
@@ -336,6 +337,8 @@ class WeightedRatingResult:
             columns (frequency, measured value, shifted reference,
             unfavourable deviation) instead of the two-column ``f | value``
             table.
+        :param language: Fiche language: ``"en"`` (default, English) or
+            ``"es"`` (Spanish, with a comma decimal separator).
         :return: The written ``path`` as a :class:`str`.
         :raises ValueError: If ``engine`` is not ``"reportlab"`` or the result
             was built without the per-band data (``band_centers``,
@@ -344,7 +347,8 @@ class WeightedRatingResult:
             (``pip install phonometry[report]``).
         """
         return _render_iso717(
-            self, path, metadata=metadata, engine=engine, verbose=verbose
+            self, path, metadata=metadata, engine=engine, verbose=verbose,
+            language=language,
         )
 
 
@@ -426,6 +430,7 @@ class ImpactRatingResult:
         metadata: "ReportMetadata | None" = None,
         engine: str = "reportlab",
         verbose: bool = False,
+        language: str = "en",
     ) -> str:
         """Render an ISO 717-2 impact-insulation fiche to a PDF.
 
@@ -444,6 +449,8 @@ class ImpactRatingResult:
             columns (frequency, measured value, shifted reference,
             unfavourable deviation) instead of the two-column ``f | value``
             table.
+        :param language: Fiche language: ``"en"`` (default, English) or
+            ``"es"`` (Spanish, with a comma decimal separator).
         :return: The written ``path`` as a :class:`str`.
         :raises ValueError: If ``engine`` is not ``"reportlab"`` or the result
             was built without the per-band data (``band_centers``,
@@ -452,7 +459,8 @@ class ImpactRatingResult:
             (``pip install phonometry[report]``).
         """
         return _render_iso717(
-            self, path, metadata=metadata, engine=engine, verbose=verbose
+            self, path, metadata=metadata, engine=engine, verbose=verbose,
+            language=language,
         )
 
 
@@ -501,6 +509,7 @@ def _render_iso717(
     metadata: "ReportMetadata | None",
     engine: str,
     verbose: bool,
+    language: str,
 ) -> str:
     """Validate the report request and delegate to the reportlab renderer.
 
@@ -509,6 +518,9 @@ def _render_iso717(
     built without the per-band data, then calls the reportlab renderer (which
     raises a clear :class:`ImportError` when reportlab is absent).
     """
+    from .._i18n import check_language
+
+    check_language(language)
     if engine != "reportlab":
         raise ValueError(
             f"Unknown report engine {engine!r}; only 'reportlab' is supported."
@@ -526,7 +538,7 @@ def _render_iso717(
     from .._report.iso717 import render_iso717_report
 
     return render_iso717_report(
-        result, path, metadata=metadata, verbose=verbose
+        result, path, metadata=metadata, verbose=verbose, language=language
     )
 
 

--- a/src/phonometry/materials/absorption_rating.py
+++ b/src/phonometry/materials/absorption_rating.py
@@ -251,6 +251,7 @@ class AbsorptionRatingResult:
         metadata: "ReportMetadata | None" = None,
         engine: str = "reportlab",
         verbose: bool = False,
+        language: str = "en",
     ) -> str:
         """Render an ISO 11654 sound-absorption rating fiche to a PDF.
 
@@ -272,11 +273,16 @@ class AbsorptionRatingResult:
         :param verbose: When ``True``, the table adds the ISO 11654 evaluation
             columns (practical coefficient, shifted reference, unfavourable
             deviation) instead of the two-column ``f | alpha_p`` table.
+        :param language: Fiche language: ``"en"`` (default, English) or
+            ``"es"`` (Spanish, with a comma decimal separator).
         :return: The written ``path`` as a :class:`str`.
         :raises ValueError: If ``engine`` is not ``"reportlab"``.
         :raises ImportError: If reportlab is not installed
             (``pip install phonometry[report]``).
         """
+        from .._i18n import check_language
+
+        check_language(language)
         if engine != "reportlab":
             raise ValueError(
                 f"Unknown report engine {engine!r}; only 'reportlab' is supported."
@@ -284,7 +290,7 @@ class AbsorptionRatingResult:
         from .._report.iso11654 import render_iso11654_report
 
         return render_iso11654_report(
-            self, path, metadata=metadata, verbose=verbose
+            self, path, metadata=metadata, verbose=verbose, language=language
         )
 
 

--- a/src/phonometry/metrology/compliance.py
+++ b/src/phonometry/metrology/compliance.py
@@ -409,6 +409,7 @@ class FilterComplianceResult:
         metadata: "ReportMetadata | None" = None,
         engine: str = "reportlab",
         verbose: bool = False,
+        language: str = "en",
     ) -> str:
         """Render an IEC 61260-1 filter-class-compliance fiche to a PDF.
 
@@ -426,18 +427,25 @@ class FilterComplianceResult:
         :param engine: Rendering back end; only ``"reportlab"`` is supported.
         :param verbose: Accepted for a uniform signature; it has no effect on
             the single-layout filter-compliance fiche.
+        :param language: Fiche language: ``"en"`` (default, English) or
+            ``"es"`` (Spanish, with a comma decimal separator).
         :return: The written ``path`` as a :class:`str`.
         :raises ValueError: If ``engine`` is not ``"reportlab"``.
         :raises ImportError: If reportlab is not installed
             (``pip install phonometry[report]``).
         """
+        from .._i18n import check_language
+
+        check_language(language)
         if engine != "reportlab":
             raise ValueError(
                 f"Unknown report engine {engine!r}; only 'reportlab' is supported."
             )
         from .._report.iec61260 import render_iec61260_report
 
-        return render_iec61260_report(self, path, metadata=metadata, verbose=verbose)
+        return render_iec61260_report(
+            self, path, metadata=metadata, verbose=verbose, language=language
+        )
 
 
 def filter_class_compliance(

--- a/src/phonometry/psychoacoustics/loudness_zwicker.py
+++ b/src/phonometry/psychoacoustics/loudness_zwicker.py
@@ -130,6 +130,7 @@ class ZwickerLoudness:
         metadata: "ReportMetadata | None" = None,
         engine: str = "reportlab",
         verbose: bool = False,
+        language: str = "en",
     ) -> str:
         """Render an ISO 532-1 Zwicker loudness fiche to a PDF.
 
@@ -148,11 +149,16 @@ class ZwickerLoudness:
         :param engine: Rendering back end; only ``"reportlab"`` is supported.
         :param verbose: Accepted for a uniform signature; it has no effect on
             the single-layout loudness fiche.
+        :param language: Fiche language: ``"en"`` (default, English) or
+            ``"es"`` (Spanish, with a comma decimal separator).
         :return: The written ``path`` as a :class:`str`.
         :raises ValueError: If ``engine`` is not ``"reportlab"``.
         :raises ImportError: If reportlab is not installed
             (``pip install phonometry[report]``).
         """
+        from .._i18n import check_language
+
+        check_language(language)
         if engine != "reportlab":
             raise ValueError(
                 f"Unknown report engine {engine!r}; only 'reportlab' is supported."
@@ -160,7 +166,7 @@ class ZwickerLoudness:
         from .._report.iso532 import render_iso532_report
 
         return render_iso532_report(
-            self, path, metadata=metadata, verbose=verbose
+            self, path, metadata=metadata, verbose=verbose, language=language
         )
 
 

--- a/tests/aircraft/test_epnl_report.py
+++ b/tests/aircraft/test_epnl_report.py
@@ -110,3 +110,30 @@ def test_no_metadata_prediction_fiche(tmp_path) -> None:
     out = tmp_path / "prediction.pdf"
     _flyover().report(str(out))
     _assert_one_page(str(out))
+
+
+def _extract_text(path: str) -> str:
+    """The concatenated text of every page (for language assertions)."""
+    from pypdf import PdfReader
+
+    return "\n".join(page.extract_text() for page in PdfReader(path).pages)
+
+
+def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
+    """``language="es"`` renders a one-page Spanish fiche with comma decimals."""
+    import re
+
+    result = _flyover()
+    out = tmp_path / "epnl_es.pdf"
+    result.report(str(out), metadata=ReportMetadata(requirement=101.0), language="es")
+    _assert_one_page(str(out))
+    text = _extract_text(str(out))
+    assert "Certificación de ruido de aeronaves" in text
+    assert re.search(r"\d,\d", text) is not None  # comma decimal separator
+
+
+def test_unknown_language_rejected(tmp_path) -> None:
+    """An unknown fiche language raises ``ValueError``."""
+    result = _flyover()
+    with pytest.raises(ValueError, match="language"):
+        result.report(str(tmp_path / "bad.pdf"), language="xx")

--- a/tests/broadcast/test_program_loudness_report.py
+++ b/tests/broadcast/test_program_loudness_report.py
@@ -137,3 +137,30 @@ def test_informational_rows_do_not_change_verdict(tmp_path) -> None:
     out = tmp_path / "info.pdf"
     tampered.report(str(out), metadata=ReportMetadata(requirement=-23.0))
     _assert_one_page(str(out))
+
+
+def _extract_text(path: str) -> str:
+    """The concatenated text of every page (for language assertions)."""
+    from pypdf import PdfReader
+
+    return "\n".join(page.extract_text() for page in PdfReader(path).pages)
+
+
+def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
+    """``language="es"`` renders a one-page Spanish fiche with comma decimals."""
+    import re
+
+    result = _case1_result()
+    out = tmp_path / "program_es.pdf"
+    result.report(str(out), language="es")
+    _assert_one_page(str(out))
+    text = _extract_text(str(out))
+    assert "Conformidad de sonoridad de programa" in text
+    assert re.search(r"\d,\d", text) is not None  # comma decimal separator
+
+
+def test_unknown_language_rejected(tmp_path) -> None:
+    """An unknown fiche language raises ``ValueError``."""
+    result = _case1_result()
+    with pytest.raises(ValueError, match="language"):
+        result.report(str(tmp_path / "bad.pdf"), language="xx")

--- a/tests/building/test_iso717_report.py
+++ b/tests/building/test_iso717_report.py
@@ -240,3 +240,31 @@ def test_metadata_rejects_negative_area() -> None:
     """``ReportMetadata`` rejects a non-positive numeric field."""
     with pytest.raises(ValueError, match="area"):
         ReportMetadata(area=-5.0)
+
+
+def _extract_text(path: str) -> str:
+    """The concatenated text of every page (for language assertions)."""
+    from pypdf import PdfReader
+
+    return "\n".join(page.extract_text() for page in PdfReader(path).pages)
+
+
+def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
+    """``language="es"`` renders a one-page Spanish fiche with comma decimals."""
+    import re
+
+    result = weighted_rating(_AIRBORNE_R)  # Rw = 30 dB, passes a 25 dB minimum
+    out = tmp_path / "airborne_es.pdf"
+    result.report(str(out), metadata=_full_metadata(requirement=25.0), language="es")
+    _assert_one_page(str(out))
+    text = _extract_text(str(out))
+    assert "Índice de aislamiento acústico a ruido aéreo" in text
+    assert "CUMPLE" in text
+    assert re.search(r"\d,\d", text) is not None  # comma decimal separator
+
+
+def test_unknown_language_rejected(tmp_path) -> None:
+    """An unknown fiche language raises ``ValueError``."""
+    result = weighted_rating(_AIRBORNE_R)
+    with pytest.raises(ValueError, match="language"):
+        result.report(str(tmp_path / "bad.pdf"), language="xx")

--- a/tests/materials/test_iso11654_report.py
+++ b/tests/materials/test_iso11654_report.py
@@ -191,3 +191,35 @@ def test_report_escapes_xml_specials_in_metadata(tmp_path) -> None:
     out = tmp_path / "xml.pdf"
     result.report(str(out), metadata=md)
     _assert_one_page(str(out))
+
+
+def _extract_text(path: str) -> str:
+    """The concatenated text of every page (for language assertions)."""
+    from pypdf import PdfReader
+
+    return "\n".join(page.extract_text() for page in PdfReader(path).pages)
+
+
+def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
+    """``language="es"`` renders a one-page Spanish fiche with comma decimals."""
+    import re
+
+    result = weighted_absorption_from_third_octave(_THIRD_OCTAVE_ALPHA_S)
+    out = tmp_path / "absorption_es.pdf"
+    result.report(
+        str(out),
+        metadata=ReportMetadata(requirement=0.55, temperature=21.4),
+        language="es",
+    )
+    _assert_one_page(str(out))
+    text = _extract_text(str(out))
+    assert "Índice de absorción acústica" in text
+    assert "CUMPLE" in text
+    assert re.search(r"\d,\d", text) is not None  # comma decimal separator
+
+
+def test_unknown_language_rejected(tmp_path) -> None:
+    """An unknown fiche language raises ``ValueError``."""
+    result = weighted_absorption_from_third_octave(_THIRD_OCTAVE_ALPHA_S)
+    with pytest.raises(ValueError, match="language"):
+        result.report(str(tmp_path / "bad.pdf"), language="xx")

--- a/tests/metrology/test_iec61260_report.py
+++ b/tests/metrology/test_iec61260_report.py
@@ -155,3 +155,32 @@ def test_empty_bands_result_is_graceful() -> None:
         empty.reference_class()
     with pytest.raises(ValueError, match="no bands"):
         empty.report("/dev/null")
+
+
+def _extract_text(path: str) -> str:
+    """The concatenated text of every page (for language assertions)."""
+    from pypdf import PdfReader
+
+    return "\n".join(page.extract_text() for page in PdfReader(path).pages)
+
+
+def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
+    """``language="es"`` renders a one-page Spanish fiche with comma decimals."""
+    import re
+
+    result = filter_class_compliance(_class1_bank())
+    out = tmp_path / "filter_es.pdf"
+    result.report(str(out), metadata=ReportMetadata(required_class=1), language="es")
+    _assert_one_page(str(out))
+    text = _extract_text(str(out))
+    assert "Conformidad de clase de filtro" in text
+    assert "CUMPLE" in text
+    assert re.search(r"\d,\d", text) is not None  # comma decimal margins
+    assert "margen" in text
+
+
+def test_unknown_language_rejected(tmp_path) -> None:
+    """An unknown fiche language raises ``ValueError``."""
+    result = filter_class_compliance(_class1_bank())
+    with pytest.raises(ValueError, match="language"):
+        result.report(str(tmp_path / "bad.pdf"), language="xx")

--- a/tests/psychoacoustics/test_iso532_report.py
+++ b/tests/psychoacoustics/test_iso532_report.py
@@ -111,3 +111,35 @@ def test_report_escapes_xml_specials_in_metadata(tmp_path) -> None:
     out = tmp_path / "xml.pdf"
     _result().report(str(out), metadata=md)
     _assert_one_page(str(out))
+
+
+def _extract_text(path: str) -> str:
+    """The concatenated text of every page (for language assertions)."""
+    from pypdf import PdfReader
+
+    return "\n".join(page.extract_text() for page in PdfReader(path).pages)
+
+
+def test_spanish_report_renders_translated_fiche(tmp_path) -> None:
+    """``language="es"`` renders a one-page Spanish fiche with comma decimals."""
+    import re
+
+    result = _result()
+    out = tmp_path / "loudness_es.pdf"
+    result.report(
+        str(out),
+        metadata=ReportMetadata(specimen="ruido de electrodoméstico"),
+        language="es",
+    )
+    _assert_one_page(str(out))
+    text = _extract_text(str(out))
+    assert "Índice de sonoridad" in text
+    assert "Sonoridad total" in text
+    assert re.search(r"\d,\d", text) is not None  # comma decimal separator
+
+
+def test_unknown_language_rejected(tmp_path) -> None:
+    """An unknown fiche language raises ``ValueError``."""
+    result = _result()
+    with pytest.raises(ValueError, match="language"):
+        result.report(str(tmp_path / "bad.pdf"), language="xx")


### PR DESCRIPTION
## Summary

Every result's `.report()` method now accepts a per-call `language` argument (`'en'` by default, `'es'`). Spanish renders the fiche's fixed strings in Spanish and switches the decimal separator to a comma, the way a Spanish-language report writes numbers. English stays the default and is byte-for-byte unchanged.

## What changed

- New shared helper `phonometry._i18n`: the `Language` type plus locale-aware number and axis formatting (a no-op for English, so English figures are unchanged).
- New `phonometry._report._i18n`: the translated report strings keyed by a stable English string-id, next to the renderers that consume them.
- The six report renderers (ISO 717, ISO 11654, ISO 532-1, EBU R 128, ICAO Annex 16 EPNL, IEC 61260-1) and the shared `_layout` helpers thread `language` through and format every number through the locale-aware path. Covered strings: titles, standard-basis lines, table and compliance-table headers, metadata-grid labels, metric-row labels, verdict prose and the footer identity/disclaimer block. Unit symbols and published standard designations are never translated; the user's own free-text metadata values are never translated, only the fixed labels.
- Each `.report()` validates the language and raises a clear `ValueError` for an unknown one.

## Backward compatibility

`language="en"` produces byte-identical output to before: the committed English example fiches under `.github/reports/` regenerate with no diff, and the existing report tests pass unchanged.

## Tests, docs

- Each of the six per-fiche test files gains a Spanish-rendering test (a valid one-page PDF whose extracted text carries a translated title and a comma-decimal number) and an unknown-language test.
- The report guides (EN and ES) document the option with a short example; the API reference and `llms-full.txt` are regenerated for the new signatures.

## Gates

- `ruff check .`: clean
- `mypy src scripts`: clean
- `pytest` (building, materials, psychoacoustics, broadcast, aircraft, metrology, generate-reports, package-architecture and the full suite): passing
- `make api-docs && make llms`: regenerated and committed
- Reports regenerated: no diff to the committed English PDFs/PNGs
- Site: i18n parity OK, `npm run build` succeeds, `html-validate` clean

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

