### PR TITLE
fix(emission): round the ISO 4871 declared value as round(L + K), not round(L) + round(K)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   (`fc = sqrt(12) c0^2 / (2 pi h cL)`, `c0 = 343 m/s`) and stores them on
   `JunctionTransmissionResult.critical_frequency1`/`critical_frequency2`, and
   `corner_reduction_index` uses the receiving plate's value.
+- The ISO 4871 declared single-number values
+  (`OperatingModeDeclaration.declared_sound_power_level` and
+  `.declared_emission_pressure_level`) now round the sum `L + K` once to the
+  nearest decibel, as clause 3.15 defines (`L_d = L + K`, the sum of the
+  unrounded quantities rounded to the nearest decibel), instead of adding the
+  separately rounded `L` and `K` of the dual-number form (clause 3.16). The
+  previous behaviour could understate the declared value by 1 dB (for example
+  `L_WA = 91.4`, `K_WA = 2.4` gave 93 dB instead of 94 dB) and thereby flip
+  the clause 6.2 verification verdict at the boundary.
 
 ### Changed
 

--- a/site/src/content/docs/reference/api/power/declaration.md
+++ b/site/src/content/docs/reference/api/power/declaration.md
@@ -24,9 +24,9 @@ of two forms selected by the relevant noise test code (clause 4):
   and its associated uncertainty `K`, stated together but separately, both
   rounded to the nearest decibel; and
 * the **single-number** form (clause 3.15): the derived declared value
