### PR TITLE
feat: EN/ES language option for the metrology/electroacoustics/simulation/broadcast plots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   accept a `language` keyword (`"en"`, the default, or `"es"`). Spanish renders
   the axis labels, titles and legends in Spanish and switches the decimal
   separator to a comma; English output is unchanged.
+- The `.plot()` methods of the metrology, electroacoustics, simulation and
+  broadcast results accept a `language` keyword (`"en"`, the default, or
+  `"es"`). Spanish renders localised axis labels, titles and legends and uses a
+  comma decimal separator; English is unchanged. An unsupported language raises
+  a clear `ValueError`.
 - IEC 61260-1 filter class compliance can now be exported as a one-page PDF
   fiche. A new `filter_class_compliance(bank, *, num_points=..., edition=...)`
   runs the same verification as `verify_filter_class` and returns a frozen

--- a/site/src/content/docs/reference/api/broadcast/program-loudness.md
+++ b/site/src/content/docs/reference/api/broadcast/program-loudness.md
@@ -268,7 +268,12 @@ EBU Mode loudness measurement of a programme (BS.1770-5 / EBU R 128).
 ### ProgramLoudnessResult.plot()
 
 ```python
-ProgramLoudnessResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+ProgramLoudnessResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot momentary and short-term loudness over time, with the
@@ -276,6 +281,12 @@ integrated loudness and the loudness range annotated.
 
 Requires matplotlib (`pip install phonometry[plot]`); returns the
 `Axes`.
+
+**Parameters**
+
+| Name | Description |
+| :--- | :--- |
+| `language` | Label language, `"en"` (default) or `"es"`. |
 
 ### ProgramLoudnessResult.report()
 

--- a/site/src/content/docs/reference/api/correlation/correlation.md
+++ b/site/src/content/docs/reference/api/correlation/correlation.md
@@ -115,11 +115,19 @@ An impulse response aligned onto a reference.
 ```python
 AlignedImpulseResponseResult.plot(
     ax: Axes | None = None,
+    *,
+    language: str = 'en',
     **kwargs: Any,
 ) -> Axes
 ```
 
 Plot the reference and the aligned impulse response.
+
+**Parameters**
+
+| Name | Description |
+| :--- | :--- |
+| `language` | Label language, `"en"` (default) or `"es"`. |
 
 ## correlation
 
@@ -241,10 +249,21 @@ Auto- or cross-correlation estimate (B&P Sections 5.1, 8.4, 11.4).
 ### CorrelationResult.plot()
 
 ```python
-CorrelationResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+CorrelationResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the correlation estimate against the lag in seconds.
+
+**Parameters**
+
+| Name | Description |
+| :--- | :--- |
+| `language` | Label language, `"en"` (default) or `"es"`. |
 
 ### CorrelationResult.random_error()
 
@@ -451,7 +470,18 @@ Time-delay estimate between two records.
 ### TimeDelayResult.plot()
 
 ```python
-TimeDelayResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+TimeDelayResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the correlation function with the estimated delay marked.
+
+**Parameters**
+
+| Name | Description |
+| :--- | :--- |
+| `language` | Label language, `"en"` (default) or `"es"`. |

--- a/site/src/content/docs/reference/api/correlation/envelope.md
+++ b/site/src/content/docs/reference/api/correlation/envelope.md
@@ -125,8 +125,16 @@ All output arrays share the (possibly decimated) time axis
 ```python
 EnvelopeResult.plot(
     ax: Axes | None = None,
+    *,
+    language: str = 'en',
     **kwargs: Any,
 ) -> Axes | NDArray[Any]
 ```
 
 Plot the signal with its envelope and the instantaneous frequency.
+
+**Parameters**
+
+| Name | Description |
+| :--- | :--- |
+| `language` | Label language, `"en"` (default) or `"es"`. |

--- a/site/src/content/docs/reference/api/electroacoustics/distortion.md
+++ b/site/src/content/docs/reference/api/electroacoustics/distortion.md
@@ -279,10 +279,21 @@ Harmonic analysis of a signal (IEC 60268-3 / AES17).
 ### HarmonicDistortionResult.plot()
 
 ```python
-HarmonicDistortionResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+HarmonicDistortionResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the magnitude spectrum with the harmonics marked.
+
+**Parameters**
+
+| Name | Description |
+| :--- | :--- |
+| `language` | Label language, `"en"` (default) or `"es"`. |
 
 ## idle_channel_noise
 

--- a/site/src/content/docs/reference/api/electroacoustics/frequency-response.md
+++ b/site/src/content/docs/reference/api/electroacoustics/frequency-response.md
@@ -93,11 +93,19 @@ Estimated frequency response of an input/output path (Bendat & Piersol).
 ```python
 FrequencyResponseResult.plot(
     ax: Axes | None = None,
+    *,
+    language: str = 'en',
     **kwargs: Any,
 ) -> Axes | NDArray[Any]
 ```
 
 Plot the Bode magnitude/phase and the coherence.
+
+**Parameters**
+
+| Name | Description |
+| :--- | :--- |
+| `language` | Label language, `"en"` (default) or `"es"`. |
 
 ## transfer_function
 

--- a/site/src/content/docs/reference/api/electroacoustics/piston.md
+++ b/site/src/content/docs/reference/api/electroacoustics/piston.md
@@ -199,7 +199,12 @@ Radiation impedance and directivity of a baffled circular piston.
 ### RadiatingPistonResult.plot()
 
 ```python
-RadiatingPistonResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+RadiatingPistonResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the normalized piston resistance and reactance against `ka`.
@@ -207,3 +212,9 @@ Plot the normalized piston resistance and reactance against `ka`.
 Reproduces the classic Beranek & Mellow figure: `R1` rising to 1 and
 `X1` peaking then decaying, over the `ka` range of the result.
 Requires matplotlib (`pip install phonometry[plot]`).
+
+**Parameters**
+
+| Name | Description |
+| :--- | :--- |
+| `language` | Label language, `"en"` (default) or `"es"`. |

--- a/site/src/content/docs/reference/api/electroacoustics/swept-sine.md
+++ b/site/src/content/docs/reference/api/electroacoustics/swept-sine.md
@@ -175,6 +175,8 @@ Number of separated harmonic orders (including the linear H1).
 ```python
 SweptSineDistortionResult.plot(
     ax: Axes | None = None,
+    *,
+    language: str = 'en',
     **kwargs: Any,
 ) -> Axes | NDArray[Any]
 ```
@@ -185,6 +187,12 @@ Two stacked panels: the magnitudes of `H1..HN` in dB against
 their own frequency axes, and the total harmonic distortion in %
 against the excitation frequency. With `ax` given, only the THD
 panel is drawn on it.
+
+**Parameters**
+
+| Name | Description |
+| :--- | :--- |
+| `language` | Label language, `"en"` (default) or `"es"`. |
 
 ## synchronized_sweep_signal
 

--- a/site/src/content/docs/reference/api/filters/compliance.md
+++ b/site/src/content/docs/reference/api/filters/compliance.md
@@ -154,7 +154,12 @@ carries no verdicts, so this returns an empty list.
 ### FilterComplianceResult.plot()
 
 ```python
-FilterComplianceResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+FilterComplianceResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the worst-margin band against its class-limit corridor.
@@ -164,6 +169,12 @@ acceptance corridor of the achieved (or, when non-compliant, the
 loosest) class; see `phonometry._plot.metrology.plot_filter_class`.
 Requires matplotlib (`pip install phonometry[plot]`) and returns the
 `Axes`.
+
+**Parameters**
+
+| Name | Description |
+| :--- | :--- |
+| `language` | Label language, `"en"` (default) or `"es"`. |
 
 ### FilterComplianceResult.reference_class()
 

--- a/site/src/content/docs/reference/api/metrology/uncertainty.md
+++ b/site/src/content/docs/reference/api/metrology/uncertainty.md
@@ -136,7 +136,12 @@ Result of the Monte Carlo method (Guide 98-3-1, Supplement 1).
 ### MonteCarloResult.plot()
 
 ```python
-MonteCarloResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+MonteCarloResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the output histogram with the coverage interval marked.
@@ -144,6 +149,12 @@ Plot the output histogram with the coverage interval marked.
 Needs the raw output sample, so call `monte_carlo(...,
 keep_samples=True)`. Requires matplotlib (`pip install
 phonometry[plot]`); returns the `Axes`.
+
+**Parameters**
+
+| Name | Description |
+| :--- | :--- |
+| `language` | Label language, `"en"` (default) or `"es"`. |
 
 ## Quantity
 
@@ -255,13 +266,24 @@ Coverage factor `k` and expanded uncertainty `U = k*uc`.
 ### UncertaintyResult.plot()
 
 ```python
-UncertaintyResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+UncertaintyResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the uncertainty budget (per-input contributions).
 
 Requires matplotlib (`pip install phonometry[plot]`); returns the
 `Axes`.
+
+**Parameters**
+
+| Name | Description |
+| :--- | :--- |
+| `language` | Label language, `"en"` (default) or `"es"`. |
 
 ## UncertaintyWarning
 

--- a/site/src/content/docs/reference/api/simulation/fdtd.md
+++ b/site/src/content/docs/reference/api/simulation/fdtd.md
@@ -286,6 +286,7 @@ FDTDResult.plot(
     *,
     kind: str = 'probes',
     frame: int = -1,
+    language: str = 'en',
     **kwargs: Any,
 ) -> Axes
 ```
@@ -299,6 +300,7 @@ Plot the probe histories or one recorded field snapshot.
 | `ax` | Existing axes, or `None` to create a figure. |
 | `kind` | `"probes"` (default) draws the per-probe pressure time histories; `"snapshot"` renders one recorded pressure field with the geometry overlaid (`imshow` raster). |
 | `frame` | Snapshot index for `kind="snapshot"` (default: the last recorded frame). |
+| `language` | Label language, `"en"` (default) or `"es"`. |
 | `kwargs` | Forwarded to the underlying `plot`/`imshow`. |
 
 **Returns:** The axes.

--- a/site/src/content/docs/reference/api/spectra/phase.md
+++ b/site/src/content/docs/reference/api/spectra/phase.md
@@ -224,6 +224,8 @@ Minimum-phase / all-pass decomposition of a frequency response.
 ```python
 PhaseDecompositionResult.plot(
     ax: Axes | None = None,
+    *,
+    language: str = 'en',
     **kwargs: Any,
 ) -> Axes | NDArray[Any]
 ```
@@ -233,3 +235,9 @@ Plot the magnitude, the phase decomposition and the group delay.
 Three stacked panels: `|H|` in dB, the measured / minimum /
 excess phases, and the total and excess group delays. With `ax`
 given, only the phase panel is drawn on it.
+
+**Parameters**
+
+| Name | Description |
+| :--- | :--- |
+| `language` | Label language, `"en"` (default) or `"es"`. |

--- a/site/src/content/docs/reference/api/spectra/spectra.md
+++ b/site/src/content/docs/reference/api/spectra/spectra.md
@@ -153,11 +153,19 @@ remainder `Gnn = (1-γ²xy)·Gyy` (Eq. 9.56), with `Gyy = Gvv + Gnn`
 ```python
 CoherentOutputSpectrumResult.plot(
     ax: Axes | None = None,
+    *,
+    language: str = 'en',
     **kwargs: Any,
 ) -> Axes | NDArray[Any]
 ```
 
 Plot the output/coherent/noise spectra and the spectral SNR.
+
+**Parameters**
+
+| Name | Description |
+| :--- | :--- |
+| `language` | Label language, `"en"` (default) or `"es"`. |
 
 ## cross_spectral_density
 
@@ -252,11 +260,19 @@ estimate, as Bendat & Piersol recommend for measured data (Section 9.2).
 ```python
 CrossSpectralDensityResult.plot(
     ax: Axes | None = None,
+    *,
+    language: str = 'en',
     **kwargs: Any,
 ) -> Axes | NDArray[Any]
 ```
 
 Plot the magnitude, phase (with ±σ band) and coherence.
+
+**Parameters**
+
+| Name | Description |
+| :--- | :--- |
+| `language` | Label language, `"en"` (default) or `"es"`. |
 
 ## fractional_octave_smoothing
 
@@ -426,7 +442,18 @@ Welch autospectral density with its statistical error (B&P Ch. 8).
 ### SpectralDensityResult.plot()
 
 ```python
-SpectralDensityResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+SpectralDensityResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the spectral density in dB with its confidence band.
+
+**Parameters**
+
+| Name | Description |
+| :--- | :--- |
+| `language` | Label language, `"en"` (default) or `"es"`. |

--- a/src/phonometry/_plot/broadcast.py
+++ b/src/phonometry/_plot/broadcast.py
@@ -22,9 +22,25 @@ if TYPE_CHECKING:
 
     from ..broadcast.program_loudness import ProgramLoudnessResult
 
+_STRINGS = {
+    "momentary": {"en": "Momentary (400 ms)", "es": "Momentánea (400 ms)"},
+    "short_term": {"en": "Short-term (3 s)", "es": "Corto plazo (3 s)"},
+    "time_s": {"en": "Time [s]", "es": "Tiempo [s]"},
+    "loudness_lufs": {"en": "Loudness [LUFS]", "es": "Sonoridad [LUFS]"},
+    "title": {"en": "Programme loudness (EBU R 128)",
+              "es": "Sonoridad de programa (EBU R 128)"},
+    "integrated": {"en": "Integrated", "es": "Integrada"},
+}
+
+
+def _t(key: str, language: str) -> str:
+    """Return the localised fixed string for *key*."""
+    return _STRINGS[key][language]
+
 
 def plot_program_loudness(
-    result: "ProgramLoudnessResult", ax: Axes | None = None, **kwargs: Any
+    result: "ProgramLoudnessResult", ax: Axes | None = None, *,
+    language: str = "en", **kwargs: Any
 ) -> Axes:
     """EBU Mode loudness over time (ITU-R BS.1770-5 / EBU R 128).
 
@@ -34,17 +50,21 @@ def plot_program_loudness(
 
     :param result: A :class:`~phonometry.broadcast.ProgramLoudnessResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the short-term ``plot``.
     :return: The axes.
     """
