### PR TITLE
docs: serve the ISO 717 fiche PDFs from the same raw host as the images

### DIFF
--- a/docs/insulation-field.md
+++ b/docs/insulation-field.md
@@ -384,11 +384,11 @@ building.weighted_impact_rating(l_nt).report("Lnw_fiche.pdf")  # Ln,w (CI)
 Rendered examples of both fiches, regenerated with `make reports`, are kept in
 the repository. Click either preview to open the PDF:
 
-[![Airborne ISO 717-1 example report: metadata header, one-third-octave R table beside the measured-versus-shifted-reference plot, boxed Rw (C; Ctr) and a PASS verdict](https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/reports/iso717_airborne_example.png)](https://github.com/jmrplens/phonometry/raw/main/.github/reports/iso717_airborne_example.pdf)
+[![Airborne ISO 717-1 example report: metadata header, one-third-octave R table beside the measured-versus-shifted-reference plot, boxed Rw (C; Ctr) and a PASS verdict](https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/reports/iso717_airborne_example.png)](https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/reports/iso717_airborne_example.pdf)
 
 *Airborne rating fiche (`WeightedRatingResult.report`), Rw (C; Ctr).*
 
-[![Impact ISO 717-2 example report: the same accredited layout for the normalized impact level Ln, boxed Ln,w (CI) and a FAIL verdict](https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/reports/iso717_impact_example.png)](https://github.com/jmrplens/phonometry/raw/main/.github/reports/iso717_impact_example.pdf)
+[![Impact ISO 717-2 example report: the same accredited layout for the normalized impact level Ln, boxed Ln,w (CI) and a FAIL verdict](https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/reports/iso717_impact_example.png)](https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/reports/iso717_impact_example.pdf)
 
 *Impact rating fiche (`ImpactRatingResult.report`), Ln,w (CI).*
 


### PR DESCRIPTION
The two example-report PDF links in `docs/insulation-field.md` used `github.com/jmrplens/phonometry/raw/main/...` while every image in the page (and the rest of the docs) uses `raw.githubusercontent.com/.../main/...`. This points the PDF links at the same host so the fiche assets are served consistently. Docs-only, no code change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

