### PR TITLE
feat: EN/ES language option for the room/materials plots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `"es"`). Spanish renders localised axis labels, titles and legends and uses a
   comma decimal separator; English is unchanged. An unsupported language raises
   a clear `ValueError`.
+- The room and materials `.plot()` renderers accept a `language` keyword
+  (`"en"` default, `"es"` for Spanish). Passing `language="es"` renders the
+  axis labels, titles and legends in Spanish and switches linear-axis tick
+  decimals to a comma; the English output is unchanged. An unsupported code
+  raises a clear `ValueError`.
 - IEC 61260-1 filter class compliance can now be exported as a one-page PDF
   fiche. A new `filter_class_compliance(bank, *, num_points=..., edition=...)`
   runs the same verification as `verify_filter_class` and returns a frozen

--- a/site/src/content/docs/reference/api/materials/absorption-rating.md
+++ b/site/src/content/docs/reference/api/materials/absorption-rating.md
@@ -105,7 +105,12 @@ Weighted sound absorption rating (ISO 11654:1997).
 ### AbsorptionRatingResult.plot()
 
 ```python
-AbsorptionRatingResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+AbsorptionRatingResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the practical curve vs the shifted reference (ISO 11654).

--- a/site/src/content/docs/reference/api/materials/absorption-uncertainty.md
+++ b/site/src/content/docs/reference/api/materials/absorption-uncertainty.md
@@ -106,6 +106,8 @@ Lower interval bound `value − U` (exact `U`).
 ```python
 AbsorptionUncertaintyResult.plot(
     ax: Axes | None = None,
+    *,
+    language: str = 'en',
     **kwargs: Any,
 ) -> Axes
 ```

--- a/site/src/content/docs/reference/api/materials/airflow-resistance.md
+++ b/site/src/content/docs/reference/api/materials/airflow-resistance.md
@@ -280,7 +280,12 @@ airflow resistance (Pa\*s/m). `pressure_drop` is the fitted `dp` at
 ### StaticAirflowResult.plot()
 
 ```python
-StaticAirflowResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+StaticAirflowResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the fitted `dp(u)` curve with the evaluation point.