+    from .._i18n import format_number, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     if math.isfinite(result.lra_low) and math.isfinite(result.lra_high):
+        lra = format_number(result.loudness_range, language, decimals=1)
         ax.axhspan(
             result.lra_low,
             result.lra_high,
             color=_C_SECONDARY,
             alpha=0.15,
-            label=f"LRA {result.loudness_range:.1f} LU",
+            label=f"LRA {lra} LU",
         )
     if result.momentary.size:
         ax.plot(
@@ -52,24 +72,25 @@ def plot_program_loudness(
             result.momentary,
             color=_C_MUTED,
             linewidth=1.0,
-            label="Momentary (400 ms)",
+            label=_t("momentary", language),
         )
     if result.short_term.size:
         kwargs.setdefault("color", _C_PRIMARY)
         kwargs.setdefault("linewidth", 2.0)
-        kwargs.setdefault("label", "Short-term (3 s)")
+        kwargs.setdefault("label", _t("short_term", language))
         ax.plot(
             result.short_term_time,
             result.short_term,
             **kwargs,
         )
     if math.isfinite(result.integrated):
+        integ = format_number(result.integrated, language, decimals=1)
         ax.axhline(
             result.integrated,
             color=_C_REFERENCE,
             linestyle="--",
             linewidth=1.6,
-            label=f"Integrated {result.integrated:.1f} LUFS",
+            label=f"{_t('integrated', language)} {integ} LUFS",
         )
     finite = np.concatenate(
         [
@@ -81,9 +102,10 @@ def plot_program_loudness(
         low = float(np.min(finite))
         high = float(np.max(finite))
         ax.set_ylim(low - 5.0, high + 5.0)
-    ax.set_xlabel("Time [s]")
-    ax.set_ylabel("Loudness [LUFS]")
-    ax.set_title("Programme loudness (EBU R 128)")
+    ax.set_xlabel(_t("time_s", language))
+    ax.set_ylabel(_t("loudness_lufs", language))
+    ax.set_title(_t("title", language))
     ax.grid(True, alpha=0.3)
     ax.legend(loc=_LEGEND_UPPER_RIGHT, fontsize=9)
+    localize_axes(ax, language)
     return ax

--- a/src/phonometry/_plot/electroacoustics.py
+++ b/src/phonometry/_plot/electroacoustics.py
@@ -28,8 +28,46 @@ if TYPE_CHECKING:
 #: Shared frequency-axis label of the electroacoustics renderers.
 _FREQ_LABEL = "Frequency [Hz]"
 
+_STRINGS = {
+    "freq": {"en": "Frequency [Hz]", "es": "Frecuencia [Hz]"},
+    "magnitude": {"en": "Magnitude [dB]", "es": "Magnitud [dB]"},
+    "phase": {"en": "Phase [deg]", "es": "Fase [grados]"},
+    "coherence": {"en": r"Coherence $\gamma^2$", "es": r"Coherencia $\gamma^2$"},
+    "harmonic_order": {"en": "Harmonic order n  (f = n·f₁)",
+                       "es": "Orden del armónico n  (f = n·f₁)"},
+    "level_re_fund": {"en": "Level re fundamental [dB]",
+                      "es": "Nivel respecto al fundamental [dB]"},
+    "harmonics": {"en": "Harmonics", "es": "Armónicos"},
+    "fr_title": {"en": "Frequency response", "es": "Respuesta en frecuencia"},
+    "and_coherence": {"en": " and coherence", "es": " y coherencia"},
+    "thd_pct": {"en": "THD [%]", "es": "THD [%]"},
+    "excitation_freq": {"en": "Excitation frequency [Hz]",
+                        "es": "Frecuencia de excitación [Hz]"},
+    "swept_thd_title": {"en": "Swept-sine THD (Farina / Novak)",
+                        "es": "THD de barrido sinusoidal (Farina / Novak)"},
+    "harmonic_resp_title_with_method": {
+        "en": "Harmonic frequency responses ({method} sweep)",
+        "es": "Respuestas en frecuencia de los armónicos (barrido {method})"},
+    "piston_resistance": {"en": r"$R_1$ (resistance)",
+                          "es": r"$R_1$ (resistencia)"},
+    "piston_reactance": {"en": r"$X_1$ (reactance)",
+                         "es": r"$X_1$ (reactancia)"},
+    "piston_ylabel": {"en": r"Normalized radiation impedance $Z_r / \rho c S$",
+                      "es": r"Impedancia de radiación normalizada $Z_r / \rho c S$"},
+    "piston_title": {"en": "Baffled circular piston radiation impedance",
+                     "es": "Impedancia de radiación de un pistón circular con pantalla"},
+}
+
+
+def _t(key: str, language: str, **fmt: Any) -> str:
+    """Return the localised fixed string for *key* (optionally ``str.format``ed)."""
+    text = _STRINGS[key][language]
+    return text.format(**fmt) if fmt else text
+
+
 def plot_harmonic_distortion(
-    result: "HarmonicDistortionResult", ax: Axes | None = None, **kwargs: Any
+    result: "HarmonicDistortionResult", ax: Axes | None = None, *,
+    language: str = "en", **kwargs: Any
 ) -> Axes:
     """Harmonic amplitude spectrum with the harmonics marked and THD annotated.
 
@@ -39,9 +77,12 @@ def plot_harmonic_distortion(
 
     :param result: A :class:`~phonometry.distortion.HarmonicDistortionResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the marker ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import decimal_comma, format_number, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     amps = np.asarray(result.harmonic_amplitudes, dtype=np.float64)
     tiny = np.finfo(np.float64).tiny
@@ -51,7 +92,7 @@ def plot_harmonic_distortion(
 
     ax.vlines(orders, -160.0, levels_db, color=_C_PRIMARY, lw=1.5)
     kwargs.setdefault("color", _C_PRIMARY)
-    kwargs.setdefault("label", "Harmonics")
+    kwargs.setdefault("label", _t("harmonics", language))
     ax.plot(orders, levels_db, "o", **kwargs)
     for order, level in zip(orders, levels_db):
         if level > -160.0:
@@ -63,21 +104,27 @@ def plot_harmonic_distortion(
                 ha="center",
                 fontsize="x-small",
             )
-    ax.set_xlabel("Harmonic order n  (f = n·f₁)")
-    ax.set_ylabel("Level re fundamental [dB]")
+    ax.set_xlabel(_t("harmonic_order", language))
+    ax.set_ylabel(_t("level_re_fund", language))
     ax.set_xticks(orders)
     ax.set_ylim(bottom=-160.0, top=10.0)
+    thd_f = decimal_comma(f"{result.thd_f * 100.0:.3g}", language)
+    thd_r = decimal_comma(f"{result.thd_r * 100.0:.3g}", language)
+    sinad = format_number(result.sinad_db, language, decimals=1)
+    freq = decimal_comma(_format_freq(result.fundamental), language)
     ax.set_title(
-        f"IEC 60268-3 THD = {result.thd_f * 100.0:.3g}% (F), "
-        f"{result.thd_r * 100.0:.3g}% (R); SINAD = {result.sinad_db:.1f} dB "
-        f"(f₁ = {_format_freq(result.fundamental)}Hz)"
+        f"IEC 60268-3 THD = {thd_f}% (F), "
+        f"{thd_r}% (R); SINAD = {sinad} dB "
+        f"(f₁ = {freq}Hz)"
     )
     ax.grid(True, alpha=0.3)
     ax.set_axisbelow(True)
+    localize_axes(ax, language)
     return ax
 
 def plot_frequency_response(
-    result: "FrequencyResponseResult", ax: Axes | None = None, **kwargs: Any
+    result: "FrequencyResponseResult", ax: Axes | None = None, *,
+    language: str = "en", **kwargs: Any
 ) -> Axes | np.ndarray:
     """Bode magnitude / phase and coherence of an estimated frequency response.
 
@@ -89,9 +136,12 @@ def plot_frequency_response(
         :class:`~phonometry.frequency_response.FrequencyResponseResult`.
     :param ax: Existing axes for the magnitude panel, or ``None`` for a fresh
         three-panel figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the magnitude ``plot`` call.
     :return: The magnitude-panel axes (``ax`` given) or the array of three axes.
     """
+    from .._i18n import localize_axes
+
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     mag = np.asarray(result.magnitude_db, dtype=np.float64)
     phase_deg = np.degrees(np.asarray(result.phase, dtype=np.float64))
@@ -102,36 +152,42 @@ def plot_frequency_response(
     def _magnitude(axm: Axes) -> None:
         kwargs.setdefault("label", f"|H| ({result.estimator})")
         axm.semilogx(freqs[pos], mag[pos], color=color, **kwargs)
-        axm.set_ylabel("Magnitude [dB]")
+        axm.set_ylabel(_t("magnitude", language))
         axm.grid(True, which="both", alpha=0.3)
         axm.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
 
     fmin, fmax = float(freqs[pos].min()), float(freqs[pos].max())
     if ax is not None:
         _magnitude(ax)
-        ax.set_xlabel(_FREQ_LABEL)
-        ax.set_title(f"Frequency response ({result.estimator})")
+        ax.set_xlabel(_t("freq", language))
+        ax.set_title(f"{_t('fr_title', language)} ({result.estimator})")
         format_frequency_axis(ax, fmin, fmax)
+        localize_axes(ax, language)
         return ax
 
     axes = _new_axes_column(3, sharex=True, figsize=(8.0, 8.0))
     _magnitude(axes[0])
-    axes[0].set_title(f"Frequency response ({result.estimator}) and coherence")
+    axes[0].set_title(
+        f"{_t('fr_title', language)} ({result.estimator})"
+        f"{_t('and_coherence', language)}"
+    )
     axes[1].semilogx(freqs[pos], phase_deg[pos], color=_C_SECONDARY)
-    axes[1].set_ylabel("Phase [deg]")
+    axes[1].set_ylabel(_t("phase", language))
     axes[1].grid(True, which="both", alpha=0.3)
     axes[2].semilogx(freqs[pos], coh[pos], color=_C_TERTIARY)
-    axes[2].set_ylabel(r"Coherence $\gamma^2$")
-    axes[2].set_xlabel(_FREQ_LABEL)
+    axes[2].set_ylabel(_t("coherence", language))
+    axes[2].set_xlabel(_t("freq", language))
     axes[2].set_ylim(0.0, 1.05)
     axes[2].grid(True, which="both", alpha=0.3)
     for axf in axes:
         format_frequency_axis(axf, fmin, fmax)
+        localize_axes(axf, language)
     return axes
 
 
 def plot_swept_sine_distortion(
-    result: "SweptSineDistortionResult", ax: Axes | None = None, **kwargs: Any
+    result: "SweptSineDistortionResult", ax: Axes | None = None, *,
+    language: str = "en", **kwargs: Any
 ) -> Axes | np.ndarray:
     """Harmonic frequency responses and THD(f) of a swept-sine measurement.
 
@@ -144,9 +200,12 @@ def plot_swept_sine_distortion(
         :class:`~phonometry.electroacoustics.swept_sine.SweptSineDistortionResult`.
     :param ax: Existing axes for the THD panel, or ``None`` for a fresh
         two-panel figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the THD ``plot`` call.
     :return: The THD axes (``ax`` given) or the array of two axes.
     """
+    from .._i18n import localize_axes
+
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     tiny = np.finfo(np.float64).tiny
     nyquist = result.fs / 2.0
@@ -159,15 +218,16 @@ def plot_swept_sine_distortion(
             100.0 * np.maximum(result.thd, tiny),
             **kwargs,
         )
-        axt.set_ylabel("THD [%]")
+        axt.set_ylabel(_t("thd_pct", language))
         axt.grid(True, which="both", alpha=0.3)
         axt.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
 
     if ax is not None:
         _thd_panel(ax)
-        ax.set_xlabel("Excitation frequency [Hz]")
-        ax.set_title("Swept-sine THD (Farina / Novak)")
+        ax.set_xlabel(_t("excitation_freq", language))
+        ax.set_title(_t("swept_thd_title", language))
         format_frequency_axis(ax)
+        localize_axes(ax, language)
         return ax
 
     axes = _new_axes_column(2, sharex=False, figsize=(8.0, 6.4))
@@ -189,22 +249,25 @@ def plot_swept_sine_distortion(
             lw=1.6 if k == 0 else 1.2,
             label=f"$|H_{{{order}}}(f)|$",
         )
-    axes[0].set_ylabel("Magnitude [dB]")
-    axes[0].set_xlabel(_FREQ_LABEL)
+    axes[0].set_ylabel(_t("magnitude", language))
+    axes[0].set_xlabel(_t("freq", language))
     axes[0].set_title(
-        f"Harmonic frequency responses ({result.method} sweep)"
+        _t("harmonic_resp_title_with_method", language, method=result.method)
     )
     axes[0].grid(True, which="both", alpha=0.3)
     axes[0].legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
     format_frequency_axis(axes[0])
+    localize_axes(axes[0], language)
     _thd_panel(axes[1])
-    axes[1].set_xlabel("Excitation frequency [Hz]")
+    axes[1].set_xlabel(_t("excitation_freq", language))
     format_frequency_axis(axes[1])
+    localize_axes(axes[1], language)
     return axes
 
 
 def plot_piston_impedance(
-    result: "RadiatingPistonResult", ax: Axes | None = None, **kwargs: Any
+    result: "RadiatingPistonResult", ax: Axes | None = None, *,
+    language: str = "en", **kwargs: Any
 ) -> Axes:
     """Normalized radiation resistance and reactance of a baffled piston.
 
@@ -214,21 +277,25 @@ def plot_piston_impedance(
 
     :param result: A :class:`~phonometry.electroacoustics.piston.RadiatingPistonResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the resistance ``Axes.plot`` (its primary curve).
     :return: The axes.
     """
+    from .._i18n import localize_axes
+
     ax = ax if ax is not None else _new_axes()
     ka = np.asarray(result.ka, dtype=np.float64)
     kwargs.setdefault("color", _C_PRIMARY)
-    kwargs.setdefault("label", r"$R_1$ (resistance)")
+    kwargs.setdefault("label", _t("piston_resistance", language))
     ax.semilogx(ka, np.asarray(result.resistance), lw=1.8, **kwargs)
     ax.semilogx(ka, np.asarray(result.reactance), color=_C_SECONDARY, lw=1.8,
-                ls="--", label=r"$X_1$ (reactance)")
+                ls="--", label=_t("piston_reactance", language))
     ax.axhline(1.0, color=_C_TERTIARY, ls=":", lw=1.0,
                label=r"$R_1 \to 1$ ($ka \gg 1$)")
     ax.set_xlabel(r"$ka$")
-    ax.set_ylabel(r"Normalized radiation impedance $Z_r / \rho c S$")
-    ax.set_title("Baffled circular piston radiation impedance")
+    ax.set_ylabel(_t("piston_ylabel", language))
+    ax.set_title(_t("piston_title", language))
     ax.grid(True, which="both", alpha=0.3)
     ax.legend(loc="best", fontsize="small")
+    localize_axes(ax, language)
     return ax

--- a/src/phonometry/_plot/metrology.py
+++ b/src/phonometry/_plot/metrology.py
@@ -41,6 +41,119 @@ from .common import (
 #: Shared frequency-axis label of the spectral renderers.
 _FREQ_LABEL = "Frequency [Hz]"
 
+_STRINGS = {
+    "freq": {"en": "Frequency [Hz]", "es": "Frecuencia [Hz]"},
+    "lag": {"en": "Lag [s]", "es": "Retardo [s]"},
+    "time": {"en": "Time [s]", "es": "Tiempo [s]"},
+    "amplitude": {"en": "Amplitude", "es": "Amplitud"},
+    "magnitude": {"en": "Magnitude [dB]", "es": "Magnitud [dB]"},
+    "phase_deg": {"en": "Phase [deg]", "es": "Fase [grados]"},
+    "phase_rad": {"en": "Phase [rad]", "es": "Fase [rad]"},
+    # Filter class corridor
+    "class_corridor": {"en": "Class {cls} pass corridor",
+                       "es": "Corredor de aceptación clase {cls}"},
+    "measured_da": {"en": "Measured $\\Delta A$", "es": "$\\Delta A$ medida"},
+    "out_of_tol": {"en": "Out of tolerance", "es": "Fuera de tolerancia"},
+    "norm_freq": {"en": "Normalised frequency $f\\,/\\,f_m$",
+                  "es": "Frecuencia normalizada $f\\,/\\,f_m$"},
+    "rel_atten": {"en": "Relative attenuation [dB]",
+                  "es": "Atenuación relativa [dB]"},
+    "class_mask_title": {"en": "IEC 61260-1 class {cls} mask — $f_m$ = {fm} Hz",
+                         "es": "Máscara clase {cls} IEC 61260-1 — $f_m$ = {fm} Hz"},
+    # Uncertainty budget
+    "budget_xlabel": {
+        "en": "Contribution to combined uncertainty $|c_i|\\,u(x_i)$",
+        "es": "Contribución a la incertidumbre combinada $|c_i|\\,u(x_i)$"},
+    "budget_title": {"en": "GUM uncertainty budget — y = {value}",
+                     "es": "Presupuesto de incertidumbre (GUM) — y = {value}"},
+    # Monte Carlo
+    "coverage_interval": {"en": "{pct} % coverage interval",
+                          "es": "Intervalo de cobertura {pct} %"},
+    "output_quantity": {"en": "Output quantity y", "es": "Magnitud de salida y"},
+    "prob_density": {"en": "Probability density", "es": "Densidad de probabilidad"},
+    "mc_title": {
+        "en": "Monte Carlo distribution (GUM Supplement 1) — u(y) = {uy}",
+        "es": "Distribución de Monte Carlo (GUM Suplemento 1) — u(y) = {uy}"},
+    # PSD labels
+    "spectral_density": {"en": "Spectral density [dB re 1/Hz]",
+                         "es": "Densidad espectral [dB re 1/Hz]"},
+    "power_spectrum": {"en": "Power spectrum [dB]",
+                       "es": "Espectro de potencia [dB]"},
+    "psd_confidence": {
+        "en": "{pct} % confidence ($\\chi^2$, $n_d$ = {nd})",
+        "es": "{pct} % de confianza ($\\chi^2$, $n_d$ = {nd})"},
+    "welch_title": {"en": "Welch spectral density — $\\varepsilon_r$ = {er} %",
+                    "es": "Densidad espectral de Welch — $\\varepsilon_r$ = {er} %"},
+    # Cross-spectral density
+    "csd_title": {"en": "Cross-spectral density (Bendat & Piersol)",
+                  "es": "Densidad espectral cruzada (Bendat y Piersol)"},
+    "phase_sd_band": {"en": "$\\pm$ s.d.$[\\hat{\\theta}_{xy}]$ (Eq. 9.52)",
+                      "es": "$\\pm$ d.e.$[\\hat{\\theta}_{xy}]$ (Ec. 9.52)"},
+    # Coherent output spectrum
+    "gyy_output": {"en": "$\\hat{G}_{yy}$ (output)",
+                   "es": "$\\hat{G}_{yy}$ (salida)"},
+    "gnn_noise": {"en": "$\\hat{G}_{nn}$ (noise)",
+                  "es": "$\\hat{G}_{nn}$ (ruido)"},
+    "cos_title": {"en": "Coherent output spectrum (Bendat & Piersol 9.2.2)",
+                  "es": "Espectro de salida coherente (Bendat y Piersol 9.2.2)"},
+    "spectral_snr": {"en": "Spectral SNR [dB]", "es": "SNR espectral [dB]"},
+    # Correlation
+    "corr_coeff": {"en": "Correlation coefficient",
+                   "es": "Coeficiente de correlación"},
+    "correlation_of": {"en": "Correlation ({norm})", "es": "Correlación ({norm})"},
+    "corr_title": {"en": "{kind} estimate (Bendat & Piersol)",
+                   "es": "Estimación de {kind} (Bendat y Piersol)"},
+    "autocorrelation": {"en": "Autocorrelation", "es": "autocorrelación"},
+    "cross-correlation": {"en": "Cross-correlation", "es": "correlación cruzada"},
+    # Time delay
+    "phase_context": {"en": "$\\hat{R}_{xy}(\\tau)$ (context)",
+                      "es": "$\\hat{R}_{xy}(\\tau)$ (contexto)"},
+    "delay_interval": {"en": "95 % interval (Eq. 8.130)",
+                       "es": "Intervalo 95 % (Ec. 8.130)"},
+    "norm_correlation": {"en": "Normalized correlation",
+                         "es": "Correlación normalizada"},
+    "tde_title": {"en": "Time-delay estimate — {method}",
+                  "es": "Estimación del retardo temporal — {method}"},
+    # Aligned impulse response
+    "reference_ir": {"en": "Reference IR", "es": "RI de referencia"},
+    "aligned_ir": {"en": "Aligned IR (delay {n} samples)",
+                   "es": "RI alineada (retardo {n} muestras)"},
+    "ir_align_title": {"en": "Impulse-response alignment (sub-sample)",
+                       "es": "Alineación de la respuesta al impulso (submuestra)"},
+    # Envelope
+    "signal": {"en": "Signal", "es": "Señal"},
+    "envelope": {"en": "Envelope $A(t)$ (Eq. 13.17)",
+                 "es": "Envolvente $A(t)$ (Ec. 13.17)"},
+    "hilbert_title": {"en": "Hilbert envelope (Bendat & Piersol Ch. 13)",
+                      "es": "Envolvente de Hilbert (Bendat y Piersol Cap. 13)"},
+    "inst_freq": {"en": "Instantaneous frequency [Hz]",
+                  "es": "Frecuencia instantánea [Hz]"},
+    # Phase decomposition
+    "measured_phase": {"en": "Measured phase", "es": "Fase medida"},
+    "minimum_phase": {"en": "Minimum phase (from |H|)",
+                      "es": "Fase mínima (de |H|)"},
+    "excess_phase": {"en": "Excess phase (all-pass)",
+                     "es": "Fase de exceso (pasa-todo)"},
+    "phase_decomp_title": {"en": "Phase decomposition",
+                           "es": "Descomposición de fase"},
+    "minphase_title": {"en": "Minimum-phase / all-pass decomposition",
+                       "es": "Descomposición fase mínima / pasa-todo"},
+    "group_delay": {"en": "Group delay", "es": "Retardo de grupo"},
+    "excess_group_delay": {"en": "Excess group delay",
+                           "es": "Retardo de grupo de exceso"},
+    "group_delay_axis": {"en": "Group delay [ms]",
+                         "es": "Retardo de grupo [ms]"},
+    # normalization modes
+    "biased": {"en": "biased", "es": "sesgada"},
+    "unbiased": {"en": "unbiased", "es": "insesgada"},
+}
+
+
+def _t(key: str, language: str, **fmt: Any) -> str:
+    """Return the localised fixed string for *key* (optionally ``str.format``ed)."""
+    text = _STRINGS[key][language]
+    return text.format(**fmt) if fmt else text
+
 
 # ---------------------------------------------------------------------------
 # IEC 61260-1 filter class compliance
@@ -55,7 +168,8 @@ def _worst_band_index(result: "FilterComplianceResult") -> int:
 
 
 def plot_filter_class(
-    result: "FilterComplianceResult", ax: Axes | None = None, **kwargs: Any
+    result: "FilterComplianceResult", ax: Axes | None = None, *,
+    language: str = "en", **kwargs: Any
 ) -> Axes:
     """Measured relative attenuation of the binding band over its class corridor.
 
@@ -71,11 +185,13 @@ def plot_filter_class(
     :param result: A
         :class:`~phonometry.metrology.compliance.FilterComplianceResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the measured-curve ``plot`` call.
     :return: The axes.
     """
     from scipy import signal
 
+    from .._i18n import format_number, localize_axes
     from ..metrology.compliance import class_limits
 
     ax = ax if ax is not None else _new_axes()
@@ -128,7 +244,7 @@ def plot_filter_class(
     upper_fill = np.where(finite_upper, upper, y_top)
     ax.fill_between(
         omega[win], lower[win], upper_fill[win], color=_C_TERTIARY, alpha=0.18,
-        lw=0.0, label=f"Class {cls} pass corridor",
+        lw=0.0, label=_t("class_corridor", language, cls=cls),
     )
     ax.plot(omega[win], lower[win], color=_C_TERTIARY, lw=1.0, ls="--")
     fin = win & finite_upper
@@ -136,7 +252,7 @@ def plot_filter_class(
 
     kwargs.setdefault("color", _C_PRIMARY)
     kwargs.setdefault("lw", 1.6)
-    kwargs.setdefault("label", "Measured $\\Delta A$")
+    kwargs.setdefault("label", _t("measured_da", language))
     ax.plot(omega[win], delta_a[win], **kwargs)
 
     violated = (delta_a < lower - 1e-9) | (finite_upper & (delta_a > upper + 1e-9))
@@ -144,20 +260,22 @@ def plot_filter_class(
     if np.any(viol_win):
         ax.plot(
             omega[viol_win], delta_a[viol_win], ls="", marker="o", ms=3.5,
-            color=_C_REFERENCE, label="Out of tolerance",
+            color=_C_REFERENCE, label=_t("out_of_tol", language),
         )
 
     ax.axvline(1.0, color=_C_MUTED, ls=":", lw=1.0)
     _normalized_frequency_axis(ax, lo_x, hi_x)
     ax.set_xlim(lo_x, hi_x)
     ax.set_ylim(y_bot, y_top)
-    ax.set_xlabel("Normalised frequency $f\\,/\\,f_m$")
-    ax.set_ylabel("Relative attenuation [dB]")
+    ax.set_xlabel(_t("norm_freq", language))
+    ax.set_ylabel(_t("rel_atten", language))
     ax.set_title(
-        f"IEC 61260-1 class {cls} mask — $f_m$ = {fm:.0f} Hz"
+        _t("class_mask_title", language, cls=cls,
+           fm=format_number(fm, language, decimals=0))
     )
     ax.legend(loc="upper center", fontsize="small")
     ax.grid(True, which="both", alpha=0.3)
+    localize_axes(ax, language)
     return ax
 
 
@@ -175,34 +293,44 @@ def _normalized_frequency_axis(ax: Axes, lo: float, hi: float) -> None:
 
 
 def plot_uncertainty_budget(
-    result: "UncertaintyResult", ax: Axes | None = None, **kwargs: Any
+    result: "UncertaintyResult", ax: Axes | None = None, *,
+    language: str = "en", **kwargs: Any
 ) -> Axes:
     """Bar chart of each input's contribution to the combined uncertainty.
 
     :param result: An :class:`~phonometry.uncertainty.UncertaintyResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to :meth:`barh`.
     :return: The axes.
     """
+    # The y-axis carries categorical input names (a FixedFormatter), so
+    # localize_axes is intentionally not applied here: it would overwrite
+    # those labels with comma-formatted tick numbers.
+    from .._i18n import decimal_comma
+
     ax = ax if ax is not None else _new_axes()
     contributions = np.asarray(result.contributions, dtype=np.float64)
     names = list(result.names) or [f"x{i + 1}" for i in range(contributions.size)]
     positions = np.arange(contributions.size)
     kwargs.setdefault("color", _C_PRIMARY)
     ax.barh(positions, contributions, **kwargs)
+    uc = decimal_comma(f"{result.combined_uncertainty:.3g}", language)
     ax.axvline(result.combined_uncertainty, color=_C_REFERENCE, ls="--",
-               label=f"$u_c$ = {result.combined_uncertainty:.3g}")
+               label=f"$u_c$ = {uc}")
     ax.set_yticks(positions)
     ax.set_yticklabels(names)
     ax.invert_yaxis()
-    ax.set_xlabel("Contribution to combined uncertainty $|c_i|\\,u(x_i)$")
-    ax.set_title(f"GUM uncertainty budget — y = {result.value:.4g}")
+    ax.set_xlabel(_t("budget_xlabel", language))
+    value = decimal_comma(f"{result.value:.4g}", language)
+    ax.set_title(_t("budget_title", language, value=value))
     ax.legend(loc="lower right", fontsize="small")
     ax.grid(True, axis="x", alpha=0.3)
     return ax
 
 def plot_monte_carlo(
-    result: "MonteCarloResult", ax: Axes | None = None, **kwargs: Any
+    result: "MonteCarloResult", ax: Axes | None = None, *,
+    language: str = "en", **kwargs: Any
 ) -> Axes:
     """Histogram of the Monte Carlo output with the coverage interval marked.
 
@@ -210,10 +338,13 @@ def plot_monte_carlo(
         obtained with ``keep_samples=True`` (the histogram needs the raw
         output sample).
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to :meth:`~matplotlib.axes.Axes.hist`.
     :return: The axes.
     :raises ValueError: If the result carries no output samples.
     """
+    from .._i18n import decimal_comma, localize_axes
+
     if result.samples is None:
         raise ValueError(
             "plot() needs the Monte Carlo output samples; call "
@@ -226,18 +357,19 @@ def plot_monte_carlo(
     kwargs.setdefault("density", True)
     ax.hist(samples, **kwargs)
     low, high = result.interval
+    pct = decimal_comma(f"{100.0 * result.coverage:g}", language)
     ax.axvspan(low, high, color=_C_PRIMARY, alpha=0.12,
-               label=f"{100.0 * result.coverage:g} % coverage interval")
+               label=_t("coverage_interval", language, pct=pct))
+    value = decimal_comma(f"{result.value:.4g}", language)
     ax.axvline(result.value, color=_C_REFERENCE, ls="--",
-               label=f"y = {result.value:.4g}")
-    ax.set_xlabel("Output quantity y")
-    ax.set_ylabel("Probability density")
-    ax.set_title(
-        "Monte Carlo distribution (GUM Supplement 1) — "
-        f"u(y) = {result.standard_uncertainty:.3g}"
-    )
+               label=f"y = {value}")
+    ax.set_xlabel(_t("output_quantity", language))
+    ax.set_ylabel(_t("prob_density", language))
+    uy = decimal_comma(f"{result.standard_uncertainty:.3g}", language)
+    ax.set_title(_t("mc_title", language, uy=uy))
     ax.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
     ax.grid(True, axis="y", alpha=0.3)
+    localize_axes(ax, language)
     return ax
 
 
@@ -248,28 +380,34 @@ def _db10(values: np.ndarray) -> np.ndarray:
     return out
 
 
-def _psd_ylabel(scaling: str) -> str:
+def _psd_ylabel(scaling: str, language: str = "en") -> str:
     return (
-        "Spectral density [dB re 1/Hz]"
+        _t("spectral_density", language)
         if scaling == "density"
-        else "Power spectrum [dB]"
+        else _t("power_spectrum", language)
     )
 
 
 def plot_spectral_density(
-    result: "SpectralDensityResult", ax: Axes | None = None, **kwargs: Any
+    result: "SpectralDensityResult", ax: Axes | None = None, *,
+    language: str = "en", **kwargs: Any
 ) -> Axes:
     """Spectral density in dB with its chi-square confidence band.
 
     :param result: A :class:`~phonometry.metrology.spectra.SpectralDensityResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the density ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import decimal_comma, format_number, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     pos = freqs > 0.0
     color = kwargs.pop("color", _C_PRIMARY)
+    pct = decimal_comma(f"{100.0 * result.confidence:g}", language)
+    nd = format_number(result.n_averages, language, decimals=1)
     ax.fill_between(
         freqs[pos],
         _db10(np.asarray(result.ci_lower, dtype=np.float64)[pos]),
@@ -277,26 +415,26 @@ def plot_spectral_density(
         color=color,
         alpha=0.25,
         lw=0.0,
-        label=f"{100.0 * result.confidence:g} % confidence ($\\chi^2$, "
-        f"$n_d$ = {result.n_averages:.1f})",
+        label=_t("psd_confidence", language, pct=pct, nd=nd),
     )
     kwargs.setdefault("label", "$\\hat{G}_{xx}(f)$")
     ax.semilogx(freqs[pos], _db10(np.asarray(result.psd)[pos]), color=color, **kwargs)
-    ax.set_xlabel(_FREQ_LABEL)
-    ax.set_ylabel(_psd_ylabel(result.scaling))
-    ax.set_title(
-        "Welch spectral density — "
-        f"$\\varepsilon_r$ = {100.0 * result.random_error:.1f} %"
-    )
+    ax.set_xlabel(_t("freq", language))
+    ax.set_ylabel(_psd_ylabel(result.scaling, language))
+    er = format_number(100.0 * result.random_error, language, decimals=1)
+    ax.set_title(_t("welch_title", language, er=er))
     ax.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
     ax.grid(True, which="both", alpha=0.3)
     format_frequency_axis(ax, float(freqs[pos].min()), float(freqs[pos].max()))
+    localize_axes(ax, language)
     return ax
 
 
 def plot_cross_spectral_density(
     result: "CrossSpectralDensityResult",
     ax: Axes | None = None,
+    *,
+    language: str = "en",
     **kwargs: Any,
 ) -> Axes | np.ndarray:
     """Cross-spectrum magnitude, phase (with ±σ band) and coherence.
@@ -307,9 +445,12 @@ def plot_cross_spectral_density(
         :class:`~phonometry.metrology.spectra.CrossSpectralDensityResult`.
     :param ax: Existing axes for the magnitude panel, or ``None`` for a
         fresh three-panel figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the magnitude ``plot`` call.
     :return: The magnitude axes (``ax`` given) or the array of three axes.
     """
+    from .._i18n import localize_axes
+
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     pos = freqs > 0.0
     color = kwargs.pop("color", _C_PRIMARY)
@@ -319,20 +460,21 @@ def plot_cross_spectral_density(
         axm.semilogx(
             freqs[pos], _db10(result.magnitude[pos]), color=color, **kwargs
         )
-        axm.set_ylabel(_psd_ylabel(result.scaling))
+        axm.set_ylabel(_psd_ylabel(result.scaling, language))
         axm.grid(True, which="both", alpha=0.3)
         axm.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
 
     fmin, fmax = float(freqs[pos].min()), float(freqs[pos].max())
     if ax is not None:
         _magnitude(ax)
-        ax.set_xlabel(_FREQ_LABEL)
+        ax.set_xlabel(_t("freq", language))
         format_frequency_axis(ax, fmin, fmax)
+        localize_axes(ax, language)
         return ax
 
     axes = _new_axes_column(3, sharex=True, figsize=(8.0, 7.0))
     _magnitude(axes[0])
-    axes[0].set_title("Cross-spectral density (Bendat & Piersol)")
+    axes[0].set_title(_t("csd_title", language))
     phase = np.degrees(result.phase[pos])
     # Cap the drawn band at +/-180 deg: at near-zero coherence the Eq. 9.52
     # s.d. diverges and a literal band would blow the panel's autoscale.
@@ -345,25 +487,28 @@ def plot_cross_spectral_density(
         color=_C_SECONDARY,
         alpha=0.3,
         lw=0.0,
-        label="$\\pm$ s.d.$[\\hat{\\theta}_{xy}]$ (Eq. 9.52)",
+        label=_t("phase_sd_band", language),
     )
     axes[1].semilogx(freqs[pos], phase, color=color)
-    axes[1].set_ylabel("Phase [deg]")
+    axes[1].set_ylabel(_t("phase_deg", language))
     axes[1].grid(True, which="both", alpha=0.3)
     axes[1].legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
     axes[2].semilogx(freqs[pos], result.coherence[pos], color=_C_MUTED)
     axes[2].set_ylabel("$\\gamma^2_{xy}$")
     axes[2].set_ylim(0.0, 1.05)
-    axes[2].set_xlabel(_FREQ_LABEL)
+    axes[2].set_xlabel(_t("freq", language))
     axes[2].grid(True, which="both", alpha=0.3)
     for axf in axes:
         format_frequency_axis(axf, fmin, fmax)
+        localize_axes(axf, language)
     return axes
 
 
 def plot_coherent_output_spectrum(
     result: "CoherentOutputSpectrumResult",
     ax: Axes | None = None,
+    *,
+    language: str = "en",
     **kwargs: Any,
 ) -> Axes | np.ndarray:
     """Output, coherent and noise spectra plus the spectral SNR.
@@ -374,9 +519,12 @@ def plot_coherent_output_spectrum(
         :class:`~phonometry.metrology.spectra.CoherentOutputSpectrumResult`.
     :param ax: Existing axes for the spectra panel, or ``None`` for a fresh
         two-panel figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the coherent-spectrum ``plot`` call.
     :return: The spectra axes (``ax`` given) or the array of two axes.
     """
+    from .._i18n import localize_axes
+
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     pos = freqs > 0.0
     color = kwargs.pop("color", _C_PRIMARY)
@@ -386,7 +534,7 @@ def plot_coherent_output_spectrum(
             freqs[pos],
             _db10(result.output_psd[pos]),
             color=_C_MUTED,
-            label="$\\hat{G}_{yy}$ (output)",
+            label=_t("gyy_output", language),
         )
         kwargs.setdefault(
             "label", "$\\hat{G}_{vv} = \\hat{\\gamma}^2_{xy}\\hat{G}_{yy}$"
@@ -398,29 +546,31 @@ def plot_coherent_output_spectrum(
             _db10(result.noise_psd[pos]),
             color=_C_REFERENCE,
             ls="--",
-            label="$\\hat{G}_{nn}$ (noise)",
+            label=_t("gnn_noise", language),
         )
-        axs.set_ylabel(_psd_ylabel(result.scaling))
+        axs.set_ylabel(_psd_ylabel(result.scaling, language))
         axs.grid(True, which="both", alpha=0.3)
         axs.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
 
     fmin, fmax = float(freqs[pos].min()), float(freqs[pos].max())
     if ax is not None:
         _spectra_panel(ax)
-        ax.set_xlabel(_FREQ_LABEL)
+        ax.set_xlabel(_t("freq", language))
         format_frequency_axis(ax, fmin, fmax)
+        localize_axes(ax, language)
         return ax
 
     axes = _new_axes_column(2, sharex=True, figsize=(8.0, 5.6))
     _spectra_panel(axes[0])
-    axes[0].set_title("Coherent output spectrum (Bendat & Piersol 9.2.2)")
+    axes[0].set_title(_t("cos_title", language))
     axes[1].semilogx(freqs[pos], result.snr_db[pos], color=_C_SECONDARY)
     axes[1].axhline(0.0, color=_C_MUTED, ls=":", lw=1.0)
-    axes[1].set_ylabel("Spectral SNR [dB]")
-    axes[1].set_xlabel(_FREQ_LABEL)
+    axes[1].set_ylabel(_t("spectral_snr", language))
+    axes[1].set_xlabel(_t("freq", language))
     axes[1].grid(True, which="both", alpha=0.3)
     for axf in axes:
         format_frequency_axis(axf, fmin, fmax)
+        localize_axes(axf, language)
     return axes
 
 
@@ -429,15 +579,19 @@ _TIME_AXIS_LABEL = "Time [s]"
 
 
 def plot_correlation(
-    result: "CorrelationResult", ax: Axes | None = None, **kwargs: Any
+    result: "CorrelationResult", ax: Axes | None = None, *,
+    language: str = "en", **kwargs: Any
 ) -> Axes:
     """Correlation estimate against the lag in seconds.
 
     :param result: A :class:`~phonometry.metrology.correlation.CorrelationResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import localize_axes
+
     ax = ax if ax is not None else _new_axes()
     symbol = (
         "\\hat{\\rho}" if result.normalization == "coefficient" else "\\hat{R}"
@@ -447,33 +601,42 @@ def plot_correlation(
     kwargs.setdefault("label", f"${symbol}_{{{sub}}}(\\tau)$")
     ax.plot(result.lags, result.values, **kwargs)
     ax.axvline(0.0, color=_C_MUTED, ls=":", lw=1.0)
-    ax.set_xlabel(_LAG_LABEL)
-    ax.set_ylabel(
-        "Correlation coefficient"
-        if result.normalization == "coefficient"
-        else f"Correlation ({result.normalization})"
-    )
-    ax.set_title(f"{result.kind.capitalize()} estimate (Bendat & Piersol)")
+    ax.set_xlabel(_t("lag", language))
+    if result.normalization == "coefficient":
+        ax.set_ylabel(_t("corr_coeff", language))
+    else:
+        norm = (_t(result.normalization, language)
+                if result.normalization in _STRINGS
+                else result.normalization)
+        ax.set_ylabel(_t("correlation_of", language, norm=norm))
+    kind = (_t(result.kind, language) if result.kind in _STRINGS
+            else result.kind.capitalize())
+    ax.set_title(_t("corr_title", language, kind=kind))
     ax.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
     ax.grid(True, alpha=0.3)
+    localize_axes(ax, language)
     return ax
 
 
 def plot_time_delay(
-    result: "TimeDelayResult", ax: Axes | None = None, **kwargs: Any
+    result: "TimeDelayResult", ax: Axes | None = None, *,
+    language: str = "en", **kwargs: Any
 ) -> Axes:
     """Correlation function with the estimated delay marked.
 
     :param result: A :class:`~phonometry.metrology.correlation.TimeDelayResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the correlation ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import decimal_comma, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     label = {
         "direct": "$\\hat{\\rho}_{xy}(\\tau)$",
         "gcc": f"GCC ({result.weighting})",
-        "phase": "$\\hat{R}_{xy}(\\tau)$ (context)",
+        "phase": _t("phase_context", language),
     }[result.method]
     kwargs.setdefault("color", _C_PRIMARY)
     kwargs.setdefault("label", label)
@@ -485,29 +648,33 @@ def plot_time_delay(
             color=_C_SECONDARY,
             alpha=0.25,
             lw=0.0,
-            label="95 % interval (Eq. 8.130)",
+            label=_t("delay_interval", language),
         )
+    tau = decimal_comma(f"{1e3 * result.delay:.4g}", language)
     ax.axvline(
         result.delay,
         color=_C_REFERENCE,
         ls="--",
-        label=f"$\\hat{{\\tau}}_0$ = {1e3 * result.delay:.4g} ms",
+        label=f"$\\hat{{\\tau}}_0$ = {tau} ms",
     )
-    ax.set_xlabel(_LAG_LABEL)
+    ax.set_xlabel(_t("lag", language))
     ax.set_ylabel(
-        "Correlation coefficient"
+        _t("corr_coeff", language)
         if result.method == "direct"
-        else "Normalized correlation"
+        else _t("norm_correlation", language)
     )
-    ax.set_title(f"Time-delay estimate — {result.method}")
+    ax.set_title(_t("tde_title", language, method=result.method))
     ax.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
     ax.grid(True, alpha=0.3)
+    localize_axes(ax, language)
     return ax
 
 
 def plot_aligned_impulse_response(
     result: "AlignedImpulseResponseResult",
     ax: Axes | None = None,
+    *,
+    language: str = "en",
     **kwargs: Any,
 ) -> Axes:
     """Reference and aligned impulse responses overlaid.
@@ -515,27 +682,32 @@ def plot_aligned_impulse_response(
     :param result: An
         :class:`~phonometry.metrology.correlation.AlignedImpulseResponseResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the aligned-IR ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import decimal_comma, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     t = np.arange(result.reference.size) / result.fs
-    ax.plot(t, result.reference, color=_C_MUTED, lw=1.0, label="Reference IR")
+    ax.plot(t, result.reference, color=_C_MUTED, lw=1.0,
+            label=_t("reference_ir", language))
     kwargs.setdefault("color", _C_PRIMARY)
-    kwargs.setdefault(
-        "label", f"Aligned IR (delay {result.delay_samples:+.3f} samples)"
-    )
+    n = decimal_comma(f"{result.delay_samples:+.3f}", language)
+    kwargs.setdefault("label", _t("aligned_ir", language, n=n))
     ax.plot(t, result.aligned, lw=1.2, **kwargs)
-    ax.set_xlabel(_TIME_AXIS_LABEL)
-    ax.set_ylabel("Amplitude")
-    ax.set_title("Impulse-response alignment (sub-sample)")
+    ax.set_xlabel(_t("time", language))
+    ax.set_ylabel(_t("amplitude", language))
+    ax.set_title(_t("ir_align_title", language))
     ax.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
     ax.grid(True, alpha=0.3)
+    localize_axes(ax, language)
     return ax
 
 
 def plot_envelope(
-    result: "EnvelopeResult", ax: Axes | None = None, **kwargs: Any
+    result: "EnvelopeResult", ax: Axes | None = None, *,
+    language: str = "en", **kwargs: Any
 ) -> Axes | np.ndarray:
     """Signal with its Hilbert envelope, plus the instantaneous frequency.
 
@@ -544,44 +716,52 @@ def plot_envelope(
     :param result: An :class:`~phonometry.metrology.envelope.EnvelopeResult`.
     :param ax: Existing axes for the envelope panel, or ``None`` for a
         fresh two-panel figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the envelope ``plot`` call.
     :return: The envelope axes (``ax`` given) or the array of two axes.
     """
+    from .._i18n import localize_axes
+
     t_signal = np.arange(result.signal.size) / result.signal_fs
 
     def _envelope_panel(axe: Axes) -> None:
         axe.plot(
-            t_signal, result.signal, color=_C_MUTED, lw=0.7, label="Signal"
+            t_signal, result.signal, color=_C_MUTED, lw=0.7,
+            label=_t("signal", language)
         )
         kwargs.setdefault("color", _C_PRIMARY)
-        kwargs.setdefault("label", "Envelope $A(t)$ (Eq. 13.17)")
+        kwargs.setdefault("label", _t("envelope", language))
         axe.plot(result.times, result.envelope, lw=1.8, **kwargs)
-        axe.set_ylabel("Amplitude")
+        axe.set_ylabel(_t("amplitude", language))
         axe.grid(True, alpha=0.3)
         axe.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
 
     if ax is not None:
         _envelope_panel(ax)
-        ax.set_xlabel(_TIME_AXIS_LABEL)
+        ax.set_xlabel(_t("time", language))
+        localize_axes(ax, language)
         return ax
 
     axes = _new_axes_column(2, sharex=True, figsize=(8.0, 5.6))
     _envelope_panel(axes[0])
-    axes[0].set_title("Hilbert envelope (Bendat & Piersol Ch. 13)")
+    axes[0].set_title(_t("hilbert_title", language))
     axes[1].plot(
         result.times,
         result.instantaneous_frequency,
         color=_C_SECONDARY,
         lw=1.0,
     )
-    axes[1].set_ylabel("Instantaneous frequency [Hz]")
-    axes[1].set_xlabel(_TIME_AXIS_LABEL)
+    axes[1].set_ylabel(_t("inst_freq", language))
+    axes[1].set_xlabel(_t("time", language))
     axes[1].grid(True, alpha=0.3)
+    for axf in axes:
+        localize_axes(axf, language)
     return axes
 
 
 def plot_phase_decomposition(
-    result: "PhaseDecompositionResult", ax: Axes | None = None, **kwargs: Any
+    result: "PhaseDecompositionResult", ax: Axes | None = None, *,
+    language: str = "en", **kwargs: Any
 ) -> Axes | np.ndarray:
     """Magnitude, phase decomposition and group delay of a response.
 
@@ -592,34 +772,38 @@ def plot_phase_decomposition(
     :param result: A :class:`~phonometry.metrology.phase.PhaseDecompositionResult`.
     :param ax: Existing axes for the phase panel, or ``None`` for a fresh
         three-panel figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to the measured-phase ``plot`` call.
     :return: The phase-panel axes (``ax`` given) or the array of three axes.
     """
+    from .._i18n import localize_axes
+
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     pos = freqs > 0.0
 
     def _phase_panel(axp: Axes) -> None:
         kwargs.setdefault("color", _C_PRIMARY)
-        kwargs.setdefault("label", "Measured phase")
+        kwargs.setdefault("label", _t("measured_phase", language))
         axp.semilogx(freqs[pos], result.phase[pos], **kwargs)
         axp.semilogx(
             freqs[pos], result.minimum_phase[pos], color=_C_SECONDARY,
-            ls="--", label="Minimum phase (from |H|)",
+            ls="--", label=_t("minimum_phase", language),
         )
         axp.semilogx(
             freqs[pos], result.excess_phase[pos], color=_C_MUTED,
-            label="Excess phase (all-pass)",
+            label=_t("excess_phase", language),
         )
-        axp.set_ylabel("Phase [rad]")
+        axp.set_ylabel(_t("phase_rad", language))
         axp.grid(True, which="both", alpha=0.3)
         axp.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
 
     fmin, fmax = float(freqs[pos].min()), float(freqs[pos].max())
     if ax is not None:
         _phase_panel(ax)
-        ax.set_xlabel(_FREQ_LABEL)
-        ax.set_title("Phase decomposition")
+        ax.set_xlabel(_t("freq", language))
+        ax.set_title(_t("phase_decomp_title", language))
         format_frequency_axis(ax, fmin, fmax)
+        localize_axes(ax, language)
         return ax
 
     axes = _new_axes_column(3, sharex=True, figsize=(8.0, 8.0))
@@ -629,22 +813,23 @@ def plot_phase_decomposition(
         20.0 * np.log10(np.maximum(result.magnitude[pos], tiny)),
         color=_C_PRIMARY,
     )
-    axes[0].set_ylabel("Magnitude [dB]")
-    axes[0].set_title("Minimum-phase / all-pass decomposition")
+    axes[0].set_ylabel(_t("magnitude", language))
+    axes[0].set_title(_t("minphase_title", language))
     axes[0].grid(True, which="both", alpha=0.3)
     _phase_panel(axes[1])
     axes[2].semilogx(
         freqs[pos], 1e3 * result.group_delay[pos], color=_C_PRIMARY,
-        label="Group delay",
+        label=_t("group_delay", language),
     )
     axes[2].semilogx(
         freqs[pos], 1e3 * result.excess_group_delay[pos], color=_C_MUTED,
-        label="Excess group delay",
+        label=_t("excess_group_delay", language),
     )
-    axes[2].set_ylabel("Group delay [ms]")
-    axes[2].set_xlabel(_FREQ_LABEL)
+    axes[2].set_ylabel(_t("group_delay_axis", language))
+    axes[2].set_xlabel(_t("freq", language))
     axes[2].grid(True, which="both", alpha=0.3)
     axes[2].legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
     for axf in axes:
         format_frequency_axis(axf, fmin, fmax)
+        localize_axes(axf, language)
     return axes

--- a/src/phonometry/_plot/simulation.py
+++ b/src/phonometry/_plot/simulation.py
@@ -14,35 +14,59 @@ if TYPE_CHECKING:
 
     from ..simulation.fdtd import FDTDResult
 
+_STRINGS = {
+    "time_ms": {"en": "Time [ms]", "es": "Tiempo [ms]"},
+    "pressure_pa": {"en": "Pressure [Pa]", "es": "Presión [Pa]"},
+    "snapshot_title": {"en": "FDTD pressure field at t = {t_txt} ms",
+                       "es": "Campo de presión FDTD en t = {t_txt} ms"},
+    "probe_title": {"en": "FDTD probe pressure",
+                    "es": "Presión en las sondas FDTD"},
+    "probe_label": {"en": "probe", "es": "sonda"},
+}
+
+
+def _t(key: str, language: str, **fmt: Any) -> str:
+    """Return the localised fixed string for *key* (optionally ``str.format``ed)."""
+    text = _STRINGS[key][language]
+    return text.format(**fmt) if fmt else text
+
 
 def plot_fdtd_probes(
-    result: "FDTDResult", ax: Axes | None = None, **kwargs: Any
+    result: "FDTDResult", ax: Axes | None = None, *, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Pressure time history at each probe of an FDTD run.
 
     :param result: A :class:`~phonometry.simulation.fdtd.FDTDResult`.
     :param ax: Existing axes, or ``None`` to create a figure.
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to ``Axes.plot``.
     :return: The axes.
     """
+    from .._i18n import format_number, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     t_ms = np.asarray(result.times, dtype=np.float64) * 1000.0
+    label = _t("probe_label", language)
     for k in range(result.pressures.shape[0]):
         x, y = result.probe_positions[k]
+        px = format_number(x, language, decimals=2)
+        py = format_number(y, language, decimals=2)
         ax.plot(t_ms, result.pressures[k],
-                label=f"probe ({x:.2f}, {y:.2f}) m", **kwargs)
-    ax.set_xlabel("Time [ms]")
-    ax.set_ylabel("Pressure [Pa]")
-    ax.set_title("FDTD probe pressure")
+                label=f"{label} ({px}, {py}) m", **kwargs)
+    ax.set_xlabel(_t("time_ms", language))
+    ax.set_ylabel(_t("pressure_pa", language))
+    ax.set_title(_t("probe_title", language))
     ax.grid(True, alpha=0.3)
     if result.pressures.shape[0]:
         ax.legend(loc="upper right", fontsize="small")
+    localize_axes(ax, language)
     return ax
 
 
 def plot_fdtd_snapshot(
     result: "FDTDResult", ax: Axes | None = None, *, frame: int = -1,
-    **kwargs: Any
+    language: str = "en", **kwargs: Any
 ) -> Axes:
     """One recorded pressure-field snapshot with the geometry overlaid.
 
@@ -54,10 +78,13 @@ def plot_fdtd_snapshot(
         recorded snapshots.
     :param ax: Existing axes, or ``None`` to create a figure.
     :param frame: Snapshot index (default: the last recorded frame).
+    :param language: Label language, ``"en"`` (default) or ``"es"``.
     :param kwargs: Forwarded to ``imshow``.
     :return: The axes.
     :raises ValueError: If the result holds no snapshots.
     """
+    from .._i18n import format_number, localize_axes
+
     if result.snapshots is None or result.snapshot_times is None:
         raise ValueError("the result holds no snapshots; rerun the "
                          "simulation with snapshot_every set")
@@ -91,9 +118,11 @@ def plot_fdtd_snapshot(
         x, y = result.probe_positions[k]
         ax.plot(x, y, marker="o", markersize=5, color=_C_MUTED,
                 markeredgecolor="black", linestyle="none")
-    ax.figure.colorbar(img, ax=ax, label="Pressure [Pa]")
+    ax.figure.colorbar(img, ax=ax, label=_t("pressure_pa", language))
     ax.set_xlabel("x [m]")
     ax.set_ylabel("y [m]")
     t_ms = float(result.snapshot_times[frame]) * 1000.0
-    ax.set_title(f"FDTD pressure field at t = {t_ms:.2f} ms")
+    t_txt = format_number(t_ms, language, decimals=2)
+    ax.set_title(_t("snapshot_title", language, t_txt=t_txt))
+    localize_axes(ax, language)
     return ax

--- a/src/phonometry/broadcast/program_loudness.py
+++ b/src/phonometry/broadcast/program_loudness.py
@@ -538,16 +538,21 @@ class ProgramLoudnessResult:
     channel_weights: np.ndarray
     fs: float
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en",
+             **kwargs: Any) -> "Axes":
         """Plot momentary and short-term loudness over time, with the
         integrated loudness and the loudness range annotated.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
+
+        :param language: Label language, ``"en"`` (default) or ``"es"``.
         """
+        from .._i18n import check_language
         from .._plot.broadcast import plot_program_loudness
 
-        return plot_program_loudness(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_program_loudness(self, ax=ax, language=language, **kwargs)
 
     def report(
         self,

--- a/src/phonometry/electroacoustics/distortion.py
+++ b/src/phonometry/electroacoustics/distortion.py
@@ -869,11 +869,17 @@ class HarmonicDistortionResult:
     thd_plus_noise: float
     sinad_db: float
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
-        """Plot the magnitude spectrum with the harmonics marked."""
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en",
+             **kwargs: Any) -> "Axes":
+        """Plot the magnitude spectrum with the harmonics marked.
+
+        :param language: Label language, ``"en"`` (default) or ``"es"``.
+        """
+        from .._i18n import check_language
         from .._plot.electroacoustics import plot_harmonic_distortion
 
-        return plot_harmonic_distortion(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_harmonic_distortion(self, ax=ax, language=language, **kwargs)
 
 
 def harmonic_analysis(

--- a/src/phonometry/electroacoustics/frequency_response.py
+++ b/src/phonometry/electroacoustics/frequency_response.py
@@ -102,12 +102,17 @@ class FrequencyResponseResult:
     estimator: str
 
     def plot(
-        self, ax: "Axes | None" = None, **kwargs: Any
+        self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any
     ) -> "Axes | NDArray[Any]":
-        """Plot the Bode magnitude/phase and the coherence."""
+        """Plot the Bode magnitude/phase and the coherence.
+
+        :param language: Label language, ``"en"`` (default) or ``"es"``.
+        """
+        from .._i18n import check_language
         from .._plot.electroacoustics import plot_frequency_response
 
-        return plot_frequency_response(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_frequency_response(self, ax=ax, language=language, **kwargs)
 
 
 def transfer_function(

--- a/src/phonometry/electroacoustics/piston.py
+++ b/src/phonometry/electroacoustics/piston.py
@@ -206,16 +206,21 @@ class RadiatingPistonResult:
     speed_of_sound: float
     density: float
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en",
+             **kwargs: Any) -> "Axes":
         """Plot the normalized piston resistance and reactance against ``ka``.
 
         Reproduces the classic Beranek & Mellow figure: ``R1`` rising to 1 and
         ``X1`` peaking then decaying, over the ``ka`` range of the result.
         Requires matplotlib (``pip install phonometry[plot]``).
+
+        :param language: Label language, ``"en"`` (default) or ``"es"``.
         """
+        from .._i18n import check_language
         from .._plot.electroacoustics import plot_piston_impedance
 
-        return plot_piston_impedance(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_piston_impedance(self, ax=ax, language=language, **kwargs)
 
 
 def radiating_piston(

--- a/src/phonometry/electroacoustics/swept_sine.py
+++ b/src/phonometry/electroacoustics/swept_sine.py
@@ -221,7 +221,7 @@ class SweptSineDistortionResult:
         return int(self.harmonic_responses.shape[0])
 
     def plot(
-        self, ax: "Axes | None" = None, **kwargs: Any
+        self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any
     ) -> "Axes | NDArray[Any]":
         """Plot the harmonic responses and the THD(f).
 
@@ -229,10 +229,15 @@ class SweptSineDistortionResult:
         their own frequency axes, and the total harmonic distortion in %
         against the excitation frequency. With ``ax`` given, only the THD
         panel is drawn on it.
+
+        :param language: Label language, ``"en"`` (default) or ``"es"``.
         """
+        from .._i18n import check_language
         from .._plot.electroacoustics import plot_swept_sine_distortion
 
-        return plot_swept_sine_distortion(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_swept_sine_distortion(self, ax=ax, language=language,
+                                          **kwargs)
 
 
 def _analytic_inverse_spectrum(

--- a/src/phonometry/metrology/compliance.py
+++ b/src/phonometry/metrology/compliance.py
@@ -389,7 +389,8 @@ class FilterComplianceResult:
             )
         return max(classes)
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en",
+             **kwargs: Any) -> "Axes":
         """Plot the worst-margin band against its class-limit corridor.
 
         Draws the measured relative attenuation of the binding band over the
@@ -397,10 +398,14 @@ class FilterComplianceResult:
         loosest) class; see :func:`phonometry._plot.metrology.plot_filter_class`.
         Requires matplotlib (``pip install phonometry[plot]``) and returns the
         :class:`~matplotlib.axes.Axes`.
+
+        :param language: Label language, ``"en"`` (default) or ``"es"``.
         """
+        from .._i18n import check_language
         from .._plot.metrology import plot_filter_class
 
-        return plot_filter_class(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_filter_class(self, ax=ax, language=language, **kwargs)
 
     def report(
         self,

--- a/src/phonometry/metrology/correlation.py
+++ b/src/phonometry/metrology/correlation.py
@@ -182,11 +182,17 @@ class CorrelationResult:
             dtype=np.float64,
         )
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
-        """Plot the correlation estimate against the lag in seconds."""
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en",
+             **kwargs: Any) -> "Axes":
+        """Plot the correlation estimate against the lag in seconds.
+
+        :param language: Label language, ``"en"`` (default) or ``"es"``.
+        """
+        from .._i18n import check_language
         from .._plot.metrology import plot_correlation
 
-        return plot_correlation(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_correlation(self, ax=ax, language=language, **kwargs)
 
 
 def correlation(
@@ -447,11 +453,17 @@ class TimeDelayResult:
     signal_bandwidth: float | None
     fs: float
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
-        """Plot the correlation function with the estimated delay marked."""
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en",
+             **kwargs: Any) -> "Axes":
+        """Plot the correlation function with the estimated delay marked.
+
+        :param language: Label language, ``"en"`` (default) or ``"es"``.
+        """
+        from .._i18n import check_language
         from .._plot.metrology import plot_time_delay
 
-        return plot_time_delay(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_time_delay(self, ax=ax, language=language, **kwargs)
 
 
 def _gcc_weight(
@@ -818,11 +830,18 @@ class AlignedImpulseResponseResult:
     delay_samples: float
     fs: float
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
-        """Plot the reference and the aligned impulse response."""
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en",
+             **kwargs: Any) -> "Axes":
+        """Plot the reference and the aligned impulse response.
+
+        :param language: Label language, ``"en"`` (default) or ``"es"``.
+        """
+        from .._i18n import check_language
         from .._plot.metrology import plot_aligned_impulse_response
 
-        return plot_aligned_impulse_response(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_aligned_impulse_response(self, ax=ax, language=language,
+                                             **kwargs)
 
 
 def _fractional_advance(

--- a/src/phonometry/metrology/envelope.py
+++ b/src/phonometry/metrology/envelope.py
@@ -82,12 +82,17 @@ class EnvelopeResult:
     antialias: bool
 
     def plot(
-        self, ax: "Axes | None" = None, **kwargs: Any
+        self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any
     ) -> "Axes | NDArray[Any]":
-        """Plot the signal with its envelope and the instantaneous frequency."""
+        """Plot the signal with its envelope and the instantaneous frequency.
+
+        :param language: Label language, ``"en"`` (default) or ``"es"``.
+        """
+        from .._i18n import check_language
         from .._plot.metrology import plot_envelope
 
-        return plot_envelope(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_envelope(self, ax=ax, language=language, **kwargs)
 
 
 def _decimate_envelope(

--- a/src/phonometry/metrology/phase.py
+++ b/src/phonometry/metrology/phase.py
@@ -258,17 +258,21 @@ class PhaseDecompositionResult:
     fs: float
 
     def plot(
-        self, ax: "Axes | None" = None, **kwargs: Any
+        self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any
     ) -> "Axes | NDArray[Any]":
         """Plot the magnitude, the phase decomposition and the group delay.
 
         Three stacked panels: ``|H|`` in dB, the measured / minimum /
         excess phases, and the total and excess group delays. With ``ax``
         given, only the phase panel is drawn on it.
+
+        :param language: Label language, ``"en"`` (default) or ``"es"``.
         """
+        from .._i18n import check_language
         from .._plot.metrology import plot_phase_decomposition
 
-        return plot_phase_decomposition(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_phase_decomposition(self, ax=ax, language=language, **kwargs)
 
 
 def phase_decomposition(

--- a/src/phonometry/metrology/spectra.py
+++ b/src/phonometry/metrology/spectra.py
@@ -358,11 +358,17 @@ class SpectralDensityResult:
     overlap: float
     scaling: str
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
-        """Plot the spectral density in dB with its confidence band."""
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en",
+             **kwargs: Any) -> "Axes":
+        """Plot the spectral density in dB with its confidence band.
+
+        :param language: Label language, ``"en"`` (default) or ``"es"``.
+        """
+        from .._i18n import check_language
         from .._plot.metrology import plot_spectral_density
 
-        return plot_spectral_density(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_spectral_density(self, ax=ax, language=language, **kwargs)
 
 
 def power_spectral_density(
@@ -501,12 +507,18 @@ class CrossSpectralDensityResult:
     scaling: str
 
     def plot(
-        self, ax: "Axes | None" = None, **kwargs: Any
+        self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any
     ) -> "Axes | NDArray[Any]":
-        """Plot the magnitude, phase (with ±σ band) and coherence."""
+        """Plot the magnitude, phase (with ±σ band) and coherence.
+
+        :param language: Label language, ``"en"`` (default) or ``"es"``.
+        """
+        from .._i18n import check_language
         from .._plot.metrology import plot_cross_spectral_density
 
-        return plot_cross_spectral_density(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_cross_spectral_density(self, ax=ax, language=language,
+                                           **kwargs)
 
 
 def cross_spectral_density(
@@ -636,12 +648,18 @@ class CoherentOutputSpectrumResult:
     scaling: str
 
     def plot(
-        self, ax: "Axes | None" = None, **kwargs: Any
+        self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any
     ) -> "Axes | NDArray[Any]":
-        """Plot the output/coherent/noise spectra and the spectral SNR."""
+        """Plot the output/coherent/noise spectra and the spectral SNR.
+
+        :param language: Label language, ``"en"`` (default) or ``"es"``.
+        """
+        from .._i18n import check_language
         from .._plot.metrology import plot_coherent_output_spectrum
 
-        return plot_coherent_output_spectrum(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_coherent_output_spectrum(self, ax=ax, language=language,
+                                             **kwargs)
 
 
 def coherent_output_spectrum(

--- a/src/phonometry/metrology/uncertainty.py
+++ b/src/phonometry/metrology/uncertainty.py
@@ -159,15 +159,20 @@ class UncertaintyResult:
         k = coverage_factor(coverage, self.effective_dof)
         return k, k * self.combined_uncertainty
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en",
+             **kwargs: Any) -> "Axes":
         """Plot the uncertainty budget (per-input contributions).
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
+
+        :param language: Label language, ``"en"`` (default) or ``"es"``.
         """
+        from .._i18n import check_language
         from .._plot.metrology import plot_uncertainty_budget
 
-        return plot_uncertainty_budget(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_uncertainty_budget(self, ax=ax, language=language, **kwargs)
 
 
 @dataclass(frozen=True)
@@ -192,16 +197,21 @@ class MonteCarloResult:
     trials: int
     samples: np.ndarray | None = field(default=None, repr=False)
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en",
+             **kwargs: Any) -> "Axes":
         """Plot the output histogram with the coverage interval marked.
 
         Needs the raw output sample, so call ``monte_carlo(...,
         keep_samples=True)``. Requires matplotlib (``pip install
         phonometry[plot]``); returns the :class:`~matplotlib.axes.Axes`.
+
+        :param language: Label language, ``"en"`` (default) or ``"es"``.
         """
+        from .._i18n import check_language
         from .._plot.metrology import plot_monte_carlo
 
-        return plot_monte_carlo(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_monte_carlo(self, ax=ax, language=language, **kwargs)
 
 
 def _sensitivity(model: Model, values: np.ndarray, uncertainties: np.ndarray) -> np.ndarray:

--- a/src/phonometry/simulation/fdtd.py
+++ b/src/phonometry/simulation/fdtd.py
@@ -642,7 +642,7 @@ class FDTDResult:
         return nx * self.dx, ny * self.dx
 
     def plot(self, ax: "Axes | None" = None, *, kind: str = "probes",
-             frame: int = -1, **kwargs: Any) -> "Axes":
+             frame: int = -1, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the probe histories or one recorded field snapshot.
 
         :param ax: Existing axes, or ``None`` to create a figure.
@@ -651,17 +651,22 @@ class FDTDResult:
             field with the geometry overlaid (``imshow`` raster).
         :param frame: Snapshot index for ``kind="snapshot"`` (default: the
             last recorded frame).
+        :param language: Label language, ``"en"`` (default) or ``"es"``.
         :param kwargs: Forwarded to the underlying ``plot``/``imshow``.
         :return: The axes.
         """
+        from .._i18n import check_language
+
+        check_language(language)
         if kind == "probes":
             from .._plot.simulation import plot_fdtd_probes
 
-            return plot_fdtd_probes(self, ax=ax, **kwargs)
+            return plot_fdtd_probes(self, ax=ax, language=language, **kwargs)
         if kind == "snapshot":
             from .._plot.simulation import plot_fdtd_snapshot
 
-            return plot_fdtd_snapshot(self, ax=ax, frame=frame, **kwargs)
+            return plot_fdtd_snapshot(self, ax=ax, frame=frame,
+                                      language=language, **kwargs)
         raise ValueError("kind must be 'probes' or 'snapshot'")
 
 

--- a/tests/broadcast/test_broadcast_plot_i18n.py
+++ b/tests/broadcast/test_broadcast_plot_i18n.py
@@ -1,0 +1,40 @@
+#  Copyright (c) 2026. Jose M. Requena-Plens
+
+"""EN/ES language option of the broadcast loudness ``.plot()`` renderer."""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+
+from phonometry.broadcast import program_loudness  # noqa: E402
+
+FS = 48000
+
+
+def _sine(level_dbfs: float, duration: float) -> np.ndarray:
+    t = np.arange(int(round(duration * FS))) / FS
+    return 10.0 ** (level_dbfs / 20.0) * np.sin(2.0 * np.pi * 1000.0 * t)
+
+
+def _steps() -> np.ndarray:
+    mono = np.concatenate([_sine(-30.0, 4.0), _sine(-23.0, 4.0)])
+    return np.vstack([mono, mono])
+
+
+def test_program_loudness_es_and_bad_language() -> None:
+    res = program_loudness(_steps(), FS)
+    ax = res.plot(language="es")
+    assert ax.get_ylabel() == "Sonoridad [LUFS]"
+    assert ax.get_xlabel() == "Tiempo [s]"
+    assert ax.get_title() == "Sonoridad de programa (EBU R 128)"
+    labels = [t.get_text() for t in ax.get_legend().get_texts()]
+    assert any(s.startswith("Integrada") for s in labels)
+    plt.close("all")
+    with pytest.raises(ValueError):
+        res.plot(language="xx")

--- a/tests/electroacoustics/test_electroacoustics_plot_i18n.py
+++ b/tests/electroacoustics/test_electroacoustics_plot_i18n.py
@@ -1,0 +1,86 @@
+#  Copyright (c) 2026. Jose M. Requena-Plens
+
+"""EN/ES language option of the electroacoustics ``.plot()`` renderers."""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+
+import phonometry as ph  # noqa: E402
+
+FS = 48000
+RNG = np.random.default_rng(20260720)
+
+
+def _labels(obj: object) -> str:
+    axes = obj if isinstance(obj, np.ndarray) else [obj]
+    parts = []
+    for a in axes:
+        parts += [a.get_xlabel(), a.get_ylabel(), a.get_title()]
+        leg = a.get_legend()
+        if leg is not None:
+            parts += [t.get_text() for t in leg.get_texts()]
+    return " || ".join(parts)
+
+
+def _tone() -> np.ndarray:
+    t = np.arange(FS) / FS
+    return (np.sin(2 * np.pi * 1000.0 * t)
+            + 0.03 * np.sin(2 * np.pi * 2000.0 * t)
+            + 0.01 * np.sin(2 * np.pi * 3000.0 * t))
+
+
+def test_harmonic_distortion_es() -> None:
+    res = ph.harmonic_analysis(_tone(), FS, 1000.0)
+    ax = res.plot(language="es")
+    assert ax.get_ylabel() == "Nivel respecto al fundamental [dB]"
+    assert ax.get_xlabel().startswith("Orden del armónico")
+    plt.close("all")
+    with pytest.raises(ValueError):
+        res.plot(language="xx")
+
+
+def test_frequency_response_es() -> None:
+    x = RNG.standard_normal(2 ** 15)
+    y = np.convolve(x, np.array([0.5, 0.3, 0.1]), mode="same")
+    axes = ph.transfer_function(x, y, FS).plot(language="es")
+    text = _labels(axes)
+    assert "Respuesta en frecuencia" in text and "coherencia" in text
+    assert "Magnitud [dB]" in text
+    plt.close("all")
+
+
+def test_swept_sine_distortion_es() -> None:
+    f1, f2, seconds = 100.0, 8000.0, 1.0
+    sweep = ph.synchronized_sweep_signal(FS, f1, f2, seconds)
+    rec = sweep + 0.01 * sweep ** 2
+    res = ph.swept_sine_distortion(rec, FS, f1, f2, seconds, n_harmonics=3)
+    # Two-panel figure: harmonic responses (title) + THD(f) (excitation axis).
+    axes = res.plot(language="es")
+    text = _labels(axes)
+    assert "Respuestas en frecuencia de los armónicos" in text
+    assert "Frecuencia de excitación [Hz]" in text
+    plt.close("all")
+    # Single-panel case (ax given) carries the swept-THD title.
+    fig, ext = plt.subplots()
+    single = res.plot(ax=ext, language="es")
+    assert single.get_title() == "THD de barrido sinusoidal (Farina / Novak)"
+    plt.close("all")
+    with pytest.raises(ValueError):
+        res.plot(language="xx")
+
+
+def test_piston_impedance_es() -> None:
+    res = ph.radiating_piston(0.05, np.geomspace(50.0, 5000.0, 60))
+    ax = res.plot(language="es")
+    assert "pistón circular con pantalla" in ax.get_title()
+    assert "Impedancia de radiación normalizada" in ax.get_ylabel()
+    plt.close("all")
+    with pytest.raises(ValueError):
+        res.plot(language="xx")

--- a/tests/metrology/test_metrology_plot_i18n.py
+++ b/tests/metrology/test_metrology_plot_i18n.py
@@ -1,0 +1,156 @@
+#  Copyright (c) 2026. Jose M. Requena-Plens
+
+"""EN/ES language option of the metrology ``.plot()`` renderers.
+
+Each result exposes ``plot(language=...)``; ``"es"`` must produce Spanish
+labels/titles and ``language="xx"`` must raise a clear ``ValueError``. The
+English default is covered elsewhere (and must stay byte-identical).
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+
+import phonometry as ph  # noqa: E402
+from phonometry.metrology import uncertainty as u  # noqa: E402
+
+FS = 48000
+RNG = np.random.default_rng(20260720)
+
+
+def _white(n: int = 4096) -> np.ndarray:
+    return RNG.standard_normal(n)
+
+
+def _titles(obj: object) -> str:
+    axes = obj if isinstance(obj, np.ndarray) else [obj]
+    return " || ".join(a.get_title() for a in axes)
+
+
+def _labels(obj: object) -> str:
+    axes = obj if isinstance(obj, np.ndarray) else [obj]
+    parts = []
+    for a in axes:
+        parts += [a.get_xlabel(), a.get_ylabel()]
+        leg = a.get_legend()
+        if leg is not None:
+            parts += [t.get_text() for t in leg.get_texts()]
+    return " || ".join(parts)
+
+
+def _add4(a: float, b: float, c: float, d: float) -> float:
+    return a + b + c + d
+
+
+def test_spectral_density_es_and_bad_language() -> None:
+    res = ph.power_spectral_density(_white(), FS, nperseg=1024)
+    ax = res.plot(language="es")
+    assert "Densidad espectral de Welch" in ax.get_title()
+    assert ax.get_xlabel() == "Frecuencia [Hz]"
+    plt.close("all")
+    with pytest.raises(ValueError):
+        res.plot(language="xx")
+
+
+def test_cross_spectral_density_es() -> None:
+    x = _white()
+    y = np.roll(x, 17) + 0.1 * _white()
+    axes = ph.cross_spectral_density(x, y, FS).plot(language="es")
+    assert "Densidad espectral cruzada (Bendat y Piersol)" in _titles(axes)
+    assert "Fase [grados]" in _labels(axes)
+    plt.close("all")
+
+
+def test_coherent_output_spectrum_es() -> None:
+    x = _white()
+    y = np.roll(x, 17) + 0.1 * _white()
+    axes = ph.coherent_output_spectrum(x, y, FS).plot(language="es")
+    assert "Espectro de salida coherente" in _titles(axes)
+    assert "SNR espectral [dB]" in _labels(axes)
+    plt.close("all")
+
+
+def test_correlation_es() -> None:
+    res = ph.correlation(_white(), fs=FS, max_lag=0.01)
+    ax = res.plot(language="es")
+    assert ax.get_title() == "Estimación de autocorrelación (Bendat y Piersol)"
+    assert ax.get_xlabel() == "Retardo [s]"
+    plt.close("all")
+    with pytest.raises(ValueError):
+        res.plot(language="xx")
+
+
+def test_time_delay_es() -> None:
+    x = _white(8192)
+    y = np.roll(x, 12)
+    res = ph.time_delay(x, y, FS, nperseg=2048, signal_bandwidth=FS / 2.0)
+    ax = res.plot(language="es")
+    assert ax.get_title().startswith("Estimación del retardo temporal")
+    plt.close("all")
+
+
+def test_aligned_impulse_response_es() -> None:
+    ref = np.zeros(256)
+    ref[100] = 1.0
+    res = ph.align_impulse_responses(np.roll(ref, 5), ref, FS)
+    ax = res.plot(language="es")
+    assert "Alineación de la respuesta al impulso" in ax.get_title()
+    assert "RI de referencia" in _labels(ax)
+    plt.close("all")
+    with pytest.raises(ValueError):
+        res.plot(language="xx")
+
+
+def test_envelope_es() -> None:
+    axes = ph.envelope(_white(), FS).plot(language="es")
+    assert "Envolvente de Hilbert (Bendat y Piersol Cap. 13)" in _titles(axes)
+    assert "Frecuencia instantánea [Hz]" in _labels(axes)
+    plt.close("all")
+
+
+def test_phase_decomposition_es() -> None:
+    resp = np.fft.rfft(np.exp(-np.arange(1024) / 50.0))
+    axes = ph.phase_decomposition(resp, fs=FS).plot(language="es")
+    assert "Descomposición fase mínima / pasa-todo" in _titles(axes)
+    assert "Fase medida" in _labels(axes)
+    plt.close("all")
+
+
+def test_uncertainty_budget_es() -> None:
+    result = u.combine_uncertainty(_add4, [u.Quantity(0.0, 1.0) for _ in range(4)])
+    ax = result.plot(language="es")
+    assert ax.get_title().startswith("Presupuesto de incertidumbre (GUM)")
+    assert "incertidumbre combinada" in ax.get_xlabel()
+    plt.close("all")
+    with pytest.raises(ValueError):
+        result.plot(language="xx")
+
+
+def test_monte_carlo_es() -> None:
+    mc = u.monte_carlo(
+        _add4, [u.Quantity(0.0, 1.0, "rectangular") for _ in range(4)],
+        trials=20_000, seed=3, keep_samples=True,
+    )
+    ax = mc.plot(language="es")
+    assert ax.get_ylabel() == "Densidad de probabilidad"
+    assert "Distribución de Monte Carlo" in ax.get_title()
+    plt.close("all")
+
+
+def test_filter_class_es() -> None:
+    from phonometry.metrology.compliance import filter_class_compliance
+
+    bank = ph.OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[500, 2000])
+    res = filter_class_compliance(bank)
+    ax = res.plot(language="es")
+    assert "Máscara clase" in ax.get_title()
+    assert ax.get_ylabel() == "Atenuación relativa [dB]"
+    plt.close("all")
+    with pytest.raises(ValueError):
+        res.plot(language="xx")

--- a/tests/simulation/test_simulation_plot_i18n.py
+++ b/tests/simulation/test_simulation_plot_i18n.py
@@ -1,0 +1,49 @@
+#  Copyright (c) 2026. Jose M. Requena-Plens
+
+"""EN/ES language option of the simulation (FDTD) ``.plot()`` renderer."""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+
+from phonometry.simulation.fdtd import GaussianPulse, fdtd_simulation  # noqa: E402
+
+
+def _result() -> object:
+    mask = np.zeros((30, 40), dtype=bool)
+    mask[12:18, 20:22] = True
+    return fdtd_simulation(
+        343.0, 9.0e-3, 3.0e-3, shape=(30, 40),
+        sources=[GaussianPulse(ix=7, iy=5, width=3.0e-4)],
+        probes=[(10, 5), (24, 10)],
+        obstacle_mask=mask,
+        snapshot_every=10,
+    )
+
+
+def test_fdtd_probes_es_and_bad_language() -> None:
+    res = _result()
+    ax = res.plot(kind="probes", language="es")
+    assert ax.get_title() == "Presión en las sondas FDTD"
+    assert ax.get_ylabel() == "Presión [Pa]"
+    assert ax.get_xlabel() == "Tiempo [ms]"
+    labels = [t.get_text() for t in ax.get_legend().get_texts()]
+    assert any(s.startswith("sonda") for s in labels)
+    plt.close("all")
+    with pytest.raises(ValueError):
+        res.plot(language="xx")
+
+
+def test_fdtd_snapshot_es() -> None:
+    res = _result()
+    ax = res.plot(kind="snapshot", frame=-1, language="es")
+    assert ax.get_title().startswith("Campo de presión FDTD en t =")
+    plt.close("all")
+    with pytest.raises(ValueError):
+        res.plot(kind="snapshot", language="xx")


### PR DESCRIPTION
## Summary

The `.plot()` methods of the metrology, electroacoustics, simulation and broadcast results now accept a `language` keyword: `"en"` (the default) or `"es"`. Spanish renders localised axis labels, titles and legends and switches linear-axis tick decimals and interpolated numbers to a comma separator. English output is unchanged, and an unsupported language raises a clear `ValueError`.

## What changed

- New shared `phonometry._i18n` module: language validation, locale-aware number formatting (period vs comma) and linear-axis tick localisation.
- The four render modules (`_plot/metrology.py`, `_plot/electroacoustics.py`, `_plot/simulation.py`, `_plot/broadcast.py`) translate their fixed strings through a per-module string table. Each of the 18 renderers gains a keyword-only `language` parameter; `_i18n` is imported lazily inside the functions so the render modules keep no module-level dependency on domain code.
- The result `.plot()` methods thread `language` through and validate it up front.
- Spanish terminology follows the conventions already used by the figure generator (for example "Frecuencia [Hz]", "Magnitud [dB]", "Coherencia", "Densidad espectral", "Sonoridad [LUFS]", "Presión [Pa]", "Bendat y Piersol").

## Verification

- English is byte-identical: the committed figures that render through `.plot()` regenerate with zero diff under `.github/images/`.
- New per-domain tests assert a Spanish label appears and that `language="xx"` raises `ValueError`.
- `ruff check .`, `mypy src scripts` and the metrology/electroacoustics/simulation/broadcast plus package-architecture test suites all pass.
- Regenerated the committed API reference.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

