### PR TITLE
feat: EN/ES language option for the psychoacoustics/hearing/vibration plots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   objects accept a `language` keyword (`"en"`, the default, or `"es"`). Spanish
   renders localised axis labels, titles and legends with comma decimal
   separators; English output is unchanged.
+- The `.plot()` methods of the psychoacoustics, hearing and vibration results
+  accept a `language` keyword (`"en"`, the default, or `"es"`). Spanish renders
+  the axis labels, titles and legends in Spanish and switches the decimal
+  separator to a comma; English output is unchanged.
 - IEC 61260-1 filter class compliance can now be exported as a one-page PDF
   fiche. A new `filter_class_compliance(bank, *, num_points=..., edition=...)`
   runs the same verification as `verify_filter_class` and returns a frozen

--- a/site/src/content/docs/reference/api/hearing/noise-induced-hearing-loss.md
+++ b/site/src/content/docs/reference/api/hearing/noise-induced-hearing-loss.md
@@ -102,7 +102,12 @@ All arrays are in dB and aligned with `NIPTS_FREQUENCIES`.
 ### HtlanResult.plot()
 
 ```python
-HtlanResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+HtlanResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the age, noise and combined threshold components over frequency.
@@ -183,7 +188,12 @@ All arrays are in dB and aligned with `NIPTS_FREQUENCIES`.
 ### NiptsResult.plot()
 
 ```python
-NiptsResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+NiptsResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the NIPTS spectrum with the fractile band over frequency.

--- a/site/src/content/docs/reference/api/hearing/occupational-exposure.md
+++ b/site/src/content/docs/reference/api/hearing/occupational-exposure.md
@@ -89,7 +89,12 @@ Daily noise exposure level and its expanded uncertainty (ISO 9612:2009).
 ### ExposureResult.plot()
 
 ```python
-ExposureResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+ExposureResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the per-task contributions with the `LEX,8h` line.

--- a/site/src/content/docs/reference/api/hearing/threshold.md
+++ b/site/src/content/docs/reference/api/hearing/threshold.md
@@ -99,7 +99,12 @@ All arrays are in dB and aligned with `AUDIOMETRIC_FREQUENCIES`.
 ### AgeThresholdResult.plot()
 
 ```python
-AgeThresholdResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+AgeThresholdResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the median threshold with the fractile band over frequency.

--- a/site/src/content/docs/reference/api/psychoacoustics/fluctuation-strength-ecma.md
+++ b/site/src/content/docs/reference/api/psychoacoustics/fluctuation-strength-ecma.md
@@ -125,6 +125,8 @@ fluctuation strength F'(l50, z) (Formula 168) of shape
 ```python
 EcmaFluctuationStrength.plot(
     ax: Axes | None = None,
+    *,
+    language: str = 'en',
     **kwargs: Any,
 ) -> Axes | np.ndarray
 ```

--- a/site/src/content/docs/reference/api/psychoacoustics/fluctuation-strength.md
+++ b/site/src/content/docs/reference/api/psychoacoustics/fluctuation-strength.md
@@ -176,6 +176,8 @@ Fluctuation strength of a signal (Osses 2016 model).
 ```python
 FluctuationStrengthResult.plot(
     ax: Axes | None = None,
+    *,
+    language: str = 'en',
     **kwargs: Any,
 ) -> Axes
 ```

--- a/site/src/content/docs/reference/api/psychoacoustics/loudness-ecma.md
+++ b/site/src/content/docs/reference/api/psychoacoustics/loudness-ecma.md
@@ -78,6 +78,8 @@ with `bark` the critical-band-rate scale z (0,5..26,5 Bark_HMS) and
 ```python
 EcmaLoudness.plot(
     ax: Axes | None = None,
+    *,
+    language: str = 'en',
     **kwargs: Any,
 ) -> Axes | np.ndarray
 ```

--- a/site/src/content/docs/reference/api/psychoacoustics/loudness-moore-glasberg-time.md
+++ b/site/src/content/docs/reference/api/psychoacoustics/loudness-moore-glasberg-time.md
@@ -136,6 +136,8 @@ time); the standard itself reports only the peak long-term loudness
 ```python
 MooreGlasbergTimeVaryingLoudness.plot(
     ax: Axes | None = None,
+    *,
+    language: str = 'en',
     **kwargs: Any,
 ) -> Axes
 ```

--- a/site/src/content/docs/reference/api/psychoacoustics/loudness-moore-glasberg.md
+++ b/site/src/content/docs/reference/api/psychoacoustics/loudness-moore-glasberg.md
@@ -167,7 +167,12 @@ pattern is that of a single ear before binaural inhibition; the total
 ### MooreGlasbergLoudness.plot()
 
 ```python
-MooreGlasbergLoudness.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+MooreGlasbergLoudness.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the specific loudness N'(i) over the ERB-number scale.

--- a/site/src/content/docs/reference/api/psychoacoustics/loudness-zwicker.md
+++ b/site/src/content/docs/reference/api/psychoacoustics/loudness-zwicker.md
@@ -128,6 +128,8 @@ and `time`/`loudness_vs_time` the 500 Hz loudness-vs-time trace
 ```python
 ZwickerLoudness.plot(
     ax: Axes | None = None,
+    *,
+    language: str = 'en',
     **kwargs: Any,
 ) -> Axes | np.ndarray
 ```

--- a/site/src/content/docs/reference/api/psychoacoustics/psychoacoustic-annoyance.md
+++ b/site/src/content/docs/reference/api/psychoacoustics/psychoacoustic-annoyance.md
@@ -154,6 +154,8 @@ Psychoacoustic annoyance and its contributing terms (Fastl & Zwicker).
 ```python
 PsychoacousticAnnoyanceResult.plot(
     ax: Axes | None = None,
+    *,
+    language: str = 'en',
     **kwargs: Any,
 ) -> Axes
 ```

--- a/site/src/content/docs/reference/api/psychoacoustics/roughness-ecma.md
+++ b/site/src/content/docs/reference/api/psychoacoustics/roughness-ecma.md
@@ -84,6 +84,8 @@ assumed sound field.
 ```python
 EcmaRoughness.plot(
     ax: Axes | None = None,
+    *,
+    language: str = 'en',
     **kwargs: Any,
 ) -> Axes | np.ndarray
 ```

--- a/site/src/content/docs/reference/api/psychoacoustics/tonality-ecma.md
+++ b/site/src/content/docs/reference/api/psychoacoustics/tonality-ecma.md
@@ -64,6 +64,8 @@ records the assumed sound field.
 ```python
 EcmaTonality.plot(
     ax: Axes | None = None,
+    *,
+    language: str = 'en',
     **kwargs: Any,
 ) -> Axes | np.ndarray
 ```

--- a/site/src/content/docs/reference/api/psychoacoustics/tone-audibility.md
+++ b/site/src/content/docs/reference/api/psychoacoustics/tone-audibility.md
@@ -745,7 +745,12 @@ Tone frequency of the decisive (most audible) tone, in Hz.
 ### ToneAudibilityResult.plot()
 
 ```python
-ToneAudibilityResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+ToneAudibilityResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the per-tone audibility `ΔL` against tone frequency.

--- a/site/src/content/docs/reference/api/speech/objective-intelligibility.md
+++ b/site/src/content/docs/reference/api/speech/objective-intelligibility.md
@@ -110,7 +110,12 @@ Result of a STOI or ESTOI intelligibility computation.
 ### STOIResult.plot()
 
 ```python
-STOIResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+STOIResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the intermediate intelligibility that averages to the index.

--- a/site/src/content/docs/reference/api/speech/sii.md
+++ b/site/src/content/docs/reference/api/speech/sii.md
@@ -54,7 +54,12 @@ Result of a Speech Intelligibility Index computation (ANSI S3.5-1997).
 ### SIIResult.plot()
 
 ```python
-SIIResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+SIIResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the per-band audibility weighted by importance, with the SII.

--- a/site/src/content/docs/reference/api/speech/sti.md
+++ b/site/src/content/docs/reference/api/speech/sti.md
@@ -179,7 +179,12 @@ qualification letter (`A+` .. `U`).
 ### STIResult.plot()
 
 ```python
-STIResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+STIResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the per-band MTI bars with the STI and rating letter.

--- a/site/src/content/docs/reference/api/vibration/human-vibration.md
+++ b/site/src/content/docs/reference/api/vibration/human-vibration.md
@@ -220,7 +220,12 @@ A daily exposure built from several operations, with its assessment.
 ### DailyVibrationExposure.plot()
 
 ```python
-DailyVibrationExposure.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+DailyVibrationExposure.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the partial exposures against the EAV / ELV thresholds.
@@ -696,7 +701,12 @@ A weighted one-third-octave acceleration spectrum and its `a_w`.
 ### WeightedSpectrum.plot()
 
 ```python
-WeightedSpectrum.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+WeightedSpectrum.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the unweighted and weighted band spectra with `a_w`.
@@ -759,7 +769,12 @@ A frequency-weighting magnitude response (ISO 8041-1, Formula (5)).
 ### WeightingResponse.plot()
 
 ```python
-WeightingResponse.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+WeightingResponse.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the weighting factor (dB) versus frequency.

--- a/site/src/content/docs/reference/api/vibration/mechanical-mobility.md
+++ b/site/src/content/docs/reference/api/vibration/mechanical-mobility.md
@@ -151,7 +151,12 @@ Mobility phase, in radians.
 ### MobilityResult.plot()
 
 ```python
-MobilityResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+MobilityResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the mobility magnitude `|Y(f)|`.

--- a/site/src/content/docs/reference/api/vibration/multiple-shock-vibration.md
+++ b/site/src/content/docs/reference/api/vibration/multiple-shock-vibration.md
@@ -285,7 +285,12 @@ Multiple-shock health assessment (ISO 2631-5:2018, Clause 5 + Annex C).
 ### MultipleShockResult.plot()
 
 ```python
-MultipleShockResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+MultipleShockResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the injury-probability curve with this assessment's `R`.

--- a/site/src/content/docs/reference/api/vibration/radiation-efficiency.md
+++ b/site/src/content/docs/reference/api/vibration/radiation-efficiency.md
@@ -167,6 +167,8 @@ Frequency-averaged plate radiation efficiency (Hopkins 2.9.4).
 ```python
 RadiationEfficiencyResult.plot(
     ax: Axes | None = None,
+    *,
+    language: str = 'en',
     **kwargs: Any,
 ) -> Axes
 ```