--- a/site/src/content/docs/reference/api/materials/dynamic-stiffness.md
+++ b/site/src/content/docs/reference/api/materials/dynamic-stiffness.md
@@ -114,7 +114,12 @@ Dynamic stiffness of a resilient layer and the floating-floor resonance.
 ### DynamicStiffnessResult.plot()
 
 ```python
-DynamicStiffnessResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+DynamicStiffnessResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot `f0(s')` with this design point marked.

--- a/site/src/content/docs/reference/api/materials/impedance-tube.md
+++ b/site/src/content/docs/reference/api/materials/impedance-tube.md
@@ -232,7 +232,12 @@ and `absorption` the normal-incidence coefficient `alpha = 1 - |r|^2`
 ### ImpedanceTubeResult.plot()
 
 ```python
-ImpedanceTubeResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+ImpedanceTubeResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the absorption spectrum `alpha(f)` with `|r|` overlaid.

--- a/site/src/content/docs/reference/api/materials/porous-absorber.md
+++ b/site/src/content/docs/reference/api/materials/porous-absorber.md
@@ -183,6 +183,8 @@ normalised by `sin^2(theta_limit)`.
 ```python
 DiffuseFieldAbsorptionResult.plot(
     ax: Axes | None = None,
+    *,
+    language: str = 'en',
     **kwargs: Any,
 ) -> Axes
 ```
@@ -361,7 +363,12 @@ reciprocal).
 ### LayeredAbsorberResult.plot()
 
 ```python
-LayeredAbsorberResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+LayeredAbsorberResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the absorption spectrum `alpha(f)` with `|R|` overlaid.
@@ -673,7 +680,12 @@ Wavenumber normalised by the free-air wavenumber `k0 = w / c`.
 ### PorousMediumResult.plot()
 
 ```python
-PorousMediumResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+PorousMediumResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the normalised `Zc` and `k` components against frequency.

--- a/site/src/content/docs/reference/api/materials/road-absorption.md
+++ b/site/src/content/docs/reference/api/materials/road-absorption.md
@@ -425,7 +425,12 @@ An in-situ one-third-octave absorption spectrum (ISO 13472-1).
 ### InsituAbsorptionResult.plot()
 
 ```python
-InsituAbsorptionResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+InsituAbsorptionResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the in-situ absorption spectrum `alpha(f)`.

--- a/site/src/content/docs/reference/api/materials/scattering-diffusion.md
+++ b/site/src/content/docs/reference/api/materials/scattering-diffusion.md
@@ -264,7 +264,12 @@ A measured polar response and its diffusion coefficient (ISO 17497-2).
 ### DiffusionResult.plot()
 
 ```python
-DiffusionResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+DiffusionResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the polar response with the diffusion coefficient annotated.
@@ -626,7 +631,12 @@ A random-incidence scattering-coefficient spectrum (ISO 17497-1).
 ### ScatteringResult.plot()
 
 ```python
-ScatteringResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+ScatteringResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the scattering coefficient `s` versus frequency.

--- a/site/src/content/docs/reference/api/rooms/enclosed-space-absorption.md
+++ b/site/src/content/docs/reference/api/rooms/enclosed-space-absorption.md
@@ -198,7 +198,12 @@ Absorption area and reverberation time of an enclosed space (Clause 4).
 ### ReverberationResult.plot()
 
 ```python
-ReverberationResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+ReverberationResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the reverberation time over the octave bands.

--- a/site/src/content/docs/reference/api/rooms/image-source.md
+++ b/site/src/content/docs/reference/api/rooms/image-source.md
@@ -196,7 +196,12 @@ Arrival time of the direct sound (order 0), s.
 ### ImageSourceResult.plot()
 
 ```python
-ImageSourceResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+ImageSourceResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the reflectogram: reflection level in dB against arrival time.

--- a/site/src/content/docs/reference/api/rooms/open-plan.md
+++ b/site/src/content/docs/reference/api/rooms/open-plan.md
@@ -91,7 +91,12 @@ Single-number open-plan-office quantities (ISO 3382-3:2012, Cl. 4).
 ### OpenPlanResult.plot()
 
 ```python
-OpenPlanResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+OpenPlanResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the spatial decay of speech with `rD`/`rP` marked.

--- a/site/src/content/docs/reference/api/rooms/reverberation-prediction.md
+++ b/site/src/content/docs/reference/api/rooms/reverberation-prediction.md
@@ -274,7 +274,12 @@ The five reverberation-time curves keyed by model name.
 ### ReverberationModelResult.plot()
 
 ```python
-ReverberationModelResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+ReverberationModelResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the reverberation-time curves of the five models.

--- a/site/src/content/docs/reference/api/rooms/room-acoustics.md
+++ b/site/src/content/docs/reference/api/rooms/room-acoustics.md
@@ -97,7 +97,12 @@ return of [`decay_curve`](/phonometry/reference/api/rooms/room-acoustics/#decay_
 ### DecayCurve.plot()
 
 ```python
-DecayCurve.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+DecayCurve.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the decay curve with optional straight T-fit overlays.
@@ -199,6 +204,8 @@ above 10 % indicate an unreliable, non-straight decay.
 ```python
 RoomAcousticsResult.plot(
     ax: Axes | None = None,
+    *,
+    language: str = 'en',
     **kwargs: Any,
 ) -> Axes | np.ndarray
 ```

--- a/site/src/content/docs/reference/api/rooms/room-ir.md
+++ b/site/src/content/docs/reference/api/rooms/room-ir.md
@@ -116,6 +116,8 @@ and the `size`/`ndim`/`shape`/`dtype` attributes forward to `ir`.
 ```python
 ImpulseResponseResult.plot(
     ax: Axes | None = None,
+    *,
+    language: str = 'en',
     **kwargs: Any,
 ) -> Axes | np.ndarray
 ```
@@ -254,6 +256,7 @@ plot_excitation(
     *,
     kind: str = 'sweep',
     ax: Axes | None = None,
+    language: str = 'en',
     **kwargs: Any,
 ) -> Axes | np.ndarray
 ```

--- a/site/src/content/docs/reference/api/rooms/room-noise.md
+++ b/site/src/content/docs/reference/api/rooms/room-noise.md
@@ -77,7 +77,12 @@ Result of a Noise Criteria (NC) rating (ANSI/ASA S12.2-2019, tangency).
 ### NCResult.plot()
 
 ```python
-NCResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+NCResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the measured spectrum against the NC curves.
@@ -171,7 +176,12 @@ The room-criterion label in the `RC-NN(A)` form (clause D.3.5).
 ### RCResult.plot()
 
 ```python
-RCResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+RCResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot the measured spectrum against the reference RC Mark II curve.

--- a/site/src/content/docs/reference/api/rooms/steady-field.md
+++ b/site/src/content/docs/reference/api/rooms/steady-field.md
@@ -225,7 +225,12 @@ Steady-state SPL versus distance in a room, split direct / reverberant.
 ### SteadyFieldResult.plot()
 
 ```python
-SteadyFieldResult.plot(ax: Axes | None = None, **kwargs: Any) -> Axes
+SteadyFieldResult.plot(
+    ax: Axes | None = None,
+    *,
+    language: str = 'en',
+    **kwargs: Any,
+) -> Axes
 ```
 
 Plot direct, reverberant and total SPL against distance.

--- a/src/phonometry/_plot/materials.py
+++ b/src/phonometry/_plot/materials.py
@@ -38,8 +38,76 @@ if TYPE_CHECKING:
 
 _FREQ_LABEL = "Frequency [Hz]"
 
+#: Spanish translations of the fixed strings rendered by the materials
+#: ``.plot()`` renderers, keyed by their verbatim English text.  ``_t`` returns
+#: the English key unchanged for any language other than ``"es"``, so the
+#: English output is byte-for-byte identical to the pre-i18n renderers.
+_STRINGS: dict[str, str] = {
+    "Frequency [Hz]": "Frecuencia [Hz]",
+    "Sound absorption coefficient": "Coeficiente de absorción acústica",
+    "Practical alpha_p": "alpha_p práctico",
+    "class ": "clase ",
+    "Sigma unfav. = ": "Sigma desfav. = ",
+    "Scattering coefficient s": "Coeficiente de dispersión s",
+    "Random-incidence scattering coefficient (ISO 17497-1)":
+        "Coeficiente de dispersión de incidencia aleatoria (ISO 17497-1)",
+    "Diffusion coefficient d = ": "Coeficiente de difusión d = ",
+    "Absorption coefficient": "Coeficiente de absorción",
+    "In-situ road-surface absorption (ISO 13472-1)":
+        "Absorción in situ de pavimentos (ISO 13472-1)",
+    "Dynamic stiffness per unit area $s'$ [MN/m³]":
+        "Rigidez dinámica por unidad de área $s'$ [MN/m³]",
+    "Natural frequency $f_0$ [Hz]": "Frecuencia natural $f_0$ [Hz]",
+    "EN 29052-1 floating-floor resonance": "Resonancia de suelo flotante EN 29052-1",
+    r"Absorption $\alpha$": r"Absorción $\alpha$",
+    "Reflection factor $|r|$": "Factor de reflexión $|r|$",
+    "Coefficient": "Coeficiente",
+    "ISO 10534-2 normal-incidence absorption":
+        "Absorción a incidencia normal ISO 10534-2",
+    r"Fit $\Delta p = a\,u + b\,u^2$": r"Ajuste $\Delta p = a\,u + b\,u^2$",
+    "Evaluation point (u = ": "Punto de evaluación (u = ",
+    "Linear airflow velocity u [mm/s]": "Velocidad lineal del aire u [mm/s]",
+    r"Pressure difference $\Delta p$ [Pa]": r"Diferencia de presión $\Delta p$ [Pa]",
+    "ISO 9053-1 static airflow resistance — ":
+        "Resistencia al flujo de aire ISO 9053-1 — ",
+    "ISO 12999-2 absorption uncertainty": "Incertidumbre de absorción ISO 12999-2",
+    "reproducibility": "reproducibilidad",
+    "repeatability": "repetibilidad",
+    "Sound absorption coefficient alpha_s": "Coeficiente de absorción acústica alpha_s",
+    "Equivalent absorption area A_T [m2]": "Área de absorción equivalente A_T [m2]",
+    "Practical absorption coefficient alpha_p":
+        "Coeficiente de absorción práctico alpha_p",
+    "Value": "Valor",
+    "Porous medium": "Medio poroso",
+    "Normalised characteristic value": "Valor característico normalizado",
+    r"Absorption coefficient $\alpha$": r"Coeficiente de absorción $\alpha$",
+    "Reflection factor $|R|$": "Factor de reflexión $|R|$",
+    r"Absorption $\alpha(\theta)$": r"Absorción $\alpha(\theta)$",
+    r"Absorption $\alpha_{dif}$": r"Absorción $\alpha_{dif}$",
+}
+
+
+def _t(text: str, language: str = "en") -> str:
+    """Localise a fixed string; English is returned verbatim (byte-identical)."""
+    return _STRINGS.get(text, text) if language == "es" else text
+
+
+def _localize_band_axes(ax: Any, language: str) -> None:
+    """Comma-localise the numeric y-axis of a categorical band plot.
+
+    :func:`~phonometry._i18n.localize_axes` reformats only the automatic numeric
+    axis and leaves the categorical band tick labels (a ``FuncFormatter`` on the
+    linear position axis) untouched, so no label restore is needed. English is a
+    no-op.
+    """
+    from .._i18n import localize_axes
+
+    localize_axes(ax, language)
+
+
 def plot_weighted_absorption(
-    result: "AbsorptionRatingResult", ax: Axes | None = None, **kwargs: Any
+    result: "AbsorptionRatingResult", ax: Axes | None = None, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Practical absorption curve vs the shifted reference (ISO 11654:1997).
 
@@ -53,25 +121,33 @@ def plot_weighted_absorption(
     :param kwargs: Forwarded to the measured-curve ``plot`` call.
     :return: The axes.
     """
-    return _plot_rating(
+    from .._i18n import decimal_comma, format_number, localize_axes
+
+    ax = _plot_rating(
         np.asarray(result.band_centers, dtype=np.float64),
         np.asarray(result.measured, dtype=np.float64),
         np.asarray(result.shifted_reference, dtype=np.float64),
         impact=False,
         title=(
-            f"ISO 11654 alpha_w = {result.rating_label}  "
-            f"(class {result.absorption_class}, "
-            f"Sigma unfav. = {result.unfavourable_sum:.2f})"
+            f"ISO 11654 alpha_w = {decimal_comma(result.rating_label, language)}  "
+            f"({_t('class ', language)}{result.absorption_class}, "
+            f"{_t('Sigma unfav. = ', language)}"
+            f"{format_number(result.unfavourable_sum, language, decimals=2)})"
         ),
-        ylabel="Sound absorption coefficient",
-        measured_label="Practical alpha_p",
+        ylabel=_t("Sound absorption coefficient", language),
+        measured_label=_t("Practical alpha_p", language),
         ylim=(0.0, 1.05),
         ax=ax,
         **kwargs,
     )
+    if language == "es":
+        ax.set_xlabel(_t("Frequency [Hz]", language))
+    localize_axes(ax, language)
+    return ax
 
 def plot_scattering_coefficient(
-    result: "ScatteringResult", ax: Axes | None = None, **kwargs: Any
+    result: "ScatteringResult", ax: Axes | None = None, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Random-incidence scattering coefficient ``s`` versus frequency.
 
@@ -81,6 +157,8 @@ def plot_scattering_coefficient(
     :param kwargs: Forwarded to the coefficient curve ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import localize_axes
+
     ax = ax if ax is not None else _new_axes()
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     s = np.asarray(result.scattering, dtype=np.float64)
@@ -88,17 +166,21 @@ def plot_scattering_coefficient(
     kwargs.setdefault("color", _C_PRIMARY)
     ax.plot(freqs, s, **kwargs)
     _freq_axis(ax, freqs)
-    ax.set_ylabel("Scattering coefficient s")
+    if language == "es":
+        ax.set_xlabel(_t("Frequency [Hz]", language))
+    ax.set_ylabel(_t("Scattering coefficient s", language))
     # s is normally in [0, 1], but edge effects (Clause 6.3.2) can push it above
     # 1 and those values are kept, not clipped; grow the top so they stay visible.
     top = max(1.05, float(np.nanmax(s)) * 1.05) if s.size else 1.05
     ax.set_ylim(0.0, top)
-    ax.set_title("Random-incidence scattering coefficient (ISO 17497-1)")
+    ax.set_title(_t("Random-incidence scattering coefficient (ISO 17497-1)", language))
     ax.grid(True, alpha=0.3)
+    localize_axes(ax, language)
     return ax
 
 def plot_diffusion_polar(
-    result: "DiffusionResult", ax: Axes | None = None, **kwargs: Any
+    result: "DiffusionResult", ax: Axes | None = None, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Polar reflected-level response with the diffusion coefficient annotated.
 
@@ -115,16 +197,20 @@ def plot_diffusion_polar(
     levels = np.asarray(result.levels, dtype=np.float64)
     kwargs.setdefault("marker", "o")
     kwargs.setdefault("color", _C_PRIMARY)
+    from .._i18n import format_number
+
     ax.plot(angles, levels, **kwargs)
     ax.fill(angles, levels, alpha=0.15, color=kwargs["color"])
     ax.set_title(
-        f"Diffusion coefficient d = {float(result.coefficient):.2f} "
+        f"{_t('Diffusion coefficient d = ', language)}"
+        f"{format_number(float(result.coefficient), language, decimals=2)} "
         "(ISO 17497-2)"
     )
     return cast("Axes", ax)
 
 def plot_insitu_absorption(
-    result: "InsituAbsorptionResult", ax: Axes | None = None, **kwargs: Any
+    result: "InsituAbsorptionResult", ax: Axes | None = None, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """In-situ one-third-octave absorption spectrum ``alpha(f)``.
 
@@ -138,17 +224,19 @@ def plot_insitu_absorption(
     ax = ax if ax is not None else _new_axes()
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     alpha = np.asarray(result.absorption, dtype=np.float64)
-    positions = _band_axis(ax, freqs)
+    positions = _band_axis(ax, freqs, xlabel=_t("Frequency [Hz]", language))
     kwargs.setdefault("color", _C_PRIMARY)
     ax.bar(positions, np.nan_to_num(alpha), **kwargs)
-    ax.set_ylabel("Absorption coefficient")
+    ax.set_ylabel(_t("Absorption coefficient", language))
     ax.set_ylim(0.0, 1.0)
-    ax.set_title("In-situ road-surface absorption (ISO 13472-1)")
+    ax.set_title(_t("In-situ road-surface absorption (ISO 13472-1)", language))
     ax.grid(True, axis="y", alpha=0.3)
+    _localize_band_axes(ax, language)
     return ax
 
 def plot_dynamic_stiffness(
-    result: "DynamicStiffnessResult", ax: Axes | None = None, **kwargs: Any
+    result: "DynamicStiffnessResult", ax: Axes | None = None, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Floating-floor natural frequency ``f0(s')`` with the design point marked.
 
@@ -158,13 +246,16 @@ def plot_dynamic_stiffness(
     :param kwargs: Forwarded to the design-point ``scatter``.
     :return: The axes.
     """
+    from .._i18n import decimal_comma, format_number, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     m = result.floor_mass_per_area
     s_mn = result.dynamic_stiffness / 1e6
     grid = np.logspace(np.log10(max(s_mn * 0.2, 1e-2)), np.log10(s_mn * 5.0), 240)
     f0 = np.sqrt(grid * 1e6 / m) / (2.0 * np.pi)
     ax.plot(grid, f0, color=_C_PRIMARY,
-            label=rf"$f_0 = \frac{{1}}{{2\pi}}\sqrt{{s'/m'}}$,  $m'$ = {m:g} kg/m²")
+            label=rf"$f_0 = \frac{{1}}{{2\pi}}\sqrt{{s'/m'}}$,  "
+                 rf"$m'$ = {decimal_comma(f'{m:g}', language)} kg/m²")
     ax.axhline(result.natural_frequency, color=_C_MUTED, ls=":", lw=0.8)
     ax.plot([s_mn, s_mn], [0.0, result.natural_frequency], color=_C_MUTED, ls=":", lw=0.8)
 
@@ -172,19 +263,23 @@ def plot_dynamic_stiffness(
     kwargs.setdefault("zorder", 5)
     kwargs.setdefault("s", 80)
     ax.scatter([s_mn], [result.natural_frequency],
-               label=f"$s'$ = {s_mn:.2f} MN/m³,  $f_0$ = {result.natural_frequency:.1f} Hz",
+               label=(f"$s'$ = {format_number(s_mn, language, decimals=2)} MN/m³,  "
+                      f"$f_0$ = "
+                      f"{format_number(result.natural_frequency, language, decimals=1)} Hz"),
                **kwargs)
     ax.set_xscale("log")
-    ax.set_xlabel("Dynamic stiffness per unit area $s'$ [MN/m³]")
-    ax.set_ylabel("Natural frequency $f_0$ [Hz]")
-    ax.set_title("EN 29052-1 floating-floor resonance")
+    ax.set_xlabel(_t("Dynamic stiffness per unit area $s'$ [MN/m³]", language))
+    ax.set_ylabel(_t("Natural frequency $f_0$ [Hz]", language))
+    ax.set_title(_t("EN 29052-1 floating-floor resonance", language))
     ax.set_ylim(bottom=0.0)
     ax.legend(loc="upper left", fontsize="small")
     ax.grid(True, which="both", alpha=0.3)
+    localize_axes(ax, language)
     return ax
 
 def plot_impedance_tube(
-    result: "ImpedanceTubeResult", ax: Axes | None = None, **kwargs: Any
+    result: "ImpedanceTubeResult", ax: Axes | None = None, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Normal-incidence absorption spectrum with |r| overlaid (ISO 10534-2).
 
@@ -197,24 +292,28 @@ def plot_impedance_tube(
     :param kwargs: Forwarded to the absorption-curve ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import localize_axes
+
     ax = ax if ax is not None else _new_axes()
     freqs = np.asarray(result.frequency, dtype=np.float64)
     alpha = np.asarray(result.absorption, dtype=np.float64)
     kwargs.setdefault("color", _C_PRIMARY)
-    kwargs.setdefault("label", r"Absorption $\alpha$")
+    kwargs.setdefault("label", _t(r"Absorption $\alpha$", language))
     ax.plot(freqs, alpha, **kwargs)
     ax.plot(freqs, np.abs(np.asarray(result.reflection, dtype=np.complex128)),
-            ls="--", color=_C_MUTED, label="Reflection factor $|r|$")
-    ax.set_xlabel(_FREQ_LABEL)
-    ax.set_ylabel("Coefficient")
+            ls="--", color=_C_MUTED, label=_t("Reflection factor $|r|$", language))
+    ax.set_xlabel(_t(_FREQ_LABEL, language))
+    ax.set_ylabel(_t("Coefficient", language))
     ax.set_ylim(0.0, 1.05)
-    ax.set_title("ISO 10534-2 normal-incidence absorption")
+    ax.set_title(_t("ISO 10534-2 normal-incidence absorption", language))
     ax.legend(loc="best", fontsize="small")
     ax.grid(True, alpha=0.3)
+    localize_axes(ax, language)
     return ax
 
 def plot_static_airflow(
-    result: "StaticAirflowResult", ax: Axes | None = None, **kwargs: Any
+    result: "StaticAirflowResult", ax: Axes | None = None, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Fitted pressure-drop curve with the evaluation point (ISO 9053-1).
 
@@ -227,29 +326,34 @@ def plot_static_airflow(
     :param kwargs: Forwarded to the fitted-curve ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import decimal_comma, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     u_eval = float(result.evaluation_velocity)
     u = np.linspace(0.0, 2.0 * u_eval, 200)
     dp = result.linear_coefficient * u + result.quadratic_coefficient * u**2
 
     kwargs.setdefault("color", _C_PRIMARY)
-    kwargs.setdefault("label", r"Fit $\Delta p = a\,u + b\,u^2$")
+    kwargs.setdefault("label", _t(r"Fit $\Delta p = a\,u + b\,u^2$", language))
     # Millimetres per second keep the clause 7.5 reference (0.5 mm/s) legible.
     ax.plot(u * 1e3, dp, **kwargs)
     ax.plot([u_eval * 1e3], [result.pressure_drop], "D", color=_C_REFERENCE,
-            ms=7, label=f"Evaluation point (u = {u_eval * 1e3:g} mm/s)")
-    ax.set_xlabel("Linear airflow velocity u [mm/s]")
-    ax.set_ylabel(r"Pressure difference $\Delta p$ [Pa]")
+            ms=7, label=(f"{_t('Evaluation point (u = ', language)}"
+                         f"{decimal_comma(f'{u_eval * 1e3:g}', language)} mm/s)"))
+    ax.set_xlabel(_t("Linear airflow velocity u [mm/s]", language))
+    ax.set_ylabel(_t(r"Pressure difference $\Delta p$ [Pa]", language))
     ax.set_title(
-        "ISO 9053-1 static airflow resistance — "
-        f"$R_s$ = {result.specific_resistance:.3g} Pa s/m"
+        f"{_t('ISO 9053-1 static airflow resistance — ', language)}"
+        f"$R_s$ = {decimal_comma(f'{result.specific_resistance:.3g}', language)} Pa s/m"
     )
     ax.legend(loc="upper left", fontsize="small")
     ax.grid(True, alpha=0.3)
+    localize_axes(ax, language)
     return ax
 
 def plot_absorption_uncertainty(
-    result: "AbsorptionUncertaintyResult", ax: Axes | None = None, **kwargs: Any
+    result: "AbsorptionUncertaintyResult", ax: Axes | None = None,
+    language: str = "en", **kwargs: Any
 ) -> Axes:
     """Absorption quantity with its expanded-uncertainty ribbon (ISO 12999-2).
 
@@ -269,6 +373,8 @@ def plot_absorption_uncertainty(
             "plot() needs a per-band result; single-number quantities "
             "(alpha_w, DLalpha) have no spectrum to plot."
         )
+    from .._i18n import decimal_comma, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     freqs = result.frequencies
     value = result.values
@@ -281,20 +387,24 @@ def plot_absorption_uncertainty(
         value + u_expanded,
         color=_C_PRIMARY_LIGHT,
         alpha=0.5,
-        label=f"+/-U (k = {result.coverage_factor:g})",
+        label=f"+/-U (k = {decimal_comma(f'{result.coverage_factor:g}', language)})",
     )
     ax.plot(freqs, value, **kwargs)
     _freq_axis(ax, freqs)
+    if language == "es":
+        ax.set_xlabel(_t("Frequency [Hz]", language))
     ylabel = _ABSORPTION_QUANTITY_LABELS.get(result.quantity, "Value")
-    ax.set_ylabel(ylabel)
+    ax.set_ylabel(_t(ylabel, language))
     if result.quantity != "equivalent_area":
         ax.set_ylim(0.0, 1.05)
     sigma = "sigma_R" if result.condition == "reproducibility" else "sigma_r"
     ax.set_title(
-        f"ISO 12999-2 absorption uncertainty ({sigma}) — {result.condition}"
+        f"{_t('ISO 12999-2 absorption uncertainty', language)} "
+        f"({sigma}) — {_t(result.condition, language)}"
     )
     ax.grid(True, which="both", alpha=0.3)
     ax.legend()
+    localize_axes(ax, language)
     return ax
 
 
@@ -305,24 +415,29 @@ def _absorption_spectrum_axes(
     *,
     title: str,
     label: str,
+    language: str = "en",
     **kwargs: Any,
 ) -> Axes:
     """Shared alpha(f) spectrum renderer for the absorber predictions."""
+    from .._i18n import localize_axes
+
     ax = ax if ax is not None else _new_axes()
     kwargs.setdefault("color", _C_PRIMARY)
     kwargs.setdefault("label", label)
     ax.semilogx(freqs, alpha, **kwargs)
-    ax.set_xlabel(_FREQ_LABEL)
-    ax.set_ylabel(r"Absorption coefficient $\alpha$")
+    ax.set_xlabel(_t(_FREQ_LABEL, language))
+    ax.set_ylabel(_t(r"Absorption coefficient $\alpha$", language))
     ax.set_ylim(0.0, 1.05)
     ax.set_title(title)
     ax.grid(True, which="both", alpha=0.3)
     format_frequency_axis(ax, float(freqs.min()), float(freqs.max()))
+    localize_axes(ax, language)
     return ax
 
 
 def plot_porous_medium(
-    result: "PorousMediumResult", ax: Axes | None = None, **kwargs: Any
+    result: "PorousMediumResult", ax: Axes | None = None, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Normalised characteristic values of a porous medium vs frequency.
 
@@ -336,6 +451,8 @@ def plot_porous_medium(
     :param kwargs: Forwarded to the ``Re(Zc)`` ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import decimal_comma, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     freqs = np.asarray(result.frequency, dtype=np.float64)
     zn = np.asarray(result.normalized_impedance, dtype=np.complex128)
@@ -348,19 +465,21 @@ def plot_porous_medium(
     ax.loglog(freqs, kn.real, color=_C_REFERENCE, label=r"Re$(k)/k_0$")
     ax.loglog(freqs, -kn.imag, ls="--", color=_C_MUTED, label=r"$-$Im$(k)/k_0$")
     format_frequency_axis(ax, float(freqs.min()), float(freqs.max()))
-    ax.set_xlabel(_FREQ_LABEL)
-    ax.set_ylabel("Normalised characteristic value")
+    ax.set_xlabel(_t(_FREQ_LABEL, language))
+    ax.set_ylabel(_t("Normalised characteristic value", language))
     ax.set_title(
-        f"Porous medium ({result.model}), "
-        f"$\\sigma$ = {result.flow_resistivity:g} Pa s/m$^2$"
+        f"{_t('Porous medium', language)} ({result.model}), "
+        f"$\\sigma$ = {decimal_comma(f'{result.flow_resistivity:g}', language)} Pa s/m$^2$"
     )
     ax.legend(loc="best", fontsize="small")
     ax.grid(True, which="both", alpha=0.3)
+    localize_axes(ax, language)
     return ax
 
 
 def plot_layered_absorber(
-    result: "LayeredAbsorberResult", ax: Axes | None = None, **kwargs: Any
+    result: "LayeredAbsorberResult", ax: Axes | None = None, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Oblique-incidence absorption spectrum with |R| overlaid.
 
@@ -372,29 +491,35 @@ def plot_layered_absorber(
     :param kwargs: Forwarded to the absorption-curve ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import format_number
+
     angle_deg = np.degrees(result.angle)
+    if language == "es":
+        title = (f"Predicción de absorbente multicapa "
+                 f"($\\theta$ = {format_number(float(angle_deg), language, decimals=0)}°)")
+    else:
+        title = f"Layered absorber prediction ($\\theta$ = {angle_deg:.0f}°)"
     ax = _absorption_spectrum_axes(
         ax,
         np.asarray(result.frequency, dtype=np.float64),
         np.asarray(result.absorption, dtype=np.float64),
-        title=(
-            "Layered absorber prediction "
-            f"($\\theta$ = {angle_deg:.0f}°)"
-        ),
-        label=r"Absorption $\alpha(\theta)$",
+        title=title,
+        label=_t(r"Absorption $\alpha(\theta)$", language),
+        language=language,
         **kwargs,
     )
     ax.semilogx(
         np.asarray(result.frequency, dtype=np.float64),
         np.abs(np.asarray(result.reflection, dtype=np.complex128)),
-        ls="--", color=_C_MUTED, label="Reflection factor $|R|$",
+        ls="--", color=_C_MUTED, label=_t("Reflection factor $|R|$", language),
     )
     ax.legend(loc="best", fontsize="small")
     return ax
 
 
 def plot_diffuse_field_absorption(
-    result: "DiffuseFieldAbsorptionResult", ax: Axes | None = None, **kwargs: Any
+    result: "DiffuseFieldAbsorptionResult", ax: Axes | None = None,
+    language: str = "en", **kwargs: Any
 ) -> Axes:
     """Random-incidence (Paris-integral) absorption spectrum.
 
@@ -403,16 +528,22 @@ def plot_diffuse_field_absorption(
     :param kwargs: Forwarded to the absorption-curve ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import format_number
+
     limit_deg = np.degrees(result.angle_limit)
+    if language == "es":
+        title = (f"Absorción a incidencia aleatoria "
+                 f"(integral de Paris hasta "
+                 f"{format_number(float(limit_deg), language, decimals=0)}°)")
+    else:
+        title = f"Random-incidence absorption (Paris integral to {limit_deg:.0f}°)"
     ax = _absorption_spectrum_axes(
         ax,
         np.asarray(result.frequency, dtype=np.float64),
         np.asarray(result.absorption, dtype=np.float64),
-        title=(
-            "Random-incidence absorption "
-            f"(Paris integral to {limit_deg:.0f}°)"
-        ),
-        label=r"Absorption $\alpha_{dif}$",
+        title=title,
+        label=_t(r"Absorption $\alpha_{dif}$", language),
+        language=language,
         **kwargs,
     )
     ax.legend(loc="best", fontsize="small")

--- a/src/phonometry/_plot/room.py
+++ b/src/phonometry/_plot/room.py
@@ -40,8 +40,82 @@ if TYPE_CHECKING:
     from ..room.image_source import ImageSourceResult
     from ..room.steady_field import SteadyFieldResult
 
+#: Spanish translations of the fixed strings rendered by the room ``.plot()``
+#: renderers, keyed by their verbatim English text.  ``_t`` returns the English
+#: key unchanged for any language other than ``"es"``, so the English output is
+#: byte-for-byte identical to the pre-i18n renderers.
+_STRINGS: dict[str, str] = {
+    "Reverberation time [s]": "Tiempo de reverberación [s]",
+    "ISO 3382 decay times and clarity": "Tiempos de caída y claridad ISO 3382",
+    "Frequency [Hz]": "Frecuencia [Hz]",
+    "Band": "Banda",
+    "Broadband": "Banda ancha",
+    "Clarity [dB]": "Claridad [dB]",
+    "Time [s]": "Tiempo [s]",
+    "Level re steady state [dB]": "Nivel re estado estacionario [dB]",
+    "ISO 3382 Schroeder decay curve": "Curva de caída de Schroeder ISO 3382",
+    "Schroeder decay": "Decaimiento de Schroeder",
+    "Log-magnitude envelope": "Envolvente de magnitud logarítmica",
+    "Level re peak [dB]": "Nivel re pico [dB]",
+    "Amplitude (norm.)": "Amplitud (norm.)",
+    "ISO 18233 impulse response": "Respuesta al impulso ISO 18233",
+    "Measured": "Medido",
+    "Governing band": "Banda dominante",
+    "Octave-band SPL [dB]": "NPS por bandas de octava [dB]",
+    "Reference RC-": "Referencia RC-",
+    "Rumble tolerance (+5 dB)": "Tolerancia de retumbe (+5 dB)",
+    "Hiss tolerance (+3 dB)": "Tolerancia de siseo (+3 dB)",
+    "Reverberation time $T$ [s]": "Tiempo de reverberación $T$ [s]",
+    "EN 12354-6 reverberation time": "Tiempo de reverberación EN 12354-6",
+    "Reverberation-time models — ": "Modelos de tiempo de reverberación — ",
+    " dB per doubling": " dB por duplicación",
+    " m (STI 0.50)": " m (STI 0,50)",
+    " m (STI 0.20)": " m (STI 0,20)",
+    "Distance from the sound source [m]": "Distancia a la fuente sonora [m]",
+    "A-weighted SPL of speech [dB]": "NPS del habla ponderado A [dB]",
+    "ISO 3382-3 spatial decay of speech": "Decaimiento espacial del habla ISO 3382-3",
+    "Sample": "Muestra",
+    "Amplitude": "Amplitud",
+    "Magnitude [dB]": "Magnitud [dB]",
+    "Magnitude spectrum (flat)": "Espectro de magnitud (plano)",
+    "ISO 18233 exponential sine sweep": "Barrido sinusoidal exponencial ISO 18233",
+    "Spectrogram (exponential frequency rise)":
+        "Espectrograma (subida exponencial de frecuencia)",
+    r"$1/r$ spreading envelope": r"envolvente de propagación $1/r$",
+    "Reflections": "Reflexiones",
+    "Reflection order": "Orden de reflexión",
+    "Direct sound": "Sonido directo",
+    "Arrival time [ms]": "Tiempo de llegada [ms]",
+    "Reflection level re direct [dB]": "Nivel de reflexión re directo [dB]",
+    "Direct field": "Campo directo",
+    "Reverberant field": "Campo reverberante",
+    "Total": "Total",
+    "Distance from source [m]": "Distancia a la fuente [m]",
+    "Sound pressure level [dB]": "Nivel de presión sonora [dB]",
+}
+
+
+def _t(text: str, language: str = "en") -> str:
+    """Localise a fixed string; English is returned verbatim (byte-identical)."""
+    return _STRINGS.get(text, text) if language == "es" else text
+
+
+def _localize_band_axes(ax: Any, language: str) -> None:
+    """Comma-localise the numeric y-axis of a categorical band plot.
+
+    :func:`~phonometry._i18n.localize_axes` reformats only the automatic numeric
+    axis and leaves the categorical band tick labels (a ``FuncFormatter`` on the
+    linear position axis) untouched, so no label restore is needed. English is a
+    no-op.
+    """
+    from .._i18n import localize_axes
+
+    localize_axes(ax, language)
+
+
 def plot_room_acoustics(
-    result: RoomAcousticsResult, ax: Axes | None = None, **kwargs: Any
+    result: RoomAcousticsResult, ax: Axes | None = None, language: str = "en",
+    **kwargs: Any
 ) -> Axes | np.ndarray:
     """Per-band decay times (EDT/T20/T30) and clarity (C50/C80).
 
@@ -60,7 +134,7 @@ def plot_room_acoustics(
     n = np.asarray(result.t30, dtype=np.float64).size
     if freq is None:
         centers = np.arange(n, dtype=np.float64)
-        labels = ["Broadband"] * n
+        labels = [_t("Broadband", language)] * n
         use_freq_axis = False
     else:
         centers = np.asarray(freq, dtype=np.float64)
@@ -76,15 +150,16 @@ def plot_room_acoustics(
         ax_times = cast("Axes", axes[0])
 
     _draw_decay_times(ax_times, positions, result, **kwargs)
-    ax_times.set_ylabel("Reverberation time [s]")
-    ax_times.set_title("ISO 3382 decay times and clarity")
+    ax_times.set_ylabel(_t("Reverberation time [s]", language))
+    ax_times.set_title(_t("ISO 3382 decay times and clarity", language))
     _band_axis(ax_times, labels, xlabel=None)
     ax_times.grid(True, axis="y", alpha=0.3)
     ax_times.legend(loc="best", fontsize="small")
 
     if single:
         if use_freq_axis:
-            ax_times.set_xlabel("Frequency [Hz]")
+            ax_times.set_xlabel(_t("Frequency [Hz]", language))
+        _localize_band_axes(ax_times, language)
         return ax_times
 
     ax_clarity = cast("Axes", axes[1])
@@ -102,16 +177,21 @@ def plot_room_acoustics(
         color=_C_QUATERNARY,
         label="C80",
     )
-    ax_clarity.set_ylabel("Clarity [dB]")
+    ax_clarity.set_ylabel(_t("Clarity [dB]", language))
     _band_axis(
-        ax_clarity, labels, xlabel="Frequency [Hz]" if use_freq_axis else "Band"
+        ax_clarity,
+        labels,
+        xlabel=_t("Frequency [Hz]" if use_freq_axis else "Band", language),
     )
     ax_clarity.grid(True, alpha=0.3)
     ax_clarity.legend(loc="best", fontsize="small")
+    _localize_band_axes(ax_times, language)
+    _localize_band_axes(ax_clarity, language)
     return axes
 
 def plot_decay_curve(
-    result: DecayCurve, ax: Axes | None = None, fits: bool = True, **kwargs: Any
+    result: DecayCurve, ax: Axes | None = None, fits: bool = True,
+    language: str = "en", **kwargs: Any
 ) -> Axes:
     """Schroeder decay curve with optional straight T-fit overlays.
 
@@ -122,11 +202,13 @@ def plot_decay_curve(
     :param kwargs: Forwarded to the decay-curve ``plot`` call.
     :return: The axes.
     """
+    from .._i18n import localize_axes
+
     ax = ax if ax is not None else _new_axes()
     time = np.asarray(result.time, dtype=np.float64)
     level = np.asarray(result.level, dtype=np.float64)
     kwargs.setdefault("color", _C_PRIMARY)
-    kwargs.setdefault("label", "Schroeder decay")
+    kwargs.setdefault("label", _t("Schroeder decay", language))
     ax.plot(time, level, **kwargs)
 
     if fits:
@@ -137,23 +219,27 @@ def plot_decay_curve(
         ):
             fit = _fit_segment(time, level, lo, hi)
             if fit is not None:
-                ax.plot(time, fit, style, lw=1, alpha=0.8, label=f"{label} fit")
+                fit_label = f"ajuste {label}" if language == "es" else f"{label} fit"
+                ax.plot(time, fit, style, lw=1, alpha=0.8, label=fit_label)
 
-    ax.set_xlabel("Time [s]")
-    ax.set_ylabel("Level re steady state [dB]")
+    ax.set_xlabel(_t("Time [s]", language))
+    ax.set_ylabel(_t("Level re steady state [dB]", language))
     ax.set_ylim(top=3.0)
     ax.set_xlim(left=0.0, right=float(time[-1]) if time.size else None)
     band = result.band
-    title = "ISO 3382 Schroeder decay curve"
+    title = _t("ISO 3382 Schroeder decay curve", language)
     if band is not None:
-        title += f"  ({_format_freq(float(band))} Hz band)"
+        fb = _format_freq(float(band))
+        title += f"  (banda {fb} Hz)" if language == "es" else f"  ({fb} Hz band)"
     ax.set_title(title)
     ax.grid(True, alpha=0.3)
     ax.legend(loc="best", fontsize="small")
+    localize_axes(ax, language)
     return ax
 
 def plot_impulse_response(
-    result: "ImpulseResponseResult", ax: Axes | None = None, **kwargs: Any
+    result: "ImpulseResponseResult", ax: Axes | None = None, language: str = "en",
+    **kwargs: Any
 ) -> Axes | np.ndarray:
     """Impulse-response waveform and its log-magnitude / Schroeder decay.
 
@@ -184,33 +270,40 @@ def plot_impulse_response(
 
     color = kwargs.pop("color", _C_PRIMARY)
 
+    from .._i18n import localize_axes
+
+    title = f"{_t('ISO 18233 impulse response', language)} ({result.method})"
+
     def _decay(axd: Axes) -> None:
         axd.plot(time, env_db, color=_C_PRIMARY_LIGHT, lw=0.8,
-                 label="Log-magnitude envelope")
-        axd.plot(time, edc_db, color=_C_REFERENCE, lw=1.8, label="Schroeder decay")
-        axd.set_xlabel(xlabel)
-        axd.set_ylabel("Level re peak [dB]")
+                 label=_t("Log-magnitude envelope", language))
+        axd.plot(time, edc_db, color=_C_REFERENCE, lw=1.8,
+                 label=_t("Schroeder decay", language))
+        axd.set_xlabel(_t(xlabel, language))
+        axd.set_ylabel(_t("Level re peak [dB]", language))
         axd.set_ylim(bottom=-80.0, top=5.0)
         axd.set_xlim(left=float(time[0]) if n else 0.0,
                      right=float(time[-1]) if n else None)
         axd.grid(True, alpha=0.3)
         axd.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
+        localize_axes(axd, language)
 
     if ax is not None:
         _decay(ax)
-        ax.set_title(f"ISO 18233 impulse response ({result.method})")
+        ax.set_title(title)
         return ax
 
     axes = _new_axes_column(2, sharex=True, figsize=(8.0, 6.0))
     axes[0].plot(time, h / norm, color=color, lw=0.8, **kwargs)
-    axes[0].set_ylabel("Amplitude (norm.)")
-    axes[0].set_title(f"ISO 18233 impulse response ({result.method})")
+    axes[0].set_ylabel(_t("Amplitude (norm.)", language))
+    axes[0].set_title(title)
     axes[0].grid(True, alpha=0.3)
+    localize_axes(axes[0], language)
     _decay(axes[1])
     return axes
 
 def plot_noise_criterion(
-    result: "NCResult", ax: Axes | None = None, **kwargs: Any
+    result: "NCResult", ax: Axes | None = None, language: str = "en", **kwargs: Any
 ) -> Axes:
     """Measured spectrum against the NC curve family (ANSI/ASA S12.2-2019).
 
@@ -219,6 +312,7 @@ def plot_noise_criterion(
     :param kwargs: Forwarded to the measured-spectrum :meth:`plot`.
     :return: The axes.
     """
+    from .._i18n import localize_axes
     from ..room.room_noise import NC_CURVES, NC_INDICES, OCTAVE_BANDS
 
     ax = ax if ax is not None else _new_axes()
@@ -232,7 +326,7 @@ def plot_noise_criterion(
         )
     valid = ~np.isnan(levels)
     kwargs.setdefault("color", _C_PRIMARY)
-    kwargs.setdefault("label", "Measured")
+    kwargs.setdefault("label", _t("Measured", language))
     ax.plot(freqs[valid], levels[valid], "o-", zorder=3, **kwargs)
     # Nearest *valid* band rather than float equality against the stored
     # value; the marker sits on that band so its x and y stay paired.
@@ -247,20 +341,24 @@ def plot_noise_criterion(
             [freqs[governing]],
             [levels[governing]],
             "D", color=_C_REFERENCE, zorder=4,
-            label=f"Governing band ({_format_freq(result.governing_frequency)})",
+            label=(f"{_t('Governing band', language)} "
+                   f"({_format_freq(result.governing_frequency)})"),
         )
     _freq_axis(ax, OCTAVE_BANDS)
-    ax.set_ylabel("Octave-band SPL [dB]")
+    if language == "es":
+        ax.set_xlabel(_t("Frequency [Hz]", language))
+    ax.set_ylabel(_t("Octave-band SPL [dB]", language))
     ax.set_title(
         f"ANSI/ASA S12.2 NC-{result.rating:g} "
         f"({_format_freq(result.governing_frequency)})"
     )
     ax.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
     ax.grid(True, which="both", alpha=0.3)
+    localize_axes(ax, language)
     return ax
 
 def plot_room_criterion(
-    result: "RCResult", ax: Axes | None = None, **kwargs: Any
+    result: "RCResult", ax: Axes | None = None, language: str = "en", **kwargs: Any
 ) -> Axes:
     """Measured spectrum against the reference RC Mark II curve (Annex D).
 
@@ -272,6 +370,8 @@ def plot_room_criterion(
     :param kwargs: Forwarded to the measured-spectrum :meth:`plot`.
     :return: The axes.
     """
+    from .._i18n import localize_axes
+
     ax = ax if ax is not None else _new_axes()
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     levels = np.asarray(result.levels, dtype=np.float64)
@@ -279,27 +379,31 @@ def plot_room_criterion(
     valid = ~np.isnan(levels)
 
     ax.plot(freqs, reference, "s--", color=_C_MUTED,
-            label=f"Reference RC-{result.rating}")
+            label=f"{_t('Reference RC-', language)}{result.rating}")
     low = freqs <= 500.0
     high = freqs >= 1000.0
     ax.fill_between(freqs[low], reference[low], reference[low] + 5.0,
                     color=_C_SECONDARY_LIGHT, alpha=0.35,
-                    label="Rumble tolerance (+5 dB)")
+                    label=_t("Rumble tolerance (+5 dB)", language))
     ax.fill_between(freqs[high], reference[high], reference[high] + 3.0,
                     color=_C_PRIMARY_LIGHT, alpha=0.45,
-                    label="Hiss tolerance (+3 dB)")
+                    label=_t("Hiss tolerance (+3 dB)", language))
     kwargs.setdefault("color", _C_PRIMARY)
-    kwargs.setdefault("label", "Measured")
+    kwargs.setdefault("label", _t("Measured", language))
     ax.plot(freqs[valid], levels[valid], "o-", zorder=3, **kwargs)
     _freq_axis(ax, freqs)
-    ax.set_ylabel("Octave-band SPL [dB]")
+    if language == "es":
+        ax.set_xlabel(_t("Frequency [Hz]", language))
+    ax.set_ylabel(_t("Octave-band SPL [dB]", language))
     ax.set_title(f"ANSI/ASA S12.2 {result.label}")
     ax.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
     ax.grid(True, which="both", alpha=0.3)
+    localize_axes(ax, language)
     return ax
 
 def plot_enclosed_space_absorption(
-    result: "ReverberationResult", ax: Axes | None = None, **kwargs: Any
+    result: "ReverberationResult", ax: Axes | None = None, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Reverberation time over the octave bands (EN 12354-6).
 
@@ -308,6 +412,8 @@ def plot_enclosed_space_absorption(
     :param kwargs: Forwarded to the reverberation-time ``plot``.
     :return: The axes.
     """
+    from .._i18n import localize_axes
+
     ax = ax if ax is not None else _new_axes()
     freq = np.asarray(result.frequencies, dtype=np.float64)
     rt = np.asarray(result.reverberation_time, dtype=np.float64)
@@ -315,14 +421,18 @@ def plot_enclosed_space_absorption(
     kwargs.setdefault("marker", "o")
     ax.plot(freq, rt, **kwargs)
     _freq_axis(ax, freq)
-    ax.set_ylabel("Reverberation time $T$ [s]")
-    ax.set_title("EN 12354-6 reverberation time")
+    if language == "es":
+        ax.set_xlabel(_t("Frequency [Hz]", language))
+    ax.set_ylabel(_t("Reverberation time $T$ [s]", language))
+    ax.set_title(_t("EN 12354-6 reverberation time", language))
     ax.set_ylim(bottom=0.0)
     ax.grid(True, which="both", alpha=0.3)
+    localize_axes(ax, language)
     return ax
 
 def plot_reverberation_models(
-    result: "ReverberationModelResult", ax: Axes | None = None, **kwargs: Any
+    result: "ReverberationModelResult", ax: Axes | None = None, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Reverberation time by five statistical models over the bands.
 
@@ -336,6 +446,8 @@ def plot_reverberation_models(
     :param kwargs: Forwarded to every curve ``plot``.
     :return: The axes.
     """
+    from .._i18n import format_number, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     freq = np.asarray(result.frequencies, dtype=np.float64)
     styles = (
@@ -356,18 +468,23 @@ def plot_reverberation_models(
             **kwargs,
         )
     _freq_axis(ax, freq)
-    ax.set_ylabel("Reverberation time $T$ [s]")
+    if language == "es":
+        ax.set_xlabel(_t("Frequency [Hz]", language))
+    ax.set_ylabel(_t("Reverberation time $T$ [s]", language))
     ax.set_title(
-        f"Reverberation-time models — $V$ = {result.volume:.0f} m³, "
-        f"$S$ = {result.surface_area:.0f} m²"
+        f"{_t('Reverberation-time models — ', language)}"
+        f"$V$ = {format_number(result.volume, language, decimals=0)} m³, "
+        f"$S$ = {format_number(result.surface_area, language, decimals=0)} m²"
     )
     ax.set_ylim(bottom=0.0)
     ax.legend(loc="best", fontsize="small")
     ax.grid(True, which="both", alpha=0.3)
+    localize_axes(ax, language)
     return ax
 
 def plot_open_plan(
-    result: "OpenPlanResult", ax: Axes | None = None, **kwargs: Any
+    result: "OpenPlanResult", ax: Axes | None = None, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Spatial decay of speech with the distraction/privacy distances marked.
 
@@ -392,6 +509,8 @@ def plot_open_plan(
     ax = ax if ax is not None else _new_axes()
     import matplotlib.ticker as mticker
 
+    from .._i18n import format_number, localize_axes
+
     r_max = 16.0
     for marker in (result.rd, result.rp):
         if np.isfinite(marker):
@@ -401,28 +520,34 @@ def plot_open_plan(
 
     kwargs.setdefault("color", _C_PRIMARY)
     kwargs.setdefault(
-        "label", rf"$D_{{2,S}}$ = {result.d2s:.1f} dB per doubling"
+        "label",
+        rf"$D_{{2,S}}$ = {format_number(result.d2s, language, decimals=1)}"
+        f"{_t(' dB per doubling', language)}",
     )
     ax.plot(r, level, **kwargs)
     ax.plot([4.0], [result.lp_as_4m], "o", color=_C_PRIMARY, ms=7,
-            label=rf"$L_{{p,A,S,4m}}$ = {result.lp_as_4m:.1f} dB")
+            label=rf"$L_{{p,A,S,4m}}$ = "
+                  f"{format_number(result.lp_as_4m, language, decimals=1)} dB")
     if np.isfinite(result.rd):
         ax.axvline(result.rd, color=_C_SECONDARY, ls="--",
-                   label=rf"$r_D$ = {result.rd:.1f} m (STI 0.50)")
+                   label=rf"$r_D$ = {format_number(result.rd, language, decimals=1)}"
+                         f"{_t(' m (STI 0.50)', language)}")
     if np.isfinite(result.rp):
         ax.axvline(result.rp, color=_C_REFERENCE, ls=":",
-                   label=rf"$r_P$ = {result.rp:.1f} m (STI 0.20)")
+                   label=rf"$r_P$ = {format_number(result.rp, language, decimals=1)}"
+                         f"{_t(' m (STI 0.20)', language)}")
 
     ax.set_xscale("log", base=2)
     ticks = [float(2**k) for k in range(1, int(np.ceil(np.log2(r_max))) + 1)]
     ax.set_xticks(ticks)
     ax.set_xticklabels([f"{t:g}" for t in ticks])
     ax.xaxis.set_minor_formatter(mticker.NullFormatter())
-    ax.set_xlabel("Distance from the sound source [m]")
-    ax.set_ylabel("A-weighted SPL of speech [dB]")
-    ax.set_title("ISO 3382-3 spatial decay of speech")
+    ax.set_xlabel(_t("Distance from the sound source [m]", language))
+    ax.set_ylabel(_t("A-weighted SPL of speech [dB]", language))
+    ax.set_title(_t("ISO 3382-3 spatial decay of speech", language))
     ax.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
     ax.grid(True, which="both", alpha=0.3)
+    localize_axes(ax, language)
     return ax
 
 
@@ -432,6 +557,7 @@ def plot_excitation(
     *,
     kind: str = "sweep",
     ax: Axes | None = None,
+    language: str = "en",
     **kwargs: Any,
 ) -> Axes | np.ndarray:
     """Plot an ISO 18233 excitation signal (sweep or MLS).
@@ -450,6 +576,9 @@ def plot_excitation(
     :param kwargs: Forwarded to the time-domain ``plot`` call.
     :return: The time-domain axes (``ax`` given) or the array of two axes.
     """
+    from .._i18n import check_language, localize_axes
+
+    check_language(language)
     x = np.asarray(signal, dtype=np.float64)
     n = x.shape[-1]
     if n == 0:
@@ -467,13 +596,19 @@ def plot_excitation(
     if kind == "mls":
         show = min(n, 120)
         ax_time.step(np.arange(show), x[:show], where="mid", color=color, **kwargs)
-        ax_time.set_xlabel("Sample")
-        ax_time.set_ylabel("Amplitude")
+        ax_time.set_xlabel(_t("Sample", language))
+        ax_time.set_ylabel(_t("Amplitude", language))
         ax_time.set_ylim(-1.4, 1.4)
-        ax_time.set_title(
-            f"ISO 18233 MLS excitation (first {show} of {n} samples)"
-        )
+        if language == "es":
+            ax_time.set_title(
+                f"Excitación MLS ISO 18233 (primeras {show} de {n} muestras)"
+            )
+        else:
+            ax_time.set_title(
+                f"ISO 18233 MLS excitation (first {show} of {n} samples)"
+            )
         ax_time.grid(True, alpha=0.3)
+        localize_axes(ax_time, language)
         if not two_panel:
             return ax_time
         spec = np.abs(np.fft.rfft(x))
@@ -484,32 +619,36 @@ def plot_excitation(
         ax_f.semilogx(freqs[1:], 20.0 * np.log10(
                       np.maximum(ac, 1e-10) / (denom if denom > 0.0 else 1.0)),
                       color=_C_REFERENCE, lw=0.8)
-        ax_f.set_xlabel("Frequency [Hz]")
-        ax_f.set_ylabel("Magnitude [dB]")
-        ax_f.set_title("Magnitude spectrum (flat)")
+        ax_f.set_xlabel(_t("Frequency [Hz]", language))
+        ax_f.set_ylabel(_t("Magnitude [dB]", language))
+        ax_f.set_title(_t("Magnitude spectrum (flat)", language))
         ax_f.grid(True, which="both", alpha=0.3)
         format_frequency_axis(ax_f, float(freqs[1]), float(freqs[-1]))
+        localize_axes(ax_f, language)
         return axes
 
     # Swept sine.
     ax_time.plot(t, x, color=color, lw=0.6, **kwargs)
-    ax_time.set_xlabel("Time [s]")
-    ax_time.set_ylabel("Amplitude")
-    ax_time.set_title("ISO 18233 exponential sine sweep")
+    ax_time.set_xlabel(_t("Time [s]", language))
+    ax_time.set_ylabel(_t("Amplitude", language))
+    ax_time.set_title(_t("ISO 18233 exponential sine sweep", language))
     ax_time.grid(True, alpha=0.3)
+    localize_axes(ax_time, language)
     if not two_panel:
         return ax_time
     ax_s = axes[1]
     nperseg = min(n, max(256, min(2048, n // 16)))
     ax_s.specgram(x, NFFT=nperseg, Fs=fs, noverlap=nperseg // 2, cmap="magma")
-    ax_s.set_xlabel("Time [s]")
-    ax_s.set_ylabel("Frequency [Hz]")
-    ax_s.set_title("Spectrogram (exponential frequency rise)")
+    ax_s.set_xlabel(_t("Time [s]", language))
+    ax_s.set_ylabel(_t("Frequency [Hz]", language))
+    ax_s.set_title(_t("Spectrogram (exponential frequency rise)", language))
+    localize_axes(ax_s, language)
     return axes
 
 
 def plot_image_source_reflectogram(
-    result: "ImageSourceResult", ax: Axes | None = None, **kwargs: Any
+    result: "ImageSourceResult", ax: Axes | None = None, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Reflectogram of a synthetic image-source room impulse response.
 
@@ -523,6 +662,8 @@ def plot_image_source_reflectogram(
     :param kwargs: Forwarded to the stem ``markerline`` styling.
     :return: The axes.
     """
+    from .._i18n import localize_axes
+
     ax = ax if ax is not None else _new_axes()
     times = np.asarray(result.times, dtype=np.float64)
     amp = np.asarray(result.amplitudes, dtype=np.float64)
@@ -541,7 +682,7 @@ def plot_image_source_reflectogram(
     envelope = 20.0 * np.log10(np.maximum(d0 / dist, tiny))
     order_sort = np.argsort(ms)
     ax.plot(ms[order_sort], envelope[order_sort], color=_C_MUTED, lw=1.0, ls="--",
-            label=r"$1/r$ spreading envelope", zorder=1)
+            label=_t(r"$1/r$ spreading envelope", language), zorder=1)
 
     # Reflections coloured by order (higher orders fade toward grey). A
     # max_order=0 result has no reflections, so guard the scatter/colorbar
@@ -549,34 +690,43 @@ def plot_image_source_reflectogram(
     ref_mask = ~order0
     if np.any(ref_mask):
         sc = ax.scatter(ms[ref_mask], level[ref_mask], c=orders[ref_mask],
-                        cmap="viridis", s=14, zorder=3, label="Reflections")
+                        cmap="viridis", s=14, zorder=3,
+                        label=_t("Reflections", language))
         ax.vlines(ms[ref_mask], -120.0, level[ref_mask], color=_C_EDGE,
                   lw=0.4, alpha=0.4, zorder=2)
         cbar = ax.figure.colorbar(sc, ax=ax, pad=0.02)
-        cbar.set_label("Reflection order")
+        cbar.set_label(_t("Reflection order", language))
     ax.vlines(ms[order0], -120.0, level[order0], color=_C_PRIMARY, lw=1.6,
               zorder=4)
     ax.plot(ms[order0], level[order0], "o", color=_C_PRIMARY, ms=7, zorder=5,
-            label="Direct sound", **kwargs)
+            label=_t("Direct sound", language), **kwargs)
 
     lx, ly, lz = result.dimensions
     finite = level[np.isfinite(level)]
     ax.set_ylim(bottom=max(-80.0, float(finite.min()) - 3.0) if finite.size else -80.0,
                 top=5.0)
     ax.set_xlim(left=0.0, right=float(ms.max()) if ms.size else None)
-    ax.set_xlabel("Arrival time [ms]")
-    ax.set_ylabel("Reflection level re direct [dB]")
-    ax.set_title(
-        f"Image-source reflectogram — {lx:g}×{ly:g}×{lz:g} m room, "
-        f"order ≤ {result.max_order}"
-    )
+    ax.set_xlabel(_t("Arrival time [ms]", language))
+    ax.set_ylabel(_t("Reflection level re direct [dB]", language))
+    if language == "es":
+        ax.set_title(
+            f"Reflectograma de fuentes imagen — sala de "
+            f"{lx:g}×{ly:g}×{lz:g} m, orden ≤ {result.max_order}"
+        )
+    else:
+        ax.set_title(
+            f"Image-source reflectogram — {lx:g}×{ly:g}×{lz:g} m room, "
+            f"order ≤ {result.max_order}"
+        )
     ax.grid(True, alpha=0.3)
     ax.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
+    localize_axes(ax, language)
     return ax
 
 
 def plot_steady_field(
-    result: "SteadyFieldResult", ax: Axes | None = None, **kwargs: Any
+    result: "SteadyFieldResult", ax: Axes | None = None, language: str = "en",
+    **kwargs: Any
 ) -> Axes:
     """Steady-state SPL against distance: direct, reverberant and total fields.
 
@@ -591,28 +741,40 @@ def plot_steady_field(
     """
     import matplotlib.ticker as mticker
 
+    from .._i18n import format_number, localize_axes
+
     ax = ax if ax is not None else _new_axes()
     r = np.asarray(result.distances, dtype=np.float64)
     ax.plot(r, np.asarray(result.direct, dtype=np.float64), color=_C_SECONDARY,
-            ls="--", lw=1.4, label="Direct field")
+            ls="--", lw=1.4, label=_t("Direct field", language))
     ax.plot(r, np.asarray(result.reverberant, dtype=np.float64),
-            color=_C_TERTIARY, ls=":", lw=1.4, label="Reverberant field")
+            color=_C_TERTIARY, ls=":", lw=1.4, label=_t("Reverberant field", language))
     kwargs.setdefault("color", _C_PRIMARY)
     kwargs.setdefault("lw", 2.4)
     ax.plot(r, np.asarray(result.total, dtype=np.float64),
-            label="Total", **kwargs)
+            label=_t("Total", language), **kwargs)
     ax.axvline(result.critical_distance, color=_C_REFERENCE, ls="-.", lw=1.2,
-               label=rf"$r_c$ = {result.critical_distance:.2f} m")
+               label=rf"$r_c$ = "
+                     f"{format_number(result.critical_distance, language, decimals=2)} m")
 
     ax.set_xscale("log")
     ax.xaxis.set_major_formatter(mticker.ScalarFormatter())
     ax.xaxis.set_minor_formatter(mticker.NullFormatter())
-    ax.set_xlabel("Distance from source [m]")
-    ax.set_ylabel("Sound pressure level [dB]")
-    ax.set_title(
-        f"Steady-state room field — $L_W$ = {result.sound_power_level:g} dB, "
-        f"$R$ = {result.room_constant:.0f} m², $Q$ = {result.directivity:g}"
-    )
+    ax.set_xlabel(_t("Distance from source [m]", language))
+    ax.set_ylabel(_t("Sound pressure level [dB]", language))
+    if language == "es":
+        ax.set_title(
+            f"Campo estacionario de la sala — "
+            f"$L_W$ = {result.sound_power_level:g} dB, "
+            f"$R$ = {format_number(result.room_constant, language, decimals=0)} m², "
+            f"$Q$ = {result.directivity:g}"
+        )
+    else:
+        ax.set_title(
+            f"Steady-state room field — $L_W$ = {result.sound_power_level:g} dB, "
+            f"$R$ = {result.room_constant:.0f} m², $Q$ = {result.directivity:g}"
+        )
     ax.grid(True, which="both", alpha=0.3)
     ax.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
+    localize_axes(ax, language)
     return ax

--- a/src/phonometry/materials/absorption_rating.py
+++ b/src/phonometry/materials/absorption_rating.py
@@ -232,7 +232,7 @@ class AbsorptionRatingResult:
             return f"{self.alpha_w:.2f}({self.shape_indicator})"
         return f"{self.alpha_w:.2f}"
 
-    def plot(self, ax: Axes | None = None, **kwargs: Any) -> Axes:
+    def plot(self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any) -> Axes:
         """Plot the practical curve vs the shifted reference (ISO 11654).
 
         Unfavourable deviations (measured below the shifted reference) are
@@ -240,9 +240,11 @@ class AbsorptionRatingResult:
         (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes` and never calls ``plt.show``.
         """
+        from .._i18n import check_language
         from .._plot.materials import plot_weighted_absorption
 
-        return plot_weighted_absorption(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_weighted_absorption(self, ax=ax, language=language, **kwargs)
 
     def report(
         self,

--- a/src/phonometry/materials/absorption_uncertainty.py
+++ b/src/phonometry/materials/absorption_uncertainty.py
@@ -208,15 +208,17 @@ class AbsorptionUncertaintyResult:
         """Upper interval bound ``value + U`` (exact ``U``)."""
         return np.asarray(self.values + self.expanded_uncertainty, dtype=np.float64)
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the quantity with its ``±U`` uncertainty ribbon (band quantities).
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.materials import plot_absorption_uncertainty
 
-        return plot_absorption_uncertainty(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_absorption_uncertainty(self, ax=ax, language=language, **kwargs)
 
 
 def _table_constants(

--- a/src/phonometry/materials/airflow_resistance.py
+++ b/src/phonometry/materials/airflow_resistance.py
@@ -142,15 +142,17 @@ class StaticAirflowResult:
     linear_coefficient: float
     quadratic_coefficient: float
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the fitted ``dp(u)`` curve with the evaluation point.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.materials import plot_static_airflow
 
-        return plot_static_airflow(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_static_airflow(self, ax=ax, language=language, **kwargs)
 
 
 def linear_airflow_velocity(volume_flow_rate: float, area: float) -> float:

--- a/src/phonometry/materials/dynamic_stiffness.py
+++ b/src/phonometry/materials/dynamic_stiffness.py
@@ -246,15 +246,17 @@ class DynamicStiffnessResult:
     floor_mass_per_area: float
     natural_frequency: float
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot ``f0(s')`` with this design point marked.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.materials import plot_dynamic_stiffness
 
-        return plot_dynamic_stiffness(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_dynamic_stiffness(self, ax=ax, language=language, **kwargs)
 
 
 def floating_floor_resonance(

--- a/src/phonometry/materials/impedance_tube.py
+++ b/src/phonometry/materials/impedance_tube.py
@@ -470,15 +470,17 @@ class ImpedanceTubeResult:
     normalized_impedance: Complex
     absorption: Real
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the absorption spectrum ``alpha(f)`` with ``|r|`` overlaid.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.materials import plot_impedance_tube
 
-        return plot_impedance_tube(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_impedance_tube(self, ax=ax, language=language, **kwargs)
 
 
 def two_microphone_impedance(

--- a/src/phonometry/materials/porous_absorber.py
+++ b/src/phonometry/materials/porous_absorber.py
@@ -186,15 +186,17 @@ class PorousMediumResult:
         k0 = 2.0 * np.pi * self.frequency / self.speed_of_sound
         return np.asarray(self.wavenumber / k0, dtype=np.complex128)
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the normalised ``Zc`` and ``k`` components against frequency.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.materials import plot_porous_medium
 
-        return plot_porous_medium(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_porous_medium(self, ax=ax, language=language, **kwargs)
 
 
 def _medium_from_zc_k(
@@ -749,15 +751,17 @@ class LayeredAbsorberResult:
     absorption: Real
     transfer_matrix: Complex
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the absorption spectrum ``alpha(f)`` with ``|R|`` overlaid.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.materials import plot_layered_absorber
 
-        return plot_layered_absorber(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_layered_absorber(self, ax=ax, language=language, **kwargs)
 
 
 @dataclass(frozen=True)
@@ -773,15 +777,17 @@ class DiffuseFieldAbsorptionResult:
     absorption: Real
     angle_limit: float
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the random-incidence absorption spectrum ``alpha_dif(f)``.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.materials import plot_diffuse_field_absorption
 
-        return plot_diffuse_field_absorption(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_diffuse_field_absorption(self, ax=ax, language=language, **kwargs)
 
 
 def _sheet_impedance(

--- a/src/phonometry/materials/road_absorption.py
+++ b/src/phonometry/materials/road_absorption.py
@@ -587,15 +587,17 @@ class InsituAbsorptionResult:
     frequencies: Real
     absorption: Real
 
-    def plot(self, ax: Axes | None = None, **kwargs: Any) -> Axes:
+    def plot(self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any) -> Axes:
         """Plot the in-situ absorption spectrum ``alpha(f)``.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes` and never calls ``plt.show``.
         """
+        from .._i18n import check_language
         from .._plot.materials import plot_insitu_absorption
 
-        return plot_insitu_absorption(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_insitu_absorption(self, ax=ax, language=language, **kwargs)
 
 
 def insitu_absorption_spectrum(

--- a/src/phonometry/materials/scattering_diffusion.py
+++ b/src/phonometry/materials/scattering_diffusion.py
@@ -349,15 +349,17 @@ class ScatteringResult:
     random_incidence: Real
     specular: Real
 
-    def plot(self, ax: Axes | None = None, **kwargs: Any) -> Axes:
+    def plot(self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any) -> Axes:
         """Plot the scattering coefficient ``s`` versus frequency.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes` and never calls ``plt.show``.
         """
+        from .._i18n import check_language
         from .._plot.materials import plot_scattering_coefficient
 
-        return plot_scattering_coefficient(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_scattering_coefficient(self, ax=ax, language=language, **kwargs)
 
 
 def scattering_coefficient_spectrum(
@@ -417,15 +419,17 @@ class DiffusionResult:
     levels: Real
     coefficient: float
 
-    def plot(self, ax: Axes | None = None, **kwargs: Any) -> Axes:
+    def plot(self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any) -> Axes:
         """Plot the polar response with the diffusion coefficient annotated.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         polar :class:`~matplotlib.axes.Axes` and never calls ``plt.show``.
         """
+        from .._i18n import check_language
         from .._plot.materials import plot_diffusion_polar
 
-        return plot_diffusion_polar(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_diffusion_polar(self, ax=ax, language=language, **kwargs)
 
 
 def directional_diffusion(

--- a/src/phonometry/room/enclosed_space_absorption.py
+++ b/src/phonometry/room/enclosed_space_absorption.py
@@ -215,15 +215,17 @@ class ReverberationResult:
     volume: float
     object_fraction: float
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the reverberation time over the octave bands.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.room import plot_enclosed_space_absorption
 
-        return plot_enclosed_space_absorption(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_enclosed_space_absorption(self, ax=ax, language=language, **kwargs)
 
 
 def enclosed_space_reverberation(

--- a/src/phonometry/room/image_source.py
+++ b/src/phonometry/room/image_source.py
@@ -208,7 +208,7 @@ class ImageSourceResult:
         """Arrival time of the direct sound (order 0), s."""
         return float(self.times[int(np.argmin(self.distances))])
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the reflectogram: reflection level in dB against arrival time.
 
         Stems the per-image amplitudes (in dB re the direct sound), coloured by
@@ -216,9 +216,11 @@ class ImageSourceResult:
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.room import plot_image_source_reflectogram
 
-        return plot_image_source_reflectogram(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_image_source_reflectogram(self, ax=ax, language=language, **kwargs)
 
 
 def _validate_point(

--- a/src/phonometry/room/open_plan.py
+++ b/src/phonometry/room/open_plan.py
@@ -84,7 +84,7 @@ class OpenPlanResult:
     rd: float
     rp: float
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the spatial decay of speech with ``rD``/``rP`` marked.
 
         Redraws the Clause 6.2 regression line from ``d2s`` and
@@ -92,9 +92,11 @@ class OpenPlanResult:
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.room import plot_open_plan
 
-        return plot_open_plan(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_open_plan(self, ax=ax, language=language, **kwargs)
 
 
 def _linear_fit(x: np.ndarray, y: np.ndarray) -> Tuple[float, float]:

--- a/src/phonometry/room/reverberation_prediction.py
+++ b/src/phonometry/room/reverberation_prediction.py
@@ -514,15 +514,17 @@ class ReverberationModelResult:
             "Arau-Puchades": self.arau_puchades,
         }
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the reverberation-time curves of the five models.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.room import plot_reverberation_models
 
-        return plot_reverberation_models(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_reverberation_models(self, ax=ax, language=language, **kwargs)
 
 
 def reverberation_time_models(

--- a/src/phonometry/room/room_acoustics.py
+++ b/src/phonometry/room/room_acoustics.py
@@ -136,7 +136,7 @@ class RoomAcousticsResult:
     t30_valid: np.ndarray
     curvature: np.ndarray
 
-    def plot(self, ax: Axes | None = None, **kwargs: Any) -> Axes | np.ndarray:
+    def plot(self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any) -> Axes | np.ndarray:
         """Plot per-band decay times (EDT/T20/T30) and clarity (C50/C80).
 
         Invalid bands are hatched and greyed. With ``ax`` given, only the
@@ -144,9 +144,11 @@ class RoomAcousticsResult:
         (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes` (or array thereof).
         """
+        from .._i18n import check_language
         from .._plot.room import plot_room_acoustics
 
-        return plot_room_acoustics(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_room_acoustics(self, ax=ax, language=language, **kwargs)
 
 
 def _onset_index(p2: np.ndarray) -> int:
@@ -352,16 +354,18 @@ class DecayCurve:
         yield self.time
         yield self.level
 
-    def plot(self, ax: Axes | None = None, **kwargs: Any) -> Axes:
+    def plot(self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any) -> Axes:
         """Plot the decay curve with optional straight T-fit overlays.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`. Pass ``fits=False`` to omit the
         EDT/T20/T30 fit lines.
         """
+        from .._i18n import check_language
         from .._plot.room import plot_decay_curve
 
-        return plot_decay_curve(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_decay_curve(self, ax=ax, language=language, **kwargs)
 
 
 def decay_curve(

--- a/src/phonometry/room/room_ir.py
+++ b/src/phonometry/room/room_ir.py
@@ -144,7 +144,7 @@ class ImpulseResponseResult:
     def dtype(self) -> np.dtype[Any]:
         return self.ir.dtype
 
-    def plot(self, ax: Axes | None = None, **kwargs: Any) -> "Axes | np.ndarray":
+    def plot(self, ax: Axes | None = None, *, language: str = "en", **kwargs: Any) -> "Axes | np.ndarray":
         """Plot the impulse response: waveform and log-magnitude decay.
 
         Draws the (normalised) time-domain waveform and, below it, the
@@ -153,9 +153,11 @@ class ImpulseResponseResult:
         matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes` (or an array of two axes).
         """
+        from .._i18n import check_language
         from .._plot.room import plot_impulse_response
 
-        return plot_impulse_response(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_impulse_response(self, ax=ax, language=language, **kwargs)
 
 
 def sweep_signal(

--- a/src/phonometry/room/room_noise.py
+++ b/src/phonometry/room/room_noise.py
@@ -96,15 +96,17 @@ class NCResult:
     frequencies: np.ndarray
     levels: np.ndarray
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the measured spectrum against the NC curves.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.room import plot_noise_criterion
 
-        return plot_noise_criterion(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_noise_criterion(self, ax=ax, language=language, **kwargs)
 
 
 @dataclass(frozen=True)
@@ -132,15 +134,17 @@ class RCResult:
         """The room-criterion label in the ``RC-NN(A)`` form (clause D.3.5)."""
         return f"RC-{self.rating}({self.classification})"
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot the measured spectrum against the reference RC Mark II curve.
 
         Requires matplotlib (``pip install phonometry[plot]``); returns the
         :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.room import plot_room_criterion
 
-        return plot_room_criterion(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_room_criterion(self, ax=ax, language=language, **kwargs)
 
 
 def nc_curve(index: float) -> np.ndarray:

--- a/src/phonometry/room/steady_field.py
+++ b/src/phonometry/room/steady_field.py
@@ -211,16 +211,18 @@ class SteadyFieldResult:
     sound_power_level: float
     directivity: float
 
-    def plot(self, ax: "Axes | None" = None, **kwargs: Any) -> "Axes":
+    def plot(self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any) -> "Axes":
         """Plot direct, reverberant and total SPL against distance.
 
         Marks the critical distance ``rc`` where the direct and reverberant
         fields cross. Requires matplotlib (``pip install phonometry[plot]``);
         returns the :class:`~matplotlib.axes.Axes`.
         """
+        from .._i18n import check_language
         from .._plot.room import plot_steady_field
 
-        return plot_steady_field(self, ax=ax, **kwargs)
+        check_language(language)
+        return plot_steady_field(self, ax=ax, language=language, **kwargs)
 
 
 def steady_state_field(

--- a/tests/materials/test_materials_plot_i18n.py
+++ b/tests/materials/test_materials_plot_i18n.py
@@ -1,0 +1,166 @@
+#  Copyright (c) 2026. Jose M. Requena-Plens
+"""EN/ES internationalisation of the materials-domain ``.plot()`` renderers.
+
+Each result type exposes ``plot(language=...)``: the default English output is
+covered by the existing per-module plot tests, so here we assert that Spanish
+renders a translated label/title and that an unsupported language raises a
+clear :class:`ValueError`.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pytest
+
+pytest.importorskip("matplotlib")
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+
+from phonometry import sound_absorption_coefficient_uncertainty  # noqa: E402
+from phonometry.materials.absorption_rating import weighted_absorption  # noqa: E402
+from phonometry.materials.airflow_resistance import (  # noqa: E402
+    static_airflow_resistance,
+)
+from phonometry.materials.dynamic_stiffness import (  # noqa: E402
+    floating_floor_resonance,
+)
+from phonometry.materials.impedance_tube import ImpedanceTubeResult  # noqa: E402
+from phonometry.materials.porous_absorber import (  # noqa: E402
+    PorousLayer,
+    delany_bazley,
+    diffuse_field_absorption,
+    layered_absorber,
+)
+from phonometry.materials.road_absorption import (  # noqa: E402
+    InsituAbsorptionResult,
+)
+from phonometry.materials.scattering_diffusion import (  # noqa: E402
+    directional_diffusion,
+    scattering_coefficient_spectrum,
+)
+
+_C0 = 343.0
+_RHO0 = 1.205
+_RC = _RHO0 * _C0
+
+
+def _texts(ax_or_axes: object) -> str:
+    """Concatenate every axis label, title and legend text for inspection."""
+    axes = np.atleast_1d(ax_or_axes).ravel()
+    parts: list[str] = []
+    for ax in axes:
+        parts += [ax.get_xlabel(), ax.get_ylabel(), ax.get_title()]
+        legend = ax.get_legend()
+        if legend is not None:
+            parts += [t.get_text() for t in legend.get_texts()]
+    return "\n".join(parts)
+
+
+def _weighted():
+    return weighted_absorption([0.35, 0.50, 0.65, 0.60, 0.55])
+
+
+def _scattering():
+    return scattering_coefficient_spectrum(
+        [250.0, 500.0, 1000.0], [0.2, 0.3, 0.5], [0.1, 0.1, 0.1]
+    )
+
+
+def _diffusion():
+    return directional_diffusion([-30.0, 0.0, 30.0], [70.0, 72.0, 69.0])
+
+
+def _insitu():
+    return InsituAbsorptionResult(
+        frequencies=np.array([250.0, 500.0, 1000.0, 2000.0]),
+        absorption=np.array([0.2, 0.4, 0.6, 0.5]),
+    )
+
+
+def _dynamic_stiffness():
+    return floating_floor_resonance(25.0, 200.0, 100.0)
+
+
+def _impedance_tube():
+    f = np.array([500.0, 1000.0, 1500.0])
+    reflection = np.array([0.4 - 0.3j, 0.3 - 0.2j, 0.2 - 0.1j])
+    absorption = 1.0 - np.abs(reflection) ** 2
+    normalized = (1.0 + reflection) / (1.0 - reflection)
+    return ImpedanceTubeResult(
+        frequency=f,
+        reflection=reflection,
+        surface_impedance=_RC * normalized,
+        normalized_impedance=normalized,
+        absorption=absorption,
+    )
+
+
+def _static_airflow():
+    u = np.array([1.0e-3, 2.0e-3, 4.0e-3])
+    dp = 12000.0 * u
+    return static_airflow_resistance(u, dp, 0.008)
+
+
+def _uncertainty():
+    freqs = [125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0]
+    alpha = [0.15, 0.35, 0.55, 0.70, 0.80, 0.85]
+    return sound_absorption_coefficient_uncertainty(alpha, freqs)
+
+
+def _porous_medium():
+    f = np.geomspace(100.0, 5000.0, 24)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return delany_bazley(f, 20000.0, air_density=_RHO0, speed_of_sound=_C0)
+
+
+def _layered():
+    f = np.geomspace(100.0, 5000.0, 24)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        med = delany_bazley(f, 20000.0, air_density=_RHO0, speed_of_sound=_C0)
+        return layered_absorber(f, [PorousLayer(0.05, med)])
+
+
+def _diffuse():
+    f = np.geomspace(100.0, 5000.0, 24)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        med = delany_bazley(f, 20000.0, air_density=_RHO0, speed_of_sound=_C0)
+        return diffuse_field_absorption(f, [PorousLayer(0.05, med)])
+
+
+# (id, builder, expected Spanish substring) for every materials result renderer.
+_CASES = [
+    ("weighted_absorption", _weighted, "Coeficiente de absorción acústica"),
+    ("scattering", _scattering, "Coeficiente de dispersión"),
+    ("diffusion_polar", _diffusion, "Coeficiente de difusión"),
+    ("insitu_absorption", _insitu, "Absorción in situ de pavimentos"),
+    ("dynamic_stiffness", _dynamic_stiffness, "Frecuencia natural"),
+    ("impedance_tube", _impedance_tube, "Absorción a incidencia normal"),
+    ("static_airflow", _static_airflow, "Velocidad lineal del aire"),
+    ("absorption_uncertainty", _uncertainty, "Incertidumbre de absorción"),
+    ("porous_medium", _porous_medium, "Medio poroso"),
+    ("layered_absorber", _layered, "absorbente multicapa"),
+    ("diffuse_field", _diffuse, "incidencia aleatoria"),
+]
+
+
+@pytest.mark.parametrize("name, build, spanish", _CASES, ids=[c[0] for c in _CASES])
+def test_plot_spanish_labels(name: str, build, spanish: str) -> None:
+    result = build()
+    ax = result.plot(language="es")
+    assert spanish in _texts(ax)
+    plt.close("all")
+
+
+@pytest.mark.parametrize("name, build, spanish", _CASES, ids=[c[0] for c in _CASES])
+def test_plot_rejects_unknown_language(name: str, build, spanish: str) -> None:
+    result = build()
+    with pytest.raises(ValueError, match="Unknown language"):
+        result.plot(language="xx")
+    plt.close("all")

--- a/tests/room/test_room_plot_i18n.py
+++ b/tests/room/test_room_plot_i18n.py
@@ -1,0 +1,148 @@
+#  Copyright (c) 2026. Jose M. Requena-Plens
+"""EN/ES internationalisation of the room-domain ``.plot()`` renderers.
+
+Each result type exposes ``plot(language=...)``: the default English output is
+covered by the existing per-module plot tests, so here we assert that Spanish
+renders a translated label/title and that an unsupported language raises a
+clear :class:`ValueError`.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pytest
+
+pytest.importorskip("matplotlib")
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+
+from phonometry import decay_curve, room_parameters  # noqa: E402
+from phonometry._plot.room import plot_excitation  # noqa: E402
+from phonometry.room import enclosed_space_absorption as esa  # noqa: E402
+from phonometry.room import room_noise as rn  # noqa: E402
+from phonometry.room.image_source import image_source_rir  # noqa: E402
+from phonometry.room.open_plan import open_plan_metrics  # noqa: E402
+from phonometry.room.reverberation_prediction import (  # noqa: E402
+    reverberation_time_models,
+)
+from phonometry.room.room_ir import ImpulseResponseResult  # noqa: E402
+from phonometry.room.steady_field import steady_state_field  # noqa: E402
+
+FS = 48000
+
+
+def _decaying_ir() -> np.ndarray:
+    """A short decaying-noise impulse response (RT ~ 0.4 s)."""
+    t = np.arange(int(0.6 * FS)) / FS
+    rng = np.random.default_rng(0)
+    return rng.standard_normal(t.size) * np.exp(-6.9 * t / 0.4)
+
+
+def _texts(ax_or_axes: object) -> str:
+    """Concatenate every axis label, title and legend text for inspection."""
+    axes = np.atleast_1d(ax_or_axes).ravel()
+    parts: list[str] = []
+    for ax in axes:
+        parts += [ax.get_xlabel(), ax.get_ylabel(), ax.get_title()]
+        legend = ax.get_legend()
+        if legend is not None:
+            parts += [t.get_text() for t in legend.get_texts()]
+    return "\n".join(parts)
+
+
+def _room_acoustics():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return room_parameters(_decaying_ir(), FS, limits=None)
+
+
+def _decay_curve():
+    return decay_curve(_decaying_ir(), FS)
+
+
+def _nc():
+    return rn.noise_criterion(rn.nc_curve(40.0))
+
+
+def _rc():
+    return rn.room_criterion(rn.rc_curve(35.0))
+
+
+def _enclosed():
+    return esa.enclosed_space_reverberation(
+        [(20.0, [0.10, 0.20, 0.30, 0.40, 0.50, 0.60, 0.70])],
+        50.0,
+        air_condition="20C_50-70",
+    )
+
+
+def _models():
+    return reverberation_time_models(
+        (8.0, 5.0, 3.0), (0.2, 0.15, 0.3), frequencies=[125.0, 250.0]
+    )
+
+
+def _open_plan():
+    r = np.array([2.0, 4.0, 8.0, 16.0])
+    lp = 70.0 - 6.0 * np.log2(r)
+    sti = 0.6 - 0.02 * r
+    return open_plan_metrics(r, lp, sti)
+
+
+def _impulse_response():
+    return ImpulseResponseResult(ir=_decaying_ir(), fs=FS, method="spectral")
+
+
+def _image_source():
+    return image_source_rir(
+        (5.0, 4.0, 3.0), (1.2, 1.1, 1.3), (3.5, 2.6, 1.7), 0.15, fs=16000, max_order=8
+    )
+
+
+def _steady_field():
+    return steady_state_field(90.0, 100.0, 0.2)
+
+
+# (id, builder, expected Spanish substring) for every room result renderer.
+_CASES = [
+    ("room_acoustics", _room_acoustics, "Tiempos de caída"),
+    ("decay_curve", _decay_curve, "Nivel re estado estacionario"),
+    ("noise_criterion", _nc, "NPS por bandas de octava"),
+    ("room_criterion", _rc, "NPS por bandas de octava"),
+    ("enclosed_space", _enclosed, "Tiempo de reverberación EN 12354-6"),
+    ("reverberation_models", _models, "Modelos de tiempo de reverberación"),
+    ("open_plan", _open_plan, "Decaimiento espacial del habla"),
+    ("impulse_response", _impulse_response, "Respuesta al impulso ISO 18233"),
+    ("image_source", _image_source, "Tiempo de llegada [ms]"),
+    ("steady_field", _steady_field, "Distancia a la fuente [m]"),
+]
+
+
+@pytest.mark.parametrize("name, build, spanish", _CASES, ids=[c[0] for c in _CASES])
+def test_plot_spanish_labels(name: str, build, spanish: str) -> None:
+    result = build()
+    ax = result.plot(language="es")
+    assert spanish in _texts(ax)
+    plt.close("all")
+
+
+@pytest.mark.parametrize("name, build, spanish", _CASES, ids=[c[0] for c in _CASES])
+def test_plot_rejects_unknown_language(name: str, build, spanish: str) -> None:
+    result = build()
+    with pytest.raises(ValueError, match="Unknown language"):
+        result.plot(language="xx")
+    plt.close("all")
+
+
+def test_plot_excitation_spanish_and_rejects_unknown_language() -> None:
+    signal = np.sin(2.0 * np.pi * 220.0 * np.arange(2048) / FS)
+    ax = plot_excitation(signal, FS, kind="sweep", language="es")
+    assert "Barrido sinusoidal exponencial ISO 18233" in _texts(ax)
+    plt.close("all")
+    with pytest.raises(ValueError, match="Unknown language"):
+        plot_excitation(signal, FS, kind="sweep", language="xx")
+    plt.close("all")


### PR DESCRIPTION
## Summary

Every `.plot()` in the room and materials domains now takes a `language`
keyword (`"en"` default, `"es"` for Spanish). With `language="es"` the axis
labels, titles and legends render in Spanish and linear-axis tick decimals use
a comma; the English output is unchanged. An unsupported code raises a clear
`ValueError`.

## Details

- New shared `phonometry._i18n` module holds the small locale helpers
  (`check_language`, `format_number`, `localize_axes`) used by the plot and
  report renderers. The plot layer imports it lazily inside functions, so it
  keeps no module-level dependency on it.
- `src/phonometry/_plot/room.py` and `src/phonometry/_plot/materials.py` gain a
  per-module string table and a small `_t` helper; each renderer threads
  `language` through, translating fixed strings and formatting embedded numbers
  with the locale separator.
- Each result's `.plot()` validates the language and forwards it to the
  renderer.
- Spanish acoustics terminology, for example "Coeficiente de absorción
  acústica", "Coeficiente de dispersión" and "Tiempo de reverberación".

## English output is unchanged

The default English path returns the verbatim original strings and formatting.
Rendering all 22 room/materials `.plot()` figures in English with the previous
code and with this change produces byte-for-byte identical SVGs.

## Tests

- New per-domain tests assert that every renderer yields a Spanish label under
  `language="es"` and rejects an unknown code with `ValueError`.
- The package-architecture test that forbids module-level imports in
  `_plot/*` still passes (helpers are imported lazily).
- `ruff check .` and `mypy src scripts` are clean; the API reference for the
  affected modules is regenerated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Spanish-language support for room and materials plots.
  * Spanish plots include translated labels, titles, legends, and comma-formatted decimal values.
  * English remains the default language.
  * Unsupported language codes now produce a clear error.

* **Documentation**
  * Updated plotting API references to include the new `language` option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->