### PR TITLE
Localize the shared plot helpers for Spanish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   axis labels, titles and legends in Spanish and switches linear-axis tick
   decimals to a comma; the English output is unchanged. An unsupported code
   raises a clear `ValueError`.
+- The frequency/band axes, the shifted-reference rating figure, the
+  band-level bar chart, the façade x-axis, the ISO 717-2 500 Hz annotation
+  and the time axis shared by every domain's `.plot()` renderers now
+  localise their own axis labels and legend entries for `language="es"`
+  ("Frequency [Hz]" to "Frecuencia [Hz]", "Measured" to "Medido", "Band" to
+  "Banda", and so on), instead of leaving them in English whenever a domain
+  renderer relied on the shared helper for that label. English output is
+  unchanged.
 - IEC 61260-1 filter class compliance can now be exported as a one-page PDF
   fiche. A new `filter_class_compliance(bank, *, num_points=..., edition=...)`
   runs the same verification as `verify_filter_class` and returns a frozen

--- a/src/phonometry/_plot/building.py
+++ b/src/phonometry/_plot/building.py
@@ -287,6 +287,7 @@ def plot_weighted_rating(
         ),
         ylabel=_t("Sound reduction index [dB]", language),
         ax=ax,
+        language=language,
         **kwargs,
     )
     localize_axes(ax, language)
@@ -331,9 +332,12 @@ def plot_impact_rating(
         ),
         ylabel=_t("Impact sound pressure level [dB]", language),
         ax=ax,
+        language=language,
         **kwargs,
     )
-    _annotate_impact_500(ax, band_centers, reference, int(result.rating))
+    _annotate_impact_500(
+        ax, band_centers, reference, int(result.rating), language=language
+    )
     localize_axes(ax, language)
     return ax
 