-  `L_d = L + K`, rounded to the nearest decibel, an upper limit which values
-  from repeated measurements are unlikely to exceed at the stated confidence
-  level.
+  `L_d`, the *sum* `L + K` of the unrounded quantities rounded once to the
+  nearest decibel, an upper limit which values from repeated measurements are
+  unlikely to exceed at the stated confidence level.
 
 `K` combines the measurement uncertainty (reproducibility) and, for a batch,
 the production spread (clauses 3.20 to 3.24; `K = 1,645 sigma_R` for a single
@@ -141,7 +141,7 @@ Holds the measured A-weighted sound power level `L_WA` and its uncertainty
 `K_WA` (ISO 4871 clause 3.16), and optionally the A-weighted emission sound
 pressure level `L_pA` at a work station with its uncertainty `K_pA`
 (clause 3.11). The derived declared single-number values follow from
-`L_d = L + K` (clause 3.15), both rounded to the nearest decibel. When a
+`L_d = L + K` (clause 3.15), the sum rounded to the nearest decibel. When a
 verification measurement `L_1` (an A-weighted sound power level determined
 for verification, clause 6) is supplied, `verified` applies the
 single-machine criterion of clause 6.2 (verified when `L_1 <= L_WAd`).
@@ -169,13 +169,20 @@ single-machine criterion of clause 6.2 (verified when `L_1 <= L_WAd`).
 
 Declared single-number emission pressure level `L_pAd = L_pA + K_pA`.
 
-`None` when no emission sound pressure level is declared for the mode.
+The sum `L_pA + K_pA` rounded once to the nearest decibel (clause
+3.15); `None` when no emission sound pressure level is declared for
+the mode.
 
 ### OperatingModeDeclaration.declared_sound_power_level
 
 *property*
 
 Declared single-number sound power level `L_WAd = L_WA + K_WA` (3.15).
+
+Clause 3.15 defines the declared value as the *sum* of the measured
+value and its uncertainty, rounded to the nearest decibel: the sum is
+formed from the unrounded quantities (clause 3.12) and rounded once,
+not assembled from the separately rounded dual-number values (3.16).
 
 ### OperatingModeDeclaration.verified
 

--- a/src/phonometry/emission/declaration.py
+++ b/src/phonometry/emission/declaration.py
@@ -16,9 +16,9 @@ of two forms selected by the relevant noise test code (clause 4):
   and its associated uncertainty ``K``, stated together but separately, both
   rounded to the nearest decibel; and
 * the **single-number** form (clause 3.15): the derived declared value
-  ``L_d = L + K``, rounded to the nearest decibel, an upper limit which values
-  from repeated measurements are unlikely to exceed at the stated confidence
-  level.
+  ``L_d``, the *sum* ``L + K`` of the unrounded quantities rounded once to the
+  nearest decibel, an upper limit which values from repeated measurements are
+  unlikely to exceed at the stated confidence level.
 
 ``K`` combines the measurement uncertainty (reproducibility) and, for a batch,
 the production spread (clauses 3.20 to 3.24; ``K = 1,645 sigma_R`` for a single
@@ -64,7 +64,7 @@ class OperatingModeDeclaration:
     ``K_WA`` (ISO 4871 clause 3.16), and optionally the A-weighted emission sound
     pressure level ``L_pA`` at a work station with its uncertainty ``K_pA``
     (clause 3.11). The derived declared single-number values follow from
-    ``L_d = L + K`` (clause 3.15), both rounded to the nearest decibel. When a
+    ``L_d = L + K`` (clause 3.15), the sum rounded to the nearest decibel. When a
     verification measurement ``L_1`` (an A-weighted sound power level determined
     for verification, clause 6) is supplied, :attr:`verified` applies the
     single-machine criterion of clause 6.2 (verified when ``L_1 <= L_WAd``).
@@ -139,21 +139,27 @@ class OperatingModeDeclaration:
 
     @property
     def declared_sound_power_level(self) -> int:
-        """Declared single-number sound power level ``L_WAd = L_WA + K_WA`` (3.15)."""
-        return _round_db(self.sound_power_level) + _round_db(
-            self.sound_power_uncertainty
-        )
+        """Declared single-number sound power level ``L_WAd = L_WA + K_WA`` (3.15).
+
+        Clause 3.15 defines the declared value as the *sum* of the measured
+        value and its uncertainty, rounded to the nearest decibel: the sum is
+        formed from the unrounded quantities (clause 3.12) and rounded once,
+        not assembled from the separately rounded dual-number values (3.16).
+        """
+        return _round_db(self.sound_power_level + self.sound_power_uncertainty)
 
     @property
     def declared_emission_pressure_level(self) -> int | None:
         """Declared single-number emission pressure level ``L_pAd = L_pA + K_pA``.
 
-        ``None`` when no emission sound pressure level is declared for the mode.
+        The sum ``L_pA + K_pA`` rounded once to the nearest decibel (clause
+        3.15); ``None`` when no emission sound pressure level is declared for
+        the mode.
         """
         if self.emission_pressure_level is None or self.emission_pressure_uncertainty is None:
             return None
-        return _round_db(self.emission_pressure_level) + _round_db(
-            self.emission_pressure_uncertainty
+        return _round_db(
+            self.emission_pressure_level + self.emission_pressure_uncertainty
         )
 
     @property

--- a/tests/emission/test_iso4871_report.py
+++ b/tests/emission/test_iso4871_report.py
@@ -4,9 +4,11 @@ Tests for the ISO 4871:1996 noise-emission declaration and its ``.report()``
 fiche (declaration model + PDF rendering).
 
 The declaration model is checked against ISO 4871's own definitions and Annex B
-example: the declared single-number value is ``L_WAd = L_WA + K_WA`` (clause
-3.15), the dual/single forms are the same declaration, and verification passes
-or fails at the clause 6.2 boundary ``L_1 <= L_WAd``. The rendering itself is a
+example: the declared single-number value is the sum ``L_WAd = L_WA + K_WA``
+rounded once to the nearest decibel (clause 3.15, not the sum of the separately
+rounded dual-number values of 3.16), the dual/single forms are the same
+declaration, and verification passes or fails at the clause 6.2 boundary
+``L_1 <= L_WAd``. The rendering itself is a
 feature, so those tests assert only structural facts: a valid one-page PDF,
 translated Spanish output, and rejected engines/languages.
 """
@@ -87,8 +89,30 @@ def test_declared_value_is_measured_plus_uncertainty() -> None:
 def test_declared_value_rounds_to_nearest_decibel() -> None:
     """A non-integer measurement + uncertainty is rounded to the nearest dB."""
     mode = OperatingModeDeclaration("m", 87.6, 2.4)
-    # 88 (rounded L) + 2 (rounded K) = 90.
+    # round(87.6 + 2.4) = round(90.0) = 90.
     assert mode.declared_sound_power_level == 90
+
+
+def test_declared_value_rounds_the_sum_not_the_addends() -> None:
+    """Clause 3.15 rounds the sum L + K once, not L and K separately.
+
+    L_WA = 91.4, K_WA = 2.4: the sum is 93.8, so L_WAd = 94; rounding the
+    addends first would give 91 + 2 = 93, one decibel low. The same rule
+    applies to the declared emission sound pressure level.
+    """
+    mode = OperatingModeDeclaration(
+        "m", 91.4, 2.4,
+        emission_pressure_level=81.4, emission_pressure_uncertainty=2.4,
+    )
+    assert mode.declared_sound_power_level == 94
+    assert mode.declared_emission_pressure_level == 84
+
+
+def test_declared_value_ties_round_half_up() -> None:
+    """A sum landing exactly on a half decibel rounds up (halves-up rule)."""
+    mode = OperatingModeDeclaration("m", 92.5, 2.0)
+    # round(94.5) = 95 with the halves-up rule.
+    assert mode.declared_sound_power_level == 95
 
 
 def test_verification_passes_and_fails_at_the_clause_6_2_boundary() -> None:


### PR DESCRIPTION
## What

The ISO 4871 declared single-number values (`OperatingModeDeclaration.declared_sound_power_level` and `.declared_emission_pressure_level`) computed `round(L) + round(K)`. Clause 3.15 defines the declared value as the sum of a measured noise emission value and the associated uncertainty, rounded to the nearest decibel: `L_d = L + K`, one rounding of the sum. Measured values are not rounded (clause 3.12); rounding L and K separately belongs only to the dual-number presentation of clause 3.16, which the dual-number path already does correctly.

## Why it matters

The two orders differ by up to 1 dB. Counter-example: `L_WA = 91.4`, `K_WA = 2.4`: the standard gives `round(93.8) = 94 dB`; the old code gave `91 + 2 = 93 dB`. Since the declared value is the upper limit of the clause 6.2 verification (`L_1 <= L_WAd`), a 1 dB understatement can flip the verdict, e.g. for `L_1 = 94`.

## Changes

- Both declared-value properties now return `_round_db(L + K)`, keeping the halves-up tie rule.
- Module and property docstrings state the clause 3.15 rule precisely (sum of the unrounded quantities, rounded once) and distinguish it from clause 3.16.
- Tests: the 91.4 + 2.4 counter-example for both the sound power and the emission pressure declared values, and a half-decibel tie (92.5 + 2.0 -> 95 dB).
- API reference page regenerated from the updated docstrings.
- Changelog entry under `[Unreleased]` / Fixed.

## Unchanged by design

- The committed example fiche (`.github/reports/iso4871_declaration_example.{pdf,png}`) and the two ISO 4871 conformance rows use the Annex B example with integer `L` and `K` (88 + 2, 95 + 2), for which both rounding orders agree; regenerating them produced byte-identical output (367/367 conformance checks pass).
- Guide prose (EN/ES) states `L_WAd = L_WA + K_WA` without a separate-rounding claim and uses integer examples, so no wording or numbers change.

## Verification

`ruff check .`, `mypy src scripts`, `bandit -r src` (0 issues), `pytest tests/emission` (221 passed) plus the report/conformance suites (480 passed), `make reports` determinism check, `scripts/check_figures.py` (868 figures match).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