--- a/site/src/content/docs/reference/api/vibration/transfer-stiffness.md
+++ b/site/src/content/docs/reference/api/vibration/transfer-stiffness.md
@@ -356,7 +356,12 @@ Transfer-stiffness magnitude `|k2,1|`, in N/m.
 ### TransferStiffnessResult.plot()
 
 ```python
-TransferStiffnessResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+TransferStiffnessResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the transfer-stiffness level `L_k(f)`.

--- a/src/phonometry/_plot/hearing.py
+++ b/src/phonometry/_plot/hearing.py
@@ -31,31 +31,135 @@ if TYPE_CHECKING:
     from ..hearing.sti import STIResult
     from ..hearing.objective_intelligibility import STOIResult
 
-def plot_sti(result: STIResult, ax: Axes | None = None, **kwargs: Any) -> Axes:
+#: EN/ES text for every fixed label, title and legend of this module. The
+#: English entries are byte-for-byte the historical strings; ``_t`` returns
+#: them unchanged for ``language="en"``.
+_STRINGS: dict[str, dict[str, str]] = {
+    "freq_hz": {"en": "Frequency [Hz]", "es": "Frecuencia [Hz]"},
+    "band": {"en": "Band", "es": "Banda"},
+    "mti": {
+        "en": "Modulation transfer index MTI",
+        "es": "Índice de transferencia de modulación MTI",
+    },
+    "third_octave_band": {
+        "en": "One-third-octave band [Hz]",
+        "es": "Banda de tercio de octava [Hz]",
+    },
+    "mean_corr": {
+        "en": "Mean intermediate correlation",
+        "es": "Correlación intermedia media",
+    },
+    "spectral_corr": {
+        "en": r"Spectral correlation $d_m$",
+        "es": r"Correlación espectral $d_m$",
+    },
+    "analysis_segment": {"en": "Analysis segment", "es": "Segmento de análisis"},
+    "band_audibility": {"en": "Band audibility", "es": "Audibilidad de banda"},
+    "band_audibility_ai": {
+        "en": r"Band audibility $A_i$",
+        "es": r"Audibilidad de banda $A_i$",
+    },
+    "importance_weighted": {
+        "en": r"Importance-weighted $I_i A_i$ (scaled)",
+        "es": r"$I_i A_i$ ponderada por importancia (escalada)",
+    },
+    "median": {"en": "Median", "es": "Mediana"},
+    "median_n50": {"en": r"Median $N_{50}$", "es": r"Mediana $N_{50}$"},
+    "threshold_dev_18": {
+        "en": "Threshold deviation from age 18 [dB]",
+        "es": "Desviación del umbral respecto a 18 años [dB]",
+    },
+    "nipts_db": {"en": "NIPTS [dB]", "es": "NIPTS [dB]"},
+    "htla_age": {"en": "Age (HTLA, ISO 7029)", "es": "Edad (HTLA, ISO 7029)"},
+    "noise_nipts": {"en": "Noise (NIPTS)", "es": "Ruido (NIPTS)"},
+    "age_noise_htlan": {
+        "en": "Age + noise (HTLAN)",
+        "es": "Edad + ruido (HTLAN)",
+    },
+    "htl_level": {
+        "en": "Hearing threshold level [dB]",
+        "es": "Nivel del umbral de audición [dB]",
+    },
+    "a_weighted_level": {
+        "en": "A-weighted level [dB]",
+        "es": "Nivel ponderado A [dB]",
+    },
+    # Templates (``.format`` fields hold already-localised numbers).
+    "sti_title": {
+        "en": "IEC 60268-16 STI = {sti}  (rating {rating})",
+        "es": "IEC 60268-16 STI = {sti}  (calificación {rating})",
+    },
+    "stoi_title": {"en": "{name} = {v}", "es": "{name} = {v}"},
+    "sii_title": {"en": "ANSI S3.5 SII = {sii}", "es": "ANSI S3.5 SII = {sii}"},
+    "fractile": {"en": "Fractile {v}", "es": "Fractil {v}"},
+    "iso7029_title": {
+        "en": "ISO 7029 hearing threshold — {sex}, age {age}",
+        "es": "ISO 7029 umbral de audición — {sex}, edad {age}",
+    },
+    "nipts_title": {
+        "en": "ISO 1999 NIPTS — $L_{{EX,8h}}$ = {lex} dB, {years} yr",
+        "es": "ISO 1999 NIPTS — $L_{{EX,8h}}$ = {lex} dB, {years} años",
+    },
+    "htlan_title": {
+        "en": "ISO 1999 HTLAN — {sex}, age {age}, {lex} dB / {years} yr",
+        "es": "ISO 1999 HTLAN — {sex}, edad {age}, {lex} dB / {years} años",
+    },
+    "occupational_title": {
+        "en": ("ISO 9612 daily noise exposure — $L_{{EX,8h}}$ = "
+               "{lex} dB (U = {u} dB)"),
+        "es": ("ISO 9612 exposición diaria al ruido — $L_{{EX,8h}}$ = "
+               "{lex} dB (U = {u} dB)"),
+    },
+}
+
+
+def _t(key: str, language: str) -> str:
+    """Look up the localised text for ``key`` (falls back to English)."""
+    entry = _STRINGS[key]
+    return entry.get(language, entry["en"])
+
+
+def plot_sti(
+    result: STIResult, ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any,
+) -> Axes:
     """Per-band modulation transfer index bars with the STI and rating.
 
     :param result: A :class:`~phonometry.sti.STIResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to :meth:`~matplotlib.axes.Axes.bar`.
     :return: The axes.
     """
+    from .._i18n import format_number, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     mti = np.asarray(result.mti, dtype=np.float64)
     positions = np.arange(mti.size)
     kwargs.setdefault("color", _C_PRIMARY)
     ax.bar(positions, mti, **kwargs)
-    if mti.size == len(_STI_BAND_CENTERS):
+    banded = mti.size == len(_STI_BAND_CENTERS)
+    if banded:
         _band_axis(ax, np.asarray(_STI_BAND_CENTERS))
+        ax.set_xlabel(_t("freq_hz", language))
     else:
         ax.set_xticks(positions)
-        ax.set_xlabel("Band")
-    ax.set_ylabel("Modulation transfer index MTI")
+        ax.set_xlabel(_t("band", language))
+    ax.set_ylabel(_t("mti", language))
     ax.set_ylim(0.0, 1.0)
-    ax.set_title(f"IEC 60268-16 STI = {result.sti:.2f}  (rating {result.rating})")
+    ax.set_title(_t("sti_title", language).format(
+        sti=format_number(result.sti, language, decimals=2), rating=result.rating,
+    ))
     ax.grid(True, axis="y", alpha=0.3)
+    # localize_axes leaves the categorical band axis (a FuncFormatter) alone.
+    localize_axes(ax, language)
     return ax
 
-def plot_stoi(result: "STOIResult", ax: Axes | None = None, **kwargs: Any) -> Axes:
+
+def plot_stoi(
+    result: "STOIResult", ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any,
+) -> Axes:
     """Intermediate intelligibility that averages to the STOI/ESTOI index.
 
     For STOI the intermediate measure decomposes per one-third-octave band, so