@@ -361,7 +365,9 @@ def plot_facade_insulation(
     ax = ax if ax is not None else _new_axes()
     dnt = np.asarray(result.d_2m_nt, dtype=np.float64)
     n = dnt.size
-    x = _facade_x_axis(ax, getattr(result, "frequencies", None), n)
+    x = _facade_x_axis(
+        ax, getattr(result, "frequencies", None), n, language=language
+    )
 
     # D2m,nT first so it is lines[0]; other quantities follow when present.
     curves = [("$D_{2m,nT}$", dnt)]
@@ -410,7 +416,7 @@ def plot_facade_prediction(
     ax = ax if ax is not None else _new_axes()
     r_prime = np.asarray(result.r_prime, dtype=np.float64)
     n = r_prime.size
-    x = _facade_x_axis(ax, result.frequencies, n)
+    x = _facade_x_axis(ax, result.frequencies, n, language=language)
 
     for name, rp in result.element_r.items():
         ax.plot(x, np.asarray(rp, dtype=np.float64), "--", lw=0.9, alpha=0.6, label=name)
@@ -465,7 +471,7 @@ def plot_radiated_power(
     opts: dict[str, Any] = {"color": "tab:red", "alpha": 0.8, "label": "$L_W$"}
     opts.update(kwargs)
     ax.bar(positions, l_w, **opts)
-    _band_axis(ax, labels, xlabel=_t(_FREQ_LABEL, language))
+    _band_axis(ax, labels, xlabel=_t(_FREQ_LABEL, language), language=language)
 
     if result.l_w_dba is not None:
         ax.axhline(
@@ -510,7 +516,7 @@ def plot_vibration_reduction(
     if result.frequencies is not None:
         freqs = np.asarray(result.frequencies, dtype=np.float64)
         ax.plot(freqs, k_ij, **kwargs)
-        _freq_axis(ax, freqs)
+        _freq_axis(ax, freqs, language=language)
     else:
         ax.plot(np.arange(k_ij.size), k_ij, **kwargs)
         ax.set_xlabel(_t("Band index", language))
@@ -548,6 +554,7 @@ def plot_structure_borne_power(
         ax, result.power_level, result.frequencies, result.total_level,
         ylabel=_t(r"Structure-borne power level $L_{Ws}$ [dB re 1 pW]", language),
         title=_t("EN 15657 characteristic structure-borne sound power", language),
+        language=language,
         **kwargs,
     )
     localize_axes(ax, language)
@@ -764,7 +771,7 @@ def plot_band_uncertainty(
     kwargs.setdefault("color", _C_PRIMARY)
     kwargs.setdefault("marker", "o")
     ax.plot(freqs, u, **kwargs)
-    _freq_axis(ax, freqs)
+    _freq_axis(ax, freqs, language=language)
     ax.set_ylabel(_t("Standard uncertainty u [dB]", language))
     ax.set_ylim(bottom=0.0)
     quantity = _t("sigma_R95 upper limit", language) if result.upper_limit else "u"
@@ -804,7 +811,7 @@ def plot_floor_covering_improvement(
             color=_C_SECONDARY, ms=9, mfc="none", mew=1.6, zorder=5,
             label=_t("limit of measurement (> delta-L)", language),
         )
-    _freq_axis(ax, freqs)
+    _freq_axis(ax, freqs, language=language)
     ax.set_ylabel(_t("Improvement of impact sound insulation delta-L [dB]", language))
     ax.set_ylim(bottom=0.0)
     title = _t("ISO 16251-1 Floor-Covering Impact Sound Improvement", language)

--- a/src/phonometry/_plot/common.py
+++ b/src/phonometry/_plot/common.py
@@ -77,6 +77,29 @@ _LABEL_DEPTH_M: Final = "Depth [m]"
 _LABEL_TL_DB: Final = "Transmission loss [dB]"
 _LABEL_RANGE_KM: Final = "Range [km]"
 
+#: Spanish translations of the handful of fixed strings these *shared*
+#: renderers set directly (axis labels, generic legend entries). Each
+#: ``_plot/<domain>.py`` module carries its own richer ``_STRINGS``/``_t`` for
+#: titles and quantity-specific text; ``_t`` here only covers what common.py
+#: itself draws, so a domain module that passes an already-localised string
+#: through (e.g. an ``xlabel`` built with its own ``_t``) gets it back
+#: unchanged — the lookup misses and falls back to the given text. English is
+#: always a no-op, so the byte-identical English guarantee holds.
+_STRINGS: dict[str, str] = {
+    "Frequency [Hz]": "Frecuencia [Hz]",
+    "Band": "Banda",
+    "Measured": "Medido",
+    "Shifted reference": "Referencia desplazada",
+    "Unfavourable deviations": "Desviaciones desfavorables",
+    "Time [s]": "Tiempo [s]",
+    "Sample": "Muestra",
+}
+
+
+def _t(text: str, language: str = "en") -> str:
+    """Localise a fixed string; English is returned verbatim (byte-identical)."""
+    return _STRINGS.get(text, text) if language == "es" else text
+
 
 def _import_pyplot() -> Any:
     """Import :mod:`matplotlib.pyplot` lazily with an actionable error."""
@@ -102,7 +125,7 @@ def _new_axes_column(n: int, **kwargs: Any) -> np.ndarray:
     return result
 
 
-def _freq_axis(ax: Axes, freqs: np.ndarray) -> None:
+def _freq_axis(ax: Axes, freqs: np.ndarray, *, language: str = "en") -> None:
     """Configure a logarithmic frequency x-axis labelled with band centres."""
     import matplotlib.ticker as mticker
 
@@ -112,7 +135,7 @@ def _freq_axis(ax: Axes, freqs: np.ndarray) -> None:
     # Suppress the log-scale minor-tick labels (2x10^2, 3x10^2, ...) that would
     # otherwise collide with off-decade band centres such as 750 or 1500 Hz.
     ax.xaxis.set_minor_formatter(mticker.NullFormatter())
-    ax.set_xlabel("Frequency [Hz]")
+    ax.set_xlabel(_t("Frequency [Hz]", language))
 
 
 def _format_freq(f: float) -> str:
@@ -194,6 +217,7 @@ def _band_axis(
     labels_or_freqs: "np.ndarray | Sequence[str] | Sequence[float]",
     *,
     xlabel: str | None = "Frequency [Hz]",
+    language: str = "en",
 ) -> np.ndarray:
     """Categorical band x-axis: evenly spaced positions labelled with centres.
 
@@ -211,7 +235,7 @@ def _band_axis(
     ax.set_xticks(positions)
     ax.set_xticklabels(labels, rotation=45, ha="right")
     if xlabel is not None:
-        ax.set_xlabel(xlabel)
+        ax.set_xlabel(_t(xlabel, language))
     return positions
 
 
@@ -352,6 +376,7 @@ def _plot_rating(
     measured_label: str = "Measured",
     ylim: tuple[float, float] | None = None,
     ax: Axes | None,
+    language: str = "en",
     **kwargs: Any,
 ) -> Axes:
     """Shared renderer for the shifted-reference rating figures.
@@ -364,10 +389,10 @@ def _plot_rating(
     """
     ax = ax if ax is not None else _new_axes()
     kwargs.setdefault("color", _C_PRIMARY)
-    kwargs.setdefault("label", measured_label)
+    kwargs.setdefault("label", _t(measured_label, language))
     ax.plot(band_centers, measured, "o-", **kwargs)
     ax.plot(band_centers, reference, "s--", color=_C_REFERENCE,
-            label="Shifted reference")
+            label=_t("Shifted reference", language))
     unfavourable = _unfavourable_mask(measured, reference, impact)
     ax.fill_between(
         band_centers,
@@ -376,10 +401,10 @@ def _plot_rating(
         where=unfavourable.tolist(),
         color=_C_SECONDARY,
         alpha=0.4,
-        label="Unfavourable deviations",
+        label=_t("Unfavourable deviations", language),
         interpolate=True,
     )
-    _freq_axis(ax, band_centers)
+    _freq_axis(ax, band_centers, language=language)
     ax.set_ylabel(ylabel)
     if ylim is not None:
         ax.set_ylim(*ylim)
@@ -410,16 +435,28 @@ def _unfavourable_mask(
 
 
 def _annotate_impact_500(
-    ax: Axes, band_centers: np.ndarray, reference: np.ndarray, rating: int
+    ax: Axes,
+    band_centers: np.ndarray,
+    reference: np.ndarray,
+    rating: int,
+    *,
+    language: str = "en",
 ) -> None:
     """Mark the 500 Hz read value on the reference curve and, when the
     octave-band -5 dB reduction applies (ISO 717-2 Clause 4.3.2), annotate
     the rating as ``read - 5 dB`` so the figure stays normatively truthful.
     """
+    from .._i18n import decimal_comma
+
     if band_centers.size == 0:
         return
     idx = int(np.argmin(np.abs(band_centers - 500.0)))
     read_value = float(reference[idx])
+    read_str = decimal_comma(f"{read_value:.0f}", language)
+    read_label = (
+        f"lectura 500 Hz = {read_str} dB" if language == "es"
+        else f"500 Hz read = {read_str} dB"
+    )
     ax.plot(
         [band_centers[idx]],
         [read_value],
@@ -430,12 +467,18 @@ def _annotate_impact_500(
         mfc="none",
         mew=1.6,
         zorder=5,
-        label=f"500 Hz read = {read_value:.0f} dB",
+        label=read_label,
     )
     offset = rating - read_value
     if abs(offset) >= 0.5:  # octave-band -5 dB rule (Clause 4.3.2)
+        rating_str = decimal_comma(str(rating), language)
+        annotation = (
+            f"índice = {rating_str} dB = {read_str} - 5 dB (regla de octava)"
+            if language == "es"
+            else f"rating = {rating_str} dB = {read_str} - 5 dB (octave rule)"
+        )
         ax.annotate(
-            f"rating = {rating} dB = {read_value:.0f} - 5 dB (octave rule)",
+            annotation,
             xy=(band_centers[idx], read_value),
             xytext=(0.0, -32.0),
             textcoords="offset points",
@@ -462,16 +505,21 @@ def _require_rating_curve(
 
 
 
-def _facade_x_axis(ax: Axes, freqs: "np.ndarray | None", n: int) -> np.ndarray:
+def _facade_x_axis(
+    ax: Axes, freqs: "np.ndarray | None", n: int, *, language: str = "en"
+) -> np.ndarray:
     """Frequency x-axis when centres are known, else a labelled band index."""
     if freqs is None:
         x = np.arange(n, dtype=np.float64)
         ax.set_xticks(x)
-        ax.set_xticklabels([f"Band {i + 1}" for i in range(n)], rotation=45, ha="right")
-        ax.set_xlabel("Band")
+        band_word = _t("Band", language)
+        ax.set_xticklabels(
+            [f"{band_word} {i + 1}" for i in range(n)], rotation=45, ha="right"
+        )
+        ax.set_xlabel(_t("Band", language))
         return x
     x = np.asarray(freqs, dtype=np.float64)
-    _freq_axis(ax, x)
+    _freq_axis(ax, x, language=language)
     return x
 
 
@@ -581,11 +629,13 @@ def _fit_segment(
 # ---------------------------------------------------------------------------
 
 
-def _time_axis(n: int, fs: int | None) -> tuple[np.ndarray, str]:
+def _time_axis(
+    n: int, fs: int | None, *, language: str = "en"
+) -> tuple[np.ndarray, str]:
     """Sample times in seconds when ``fs`` is known, else sample index."""
     if fs:
-        return np.arange(n) / float(fs), "Time [s]"
-    return np.arange(n, dtype=np.float64), "Sample"
+        return np.arange(n) / float(fs), _t("Time [s]", language)
+    return np.arange(n, dtype=np.float64), _t("Sample", language)
 
 
 
@@ -670,25 +720,30 @@ def _plot_band_level_bars(
     *,
     ylabel: str,
     title: str,
+    language: str = "en",
     **kwargs: Any,
 ) -> Axes:
     """Per-band level bar chart with a band-summed total line (shared helper)."""
+    from .._i18n import decimal_comma
+
     ax = ax if ax is not None else _new_axes()
     lw = np.asarray(levels, dtype=np.float64)
     n = lw.size
     if frequencies is not None:
-        labels = [f"{f:g}" for f in np.asarray(frequencies)]
-        ax.set_xlabel("Frequency [Hz]")
+        labels = [decimal_comma(f"{f:g}", language) for f in np.asarray(frequencies)]
+        ax.set_xlabel(_t("Frequency [Hz]", language))
     else:
         labels = [str(i + 1) for i in range(n)]
-        ax.set_xlabel("Band")
+        ax.set_xlabel(_t("Band", language))
     positions = np.arange(n)
     kwargs.setdefault("color", _C_PRIMARY)
     ax.bar(positions, lw, width=0.7, edgecolor=_C_EDGE, linewidth=0.6, **kwargs)
     ax.set_xticks(positions)
     ax.set_xticklabels(labels)
-    ax.axhline(total_level, color=_C_REFERENCE, ls="--", lw=1.2,
-               label=f"total {total_level:.1f} dB")
+    ax.axhline(
+        total_level, color=_C_REFERENCE, ls="--", lw=1.2,
+        label=f"total {decimal_comma(f'{total_level:.1f}', language)} dB",
+    )
     ax.set_ylabel(ylabel)
     ax.set_title(title)
     ax.legend(loc="best", fontsize="small")

--- a/src/phonometry/_plot/emission.py
+++ b/src/phonometry/_plot/emission.py
@@ -103,10 +103,12 @@ def plot_sound_power(
     if freqs is None:
         positions = _band_axis(
             ax, [f"{_t('Band', language)} {i + 1}" for i in range(n)],
-            xlabel=_t("Band", language)
+            xlabel=_t("Band", language), language=language,
         )
     else:
-        positions = _band_axis(ax, np.asarray(freqs, dtype=np.float64))
+        positions = _band_axis(
+            ax, np.asarray(freqs, dtype=np.float64), language=language
+        )
 
     # ``negative_band`` (ISO 9614-2) and ``not_applicable_band`` (ISO 9614-3)
     # both flag bands whose net power is non-positive and therefore unusable.
@@ -178,7 +180,7 @@ def plot_intensity(
     kwargs.setdefault("label", _t("Pressure level Lp", language))
     ax.plot(freqs, lp, "o-", **kwargs)
     ax.plot(freqs, li, "s--", color=_C_REFERENCE, label=_t("Intensity level LI", language))
-    _freq_axis(ax, freqs)
+    _freq_axis(ax, freqs, language=language)
     ax.set_ylabel(_t("Level [dB]", language))
     ax.grid(True, which="both", alpha=0.3)
 
@@ -222,6 +224,7 @@ def plot_vibration_sound_power(
         ax, result.sound_power_level, result.frequencies, result.total_level,
         ylabel=_t(r"Sound power level $L_W$ [dB re 1 pW]", language),
         title=_t("ISO/TS 7849 sound power from surface vibration", language),
+        language=language,
         **kwargs,
     )
     localize_axes(ax, language)

--- a/src/phonometry/_plot/environmental.py
+++ b/src/phonometry/_plot/environmental.py
@@ -271,7 +271,7 @@ def plot_outdoor_attenuation(
 
     ax = ax if ax is not None else _new_axes()
     freqs = np.asarray(result.frequencies, dtype=np.float64)
-    positions = _band_axis(ax, freqs)
+    positions = _band_axis(ax, freqs, language=language)
     n = freqs.size
 
     # Separate positive and negative cumulative baselines so a negative term
@@ -334,7 +334,7 @@ def plot_spherical_ground(
     ax.axhline(0.0, color=_C_MUTED, lw=0.8, label=_t("free_field", language))
     ax.axhline(6.0, color=_C_REFERENCE, ls="--", lw=0.9,
                label=_t("hard_ground", language))
-    _freq_axis(ax, freqs)
+    _freq_axis(ax, freqs, language=language)
     ax.set_ylabel(_t("level_re_ff", language))
     ax.set_title(_t("spherical_title", language))
     ax.legend(loc="best", fontsize="small")
@@ -368,7 +368,7 @@ def plot_barrier_insertion_loss(
     ax.axhline(0.0, color=_C_MUTED, lw=0.8)
     ax.axhline(5.0, color=_C_MUTED, ls=":", lw=0.9,
                label=_t("grazing_limit", language))
-    _freq_axis(ax, freqs)
+    _freq_axis(ax, freqs, language=language)
     ax.set_ylabel(_t("insertion_loss_db", language))
     ax.set_title(_t("barrier_title", language))
     ax.legend(loc="best", fontsize="small")

--- a/src/phonometry/_plot/hearing.py
+++ b/src/phonometry/_plot/hearing.py
@@ -140,7 +140,7 @@ def plot_sti(
     ax.bar(positions, mti, **kwargs)
     banded = mti.size == len(_STI_BAND_CENTERS)
     if banded:
-        _band_axis(ax, np.asarray(_STI_BAND_CENTERS))
+        _band_axis(ax, np.asarray(_STI_BAND_CENTERS), language=language)
         ax.set_xlabel(_t("freq_hz", language))
     else:
         ax.set_xticks(positions)
@@ -227,7 +227,7 @@ def plot_sii(
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     audibility = np.asarray(result.band_audibility, dtype=np.float64)
     contribution = audibility * np.asarray(result.band_importance, dtype=np.float64)
-    positions = _band_axis(ax, freqs)
+    positions = _band_axis(ax, freqs, language=language)
     ax.set_xlabel(_t("freq_hz", language))
     ax.bar(positions, audibility, color=_C_PRIMARY_LIGHT,
            label=_t("band_audibility_ai", language))
@@ -277,7 +277,7 @@ def plot_age_threshold(
         ax.plot(freqs, np.asarray(result.threshold, dtype=np.float64), "s--",
                 color=_C_REFERENCE, label=_t("fractile", language).format(
                     v=decimal_comma(f"{result.fractile:g}", language)))
-    _freq_axis(ax, freqs)
+    _freq_axis(ax, freqs, language=language)
     ax.set_xlabel(_t("freq_hz", language))
     ax.set_ylabel(_t("threshold_dev_18", language))
     ax.invert_yaxis()  # audiogram convention: worse hearing downward
@@ -316,7 +316,7 @@ def plot_nipts(
         ax.plot(freqs, np.asarray(result.value, dtype=np.float64), "s--",
                 color=_C_REFERENCE, label=_t("fractile", language).format(
                     v=decimal_comma(f"{result.fractile:g}", language)))
-    _freq_axis(ax, freqs)
+    _freq_axis(ax, freqs, language=language)
     ax.set_xlabel(_t("freq_hz", language))
     ax.set_ylabel(_t("nipts_db", language))
     ax.invert_yaxis()  # audiogram convention: worse hearing downward
@@ -352,7 +352,7 @@ def plot_htlan(
     kwargs.setdefault("color", _C_REFERENCE)
     ax.plot(freqs, np.asarray(result.threshold, dtype=np.float64), "s--",
             label=_t("age_noise_htlan", language), **kwargs)
-    _freq_axis(ax, freqs)
+    _freq_axis(ax, freqs, language=language)
     ax.set_xlabel(_t("freq_hz", language))
     ax.set_ylabel(_t("htl_level", language))
     ax.invert_yaxis()  # audiogram convention: worse hearing downward

--- a/src/phonometry/_plot/materials.py
+++ b/src/phonometry/_plot/materials.py
@@ -138,10 +138,9 @@ def plot_weighted_absorption(
         measured_label=_t("Practical alpha_p", language),
         ylim=(0.0, 1.05),
         ax=ax,
+        language=language,
         **kwargs,
     )
-    if language == "es":
-        ax.set_xlabel(_t("Frequency [Hz]", language))
     localize_axes(ax, language)
     return ax
 
@@ -165,9 +164,7 @@ def plot_scattering_coefficient(
     kwargs.setdefault("marker", "o")
     kwargs.setdefault("color", _C_PRIMARY)
     ax.plot(freqs, s, **kwargs)
-    _freq_axis(ax, freqs)
-    if language == "es":
-        ax.set_xlabel(_t("Frequency [Hz]", language))
+    _freq_axis(ax, freqs, language=language)
     ax.set_ylabel(_t("Scattering coefficient s", language))
     # s is normally in [0, 1], but edge effects (Clause 6.3.2) can push it above
     # 1 and those values are kept, not clipped; grow the top so they stay visible.
@@ -224,7 +221,9 @@ def plot_insitu_absorption(
     ax = ax if ax is not None else _new_axes()
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     alpha = np.asarray(result.absorption, dtype=np.float64)
-    positions = _band_axis(ax, freqs, xlabel=_t("Frequency [Hz]", language))
+    positions = _band_axis(
+        ax, freqs, xlabel=_t("Frequency [Hz]", language), language=language
+    )
     kwargs.setdefault("color", _C_PRIMARY)
     ax.bar(positions, np.nan_to_num(alpha), **kwargs)
     ax.set_ylabel(_t("Absorption coefficient", language))
@@ -390,9 +389,7 @@ def plot_absorption_uncertainty(
         label=f"+/-U (k = {decimal_comma(f'{result.coverage_factor:g}', language)})",
     )
     ax.plot(freqs, value, **kwargs)
-    _freq_axis(ax, freqs)
-    if language == "es":
-        ax.set_xlabel(_t("Frequency [Hz]", language))
+    _freq_axis(ax, freqs, language=language)
     ylabel = _ABSORPTION_QUANTITY_LABELS.get(result.quantity, "Value")
     ax.set_ylabel(_t(ylabel, language))
     if result.quantity != "equivalent_area":

--- a/src/phonometry/_plot/room.py
+++ b/src/phonometry/_plot/room.py
@@ -152,7 +152,7 @@ def plot_room_acoustics(
     _draw_decay_times(ax_times, positions, result, **kwargs)
     ax_times.set_ylabel(_t("Reverberation time [s]", language))
     ax_times.set_title(_t("ISO 3382 decay times and clarity", language))
-    _band_axis(ax_times, labels, xlabel=None)
+    _band_axis(ax_times, labels, xlabel=None, language=language)
     ax_times.grid(True, axis="y", alpha=0.3)
     ax_times.legend(loc="best", fontsize="small")
 
@@ -182,6 +182,7 @@ def plot_room_acoustics(
         ax_clarity,
         labels,
         xlabel=_t("Frequency [Hz]" if use_freq_axis else "Band", language),
+        language=language,
     )
     ax_clarity.grid(True, alpha=0.3)
     ax_clarity.legend(loc="best", fontsize="small")
@@ -258,7 +259,7 @@ def plot_impulse_response(
     n = h.shape[-1]
     if n == 0:
         raise ValueError("impulse response is empty; nothing to plot.")
-    time, xlabel = _time_axis(n, result.fs)
+    time, xlabel = _time_axis(n, result.fs, language=language)
     peak = float(np.max(np.abs(h)))
     tiny = np.finfo(np.float64).tiny
     norm = peak if peak > 0.0 else 1.0
@@ -344,9 +345,7 @@ def plot_noise_criterion(
             label=(f"{_t('Governing band', language)} "
                    f"({_format_freq(result.governing_frequency)})"),
         )
-    _freq_axis(ax, OCTAVE_BANDS)
-    if language == "es":
-        ax.set_xlabel(_t("Frequency [Hz]", language))
+    _freq_axis(ax, OCTAVE_BANDS, language=language)
     ax.set_ylabel(_t("Octave-band SPL [dB]", language))
     ax.set_title(
         f"ANSI/ASA S12.2 NC-{result.rating:g} "
@@ -391,9 +390,7 @@ def plot_room_criterion(
     kwargs.setdefault("color", _C_PRIMARY)
     kwargs.setdefault("label", _t("Measured", language))
     ax.plot(freqs[valid], levels[valid], "o-", zorder=3, **kwargs)
-    _freq_axis(ax, freqs)
-    if language == "es":
-        ax.set_xlabel(_t("Frequency [Hz]", language))
+    _freq_axis(ax, freqs, language=language)
     ax.set_ylabel(_t("Octave-band SPL [dB]", language))
     ax.set_title(f"ANSI/ASA S12.2 {result.label}")
     ax.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
@@ -420,9 +417,7 @@ def plot_enclosed_space_absorption(
     kwargs.setdefault("color", _C_PRIMARY)
     kwargs.setdefault("marker", "o")
     ax.plot(freq, rt, **kwargs)
-    _freq_axis(ax, freq)
-    if language == "es":
-        ax.set_xlabel(_t("Frequency [Hz]", language))
+    _freq_axis(ax, freq, language=language)
     ax.set_ylabel(_t("Reverberation time $T$ [s]", language))
     ax.set_title(_t("EN 12354-6 reverberation time", language))
     ax.set_ylim(bottom=0.0)
@@ -467,9 +462,7 @@ def plot_reverberation_models(
             label=label,
             **kwargs,
         )
-    _freq_axis(ax, freq)
-    if language == "es":
-        ax.set_xlabel(_t("Frequency [Hz]", language))
+    _freq_axis(ax, freq, language=language)
     ax.set_ylabel(_t("Reverberation time $T$ [s]", language))
     ax.set_title(
         f"{_t('Reverberation-time models — ', language)}"

--- a/src/phonometry/_plot/vibration.py
+++ b/src/phonometry/_plot/vibration.py
@@ -178,7 +178,7 @@ def plot_weighted_spectrum(
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     raw = np.asarray(result.band_accelerations, dtype=np.float64)
     weighted = np.asarray(result.weighted, dtype=np.float64)
-    positions = _band_axis(ax, freqs)
+    positions = _band_axis(ax, freqs, language=language)
     ax.set_xlabel(_t("freq_hz", language))
     width = 0.4
     # The weighted bars are the primary artist; forward user kwargs there.

--- a/tests/environmental/test_environmental_plot_i18n.py
+++ b/tests/environmental/test_environmental_plot_i18n.py
@@ -10,6 +10,10 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
+from phonometry.environmental.ground_barriers import ground_effect
+from phonometry.environmental.outdoor_propagation import (
+    outdoor_propagation_attenuation,
+)
 from phonometry.environmental.wind_turbine_noise import wind_turbine_tonality
 
 
@@ -39,4 +43,30 @@ def test_plot_unknown_language_raises() -> None:
     result = _result()
     with pytest.raises(ValueError, match="Unknown language"):
         result.plot(language="xx")
+    plt.close("all")
+
+
+def test_plot_outdoor_attenuation_spanish_xaxis_label() -> None:
+    # plot_outdoor_attenuation draws its per-band terms through the shared
+    # ``_band_axis`` helper and sets no xlabel of its own, so the Spanish
+    # label only appears once the language is threaded into that helper.
+    result = outdoor_propagation_attenuation(100.0, 2.0, 2.0)
+    ax = result.plot(language="es")
+    assert ax.get_xlabel() == "Frecuencia [Hz]"
+    plt.close("all")
+    ax = result.plot()
+    assert ax.get_xlabel() == "Frequency [Hz]"
+    plt.close("all")
+
+
+def test_plot_spherical_ground_spanish_xaxis_label() -> None:
+    # plot_spherical_ground draws its frequency axis through the shared
+    # ``_freq_axis`` helper without overriding the xlabel afterwards.
+    freqs = np.array([250.0, 500.0, 1000.0, 2000.0])
+    result = ground_effect(freqs, 2.0, 1.5, 20.0, flow_resistivity=2.0e4)
+    ax = result.plot(language="es")
+    assert ax.get_xlabel() == "Frecuencia [Hz]"
+    plt.close("all")
+    ax = result.plot()
+    assert ax.get_xlabel() == "Frequency [Hz]"
     plt.close("all")

--- a/tests/test_plot_common_i18n.py
+++ b/tests/test_plot_common_i18n.py
@@ -1,0 +1,217 @@
+#  Copyright (c) 2026. Jose M. Requena-Plens
+"""EN/ES internationalisation of the shared ``_plot/common.py`` renderers.
+
+These low-level helpers (frequency/band axes, the shifted-reference rating
+figure, the band-level bar chart, the facade x-axis, the ISO 717-2 500 Hz
+annotation and the time axis) are reused by every ``_plot/<domain>.py``
+module. Each domain module owns its own titles and legends, but the axis
+labels and legend entries these *shared* helpers draw themselves must also
+localise to Spanish once a domain's ``plot(language="es")`` reaches them.
+
+English stays byte-identical to the pre-i18n renderers (``_t`` is a no-op for
+``language="en"``), which is verified separately by the committed
+documentation figures via ``scripts/check_figures.py``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytest.importorskip("matplotlib")
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+
+from phonometry._plot.common import (  # noqa: E402
+    _annotate_impact_500,
+    _band_axis,
+    _facade_x_axis,
+    _freq_axis,
+    _plot_band_level_bars,
+    _plot_rating,
+    _time_axis,
+)
+
+
+def _axes():
+    _fig, ax = plt.subplots()
+    return ax
+
+
+def _legend_texts(ax) -> list[str]:
+    legend = ax.get_legend()
+    return [] if legend is None else [t.get_text() for t in legend.get_texts()]
+
+
+def test_freq_axis_spanish_label() -> None:
+    ax = _axes()
+    _freq_axis(ax, np.array([125.0, 250.0, 500.0]), language="es")
+    assert ax.get_xlabel() == "Frecuencia [Hz]"
+    plt.close("all")
+
+
+def test_freq_axis_english_default_unchanged() -> None:
+    ax = _axes()
+    _freq_axis(ax, np.array([125.0, 250.0, 500.0]))
+    assert ax.get_xlabel() == "Frequency [Hz]"
+    plt.close("all")
+
+
+def test_band_axis_spanish_default_label() -> None:
+    ax = _axes()
+    _band_axis(ax, np.array([125.0, 250.0]), language="es")
+    assert ax.get_xlabel() == "Frecuencia [Hz]"
+    plt.close("all")
+
+
+def test_band_axis_spanish_band_xlabel() -> None:
+    ax = _axes()
+    _band_axis(ax, ["1", "2", "3"], xlabel="Band", language="es")
+    assert ax.get_xlabel() == "Banda"
+    plt.close("all")
+
+
+def test_band_axis_none_xlabel_left_untouched() -> None:
+    ax = _axes()
+    ax.set_xlabel("kept")
+    _band_axis(ax, np.array([125.0, 250.0]), xlabel=None, language="es")
+    assert ax.get_xlabel() == "kept"
+    plt.close("all")
+
+
+def test_plot_rating_spanish_labels_and_legend() -> None:
+    band_centers = np.array([125.0, 250.0, 500.0, 1000.0])
+    measured = np.array([30.0, 35.0, 40.0, 45.0])
+    reference = np.array([32.0, 34.0, 42.0, 44.0])
+    ax = _plot_rating(
+        band_centers, measured, reference,
+        impact=False, title="t", ylabel="y", ax=None, language="es",
+    )
+    assert ax.get_xlabel() == "Frecuencia [Hz]"
+    legend_texts = _legend_texts(ax)
+    assert "Medido" in legend_texts
+    assert "Referencia desplazada" in legend_texts
+    plt.close("all")
+
+
+def test_plot_rating_unfavourable_deviations_localised() -> None:
+    band_centers = np.array([125.0, 250.0, 500.0])
+    measured = np.array([50.0, 55.0, 60.0])
+    reference = np.array([40.0, 45.0, 50.0])
+    ax = _plot_rating(
+        band_centers, measured, reference,
+        impact=True, title="t", ylabel="y", ax=None, language="es",
+    )
+    assert "Desviaciones desfavorables" in _legend_texts(ax)
+    plt.close("all")
+
+
+def test_plot_rating_english_default_unchanged() -> None:
+    band_centers = np.array([125.0, 250.0, 500.0])
+    measured = np.array([30.0, 35.0, 40.0])
+    reference = np.array([32.0, 34.0, 42.0])
+    ax = _plot_rating(
+        band_centers, measured, reference,
+        impact=False, title="t", ylabel="y", ax=None,
+    )
+    assert ax.get_xlabel() == "Frequency [Hz]"
+    legend_texts = _legend_texts(ax)
+    assert "Measured" in legend_texts
+    assert "Shifted reference" in legend_texts
+    plt.close("all")
+
+
+def test_plot_band_level_bars_spanish_xlabel_and_comma_total() -> None:
+    ax = _plot_band_level_bars(
+        None, np.array([50.0, 55.0, 60.0]), np.array([125.0, 250.0, 500.0]),
+        62.3, ylabel="y", title="t", language="es",
+    )
+    assert ax.get_xlabel() == "Frecuencia [Hz]"
+    assert "total 62,3 dB" in _legend_texts(ax)
+    plt.close("all")
+
+
+def test_plot_band_level_bars_band_xlabel_when_no_frequencies() -> None:
+    ax = _plot_band_level_bars(
+        None, np.array([50.0, 55.0]), None, 53.0, ylabel="y", title="t",
+        language="es",
+    )
+    assert ax.get_xlabel() == "Banda"
+    plt.close("all")
+
+
+def test_plot_band_level_bars_english_default_unchanged() -> None:
+    ax = _plot_band_level_bars(
+        None, np.array([50.0, 55.0, 60.0]), np.array([125.0, 250.0, 500.0]),
+        62.3, ylabel="y", title="t",
+    )
+    assert ax.get_xlabel() == "Frequency [Hz]"
+    assert "total 62.3 dB" in _legend_texts(ax)
+    plt.close("all")
+
+
+def test_facade_x_axis_frequency_path_spanish() -> None:
+    ax = _axes()
+    _facade_x_axis(ax, np.array([125.0, 250.0]), 2, language="es")
+    assert ax.get_xlabel() == "Frecuencia [Hz]"
+    plt.close("all")
+
+
+def test_facade_x_axis_band_index_path_spanish() -> None:
+    ax = _axes()
+    _facade_x_axis(ax, None, 3, language="es")
+    assert ax.get_xlabel() == "Banda"
+    tick_labels = [t.get_text() for t in ax.get_xticklabels()]
+    assert tick_labels == ["Banda 1", "Banda 2", "Banda 3"]
+    plt.close("all")
+
+
+def test_facade_x_axis_band_index_path_english_unchanged() -> None:
+    ax = _axes()
+    _facade_x_axis(ax, None, 2)
+    assert ax.get_xlabel() == "Band"
+    tick_labels = [t.get_text() for t in ax.get_xticklabels()]
+    assert tick_labels == ["Band 1", "Band 2"]
+    plt.close("all")
+
+
+def test_annotate_impact_500_spanish_legend_and_annotation() -> None:
+    ax = _axes()
+    band_centers = np.array([125.0, 250.0, 500.0, 1000.0])
+    reference = np.array([30.0, 35.0, 40.0, 45.0])
+    ax.plot(band_centers, reference)
+    _annotate_impact_500(ax, band_centers, reference, 35, language="es")
+    legend_texts = _legend_texts(ax)
+    assert any("lectura 500 Hz" in t for t in legend_texts)
+    annotation_texts = [child.get_text() for child in ax.texts]
+    assert any("regla de octava" in t for t in annotation_texts)
+    plt.close("all")
+
+
+def test_annotate_impact_500_english_default_unchanged() -> None:
+    ax = _axes()
+    band_centers = np.array([125.0, 250.0, 500.0, 1000.0])
+    reference = np.array([30.0, 35.0, 40.0, 45.0])
+    ax.plot(band_centers, reference)
+    _annotate_impact_500(ax, band_centers, reference, 35)
+    legend_texts = _legend_texts(ax)
+    assert any("500 Hz read" in t for t in legend_texts)
+    annotation_texts = [child.get_text() for child in ax.texts]
+    assert any("octave rule" in t for t in annotation_texts)
+    plt.close("all")
+
+
+def test_time_axis_spanish_labels() -> None:
+    _, xlabel = _time_axis(100, 1000, language="es")
+    assert xlabel == "Tiempo [s]"
+    _, xlabel_no_fs = _time_axis(100, None, language="es")
+    assert xlabel_no_fs == "Muestra"
+
+
+def test_time_axis_english_default_unchanged() -> None:
+    _, xlabel = _time_axis(100, 1000)
+    assert xlabel == "Time [s]"
+    _, xlabel_no_fs = _time_axis(100, None)
+    assert xlabel_no_fs == "Sample"


### PR DESCRIPTION
## Summary

CodeRabbit flagged on #251 that the EN/ES i18n support only reached each `_plot/<domain>.py` module's own strings, not the shared low-level renderers in `_plot/common.py` (frequency/band axes, the shifted-reference rating figure, the band-level bar chart, the facade x-axis, the ISO 717-2 500 Hz annotation and the time axis). Those helpers always drew their own axis labels and legend text in English, so several `language="es"` figures ended up mixed-language (an English "Frequency [Hz]" xlabel next to a Spanish title), and a handful of renderers (`plot_intensity`, `plot_outdoor_attenuation`, `plot_vibration_reduction`, `plot_band_uncertainty`, `plot_floor_covering_improvement`, `plot_scattering_coefficient`, `plot_absorption_uncertainty`, `plot_sound_power`) had no override at all, so their frequency/band axis stayed English even in Spanish.

This PR:

- Gives `_freq_axis`, `_band_axis`, `_plot_rating`, `_plot_band_level_bars`, `_facade_x_axis`, `_annotate_impact_500` and `_time_axis` a keyword-only `language` parameter and a small `_STRINGS`/`_t` lookup local to `common.py` (`"Frequency [Hz]"` -> `"Frecuencia [Hz]"`, `"Band"` -> `"Banda"`, `"Measured"` -> `"Medido"`, `"Shifted reference"` -> `"Referencia desplazada"`, `"Unfavourable deviations"` -> `"Desviaciones desfavorables"`, `"Time [s]"` -> `"Tiempo [s]"`, `"Sample"` -> `"Muestra"`).
- Threads `language=language` into every call site of those helpers across `building.py`, `emission.py`, `environmental.py`, `hearing.py`, `materials.py`, `room.py` and `vibration.py`.
- Drops the now-redundant `if language == "es": ax.set_xlabel(...)` patches that a few renderers used to work around the missing parameter.
- Localizes the `_plot_band_level_bars` total-line legend (`"total {x} dB"`) and the `_annotate_impact_500` 500 Hz read/rating annotations, using `decimal_comma` for the numbers.

`_i18n` imports stay lazy inside each function body (never at module level), so the `_plot` module-level import architecture test is unaffected.

English output is unchanged: `_t` is a no-op for `language="en"`, and `scripts/check_figures.py` still reports every committed documentation figure matching within tolerance.

## Test plan

- [x] `ruff check .`
- [x] `mypy src scripts` (only the pre-existing, unrelated baseline errors remain)
- [x] `python -m pytest tests/ -q` — 4169 passed, 64 skipped
- [x] `python scripts/check_figures.py` — all 864 committed figures match
- [x] `make api-docs && make llms` — no drift (no public signature changed)
- [x] New `tests/test_plot_common_i18n.py` exercises each of the seven shared helpers directly in both languages
- [x] Extended `tests/environmental/test_environmental_plot_i18n.py` to cover `plot_outdoor_attenuation` and `plot_spherical_ground` (the two renderers that previously had no Spanish xlabel at all)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded Spanish localization across plot axes, legends, annotations, band labels, and time/sample labels throughout all plotting domains.
  * Added Spanish decimal formatting where applicable.

* **Bug Fixes**
  * Fixed remaining plot labels that appeared in English when Spanish was selected.
  * Preserved existing English output when no language is specified.

* **Tests**
  * Added coverage verifying Spanish and English labels across shared and environmental plotting features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->