@@ -65,74 +169,101 @@ def plot_stoi(result: "STOIResult", ax: Axes | None = None, **kwargs: Any) -> Ax
 
     :param result: A :class:`~phonometry.hearing.objective_intelligibility.STOIResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the underlying :meth:`bar`/:meth:`plot`.
     :return: The axes.
     """
+    from .._i18n import decimal_comma, format_number, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     name = "ESTOI" if result.extended else "STOI"
-    if result.band_scores is not None:
+    banded = result.band_scores is not None
+    if banded:
         freqs = np.asarray(result.band_frequencies, dtype=np.float64)
         scores = np.asarray(result.band_scores, dtype=np.float64)
         positions = np.arange(scores.size)
         kwargs.setdefault("color", _C_PRIMARY)
         ax.bar(positions, scores, **kwargs)
         ax.set_xticks(positions)
-        ax.set_xticklabels([f"{f:g}" for f in freqs], rotation=45, ha="right")
-        ax.set_xlabel("One-third-octave band [Hz]")
-        ax.set_ylabel("Mean intermediate correlation")
+        ax.set_xticklabels([decimal_comma(f"{f:g}", language) for f in freqs],
+                           rotation=45, ha="right")
+        ax.set_xlabel(_t("third_octave_band", language))
+        ax.set_ylabel(_t("mean_corr", language))
     else:
         scores = np.asarray(result.segment_scores, dtype=np.float64)
         kwargs.setdefault("color", _C_PRIMARY)
         ax.plot(np.arange(scores.size), scores, **kwargs)
-        ax.set_xlabel("Analysis segment")
-        ax.set_ylabel("Spectral correlation $d_m$")
+        ax.set_xlabel(_t("analysis_segment", language))
+        ax.set_ylabel(_t("spectral_corr", language))
     # The intermediate correlations are cosine-similarity quantities in
     # [-1, 1] (unlike the [0, 1] ratios of plot_sti/plot_sii), so keep room
     # for anti-correlated bands rather than clipping them at zero.
     ax.set_ylim(-1.0, 1.0)
-    ax.set_title(f"{name} = {result.value:.3f}")
+    ax.set_title(_t("stoi_title", language).format(
+        name=name, v=format_number(result.value, language, decimals=3),
+    ))
     ax.grid(True, axis="y", alpha=0.3)
+    # localize_axes leaves the categorical band labels (a FuncFormatter) alone,
+    # so the comma-localized labels set above survive.
+    localize_axes(ax, language)
     return ax
 
-def plot_sii(result: "SIIResult", ax: Axes | None = None, **kwargs: Any) -> Axes:
+
+def plot_sii(
+    result: "SIIResult", ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any,
+) -> Axes:
     """Per-band audibility and its importance-weighted contribution to the SII.
 
     :param result: A :class:`~phonometry.sii.SIIResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the weighted-contribution :meth:`bar`.
     :return: The axes.
     """
+    from .._i18n import format_number, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     audibility = np.asarray(result.band_audibility, dtype=np.float64)
     contribution = audibility * np.asarray(result.band_importance, dtype=np.float64)
     positions = _band_axis(ax, freqs)
+    ax.set_xlabel(_t("freq_hz", language))
     ax.bar(positions, audibility, color=_C_PRIMARY_LIGHT,
-           label="Band audibility $A_i$")
+           label=_t("band_audibility_ai", language))
     kwargs.setdefault("color", _C_PRIMARY)
     # A fully masked speech signal (SII = 0) has an all-zero contribution;
     # keep the zero bars rather than dividing 0/0 into NaN.
     peak = float(contribution.max()) if contribution.size else 0.0
     scaled = contribution / peak if peak > 0.0 else contribution
     ax.bar(positions, scaled, width=0.5,
-           label=r"Importance-weighted $I_i A_i$ (scaled)", **kwargs)
-    ax.set_ylabel("Band audibility")
+           label=_t("importance_weighted", language), **kwargs)
+    ax.set_ylabel(_t("band_audibility", language))
     ax.set_ylim(0.0, 1.0)
-    ax.set_title(f"ANSI S3.5 SII = {result.sii:.3f}")
+    ax.set_title(_t("sii_title", language).format(
+        sii=format_number(result.sii, language, decimals=3),
+    ))
     ax.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
     ax.grid(True, axis="y", alpha=0.3)
+    # localize_axes leaves the categorical band axis (a FuncFormatter) alone.
+    localize_axes(ax, language)
     return ax
 
+
 def plot_age_threshold(
-    result: "AgeThresholdResult", ax: Axes | None = None, **kwargs: Any
+    result: "AgeThresholdResult", ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any,
 ) -> Axes:
     """Median age-related hearing threshold with the 10-90 % fractile band.
 
     :param result: An :class:`~phonometry.hearing.AgeThresholdResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the median line ``plot``.
     :return: The axes.
     """
+    from .._i18n import decimal_comma, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     median = np.asarray(result.median, dtype=np.float64)
@@ -141,28 +272,37 @@ def plot_age_threshold(
 
     _fractile_band(ax, freqs, median, sl, su, color=_C_PRIMARY_LIGHT)
     kwargs.setdefault("color", _C_PRIMARY)
-    ax.plot(freqs, median, "o-", label="Median", **kwargs)
+    ax.plot(freqs, median, "o-", label=_t("median", language), **kwargs)
     if abs(result.fractile - 0.5) > 1e-9:
         ax.plot(freqs, np.asarray(result.threshold, dtype=np.float64), "s--",
-                color=_C_REFERENCE, label=f"Fractile {result.fractile:g}")
+                color=_C_REFERENCE, label=_t("fractile", language).format(
+                    v=decimal_comma(f"{result.fractile:g}", language)))
     _freq_axis(ax, freqs)
-    ax.set_ylabel("Threshold deviation from age 18 [dB]")
+    ax.set_xlabel(_t("freq_hz", language))
+    ax.set_ylabel(_t("threshold_dev_18", language))
     ax.invert_yaxis()  # audiogram convention: worse hearing downward
-    ax.set_title(f"ISO 7029 hearing threshold — {result.sex}, age {result.age:g}")
+    ax.set_title(_t("iso7029_title", language).format(
+        sex=result.sex, age=decimal_comma(f"{result.age:g}", language)))
     ax.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
     ax.grid(True, which="both", alpha=0.3)
+    localize_axes(ax, language)
     return ax
 
+
 def plot_nipts(
-    result: "NiptsResult", ax: Axes | None = None, **kwargs: Any
+    result: "NiptsResult", ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any,
 ) -> Axes:
     """Median NIPTS spectrum with the 10-90 % fractile band (ISO 1999).
 
     :param result: A :class:`~phonometry.noise_induced_hearing_loss.NiptsResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the median line ``plot``.
     :return: The axes.
     """
+    from .._i18n import decimal_comma, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     median = np.asarray(result.median, dtype=np.float64)
@@ -171,53 +311,64 @@ def plot_nipts(
 
     _fractile_band(ax, freqs, median, dl, du, color=_C_SECONDARY_LIGHT, floor=0.0)
     kwargs.setdefault("color", _C_SECONDARY)
-    ax.plot(freqs, median, "o-", label="Median $N_{50}$", **kwargs)
+    ax.plot(freqs, median, "o-", label=_t("median_n50", language), **kwargs)
     if abs(result.fractile - 0.5) > 1e-9:
         ax.plot(freqs, np.asarray(result.value, dtype=np.float64), "s--",
-                color=_C_REFERENCE, label=f"Fractile {result.fractile:g}")
+                color=_C_REFERENCE, label=_t("fractile", language).format(
+                    v=decimal_comma(f"{result.fractile:g}", language)))
     _freq_axis(ax, freqs)
-    ax.set_ylabel("NIPTS [dB]")
+    ax.set_xlabel(_t("freq_hz", language))
+    ax.set_ylabel(_t("nipts_db", language))
     ax.invert_yaxis()  # audiogram convention: worse hearing downward
-    ax.set_title(
-        f"ISO 1999 NIPTS — $L_{{EX,8h}}$ = {result.l_ex:g} dB, "
-        f"{result.years:g} yr"
-    )
+    ax.set_title(_t("nipts_title", language).format(
+        lex=decimal_comma(f"{result.l_ex:g}", language),
+        years=decimal_comma(f"{result.years:g}", language)))
     ax.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
     ax.grid(True, which="both", alpha=0.3)
+    localize_axes(ax, language)
     return ax
 
+
 def plot_htlan(
-    result: "HtlanResult", ax: Axes | None = None, **kwargs: Any
+    result: "HtlanResult", ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any,
 ) -> Axes:
     """Age, noise and combined hearing threshold components (ISO 1999, 6.1).
 
     :param result: A :class:`~phonometry.noise_induced_hearing_loss.HtlanResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the combined-threshold line ``plot``.
     :return: The axes.
     """
+    from .._i18n import decimal_comma, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     ax.plot(freqs, np.asarray(result.htla, dtype=np.float64), "o-",
-            color=_C_PRIMARY, label="Age (HTLA, ISO 7029)")
+            color=_C_PRIMARY, label=_t("htla_age", language))
     ax.plot(freqs, np.asarray(result.nipts, dtype=np.float64), "^-",
-            color=_C_SECONDARY, label="Noise (NIPTS)")
+            color=_C_SECONDARY, label=_t("noise_nipts", language))
     kwargs.setdefault("color", _C_REFERENCE)
     ax.plot(freqs, np.asarray(result.threshold, dtype=np.float64), "s--",
-            label="Age + noise (HTLAN)", **kwargs)
+            label=_t("age_noise_htlan", language), **kwargs)
     _freq_axis(ax, freqs)
-    ax.set_ylabel("Hearing threshold level [dB]")
+    ax.set_xlabel(_t("freq_hz", language))
+    ax.set_ylabel(_t("htl_level", language))
     ax.invert_yaxis()  # audiogram convention: worse hearing downward
-    ax.set_title(
-        f"ISO 1999 HTLAN — {result.sex}, age {result.age:g}, "
-        f"{result.l_ex:g} dB / {result.years:g} yr"
-    )
+    ax.set_title(_t("htlan_title", language).format(
+        sex=result.sex, age=decimal_comma(f"{result.age:g}", language),
+        lex=decimal_comma(f"{result.l_ex:g}", language),
+        years=decimal_comma(f"{result.years:g}", language)))
     ax.legend(loc="lower left", fontsize="small")
     ax.grid(True, which="both", alpha=0.3)
+    localize_axes(ax, language)
     return ax
 
+
 def plot_occupational_exposure(
-    result: "ExposureResult", ax: Axes | None = None, **kwargs: Any
+    result: "ExposureResult", ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any,
 ) -> Axes:
     """Per-task contributions to the daily exposure level (ISO 9612).
 
@@ -229,10 +380,13 @@ def plot_occupational_exposure(
         :class:`~phonometry.occupational_exposure.ExposureResult` from the
         task-based strategy (the one that carries per-task contributions).
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the task :meth:`~matplotlib.axes.Axes.bar`.
     :return: The axes.
     :raises ValueError: If the result carries no per-task contributions.
     """
+    from .._i18n import format_number, localize_axes
+
     if not result.tasks:
         raise ValueError(
             "plot() needs per-task contributions; only task_based_exposure() "
@@ -248,17 +402,21 @@ def plot_occupational_exposure(
     ax.set_xticklabels(labels, rotation=45, ha="right")
 
     ax.axhline(result.lex_8h, color=_C_REFERENCE, ls="--",
-               label=f"$L_{{EX,8h}}$ = {result.lex_8h:.1f} dB")
+               label="$L_{EX,8h}$ = "
+                     + format_number(result.lex_8h, language, decimals=1) + " dB")
     ax.axhline(result.upper_limit, color=_C_MUTED, ls=":",
-               label=f"$L_{{EX,8h}} + U$ = {result.upper_limit:.1f} dB")
+               label="$L_{EX,8h} + U$ = "
+                     + format_number(result.upper_limit, language, decimals=1)
+                     + " dB")
     top = max(result.upper_limit, max(contributions))
     bottom = min(0.0, min(contributions))
     ax.set_ylim(bottom * 1.12 if bottom < 0.0 else 0.0, top * 1.12)
-    ax.set_ylabel("A-weighted level [dB]")
-    ax.set_title(
-        f"ISO 9612 daily noise exposure — $L_{{EX,8h}}$ = "
-        f"{result.lex_8h:.1f} dB (U = {result.expanded_uncertainty:.1f} dB)"
-    )
+    ax.set_ylabel(_t("a_weighted_level", language))
+    ax.set_title(_t("occupational_title", language).format(
+        lex=format_number(result.lex_8h, language, decimals=1),
+        u=format_number(result.expanded_uncertainty, language, decimals=1)))
     ax.legend(loc="lower right", fontsize="small")
     ax.grid(True, axis="y", alpha=0.3)
+    # localize_axes leaves the categorical task-label axis (a FuncFormatter) alone.
+    localize_axes(ax, language)
     return ax

--- a/src/phonometry/_plot/psychoacoustics.py
+++ b/src/phonometry/_plot/psychoacoustics.py
@@ -33,8 +33,127 @@ if TYPE_CHECKING:
     from ..psychoacoustics.fluctuation_strength_ecma import EcmaFluctuationStrength
     from ..psychoacoustics.psychoacoustic_annoyance import PsychoacousticAnnoyanceResult
 
+#: EN/ES text for every fixed label, title and legend of this module. The
+#: English entries are byte-for-byte the historical strings; ``_t`` returns
+#: them unchanged for ``language="en"``.
+_STRINGS: dict[str, dict[str, str]] = {
+    "cbr_bark": {
+        "en": "Critical-band rate z [Bark]",
+        "es": "Razón de banda crítica z [Bark]",
+    },
+    "cbr_bark_hms": {
+        "en": "Critical-band rate z [Bark_HMS]",
+        "es": "Razón de banda crítica z [Bark_HMS]",
+    },
+    "spec_loudness_bark": {
+        "en": "Specific loudness N' [sone/Bark]",
+        "es": "Sonoridad específica N' [sonios/Bark]",
+    },
+    "spec_loudness_hms": {
+        "en": "Specific loudness N' [sone_HMS/Bark_HMS]",
+        "es": "Sonoridad específica N' [sonios_HMS/Bark_HMS]",
+    },
+    "spec_loudness_cam": {
+        "en": "Specific loudness N' [sone/Cam]",
+        "es": "Sonoridad específica N' [sonios/Cam]",
+    },
+    "erb_cam": {"en": "ERB number [Cam]", "es": "Número ERB [Cam]"},
+    "time_s": {"en": "Time [s]", "es": "Tiempo [s]"},
+    "loudness_n_sone": {"en": "Loudness N [sone]", "es": "Sonoridad N [sonios]"},
+    "loudness_n_sone_hms": {
+        "en": "Loudness N [sone_HMS]",
+        "es": "Sonoridad N [sonios_HMS]",
+    },
+    "loudness_sone": {"en": "Loudness [sone]", "es": "Sonoridad [sonios]"},
+    "short_term_loudness": {
+        "en": "Short-term loudness",
+        "es": "Sonoridad a corto plazo",
+    },
+    "long_term_loudness": {
+        "en": "Long-term loudness",
+        "es": "Sonoridad a largo plazo",
+    },
+    "spec_tonality": {
+        "en": "Specific tonality T' [tu_HMS]",
+        "es": "Tonalidad específica T' [tu_HMS]",
+    },
+    "tonality_t": {"en": "Tonality T [tu_HMS]", "es": "Tonalidad T [tu_HMS]"},
+    "roughness_r": {"en": "Roughness R [asper]", "es": "Aspereza R [asper]"},
+    "fluct_f_hms": {
+        "en": "Fluctuation strength F [vacil_HMS]",
+        "es": "Intensidad de fluctuación F [vacil_HMS]",
+    },
+    "spec_fluct": {
+        "en": r"Specific fluctuation strength $f'(z)$ [vacil/Bark]",
+        "es": r"Intensidad de fluctuación específica $f'(z)$ [vacil/Bark]",
+    },
+    "value": {"en": "Value", "es": "Valor"},
+    "tone_frequency": {"en": "Tone frequency [Hz]", "es": "Frecuencia del tono [Hz]"},
+    "audibility_dl": {
+        "en": r"Audibility $\Delta L$ [dB]",
+        "es": r"Audibilidad $\Delta L$ [dB]",
+    },
+    "audibility_threshold": {
+        "en": r"threshold $\Delta L=0$ dB",
+        "es": r"umbral $\Delta L=0$ dB",
+    },
+    "tone_audibility_title": {
+        "en": "ISO/PAS 20065 tonal audibility",
+        "es": "Audibilidad tonal ISO/PAS 20065",
+    },
+    # Templates (``.format`` fields hold already-localised numbers).
+    "zwicker_title": {
+        "en": "ISO 532-1 loudness N = {n} sone ({ln} phon)",
+        "es": "ISO 532-1 sonoridad N = {n} sonios ({ln} fonios)",
+    },
+    "ecma_loudness_title": {
+        "en": "ECMA-418-2 loudness N = {n} sone_HMS",
+        "es": "ECMA-418-2 sonoridad N = {n} sonios_HMS",
+    },
+    "mg_loudness_title": {
+        "en": "ISO 532-2 loudness N = {n} sone ({ln} phon)",
+        "es": "ISO 532-2 sonoridad N = {n} sonios ({ln} fonios)",
+    },
+    "mg_time_title": {
+        "en": "ISO 532-3 peak long-term loudness N = {n} sone ({ln} phon)",
+        "es": "ISO 532-3 sonoridad a largo plazo máxima N = {n} sonios ({ln} fonios)",
+    },
+    "ecma_tonality_title": {
+        "en": "ECMA-418-2 tonality T = {t} tu_HMS",
+        "es": "ECMA-418-2 tonalidad T = {t} tu_HMS",
+    },
+    "ecma_roughness_title": {
+        "en": "ECMA-418-2 roughness R = {r} asper",
+        "es": "ECMA-418-2 aspereza R = {r} asper",
+    },
+    "ecma_fluct_title": {
+        "en": "ECMA-418-2 fluctuation strength F = {f} vacil_HMS",
+        "es": "ECMA-418-2 intensidad de fluctuación F = {f} vacil_HMS",
+    },
+    "fluct_title": {
+        "en": "Fluctuation strength F = {f} vacil",
+        "es": "Intensidad de fluctuación F = {f} vacil",
+    },
+    "annoyance_title": {
+        "en": "Psychoacoustic annoyance PA = {pa} (N5 = {n5} sone)",
+        "es": "Molestia psicoacústica PA = {pa} (N5 = {n5} sonios)",
+    },
+    "decisive_label": {
+        "en": r"decisive $\Delta L$ = {da} dB @ {df} Hz",
+        "es": r"decisiva $\Delta L$ = {da} dB @ {df} Hz",
+    },
+}
+
+
+def _t(key: str, language: str) -> str:
+    """Look up the localised text for ``key`` (falls back to English)."""
+    entry = _STRINGS[key]
+    return entry.get(language, entry["en"])
+
+
 def plot_zwicker_loudness(
-    result: ZwickerLoudness, ax: Axes | None = None, **kwargs: Any
+    result: ZwickerLoudness, ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any,
 ) -> Axes | np.ndarray:
     """Specific loudness N'(z) over the Bark scale (ISO 532-1).
 
@@ -46,9 +165,12 @@ def plot_zwicker_loudness(
 
     :param result: A :class:`~phonometry.loudness_zwicker.ZwickerLoudness`.
     :param ax: Existing axes to draw on, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the specific-loudness line ``plot`` call.
     :return: The axes, or an array of two axes for time-varying input.
     """
+    from .._i18n import format_number, localize_axes
+
     specific = np.asarray(result.specific, dtype=np.float64)
     bark = np.arange(1, specific.size + 1) * 0.1
     time_varying = (
@@ -64,17 +186,18 @@ def plot_zwicker_loudness(
     kwargs.setdefault("color", _C_PRIMARY)
     ax_specific.plot(bark, specific, **kwargs)
     ax_specific.fill_between(bark, specific, color=kwargs["color"], alpha=0.25)
-    ax_specific.set_xlabel("Critical-band rate z [Bark]")
-    ax_specific.set_ylabel("Specific loudness N' [sone/Bark]")
+    ax_specific.set_xlabel(_t("cbr_bark", language))
+    ax_specific.set_ylabel(_t("spec_loudness_bark", language))
     ax_specific.set_xlim(0.0, bark[-1])
     ax_specific.set_ylim(bottom=0.0)
-    ax_specific.set_title(
-        f"ISO 532-1 loudness N = {result.loudness:.2f} sone "
-        f"({result.loudness_level:.1f} phon)"
-    )
+    ax_specific.set_title(_t("zwicker_title", language).format(
+        n=format_number(result.loudness, language, decimals=2),
+        ln=format_number(result.loudness_level, language, decimals=1),
+    ))
     ax_specific.grid(True, alpha=0.3)
 
     if not time_varying:
+        localize_axes(ax_specific, language)
         return ax_specific
 
     ax_time = cast("Axes", axes[1])
@@ -83,21 +206,27 @@ def plot_zwicker_loudness(
     ax_time.plot(time, lvt, color=_C_TERTIARY, label="N(t)")
     if result.n5 is not None:
         ax_time.axhline(
-            result.n5, color=_C_REFERENCE, ls="--", lw=1, label=f"N5={result.n5:.2f}"
+            result.n5, color=_C_REFERENCE, ls="--", lw=1,
+            label="N5=" + format_number(result.n5, language, decimals=2),
         )
     if result.n10 is not None:
         ax_time.axhline(
-            result.n10, color=_C_SECONDARY, ls=":", lw=1, label=f"N10={result.n10:.2f}"
+            result.n10, color=_C_SECONDARY, ls=":", lw=1,
+            label="N10=" + format_number(result.n10, language, decimals=2),
         )
-    ax_time.set_xlabel("Time [s]")
-    ax_time.set_ylabel("Loudness N [sone]")
+    ax_time.set_xlabel(_t("time_s", language))
+    ax_time.set_ylabel(_t("loudness_n_sone", language))
     ax_time.set_ylim(bottom=0.0)
     ax_time.grid(True, alpha=0.3)
     ax_time.legend(loc="best", fontsize="small")
+    localize_axes(ax_specific, language)
+    localize_axes(ax_time, language)
     return axes
 
+
 def plot_ecma_loudness(
-    result: EcmaLoudness, ax: Axes | None = None, **kwargs: Any
+    result: EcmaLoudness, ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any,
 ) -> Axes | np.ndarray:
     """Average specific loudness N'(z) and time-dependent loudness N(l).
 
@@ -108,9 +237,12 @@ def plot_ecma_loudness(
 
     :param result: An :class:`~phonometry.loudness_ecma.EcmaLoudness`.
     :param ax: Existing axes to draw on, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the specific-loudness line ``plot`` call.
     :return: The axes, or an array of two axes.
     """
+    from .._i18n import format_number, localize_axes
+
     specific = np.asarray(result.specific_loudness, dtype=np.float64)
     bark = np.asarray(result.bark, dtype=np.float64)
     two_panel = ax is None
@@ -124,38 +256,48 @@ def plot_ecma_loudness(
     kwargs.setdefault("color", _C_PRIMARY)
     ax_specific.plot(bark, specific, **kwargs)
     ax_specific.fill_between(bark, specific, color=kwargs["color"], alpha=0.25)
-    ax_specific.set_xlabel("Critical-band rate z [Bark_HMS]")
-    ax_specific.set_ylabel("Specific loudness N' [sone_HMS/Bark_HMS]")
+    ax_specific.set_xlabel(_t("cbr_bark_hms", language))
+    ax_specific.set_ylabel(_t("spec_loudness_hms", language))
     ax_specific.set_xlim(0.0, bark[-1])
     ax_specific.set_ylim(bottom=0.0)
-    ax_specific.set_title(f"ECMA-418-2 loudness N = {result.loudness:.2f} sone_HMS")
+    ax_specific.set_title(_t("ecma_loudness_title", language).format(
+        n=format_number(result.loudness, language, decimals=2),
+    ))
     ax_specific.grid(True, alpha=0.3)
 
     if not two_panel:
+        localize_axes(ax_specific, language)
         return ax_specific
 
     ax_time = cast("Axes", axes[1])
     time = np.asarray(result.time, dtype=np.float64)
     lvt = np.asarray(result.loudness_vs_time, dtype=np.float64)
     ax_time.plot(time, lvt, color=_C_TERTIARY, label="N(l)")
-    ax_time.set_xlabel("Time [s]")
-    ax_time.set_ylabel("Loudness N [sone_HMS]")
+    ax_time.set_xlabel(_t("time_s", language))
+    ax_time.set_ylabel(_t("loudness_n_sone_hms", language))
     ax_time.set_ylim(bottom=0.0)
     ax_time.grid(True, alpha=0.3)
     ax_time.legend(loc="best", fontsize="small")
+    localize_axes(ax_specific, language)
+    localize_axes(ax_time, language)
     return axes
 
+
 def plot_moore_glasberg_loudness(
-    result: MooreGlasbergLoudness, ax: Axes | None = None, **kwargs: Any
+    result: MooreGlasbergLoudness, ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any,
 ) -> Axes:
     """Specific loudness N'(i) over the ERB-number (Cam) scale (ISO 532-2).
 
     :param result: A
         :class:`~phonometry.loudness_moore_glasberg.MooreGlasbergLoudness`.
     :param ax: Existing axes to draw on, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the specific-loudness line ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import format_number, localize_axes
+
     specific = np.asarray(result.specific, dtype=np.float64)
     erb_number = np.asarray(result.erb_number, dtype=np.float64)
     ax = ax if ax is not None else _new_axes()
@@ -163,53 +305,63 @@ def plot_moore_glasberg_loudness(
     kwargs.setdefault("color", _C_PRIMARY)
     ax.plot(erb_number, specific, **kwargs)
     ax.fill_between(erb_number, specific, color=kwargs["color"], alpha=0.25)
-    ax.set_xlabel("ERB number [Cam]")
-    ax.set_ylabel("Specific loudness N' [sone/Cam]")
+    ax.set_xlabel(_t("erb_cam", language))
+    ax.set_ylabel(_t("spec_loudness_cam", language))
     ax.set_xlim(erb_number[0], erb_number[-1])
     ax.set_ylim(bottom=0.0)
-    ax.set_title(
-        f"ISO 532-2 loudness N = {result.loudness:.2f} sone "
-        f"({result.loudness_level:.1f} phon)"
-    )
+    ax.set_title(_t("mg_loudness_title", language).format(
+        n=format_number(result.loudness, language, decimals=2),
+        ln=format_number(result.loudness_level, language, decimals=1),
+    ))
     ax.grid(True, alpha=0.3)
+    localize_axes(ax, language)
     return ax
 
+
 def plot_moore_glasberg_time_loudness(
-    result: MooreGlasbergTimeVaryingLoudness, ax: Axes | None = None, **kwargs: Any
+    result: MooreGlasbergTimeVaryingLoudness, ax: Axes | None = None, *,
+    language: str = "en", **kwargs: Any,
 ) -> Axes:
     """Short-term and long-term loudness against time (ISO 532-3).
 
     :param result: A
         :class:`~phonometry.loudness_moore_glasberg_time.MooreGlasbergTimeVaryingLoudness`.
     :param ax: Existing axes to draw on, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the long-term-loudness line ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import format_number, localize_axes
+
     time = np.asarray(result.time, dtype=np.float64)
     stl = np.asarray(result.short_term_loudness, dtype=np.float64)
     ltl = np.asarray(result.long_term_loudness, dtype=np.float64)
     ax = ax if ax is not None else _new_axes()
 
-    ax.plot(time, stl, color=_C_PRIMARY_LIGHT, lw=1.0, label="Short-term loudness")
+    ax.plot(time, stl, color=_C_PRIMARY_LIGHT, lw=1.0,
+            label=_t("short_term_loudness", language))
     kwargs.setdefault("color", _C_PRIMARY)
     kwargs.setdefault("lw", 1.8)
-    ax.plot(time, ltl, label="Long-term loudness", **kwargs)
+    ax.plot(time, ltl, label=_t("long_term_loudness", language), **kwargs)
     ax.axhline(result.n_max, color=_C_REFERENCE, ls="--", lw=1.0, alpha=0.7)
-    ax.set_xlabel("Time [s]")
-    ax.set_ylabel("Loudness [sone]")
+    ax.set_xlabel(_t("time_s", language))
+    ax.set_ylabel(_t("loudness_sone", language))
     if time.size:
         ax.set_xlim(time[0], time[-1])
     ax.set_ylim(bottom=0.0)
-    ax.set_title(
-        f"ISO 532-3 peak long-term loudness N = {result.n_max:.2f} sone "
-        f"({result.loudness_level_max:.1f} phon)"
-    )
+    ax.set_title(_t("mg_time_title", language).format(
+        n=format_number(result.n_max, language, decimals=2),
+        ln=format_number(result.loudness_level_max, language, decimals=1),
+    ))
     ax.legend(loc="best", fontsize="small")
     ax.grid(True, alpha=0.3)
+    localize_axes(ax, language)
     return ax
 
+
 def plot_ecma_tonality(
-    result: EcmaTonality, ax: Axes | None = None, **kwargs: Any
+    result: EcmaTonality, ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any,
 ) -> Axes | np.ndarray:
     """Average specific tonality T'(z) and time-dependent tonality T(l).
 
@@ -220,9 +372,12 @@ def plot_ecma_tonality(
 
     :param result: An :class:`~phonometry.tonality_ecma.EcmaTonality`.
     :param ax: Existing axes to draw on, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the specific-tonality line ``plot`` call.
     :return: The axes, or an array of two axes.
     """
+    from .._i18n import format_number, localize_axes
+
     specific = np.asarray(result.specific_tonality, dtype=np.float64)
     bark = np.asarray(result.bark, dtype=np.float64)
     two_panel = ax is None
@@ -239,26 +394,32 @@ def plot_ecma_tonality(
     kwargs.setdefault("color", "#d62728")
     ax_specific.plot(bark, specific, **kwargs)
     ax_specific.fill_between(bark, specific, color=kwargs["color"], alpha=0.25)
-    ax_specific.set_xlabel("Critical-band rate z [Bark_HMS]")
-    ax_specific.set_ylabel("Specific tonality T' [tu_HMS]")
+    ax_specific.set_xlabel(_t("cbr_bark_hms", language))
+    ax_specific.set_ylabel(_t("spec_tonality", language))
     ax_specific.set_xlim(0.0, bark[-1])
     ax_specific.set_ylim(bottom=0.0)
-    ax_specific.set_title(f"ECMA-418-2 tonality T = {result.tonality:.2f} tu_HMS")
+    ax_specific.set_title(_t("ecma_tonality_title", language).format(
+        t=format_number(result.tonality, language, decimals=2),
+    ))
     ax_specific.grid(True, alpha=0.3)
 
     if not two_panel:
+        localize_axes(ax_specific, language)
         return ax_specific
 
     ax_time = cast("Axes", axes[1])
     time = np.asarray(result.time, dtype=np.float64)
     tvt = np.asarray(result.tonality_vs_time, dtype=np.float64)
     ax_time.plot(time, tvt, color=_C_QUATERNARY, label="T(l)")
-    ax_time.set_xlabel("Time [s]")
-    ax_time.set_ylabel("Tonality T [tu_HMS]")
+    ax_time.set_xlabel(_t("time_s", language))
+    ax_time.set_ylabel(_t("tonality_t", language))
     ax_time.set_ylim(bottom=0.0)
     ax_time.grid(True, alpha=0.3)
     ax_time.legend(loc="best", fontsize="small")
+    localize_axes(ax_specific, language)
+    localize_axes(ax_time, language)
     return axes
+
 
 def _plot_hms_time_and_heatmap(
     time: np.ndarray,
@@ -271,6 +432,7 @@ def _plot_hms_time_and_heatmap(
     title: str,
     heat_label: str,
     kwargs: dict[str, Any],
+    language: str = "en",
 ) -> Axes | np.ndarray:
     """Shared renderer for the HMS time-trace + specific-value heatmaps.
 
@@ -279,6 +441,8 @@ def _plot_hms_time_and_heatmap(
     critical-band-rate scale) is drawn and an array of two axes is returned;
     otherwise only the time trace is drawn on ``ax`` and it is returned.
     """
+    from .._i18n import localize_axes
+
     two_panel = ax is None
     if two_panel:
         axes = _new_axes_column(2, figsize=(7.0, 6.0))
@@ -290,13 +454,14 @@ def _plot_hms_time_and_heatmap(
         kwargs.setdefault("color", color)
     (line,) = ax_time.plot(time, vs_time, **kwargs)
     ax_time.fill_between(time, vs_time, color=line.get_color(), alpha=0.25)
-    ax_time.set_xlabel("Time [s]")
+    ax_time.set_xlabel(_t("time_s", language))
     ax_time.set_ylabel(ylabel)
     ax_time.set_ylim(bottom=0.0)
     ax_time.set_title(title)
     ax_time.grid(True, alpha=0.3)
 
     if not two_panel:
+        localize_axes(ax_time, language)
         return ax_time
 
     ax_heat = cast("Axes", axes[1])
@@ -305,12 +470,16 @@ def _plot_hms_time_and_heatmap(
             time, bark, spec_vs_time.T, cmap="magma", shading="auto"
         )
         ax_heat.figure.colorbar(mesh, ax=ax_heat, label=heat_label)
-    ax_heat.set_xlabel("Time [s]")
-    ax_heat.set_ylabel("Critical-band rate z [Bark_HMS]")
+    ax_heat.set_xlabel(_t("time_s", language))
+    ax_heat.set_ylabel(_t("cbr_bark_hms", language))
+    localize_axes(ax_time, language)
+    localize_axes(ax_heat, language)
     return axes
 
+
 def plot_ecma_roughness(
-    result: EcmaRoughness, ax: Axes | None = None, **kwargs: Any
+    result: EcmaRoughness, ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any,
 ) -> Axes | np.ndarray:
     """Time-dependent roughness R(l50) and a specific-roughness heatmap.
 
@@ -321,9 +490,12 @@ def plot_ecma_roughness(
 
     :param result: An :class:`~phonometry.roughness_ecma.EcmaRoughness`.
     :param ax: Existing axes to draw on, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the roughness-vs-time line ``plot`` call.
     :return: The axes, or an array of two axes.
     """
+    from .._i18n import format_number
+
     # Roughness's per-metric identity color is brown across the documentation
     # figures (tonality is red); kept literal on purpose, see the module
     # color-constant note.
@@ -334,14 +506,19 @@ def plot_ecma_roughness(
         np.asarray(result.bark, dtype=np.float64),
         ax,
         "#8c564b",
-        "Roughness R [asper]",
-        f"ECMA-418-2 roughness R = {result.roughness:.2f} asper",
+        _t("roughness_r", language),
+        _t("ecma_roughness_title", language).format(
+            r=format_number(result.roughness, language, decimals=2),
+        ),
         "R' [asper/Bark_HMS]",
         kwargs,
+        language,
     )
 
+
 def plot_ecma_fluctuation_strength(
-    result: EcmaFluctuationStrength, ax: Axes | None = None, **kwargs: Any
+    result: EcmaFluctuationStrength, ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any,
 ) -> Axes | np.ndarray:
     """Time-dependent fluctuation strength F(l50) and a specific heatmap.
 
@@ -354,9 +531,12 @@ def plot_ecma_fluctuation_strength(
     :param result: An :class:`~phonometry.fluctuation_strength_ecma.
         EcmaFluctuationStrength`.
     :param ax: Existing axes to draw on, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the time-trace line ``plot`` call.
     :return: The axes, or an array of two axes.
     """
+    from .._i18n import format_number
+
     # Fluctuation strength's per-metric identity color is teal across the
     # documentation figures (roughness is brown, tonality red); kept literal
     # on purpose, see the module color-constant note.
@@ -369,17 +549,19 @@ def plot_ecma_fluctuation_strength(
         np.asarray(result.bark, dtype=np.float64),
         ax,
         "#17becf",
-        "Fluctuation strength F [vacil_HMS]",
-        (
-            "ECMA-418-2 fluctuation strength "
-            f"F = {result.fluctuation_strength:.2f} vacil_HMS"
+        _t("fluct_f_hms", language),
+        _t("ecma_fluct_title", language).format(
+            f=format_number(result.fluctuation_strength, language, decimals=2),
         ),
         "F' [vacil_HMS/Bark_HMS]",
         kwargs,
+        language,
     )
 
+
 def plot_fluctuation_strength(
-    result: "FluctuationStrengthResult", ax: Axes | None = None, **kwargs: Any
+    result: "FluctuationStrengthResult", ax: Axes | None = None, *,
+    language: str = "en", **kwargs: Any,
 ) -> Axes:
     """Specific fluctuation strength ``f(z)`` against critical-band rate.
 
@@ -389,25 +571,33 @@ def plot_fluctuation_strength(
     :param result: A
         :class:`~phonometry.fluctuation_strength.FluctuationStrengthResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import format_number, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     z = np.asarray(result.bark_axis, dtype=np.float64)
     spec = np.asarray(result.specific, dtype=np.float64)
     kwargs.setdefault("color", _C_PRIMARY)
     ax.plot(z, spec, **kwargs)
     ax.fill_between(z, spec, color=kwargs["color"], alpha=0.25)
-    ax.set_xlabel("Critical-band rate z [Bark]")
-    ax.set_ylabel(r"Specific fluctuation strength $f'(z)$ [vacil/Bark]")
-    ax.set_title(f"Fluctuation strength F = {result.fluctuation_strength:.2f} vacil")
+    ax.set_xlabel(_t("cbr_bark", language))
+    ax.set_ylabel(_t("spec_fluct", language))
+    ax.set_title(_t("fluct_title", language).format(
+        f=format_number(result.fluctuation_strength, language, decimals=2),
+    ))
     ax.set_ylim(bottom=0.0)
     ax.grid(True, alpha=0.3)
     ax.set_axisbelow(True)
+    localize_axes(ax, language)
     return ax
 
+
 def plot_psychoacoustic_annoyance(
-    result: "PsychoacousticAnnoyanceResult", ax: Axes | None = None, **kwargs: Any
+    result: "PsychoacousticAnnoyanceResult", ax: Axes | None = None, *,
+    language: str = "en", **kwargs: Any,
 ) -> Axes:
     """Psychoacoustic annoyance with its ``wS`` and ``wFR`` term contributions.
 
@@ -417,9 +607,12 @@ def plot_psychoacoustic_annoyance(
     :param result: A :class:`~phonometry.psychoacoustic_annoyance.
         PsychoacousticAnnoyanceResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the bar ``bar`` call.
     :return: The axes.
     """
+    from .._i18n import format_number, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     labels = ["PA", r"$w_S$", r"$w_{FR}$"]
     values = [result.annoyance, result.w_s, result.w_fr]
@@ -431,17 +624,21 @@ def plot_psychoacoustic_annoyance(
     ax.bar(positions, values, **kwargs)
     ax.set_xticks(positions)
     ax.set_xticklabels(labels)
-    ax.set_ylabel("Value")
-    ax.set_title(
-        f"Psychoacoustic annoyance PA = {result.annoyance:.1f} "
-        f"(N5 = {result.n5:.1f} sone)"
-    )
+    ax.set_ylabel(_t("value", language))
+    ax.set_title(_t("annoyance_title", language).format(
+        pa=format_number(result.annoyance, language, decimals=1),
+        n5=format_number(result.n5, language, decimals=1),
+    ))
     ax.grid(True, axis="y", alpha=0.3)
     ax.set_axisbelow(True)
+    # localize_axes leaves the categorical x-axis (a FuncFormatter) alone.
+    localize_axes(ax, language)
     return ax
 
+
 def plot_tone_audibility(
-    result: "ToneAudibilityResult", ax: Axes | None = None, **kwargs: Any
+    result: "ToneAudibilityResult", ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any,
 ) -> Axes:
     """Per-tone audibility ``ΔL`` against tone frequency (ISO/PAS 20065).
 
@@ -450,9 +647,12 @@ def plot_tone_audibility(
 
     :param result: A :class:`~phonometry.tone_audibility.ToneAudibilityResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the bar ``bar`` call.
     :return: The axes.
     """
+    from .._i18n import decimal_comma, format_number, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     freqs = np.asarray(result.tone_frequencies, dtype=np.float64)
     delta = np.asarray(result.audibilities, dtype=np.float64)
@@ -463,17 +663,22 @@ def plot_tone_audibility(
 
     kwargs.setdefault("width", 0.7)
     bars = ax.bar(positions, delta, color=colors, edgecolor=_C_EDGE, **kwargs)
-    bars[decisive].set_label(
-        rf"decisive $\Delta L$ = {result.decisive_audibility:.1f} dB "
-        rf"@ {result.decisive_frequency:g} Hz"
-    )
-    ax.axhline(0.0, color=_C_MUTED, ls="--", lw=1.0, label=r"threshold $\Delta L=0$ dB")
+    bars[decisive].set_label(_t("decisive_label", language).format(
+        da=format_number(result.decisive_audibility, language, decimals=1),
+        df=decimal_comma(f"{result.decisive_frequency:g}", language),
+    ))
+    ax.axhline(0.0, color=_C_MUTED, ls="--", lw=1.0,
+               label=_t("audibility_threshold", language))
     ax.set_xticks(positions)
-    ax.set_xticklabels([f"{f:g}" for f in freqs], rotation=45, ha="right")
-    ax.set_xlabel("Tone frequency [Hz]")
-    ax.set_ylabel(r"Audibility $\Delta L$ [dB]")
-    ax.set_title("ISO/PAS 20065 tonal audibility")
+    ax.set_xticklabels([decimal_comma(f"{f:g}", language) for f in freqs],
+                       rotation=45, ha="right")
+    ax.set_xlabel(_t("tone_frequency", language))
+    ax.set_ylabel(_t("audibility_dl", language))
+    ax.set_title(_t("tone_audibility_title", language))
     ax.legend(loc="best", fontsize="small")
     ax.grid(True, axis="y", alpha=0.3)
     ax.set_axisbelow(True)
+    # localize_axes leaves the categorical x-axis (a FuncFormatter) alone, so the
+    # comma-localized tick labels set above survive.
+    localize_axes(ax, language)
     return ax

--- a/src/phonometry/_plot/vibration.py
+++ b/src/phonometry/_plot/vibration.py
@@ -29,8 +29,104 @@ if TYPE_CHECKING:
     from ..vibration.multiple_shock_vibration import MultipleShockResult
     from ..vibration.radiation_efficiency import RadiationEfficiencyResult
 
+#: EN/ES text for every fixed label, title and legend of this module. The
+#: English entries are byte-for-byte the historical strings; ``_t`` returns
+#: them unchanged for ``language="en"``.
+_STRINGS: dict[str, dict[str, str]] = {
+    "freq_hz": {"en": "Frequency [Hz]", "es": "Frecuencia [Hz]"},
+    "weighting_factor": {
+        "en": "Weighting factor [dB]",
+        "es": "Factor de ponderación [dB]",
+    },
+    "unweighted_ai": {"en": r"Unweighted $a_i$", "es": r"Sin ponderar $a_i$"},
+    "rms_accel": {
+        "en": r"r.m.s. acceleration [m/s$^2$]",
+        "es": r"Aceleración eficaz [m/s$^2$]",
+    },
+    "vib_exposure_a8": {
+        "en": r"Vibration exposure A(8) [m/s$^2$]",
+        "es": r"Exposición a vibración A(8) [m/s$^2$]",
+    },
+    "mobility_driving_point": {
+        "en": "driving-point mobility",
+        "es": "movilidad en punto de excitación",
+    },
+    "mobility_transfer": {
+        "en": "transfer mobility",
+        "es": "movilidad de transferencia",
+    },
+    "mobility_y": {
+        "en": r"Mobility $|Y|$ [m/(N·s)]",
+        "es": r"Movilidad $|Y|$ [m/(N·s)]",
+    },
+    "transfer_stiffness_level": {
+        "en": r"Transfer stiffness level $L_k$ [dB re 1 N/m]",
+        "es": r"Nivel de rigidez de transferencia $L_k$ [dB re 1 N/m]",
+    },
+    "radiation_efficiency": {
+        "en": r"Radiation efficiency $\sigma$",
+        "es": r"Eficiencia de radiación $\sigma$",
+    },
+    "stress_variable": {
+        "en": r"Stress variable $R$",
+        "es": r"Variable de tensión $R$",
+    },
+    "lumbar_injury_prob": {
+        "en": "Probability of lumbar injury [%]",
+        "es": "Probabilidad de lesión lumbar [%]",
+    },
+    "mobility_title": {
+        "en": "ISO 7626-1 mechanical mobility",
+        "es": "ISO 7626-1 movilidad mecánica",
+    },
+    "transfer_stiffness_title": {
+        "en": "ISO 10846 dynamic transfer stiffness",
+        "es": "ISO 10846 rigidez dinámica de transferencia",
+    },
+    "radiation_title": {
+        "en": "Plate radiation efficiency (Leppington / Maidanik)",
+        "es": "Eficiencia de radiación de placa (Leppington / Maidanik)",
+    },
+    # Templates (``.format`` fields hold already-localised numbers / data).
+    "vib_weighting_title": {
+        "en": "Frequency weighting {name} (ISO 8041-1)",
+        "es": "Ponderación en frecuencia {name} (ISO 8041-1)",
+    },
+    "weighted_wia": {
+        "en": r"Weighted $W_i a_i$ ({name})",
+        "es": r"Ponderada $W_i a_i$ ({name})",
+    },
+    "weighted_spectrum_title": {
+        "en": "{designation} weighted acceleration spectrum  ($a_w$ = {aw} m/s$^2$)",
+        "es": "{designation} espectro de aceleración ponderada  ($a_w$ = {aw} m/s$^2$)",
+    },
+    "daily_exposure_title": {
+        "en": ("Directive 2002/44/EC daily {kind} exposure  "
+               "(A(8) = {a8} m/s$^2$, {zone})"),
+        "es": ("Directiva 2002/44/CE exposición diaria {kind}  "
+               "(A(8) = {a8} m/s$^2$, {zone})"),
+    },
+    "mobility_peak": {"en": "peak at {v} Hz", "es": "máximo en {v} Hz"},
+    "injury_title": {
+        "en": "ISO 2631-5 injury probability — {sex}",
+        "es": "ISO 2631-5 probabilidad de lesión — {sex}",
+    },
+    "injury_marker": {
+        "en": r"$R$ = {r},  $\Pi$ = {p} %",
+        "es": r"$R$ = {r},  $\Pi$ = {p} %",
+    },
+}
+
+
+def _t(key: str, language: str) -> str:
+    """Look up the localised text for ``key`` (falls back to English)."""
+    entry = _STRINGS[key]
+    return entry.get(language, entry["en"])
+
+
 def plot_vibration_weighting(
-    result: "WeightingResponse", ax: Axes | None = None, **kwargs: Any
+    result: "WeightingResponse", ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any,
 ) -> Axes:
     """Frequency-weighting factor (dB) versus frequency (ISO 8041-1).
 
@@ -38,23 +134,29 @@ def plot_vibration_weighting(
         :class:`~phonometry.human_vibration.WeightingResponse` exposing
         ``name``, ``frequencies`` and ``magnitude_db``.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the weighting curve ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import localize_axes
+
     ax = ax if ax is not None else _new_axes()
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     mag_db = np.asarray(result.magnitude_db, dtype=np.float64)
     kwargs.setdefault("color", _C_PRIMARY)
     ax.semilogx(freqs, mag_db, **kwargs)
-    ax.set_xlabel("Frequency [Hz]")
-    ax.set_ylabel("Weighting factor [dB]")
-    ax.set_title(f"Frequency weighting {result.name} (ISO 8041-1)")
+    ax.set_xlabel(_t("freq_hz", language))
+    ax.set_ylabel(_t("weighting_factor", language))
+    ax.set_title(_t("vib_weighting_title", language).format(name=result.name))
     ax.grid(True, which="both", alpha=0.3)
     format_frequency_axis(ax, float(freqs.min()), float(freqs.max()))
+    localize_axes(ax, language)
     return ax
 
+
 def plot_weighted_spectrum(
-    result: "WeightedSpectrum", ax: Axes | None = None, **kwargs: Any
+    result: "WeightedSpectrum", ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any,
 ) -> Axes:
     """Unweighted vs weighted one-third-octave acceleration spectrum.
 
@@ -66,41 +168,50 @@ def plot_weighted_spectrum(
         ``frequencies``, ``band_accelerations``, ``weighted``, ``overall`` and
         ``weighting_name``.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the weighted (primary) bars.
     :return: The axes.
     """
+    from .._i18n import format_number, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     raw = np.asarray(result.band_accelerations, dtype=np.float64)
     weighted = np.asarray(result.weighted, dtype=np.float64)
     positions = _band_axis(ax, freqs)
+    ax.set_xlabel(_t("freq_hz", language))
     width = 0.4
     # The weighted bars are the primary artist; forward user kwargs there.
     kwargs.setdefault("color", _C_PRIMARY)
     ax.bar(
-        positions - width / 2, raw, width, color=_C_MUTED, label="Unweighted $a_i$"
+        positions - width / 2, raw, width, color=_C_MUTED,
+        label=_t("unweighted_ai", language),
     )
     ax.bar(
         positions + width / 2,
         weighted,
         width,
-        label=f"Weighted $W_i a_i$ ({result.weighting_name})",
+        label=_t("weighted_wia", language).format(name=result.weighting_name),
         **kwargs,
     )
-    ax.set_ylabel(r"r.m.s. acceleration [m/s$^2$]")
+    ax.set_ylabel(_t("rms_accel", language))
     # Wh is the hand-arm weighting of ISO 5349-1; the others (Wk, Wd, Wm...)
     # are the whole-body weightings of ISO 2631.
     designation = "ISO 5349-1" if str(result.weighting_name) == "Wh" else "ISO 2631"
-    ax.set_title(
-        f"{designation} weighted acceleration spectrum  "
-        f"($a_w$ = {float(result.overall):.3f} " r"m/s$^2$)"
-    )
+    ax.set_title(_t("weighted_spectrum_title", language).format(
+        designation=designation,
+        aw=format_number(float(result.overall), language, decimals=3),
+    ))
     ax.legend(loc="best", fontsize="small")
     ax.grid(True, axis="y", alpha=0.3)
+    # localize_axes leaves the categorical band axis (a FuncFormatter) alone.
+    localize_axes(ax, language)
     return ax
 
+
 def plot_daily_exposure(
-    result: "DailyVibrationExposure", ax: Axes | None = None, **kwargs: Any
+    result: "DailyVibrationExposure", ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any,
 ) -> Axes:
     """Partial daily exposures against the EAV / ELV (Directive 2002/44/EC).
 
@@ -111,9 +222,12 @@ def plot_daily_exposure(
         :class:`~phonometry.human_vibration.DailyVibrationExposure` exposing
         ``labels``, ``partials``, ``a8`` and ``assessment``.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the exposure :meth:`~matplotlib.axes.Axes.bar`.
     :return: The axes.
     """
+    from .._i18n import decimal_comma, format_number, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     partials = np.asarray(result.partials, dtype=np.float64)
     labels = [*result.labels, "A(8)"]
@@ -124,86 +238,109 @@ def plot_daily_exposure(
     ax.bar(positions, values, **kwargs)
     ax.set_xticks(positions)
     ax.set_xticklabels(labels, rotation=45, ha="right")
-    ax.set_ylabel(r"Vibration exposure A(8) [m/s$^2$]")
+    ax.set_ylabel(_t("vib_exposure_a8", language))
 
     assessment = result.assessment
     eav = float(assessment.action_value)
     elv = float(assessment.limit_value)
-    ax.axhline(eav, color=_C_SECONDARY, ls="--", label=f"EAV = {eav:g}")
-    ax.axhline(elv, color=_C_REFERENCE, ls="--", label=f"ELV = {elv:g}")
+    ax.axhline(eav, color=_C_SECONDARY, ls="--",
+               label="EAV = " + decimal_comma(f"{eav:g}", language))
+    ax.axhline(elv, color=_C_REFERENCE, ls="--",
+               label="ELV = " + decimal_comma(f"{elv:g}", language))
     top = max(elv, float(np.max(values))) * 1.15
     ax.set_ylim(0.0, top)
     kind = str(assessment.kind).upper()
-    ax.set_title(
-        f"Directive 2002/44/EC daily {kind} exposure  "
-        f"(A(8) = {float(result.a8):.2f} " rf"m/s$^2$, {assessment.zone})"
-    )
+    ax.set_title(_t("daily_exposure_title", language).format(
+        kind=kind, a8=format_number(float(result.a8), language, decimals=2),
+        zone=assessment.zone,
+    ))
     ax.legend(loc="best", fontsize="small")
     ax.grid(True, axis="y", alpha=0.3)
+    # localize_axes leaves the categorical operation-label axis (a FuncFormatter) alone.
+    localize_axes(ax, language)
     return ax
 
+
 def plot_mobility(
-    result: "MobilityResult", ax: Axes | None = None, **kwargs: Any
+    result: "MobilityResult", ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any,
 ) -> Axes:
     """Mobility magnitude ``|Y(f)|`` on log-log axes (ISO 7626-1).
 
     :param result: A :class:`~phonometry.mechanical_mobility.MobilityResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the magnitude ``plot``.
     :return: The axes.
     """
+    from .._i18n import format_number, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     freq = np.asarray(result.frequencies, dtype=np.float64)
     mag = np.asarray(result.magnitude, dtype=np.float64)
     kwargs.setdefault("color", _C_PRIMARY)
-    label = "driving-point mobility" if result.driving_point else "transfer mobility"
+    label = (_t("mobility_driving_point", language) if result.driving_point
+             else _t("mobility_transfer", language))
     ax.loglog(freq, mag, label=label, **kwargs)
     # Mark the mobility peak (a resonance for a driving-point FRF).
     peak = int(np.argmax(mag))
     ax.plot(freq[peak], mag[peak], "o", color=_C_REFERENCE, zorder=5,
-            label=f"peak at {freq[peak]:.1f} Hz")
+            label=_t("mobility_peak", language).format(
+                v=format_number(freq[peak], language, decimals=1)))
     format_frequency_axis(ax, float(freq.min()), float(freq.max()))
-    ax.set_xlabel("Frequency [Hz]")
-    ax.set_ylabel("Mobility $|Y|$ [m/(N·s)]")
-    ax.set_title("ISO 7626-1 mechanical mobility")
+    ax.set_xlabel(_t("freq_hz", language))
+    ax.set_ylabel(_t("mobility_y", language))
+    ax.set_title(_t("mobility_title", language))
     ax.legend(loc="best", fontsize="small")
     ax.grid(True, which="both", alpha=0.3)
+    localize_axes(ax, language)
     return ax
 
+
 def plot_transfer_stiffness(
-    result: "TransferStiffnessResult", ax: Axes | None = None, **kwargs: Any
+    result: "TransferStiffnessResult", ax: Axes | None = None, *,
+    language: str = "en", **kwargs: Any,
 ) -> Axes:
     """Dynamic transfer stiffness level ``L_k(f)`` on a log-frequency axis.
 
     :param result: A :class:`~phonometry.transfer_stiffness.TransferStiffnessResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the level ``plot``.
     :return: The axes.
     """
+    from .._i18n import localize_axes
+
     ax = ax if ax is not None else _new_axes()
     freq = np.asarray(result.frequencies, dtype=np.float64)
     level = np.asarray(result.level, dtype=np.float64)
     kwargs.setdefault("color", _C_PRIMARY)
     ax.semilogx(freq, level, label=r"$L_k = 20\,\lg(|k_{2,1}|/k_0)$", **kwargs)
     format_frequency_axis(ax, float(freq.min()), float(freq.max()))
-    ax.set_xlabel("Frequency [Hz]")
-    ax.set_ylabel(r"Transfer stiffness level $L_k$ [dB re 1 N/m]")
-    ax.set_title("ISO 10846 dynamic transfer stiffness")
+    ax.set_xlabel(_t("freq_hz", language))
+    ax.set_ylabel(_t("transfer_stiffness_level", language))
+    ax.set_title(_t("transfer_stiffness_title", language))
     ax.legend(loc="best", fontsize="small")
     ax.grid(True, which="both", alpha=0.3)
+    localize_axes(ax, language)
     return ax
 
+
 def plot_radiation_efficiency(
-    result: "RadiationEfficiencyResult", ax: Axes | None = None, **kwargs: Any
+    result: "RadiationEfficiencyResult", ax: Axes | None = None, *,
+    language: str = "en", **kwargs: Any,
 ) -> Axes:
     """Radiation efficiency ``sigma(f)`` on log-log axes (Hopkins 2.9.4).
 
     :param result: A
         :class:`~phonometry.vibration.radiation_efficiency.RadiationEfficiencyResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the ``sigma`` curve ``plot``.
     :return: The axes.
     """
+    from .._i18n import localize_axes
+
     ax = ax if ax is not None else _new_axes()
     freq = np.asarray(result.frequencies, dtype=np.float64)
     sigma = np.asarray(result.radiation_efficiency, dtype=np.float64)
@@ -220,25 +357,29 @@ def plot_radiation_efficiency(
         label=f"$f_c$ = {result.critical_frequency:.0f} Hz",
     )
     format_frequency_axis(ax, float(freq.min()), float(freq.max()))
-    ax.set_xlabel("Frequency [Hz]")
-    ax.set_ylabel(r"Radiation efficiency $\sigma$")
-    ax.set_title("Plate radiation efficiency (Leppington / Maidanik)")
+    ax.set_xlabel(_t("freq_hz", language))
+    ax.set_ylabel(_t("radiation_efficiency", language))
+    ax.set_title(_t("radiation_title", language))
     ax.legend(loc="best", fontsize="small")
     ax.grid(True, which="both", alpha=0.3)
+    localize_axes(ax, language)
     return ax
 
 
 def plot_multiple_shock(
-    result: "MultipleShockResult", ax: Axes | None = None, **kwargs: Any
+    result: "MultipleShockResult", ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any,
 ) -> Axes:
     """Injury-probability curve ``P(R)`` with this assessment's ``R`` marked.
 
     :param result: A :class:`~phonometry.multiple_shock_vibration.MultipleShockResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the ``R`` marker ``scatter``.
     :return: The axes.
     """
     from ..vibration.multiple_shock_vibration import injury_probability
+    from .._i18n import format_number, localize_axes
 
     ax = ax if ax is not None else _new_axes()
     r10, r50, r90 = result.risk_thresholds
@@ -255,13 +396,16 @@ def plot_multiple_shock(
     kwargs.setdefault("zorder", 4)
     kwargs.setdefault("s", 90)
     ax.scatter([result.risk], [100.0 * result.probability],
-               label=f"$R$ = {result.risk:.2f},  $\\Pi$ = "
-                     f"{100.0 * result.probability:.0f} %", **kwargs)
-    ax.set_xlabel("Stress variable $R$")
-    ax.set_ylabel("Probability of lumbar injury [%]")
-    ax.set_title(f"ISO 2631-5 injury probability — {result.sex}")
+               label=_t("injury_marker", language).format(
+                   r=format_number(result.risk, language, decimals=2),
+                   p=format_number(100.0 * result.probability, language, decimals=0)),
+               **kwargs)
+    ax.set_xlabel(_t("stress_variable", language))
+    ax.set_ylabel(_t("lumbar_injury_prob", language))
+    ax.set_title(_t("injury_title", language).format(sex=result.sex))
     ax.set_xlim(left=0.0)
     ax.set_ylim(0.0, 100.0)
     ax.legend(loc="lower right", fontsize="small")
     ax.grid(True, alpha=0.3)
+    localize_axes(ax, language)
     return ax

--- a/src/phonometry/hearing/noise_induced_hearing_loss.py
+++ b/src/phonometry/hearing/noise_induced_hearing_loss.py
@@ -94,15 +94,16 @@ class NiptsResult:
     spread_upper: np.ndarray
     spread_lower: np.ndarray
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the NIPTS spectrum with the fractile band over frequency.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.hearing import plot_nipts
 
-        return plot_nipts(self, ax=ax, **kwargs)
+        return plot_nipts(self, ax=ax, language=check_language(language), **kwargs)
 
 
 @dataclass(frozen=True)
@@ -132,15 +133,16 @@ class HtlanResult:
     nipts: np.ndarray
     threshold: np.ndarray
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the age, noise and combined threshold components over frequency.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.hearing import plot_htlan
 
-        return plot_htlan(self, ax=ax, **kwargs)
+        return plot_htlan(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def _select(values: np.ndarray, frequencies: ArrayLike | None) -> np.ndarray:

--- a/src/phonometry/hearing/objective_intelligibility.py
+++ b/src/phonometry/hearing/objective_intelligibility.py
@@ -107,7 +107,7 @@ class STOIResult:
     band_frequencies: NDArray[np.float64]
     sample_rate: int
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the intermediate intelligibility that averages to the index.
 
         For STOI this is the mean correlation per one-third-octave band; for
@@ -115,9 +115,10 @@ class STOIResult:
         analysis segment. Requires matplotlib (``pip install phonometry[plot]``);
         returns the :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.hearing import plot_stoi
 
-        return plot_stoi(self, ax=ax, **kwargs)
+        return plot_stoi(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def _third_octave_matrix() -> tuple[NDArray[np.float64], NDArray[np.float64]]:

--- a/src/phonometry/hearing/occupational_exposure.py
+++ b/src/phonometry/hearing/occupational_exposure.py
@@ -281,7 +281,7 @@ class ExposureResult:
         """Upper limit ``LEX,8h + U`` of the one-sided 95 % interval, dB."""
         return self.lex_8h + self.expanded_uncertainty
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the per-task contributions with the ``LEX,8h`` line.
 
         Only task-based results carry per-task contributions (the job and
@@ -289,9 +289,10 @@ class ExposureResult:
         (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.hearing import plot_occupational_exposure
 
-        return plot_occupational_exposure(self, ax=ax, **kwargs)
+        return plot_occupational_exposure(self, ax=ax, language=check_language(language), **kwargs)
 
 
 # --------------------------------------------------------------------------- #

--- a/src/phonometry/hearing/sii.py
+++ b/src/phonometry/hearing/sii.py
@@ -112,15 +112,16 @@ class SIIResult:
     disturbance: np.ndarray
     masking: np.ndarray
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the per-band audibility weighted by importance, with the SII.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.hearing import plot_sii
 
-        return plot_sii(self, ax=ax, **kwargs)
+        return plot_sii(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def standard_speech_spectrum(vocal_effort: str = "normal") -> np.ndarray:

--- a/src/phonometry/hearing/sti.py
+++ b/src/phonometry/hearing/sti.py
@@ -107,15 +107,16 @@ class STIResult:
     band_levels: np.ndarray | None
     rating: str
 
-    def plot(self, ax: Axes | None = None, **kwargs: Any) -> Axes:
+    def plot(self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any) -> Axes:
         """Plot the per-band MTI bars with the STI and rating letter.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.hearing import plot_sti
 
-        return plot_sti(self, ax=ax, **kwargs)
+        return plot_sti(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def _rating(sti: float) -> str:

--- a/src/phonometry/hearing/threshold.py
+++ b/src/phonometry/hearing/threshold.py
@@ -165,15 +165,16 @@ class AgeThresholdResult:
     spread_lower: np.ndarray
     threshold: np.ndarray
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the median threshold with the fractile band over frequency.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.hearing import plot_age_threshold
 
-        return plot_age_threshold(self, ax=ax, **kwargs)
+        return plot_age_threshold(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def _select(values: np.ndarray, frequencies: ArrayLike | None) -> np.ndarray:

--- a/src/phonometry/psychoacoustics/fluctuation_strength.py
+++ b/src/phonometry/psychoacoustics/fluctuation_strength.py
@@ -199,11 +199,12 @@ class FluctuationStrengthResult:
     bark_axis: "NDArray[np.float64]"
     time_dependent: "NDArray[np.float64]"
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the specific fluctuation strength against critical-band rate."""
+        from .._i18n import check_language
         from .._plot.psychoacoustics import plot_fluctuation_strength
 
-        return plot_fluctuation_strength(self, ax=ax, **kwargs)
+        return plot_fluctuation_strength(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def _bandpass_envelope_filter(fs: float) -> Any:

--- a/src/phonometry/psychoacoustics/fluctuation_strength_ecma.py
+++ b/src/phonometry/psychoacoustics/fluctuation_strength_ecma.py
@@ -209,16 +209,17 @@ class EcmaFluctuationStrength:
     specific_fluctuation_strength_vs_time: np.ndarray
     field: str
 
-    def plot(self, ax: Axes | None = None, **kwargs: Any) -> Axes | np.ndarray:
+    def plot(self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any) -> Axes | np.ndarray:
         """Plot the fluctuation-strength result (see :mod:`._plotting`).
 
         Draws the time-dependent fluctuation strength F(l50) and a
         specific-fluctuation-strength heatmap. Requires matplotlib
         (``pip install phonometry[plot]``).
         """
+        from .._i18n import check_language
         from .._plot.psychoacoustics import plot_ecma_fluctuation_strength
 
-        return plot_ecma_fluctuation_strength(self, ax=ax, **kwargs)
+        return plot_ecma_fluctuation_strength(self, ax=ax, language=check_language(language), **kwargs)
 
 
 # --------------------------------------------------------------------------

--- a/src/phonometry/psychoacoustics/loudness_ecma.py
+++ b/src/phonometry/psychoacoustics/loudness_ecma.py
@@ -196,15 +196,16 @@ class EcmaLoudness:
     loudness_vs_time: np.ndarray
     field: str
 
-    def plot(self, ax: Axes | None = None, **kwargs: Any) -> Axes | np.ndarray:
+    def plot(self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any) -> Axes | np.ndarray:
         """Plot the average specific loudness N'(z) (see :mod:`._plotting`).
 
         Adds a loudness-vs-time panel.  Requires matplotlib
         (``pip install phonometry[plot]``).
         """
+        from .._i18n import check_language
         from .._plot.psychoacoustics import plot_ecma_loudness
 
-        return plot_ecma_loudness(self, ax=ax, **kwargs)
+        return plot_ecma_loudness(self, ax=ax, language=check_language(language), **kwargs)
 
 
 # --------------------------------------------------------------------------

--- a/src/phonometry/psychoacoustics/loudness_moore_glasberg.py
+++ b/src/phonometry/psychoacoustics/loudness_moore_glasberg.py
@@ -526,15 +526,16 @@ class MooreGlasbergLoudness:
     field: str
     presentation: str
 
-    def plot(self, ax: Axes | None = None, **kwargs: Any) -> Axes:
+    def plot(self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any) -> Axes:
         """Plot the specific loudness N'(i) over the ERB-number scale.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.  See :mod:`._plotting`.
         """
+        from .._i18n import check_language
         from .._plot.psychoacoustics import plot_moore_glasberg_loudness
 
-        return plot_moore_glasberg_loudness(self, ax=ax, **kwargs)
+        return plot_moore_glasberg_loudness(self, ax=ax, language=check_language(language), **kwargs)
 
 
 # ---------------------------------------------------------------------------

--- a/src/phonometry/psychoacoustics/loudness_moore_glasberg_time.py
+++ b/src/phonometry/psychoacoustics/loudness_moore_glasberg_time.py
@@ -369,15 +369,16 @@ class MooreGlasbergTimeVaryingLoudness:
     field: str
     presentation: str
 
-    def plot(self, ax: Axes | None = None, **kwargs: Any) -> Axes:
+    def plot(self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any) -> Axes:
         """Plot the short-term and long-term loudness against time.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.  See :mod:`._plotting`.
         """
+        from .._i18n import check_language
         from .._plot.psychoacoustics import plot_moore_glasberg_time_loudness
 
-        return plot_moore_glasberg_time_loudness(self, ax=ax, **kwargs)
+        return plot_moore_glasberg_time_loudness(self, ax=ax, language=check_language(language), **kwargs)
 
 
 # ---------------------------------------------------------------------------

--- a/src/phonometry/psychoacoustics/loudness_zwicker.py
+++ b/src/phonometry/psychoacoustics/loudness_zwicker.py
@@ -112,16 +112,17 @@ class ZwickerLoudness:
     time: np.ndarray | None = None
     loudness_vs_time: np.ndarray | None = None
 
-    def plot(self, ax: Axes | None = None, **kwargs: Any) -> Axes | np.ndarray:
+    def plot(self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any) -> Axes | np.ndarray:
         """Plot the specific loudness N'(z) over Bark (see :mod:`._plotting`).
 
         Adds a loudness-vs-time panel when the time-varying trace is
         present.  Requires matplotlib (``pip install phonometry[plot]``);
         returns the :class:`~matplotlib.axes.Axes` (or array thereof).
         """
+        from .._i18n import check_language
         from .._plot.psychoacoustics import plot_zwicker_loudness
 
-        return plot_zwicker_loudness(self, ax=ax, **kwargs)
+        return plot_zwicker_loudness(self, ax=ax, language=check_language(language), **kwargs)
 
     def report(
         self,

--- a/src/phonometry/psychoacoustics/psychoacoustic_annoyance.py
+++ b/src/phonometry/psychoacoustics/psychoacoustic_annoyance.py
@@ -89,11 +89,12 @@ class PsychoacousticAnnoyanceResult:
     w_s: float
     w_fr: float
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the PA value and the ``wS`` / ``wFR`` term contributions."""
+        from .._i18n import check_language
         from .._plot.psychoacoustics import plot_psychoacoustic_annoyance
 
-        return plot_psychoacoustic_annoyance(self, ax=ax, **kwargs)
+        return plot_psychoacoustic_annoyance(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def psychoacoustic_annoyance(

--- a/src/phonometry/psychoacoustics/roughness_ecma.py
+++ b/src/phonometry/psychoacoustics/roughness_ecma.py
@@ -174,15 +174,16 @@ class EcmaRoughness:
     specific_roughness_vs_time: np.ndarray
     field: str
 
-    def plot(self, ax: Axes | None = None, **kwargs: Any) -> Axes | np.ndarray:
+    def plot(self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any) -> Axes | np.ndarray:
         """Plot the roughness result (see :mod:`._plotting`).
 
         Draws the time-dependent roughness R(l50) and a specific-roughness
         heatmap. Requires matplotlib (``pip install phonometry[plot]``).
         """
+        from .._i18n import check_language
         from .._plot.psychoacoustics import plot_ecma_roughness
 
-        return plot_ecma_roughness(self, ax=ax, **kwargs)
+        return plot_ecma_roughness(self, ax=ax, language=check_language(language), **kwargs)
 
 
 # --------------------------------------------------------------------------

--- a/src/phonometry/psychoacoustics/tonality_ecma.py
+++ b/src/phonometry/psychoacoustics/tonality_ecma.py
@@ -90,15 +90,16 @@ class EcmaTonality:
     tonal_frequency_vs_time: np.ndarray
     field: str
 
-    def plot(self, ax: Axes | None = None, **kwargs: Any) -> Axes | np.ndarray:
+    def plot(self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any) -> Axes | np.ndarray:
         """Plot the average specific tonality T'(z) (see :mod:`._plotting`).
 
         Adds a tonality-vs-time panel. Requires matplotlib
         (``pip install phonometry[plot]``).
         """
+        from .._i18n import check_language
         from .._plot.psychoacoustics import plot_ecma_tonality
 
-        return plot_ecma_tonality(self, ax=ax, **kwargs)
+        return plot_ecma_tonality(self, ax=ax, language=check_language(language), **kwargs)
 
 
 # --------------------------------------------------------------------------

--- a/src/phonometry/psychoacoustics/tone_audibility.py
+++ b/src/phonometry/psychoacoustics/tone_audibility.py
@@ -1030,11 +1030,12 @@ class ToneAudibilityResult:
         """Tone frequency of the decisive (most audible) tone, in Hz."""
         return float(self.tone_frequencies[int(np.argmax(self.audibilities))])
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the per-tone audibility ``ΔL`` against tone frequency."""
+        from .._i18n import check_language
         from .._plot.psychoacoustics import plot_tone_audibility
 
-        return plot_tone_audibility(self, ax=ax, **kwargs)
+        return plot_tone_audibility(self, ax=ax, language=check_language(language), **kwargs)
 
 
 # Module named ``tone_audibility`` (distinct from the ISO 1996-2 Annex C

--- a/src/phonometry/vibration/human_vibration.py
+++ b/src/phonometry/vibration/human_vibration.py
@@ -271,15 +271,16 @@ class WeightingResponse:
     magnitude: Real
     magnitude_db: Real
 
-    def plot(self, ax: Axes | None = None, **kwargs: Any) -> Axes:
+    def plot(self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any) -> Axes:
         """Plot the weighting factor (dB) versus frequency.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes` and never calls ``plt.show``.
         """
+        from .._i18n import check_language
         from .._plot.vibration import plot_vibration_weighting
 
-        return plot_vibration_weighting(self, ax=ax, **kwargs)
+        return plot_vibration_weighting(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def frequency_weighting(name: str, frequencies: ArrayLike) -> WeightingResponse:
@@ -372,15 +373,16 @@ class WeightedSpectrum:
     weighted: Real
     overall: float
 
-    def plot(self, ax: Axes | None = None, **kwargs: Any) -> Axes:
+    def plot(self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any) -> Axes:
         """Plot the unweighted and weighted band spectra with ``a_w``.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes` and never calls ``plt.show``.
         """
+        from .._i18n import check_language
         from .._plot.vibration import plot_weighted_spectrum
 
-        return plot_weighted_spectrum(self, ax=ax, **kwargs)
+        return plot_weighted_spectrum(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def weighted_acceleration(
@@ -805,15 +807,16 @@ class DailyVibrationExposure:
     partials: Real
     assessment: ExposureAssessment
 
-    def plot(self, ax: Axes | None = None, **kwargs: Any) -> Axes:
+    def plot(self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any) -> Axes:
         """Plot the partial exposures against the EAV / ELV thresholds.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes` and never calls ``plt.show``.
         """
+        from .._i18n import check_language
         from .._plot.vibration import plot_daily_exposure
 
-        return plot_daily_exposure(self, ax=ax, **kwargs)
+        return plot_daily_exposure(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def daily_vibration_exposure(

--- a/src/phonometry/vibration/mechanical_mobility.py
+++ b/src/phonometry/vibration/mechanical_mobility.py
@@ -402,15 +402,16 @@ class MobilityResult:
         """
         return convert_frf(self.mobility, self.frequencies, "mobility", target)
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the mobility magnitude ``|Y(f)|``.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.vibration import plot_mobility
 
-        return plot_mobility(self, ax=ax, **kwargs)
+        return plot_mobility(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def sdof_mobility_result(

--- a/src/phonometry/vibration/multiple_shock_vibration.py
+++ b/src/phonometry/vibration/multiple_shock_vibration.py
@@ -380,15 +380,16 @@ class MultipleShockResult:
     peaks: np.ndarray
     risk_thresholds: tuple[float, float, float]
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the injury-probability curve with this assessment's ``R``.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.vibration import plot_multiple_shock
 
-        return plot_multiple_shock(self, ax=ax, **kwargs)
+        return plot_multiple_shock(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def multiple_shock_assessment(

--- a/src/phonometry/vibration/radiation_efficiency.py
+++ b/src/phonometry/vibration/radiation_efficiency.py
@@ -126,15 +126,16 @@ class RadiationEfficiencyResult:
         sigma = np.asarray(self.radiation_efficiency, dtype=np.float64)
         return np.asarray(10.0 * np.log10(sigma), dtype=np.float64)
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the radiation efficiency ``sigma(f)`` on log-log axes.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.vibration import plot_radiation_efficiency
 
-        return plot_radiation_efficiency(self, ax=ax, **kwargs)
+        return plot_radiation_efficiency(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def _sigma_below(

--- a/src/phonometry/vibration/transfer_stiffness.py
+++ b/src/phonometry/vibration/transfer_stiffness.py
@@ -312,15 +312,16 @@ class TransferStiffnessResult:
             self.transfer_stiffness, self.frequencies, "dynamic_stiffness", target
         )
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the transfer-stiffness level ``L_k(f)``.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.vibration import plot_transfer_stiffness
 
-        return plot_transfer_stiffness(self, ax=ax, **kwargs)
+        return plot_transfer_stiffness(self, ax=ax, language=check_language(language), **kwargs)
 
 
 def indirect_transfer_stiffness_result(

--- a/tests/hearing/test_hearing_plot_i18n.py
+++ b/tests/hearing/test_hearing_plot_i18n.py
@@ -1,0 +1,33 @@
+#  Copyright (c) 2026. Jose M. Requena-Plens
+"""EN/ES language option of the hearing ``.plot()`` renderers."""
+
+from __future__ import annotations
+
+import pytest
+
+from phonometry import age_threshold
+
+
+def test_spanish_labels() -> None:
+    pytest.importorskip("matplotlib")
+    import matplotlib
+
+    matplotlib.use("Agg")
+    res = age_threshold(60.0, "male", fractile=0.9)
+
+    ax_en = res.plot(language="en")
+    assert ax_en.get_ylabel() == "Threshold deviation from age 18 [dB]"
+
+    ax_es = res.plot(language="es")
+    assert ax_es.get_ylabel() == "Desviación del umbral respecto a 18 años [dB]"
+    assert "umbral de audición" in ax_es.get_title()
+
+
+def test_unknown_language_raises() -> None:
+    pytest.importorskip("matplotlib")
+    import matplotlib
+
+    matplotlib.use("Agg")
+    result = age_threshold(60.0, "male")
+    with pytest.raises(ValueError, match="Unknown language"):
+        result.plot(language="xx")

--- a/tests/psychoacoustics/test_psychoacoustics_plot_i18n.py
+++ b/tests/psychoacoustics/test_psychoacoustics_plot_i18n.py
@@ -1,0 +1,43 @@
+#  Copyright (c) 2026. Jose M. Requena-Plens
+"""EN/ES language option of the psychoacoustics ``.plot()`` renderers."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from phonometry import loudness_zwicker
+
+
+def _result():
+    fs = 48000
+    t = np.arange(int(fs * 0.3)) / fs
+    x = np.sqrt(2.0) * 0.02 * np.sin(2.0 * np.pi * 1000.0 * t)
+    return loudness_zwicker(x, fs, stationary=True)
+
+
+def test_spanish_labels_and_comma_decimals() -> None:
+    pytest.importorskip("matplotlib")
+    import matplotlib
+
+    matplotlib.use("Agg")
+    res = _result()
+
+    ax_en = res.plot(language="en")
+    assert ax_en.get_xlabel() == "Critical-band rate z [Bark]"
+
+    ax_es = res.plot(language="es")
+    assert ax_es.get_xlabel() == "Razón de banda crítica z [Bark]"
+    assert "sonios" in ax_es.get_title()
+    # Spanish uses a comma decimal separator in the annotated numbers.
+    assert "," in ax_es.get_title()
+
+
+def test_unknown_language_raises() -> None:
+    pytest.importorskip("matplotlib")
+    import matplotlib
+
+    matplotlib.use("Agg")
+    result = _result()
+    with pytest.raises(ValueError, match="Unknown language"):
+        result.plot(language="xx")

--- a/tests/vibration/test_vibration_plot_i18n.py
+++ b/tests/vibration/test_vibration_plot_i18n.py
@@ -1,0 +1,39 @@
+#  Copyright (c) 2026. Jose M. Requena-Plens
+"""EN/ES language option of the vibration ``.plot()`` renderers."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from phonometry import sdof_mobility_result
+
+
+def _result():
+    return sdof_mobility_result(np.linspace(1.0, 50.0, 200), 2.0, 8000.0, 5.0)
+
+
+def test_spanish_labels() -> None:
+    pytest.importorskip("matplotlib")
+    import matplotlib
+
+    matplotlib.use("Agg")
+    res = _result()
+
+    ax_en = res.plot(language="en")
+    assert ax_en.get_xlabel() == "Frequency [Hz]"
+    assert ax_en.get_title() == "ISO 7626-1 mechanical mobility"
+
+    ax_es = res.plot(language="es")
+    assert ax_es.get_xlabel() == "Frecuencia [Hz]"
+    assert ax_es.get_title() == "ISO 7626-1 movilidad mecánica"
+
+
+def test_unknown_language_raises() -> None:
+    pytest.importorskip("matplotlib")
+    import matplotlib
+
+    matplotlib.use("Agg")
+    result = _result()
+    with pytest.raises(ValueError, match="Unknown language"):
+        result.plot(language="xx")


### PR DESCRIPTION
## Summary

The `.plot()` methods of the psychoacoustics, hearing and vibration results now accept a `language` keyword. `"en"` is the default and its output is unchanged; `"es"` renders the axis labels, titles and legends in Spanish and switches the decimal separator to a comma.

## What changed

- New `phonometry._i18n` module with the shared locale helpers: language validation, locale-aware number formatting, and linear-axis tick localisation.
- The three `_plot` renderers (`psychoacoustics.py`, `hearing.py`, `vibration.py`, 24 plot functions in total) gain a module-level string table and localise every fixed label, title and legend. Unit symbols are kept; Spanish terminology follows the convention already used in the site (sonios, fonios, and so on).
- The `language` keyword is threaded through the delegating `.plot()` methods, which validate it before forwarding.
- The `_i18n` helpers are imported lazily inside the render functions, so the `_plot` leaves keep no module-level domain imports (the package-architecture test stays green).
- Per-domain tests: a Spanish label is produced and an unknown language raises `ValueError`.
- Regenerated API reference pages for the new `.plot()` signatures.

## Verification

- English output is byte-for-byte identical: every one of the 24 plots was rendered in English and compared against the previous implementation, with zero differences in labels, titles and legends.
- The committed documentation figures regenerate with zero diff.
- `ruff check .`, `mypy src scripts`, and `pytest tests/psychoacoustics tests/hearing tests/vibration tests/test_package_architecture.py` all pass (767 passed, 50 skipped).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plotting results across hearing, psychoacoustics, and vibration now supports English and Spanish labels, titles, legends, and localized decimal formatting.
  * Added a keyword-only `language` option to plotting methods, defaulting to English.
  * Unsupported language codes now produce a clear validation error.

* **Documentation**
  * Updated API references and changelog to describe language selection and Spanish formatting.

* **Tests**
  * Added coverage for localized labels, titles, decimal separators, and invalid language handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->