### PR TITLE
Fix the four-pole transmission-loss prefactor for unequal port areas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   direction) and `φ = β − ε` for observers to port. The sign was inverted, so
   the lateral-directivity (engine-installation) correction of every banked
   segment was mirrored between the inside and outside of a turn.
+- `noise_control.silencers.transmission_loss` had the four-pole prefactor
+  inverted (`Z1/Zn` instead of `Zn/Z1`), overstating the transmission loss by
+  `20 lg(S_out/S_in)` whenever the inlet and outlet port areas differed: a
+  zero-length element between 0.01 and 0.02 m2 (a sudden expansion, classic
+  `TL = 10 lg[(1+m)^2/(4m)] = 0.512 dB`) came out as 6.532 dB, and the TL of
+  an unequal-port chamber was not reciprocal (11.34 vs -0.70 dB, a negative
+  loss for a passive element). The formula now follows Munjal, *Acoustics of
+  Ducts and Mufflers* 2e, Eq. (3.27), reproduces the sudden-expansion limit
+  exactly in both directions and is reciprocal; regression tests pin both.
+  The four shipped silencer builders call it with equal port areas, so their
+  results are unchanged. Bies 5e Eq. (8.141) as printed also fails the
+  sudden-expansion limit (1.938 dB) and is now registered in
+  `docs/ERRATA.md`.
 
 ### Changed
 

--- a/docs/ERRATA.md
+++ b/docs/ERRATA.md
@@ -571,6 +571,38 @@ to the issuing body, with date and reference).
   ``test_high_frequency_density_asymptote``.
 - **Status:** unreported (textbook rather than a standard).
 
+## Bies, Hansen & Howard, Engineering Noise Control 5e (2017), Eq. (8.141)
+
+- **Location:** Section 8.9.1, Eq. (8.141) (printed p. 461), the transmission
+  loss of a muffler from the elements of its total four-pole matrix.
+- **The print:** TL = 10 lg[ ((1+Mₙ)/(1+M₁))² · ¼ · |(Z_A1/Z_An)·T11 +
+  T12/Z_An + Z_A1·T21 + (Z_An/Z_A1)·T22|² ], i.e. with the impedance ratio
+  Z_A1/Z_An weighting T11 and its inverse weighting T22.
+- **The problem:** the source the equation itself cites (Munjal, *Acoustics
+  of Ducts and Mufflers* 2e, Eq. (3.27), p. 105) carries the overall
+  prefactor Z_An/Z_A1 (equivalently √(S₁/Sₙ) inside a 20 lg form) with T11
+  unweighted and Z_A1/Z_An on T22. As printed, Eq. (8.141) fails the
+  sudden-expansion limit: a zero-length element (T = I) between S₁ = 0,01 m²
+  and Sₙ = 0,02 m² is a sudden area expansion with the classic
+  TL = 10 lg[(1+m)²/(4m)] = 0,512 dB (m = Sₙ/S₁ = 2), but the printed
+  equation gives ¼·(Z_A1/Z_An + Z_An/Z_A1)² = 1,938 dB. Reading the ratios
+  as an overall Z_A1/Z_An prefactor instead is also wrong: it gives 6,532 dB
+  on the same oracle and violates reciprocity (11,34 vs −0,70 dB for an
+  expansion chamber between unequal pipes; a negative TL for a passive
+  element). The misprint is invisible whenever the inlet and outlet areas
+  are equal, where every variant reduces to Eq. (8.148).
+- **Evidence:** numeric evaluation of the zero-length identity element and
+  of an unequal-port expansion chamber under the printed form, the inverted
+  prefactor and Munjal Eq. (3.27); only Munjal's form reproduces the
+  sudden-expansion classic (0,512 dB, both directions) and is reciprocal.
+- **Library behaviour:** `transmission_loss` in
+  [`silencers.py`](../src/phonometry/noise_control/silencers.py) implements
+  Munjal Eq. (3.27), with the sudden-expansion limit and TL reciprocity
+  pinned by regression tests
+  ([`tests/noise_control/test_silencers.py`](../tests/noise_control/test_silencers.py))
+  and a defensive note at the formula.
+- **Status:** unreported (textbook rather than a standard).
+
 ---
 
 ## Related source properties that are not errata

--- a/docs/noise-control.md
+++ b/docs/noise-control.md
@@ -27,8 +27,16 @@ duct of length `L` and area `S` is (Bies Eq. (8.143), no flow)
 
 and a side branch of acoustic impedance `Z_b` is the shunt
 `[[1, 0], [1/Z_b, 1]]` (Eq. (8.144)). The **transmission loss** follows from
-the compound matrix `T` (Bies Eq. (8.141); for equal inlet/outlet areas,
-Eq. (8.148))
+the compound matrix `T` with the port impedances `Z1 = rho c / S_in` and
+`Zn = rho c / S_out` (Munjal Eq. (3.27); Bies Eq. (8.141) prints the
+`T11`/`T22` impedance weights of this formula inverted and fails the
+sudden-expansion limit, see the [errata registry](ERRATA.md))
+
+```text
+TL = 10 log10[ (Zn/Z1) (1/4) | T11 + T12/Zn + Z1 T21 + (Z1/Zn) T22 |^2 ] ,
+```
+
+which for equal inlet/outlet areas reduces to (Bies Eq. (8.148))
 
 ```text
 TL = 20 log10( (1/2) | T11 + T12/Zc + Zc T21 + T22 | ) ,   Zc = rho c / S,
@@ -166,7 +174,8 @@ of a decibel (test `tests/noise_control/test_fdtd_crosscheck.py`).
   methods (§8.11–8.17) and the machine-enclosure noise reduction (§7.4).
 - Munjal, M. L. (2014). *Acoustics of ducts and mufflers* (2nd ed.). Wiley.
   [doi:10.1002/9781118443767](https://doi.org/10.1002/9781118443767). The
-  transfer-matrix formulation behind the element matrices.
+  transfer-matrix formulation behind the element matrices and the
+  transmission loss from the compound matrix (Eq. (3.27)).
 - Vér, I. L., & Beranek, L. L. (2006). *Noise and vibration control
   engineering* (2nd ed.). Wiley.
   [doi:10.1002/9780470172568](https://doi.org/10.1002/9780470172568). The

--- a/site/src/content/docs/es/guides/noise-control.mdx
+++ b/site/src/content/docs/es/guides/noise-control.mdx
@@ -17,7 +17,7 @@ references:
     edition: "2nd ed."
     publisher: "Wiley"
     doi: "10.1002/9781118443767"
-    note: "La formulación por matrices de transferencia y las matrices de los elementos del §1."
+    note: "La formulación por matrices de transferencia, las matrices de los elementos y la pérdida de transmisión de la matriz compuesta (Ec. (3.27)) del §1."
   - type: book
     authors: ["Vér, I. L.", "Beranek, L. L."]
     year: 2006
@@ -58,8 +58,19 @@ $$
 
 y una rama lateral de impedancia $Z_b$ es la derivación
 $\left[\begin{smallmatrix} 1 & 0 \\ 1/Z_b & 1 \end{smallmatrix}\right]$. La
-**pérdida de transmisión** se obtiene de la matriz compuesta $T$ (Bies Ec. (8.141);
-para áreas de entrada y salida iguales $S$, Ec. (8.148))
+**pérdida de transmisión** se obtiene de la matriz compuesta $T$ con las
+impedancias de los puertos $Z_1 = \rho c/S_\text{in}$ y $Z_n = \rho c/S_\text{out}$
+(Munjal Ec. (3.27); Bies Ec. (8.141) imprime invertidos los pesos de impedancia
+de $T_{11}$ y $T_{22}$ de esta fórmula y no cumple el límite de expansión
+brusca, véase el
+[registro de erratas](https://github.com/jmrplens/phonometry/blob/main/docs/ERRATA.md))
+
+$$
+\mathrm{TL} = 10\log_{10}\!\left[\frac{Z_n}{Z_1}\,\tfrac{1}{4}\left|\,T_{11}
++ \tfrac{T_{12}}{Z_n} + Z_1\,T_{21} + \tfrac{Z_1}{Z_n}\,T_{22}\right|^2\right],
+$$
+
+que para áreas de entrada y salida iguales $S$ se reduce a (Bies Ec. (8.148))
 
 $$
 \mathrm{TL} = 20\log_{10}\!\left(\tfrac{1}{2}\left|\,T_{11}

--- a/site/src/content/docs/guides/noise-control.mdx
+++ b/site/src/content/docs/guides/noise-control.mdx
@@ -17,7 +17,7 @@ references:
     edition: "2nd ed."
     publisher: "Wiley"
     doi: "10.1002/9781118443767"
-    note: "The transfer-matrix formulation and the element matrices behind §1."
+    note: "The transfer-matrix formulation, the element matrices and the transmission loss from the compound matrix (Eq. (3.27)) behind §1."
   - type: book
     authors: ["Vér, I. L.", "Beranek, L. L."]
     year: 2006
@@ -57,8 +57,18 @@ $$
 
 and a side branch of impedance $Z_b$ is the shunt
 $\left[\begin{smallmatrix} 1 & 0 \\ 1/Z_b & 1 \end{smallmatrix}\right]$. The
-**transmission loss** follows from the compound matrix $T$ (Bies Eq. (8.141);
-for equal inlet/outlet areas $S$, Eq. (8.148))
+**transmission loss** follows from the compound matrix $T$ with the port
+impedances $Z_1 = \rho c/S_\text{in}$ and $Z_n = \rho c/S_\text{out}$
+(Munjal Eq. (3.27); Bies Eq. (8.141) prints the $T_{11}$/$T_{22}$ impedance
+weights of this formula inverted and fails the sudden-expansion limit, see the
+[errata registry](https://github.com/jmrplens/phonometry/blob/main/docs/ERRATA.md))
+
+$$
+\mathrm{TL} = 10\log_{10}\!\left[\frac{Z_n}{Z_1}\,\tfrac{1}{4}\left|\,T_{11}
++ \tfrac{T_{12}}{Z_n} + Z_1\,T_{21} + \tfrac{Z_1}{Z_n}\,T_{22}\right|^2\right],
+$$
+
+which for equal inlet/outlet areas $S$ reduces to (Bies Eq. (8.148))
 
 $$
 \mathrm{TL} = 20\log_{10}\!\left(\tfrac{1}{2}\left|\,T_{11}

--- a/site/src/content/docs/reference/api/noise_control/silencers.md
+++ b/site/src/content/docs/reference/api/noise_control/silencers.md
@@ -31,22 +31,31 @@ and a **side branch** of acoustic impedance `Z_b` is the shunt element
     [[ 1,       0 ],
      [ 1 / Z_b, 1 ]].
 
-**Transmission loss** from the compound matrix `T` (Bies Eq. (8.141), no
-flow; reduces to Eq. (8.148) for equal inlet/outlet areas):
+**Transmission loss** from the compound matrix `T` (Munjal, *Acoustics of
+Ducts and Mufflers* 2nd ed., Eq. (3.27), no flow; reduces to Bies Eq. (8.148)
+for equal inlet/outlet areas):
 
-    TL = 10 log10[ (Z1 / Zn) (1/4) | T11 + T12 / Zn + Z1 T21 + (Z1 / Zn) T22 |^2 ]
+    TL = 10 log10[ (Zn / Z1) (1/4) | T11 + T12 / Zn + Z1 T21 + (Z1 / Zn) T22 |^2 ]
 
-with `Z1 = rho c / S_in` and `Zn = rho c / S_out`. `TL` is the intrinsic
-attenuation for an anechoic termination. The **insertion loss** for a source of
-internal impedance `Z_s` radiating into a termination impedance `Z_r` is
-the extra attenuation of inserting the silencer in place of a direct
-connection,
+with `Z1 = rho c / S_in` and `Zn = rho c / S_out`. A zero-length element
+between unequal areas then reproduces the classic sudden-expansion result
+`TL = 10 log10[(1 + m)^2 / (4 m)]` with `m = S_out / S_in`, and the TL is
+the same from either side, as reciprocity of a passive two-port requires.
+Bies Eq. (8.141) prints this formula with impedance ratios on `T11` and
+`T22` (`Z_A1/Z_An` and `Z_An/Z_A1`) instead of the overall `Zn/Z1`
+prefactor; as printed it fails the sudden-expansion limit (see
+`docs/ERRATA.md`). `TL` is the intrinsic attenuation for an anechoic
+termination. The **insertion loss** for a source of internal impedance
+`Z_s` radiating into a termination impedance `Z_r` is the extra
+attenuation of inserting the silencer in place of a direct connection,
 
     IL = 20 log10 | (T11 Z_r + T12 + Z_s Z_r T21 + Z_s T22) / (Z_s + Z_r) |,
 
 which is `0` when the silencer reduces to a through connection (`T = I`)
-and equals the transmission loss for the anechoic reference
-`Z_s = rho c / S_in`, `Z_r = rho c / S_out`.
+and, for equal inlet/outlet areas, equals the transmission loss for the
+anechoic reference `Z_s = Z_r = rho c / S` (with unequal areas the direct
+connection contains the same area jump, so its mismatch loss cancels from
+the insertion loss but not from the transmission loss).
 
 **Simple expansion chamber.** A chamber of area `S_exp` and length `L`
 between pipes of area `S_duct` has the closed-form transmission loss (Bies

--- a/src/phonometry/noise_control/silencers.py
+++ b/src/phonometry/noise_control/silencers.py
@@ -24,22 +24,31 @@ and a **side branch** of acoustic impedance ``Z_b`` is the shunt element
     [[ 1,       0 ],
      [ 1 / Z_b, 1 ]].
 
-**Transmission loss** from the compound matrix ``T`` (Bies Eq. (8.141), no
-flow; reduces to Eq. (8.148) for equal inlet/outlet areas):
+**Transmission loss** from the compound matrix ``T`` (Munjal, *Acoustics of
+Ducts and Mufflers* 2nd ed., Eq. (3.27), no flow; reduces to Bies Eq. (8.148)
+for equal inlet/outlet areas):
 
-    TL = 10 log10[ (Z1 / Zn) (1/4) | T11 + T12 / Zn + Z1 T21 + (Z1 / Zn) T22 |^2 ]
+    TL = 10 log10[ (Zn / Z1) (1/4) | T11 + T12 / Zn + Z1 T21 + (Z1 / Zn) T22 |^2 ]
 
-with ``Z1 = rho c / S_in`` and ``Zn = rho c / S_out``. ``TL`` is the intrinsic
-attenuation for an anechoic termination. The **insertion loss** for a source of
-internal impedance ``Z_s`` radiating into a termination impedance ``Z_r`` is
-the extra attenuation of inserting the silencer in place of a direct
-connection,
+with ``Z1 = rho c / S_in`` and ``Zn = rho c / S_out``. A zero-length element
+between unequal areas then reproduces the classic sudden-expansion result
+``TL = 10 log10[(1 + m)^2 / (4 m)]`` with ``m = S_out / S_in``, and the TL is
+the same from either side, as reciprocity of a passive two-port requires.
+Bies Eq. (8.141) prints this formula with impedance ratios on ``T11`` and
+``T22`` (``Z_A1/Z_An`` and ``Z_An/Z_A1``) instead of the overall ``Zn/Z1``
+prefactor; as printed it fails the sudden-expansion limit (see
+``docs/ERRATA.md``). ``TL`` is the intrinsic attenuation for an anechoic
+termination. The **insertion loss** for a source of internal impedance
+``Z_s`` radiating into a termination impedance ``Z_r`` is the extra
+attenuation of inserting the silencer in place of a direct connection,
 
     IL = 20 log10 | (T11 Z_r + T12 + Z_s Z_r T21 + Z_s T22) / (Z_s + Z_r) |,
 
 which is ``0`` when the silencer reduces to a through connection (``T = I``)
-and equals the transmission loss for the anechoic reference
-``Z_s = rho c / S_in``, ``Z_r = rho c / S_out``.
+and, for equal inlet/outlet areas, equals the transmission loss for the
+anechoic reference ``Z_s = Z_r = rho c / S`` (with unequal areas the direct
+connection contains the same area jump, so its mismatch loss cancels from
+the insertion loss but not from the transmission loss).
 
 **Simple expansion chamber.** A chamber of area ``S_exp`` and length ``L``
 between pipes of area ``S_duct`` has the closed-form transmission loss (Bies
@@ -168,7 +177,13 @@ def transmission_loss(
     speed_of_sound: float = _C_AIR,
     density: float = _RHO_AIR,
 ) -> NDArray[np.float64]:
-    """Transmission loss of a four-pole element (Bies Eq. (8.141), no flow).
+    """Transmission loss of a four-pole element (Munjal Eq. (3.27), no flow).
+
+    ``TL = 10 lg[(Zn/Z1) (1/4) |T11 + T12/Zn + Z1 T21 + (Z1/Zn) T22|^2]``
+    with ``Z1 = rho c / S_in`` and ``Zn = rho c / S_out`` (Munjal, *Acoustics
+    of Ducts and Mufflers* 2nd ed., Eq. (3.27)). Do not "restore" the Bies
+    Eq. (8.141) weighting: as printed there the equation fails the
+    sudden-expansion limit for unequal port areas (see ``docs/ERRATA.md``).
 
     :param transfer_matrix: A ``(n_freq, 2, 2)`` compound matrix.
     :param inlet_area: Inlet pipe area ``S_in``, m2.
@@ -189,7 +204,7 @@ def transmission_loss(
     t22 = transfer_matrix[:, 1, 1]
     term = t11 + t12 / zn + z1 * t21 + (z1 / zn) * t22
     return np.asarray(
-        10.0 * np.log10((z1 / zn) * 0.25 * np.abs(term) ** 2),
+        10.0 * np.log10((zn / z1) * 0.25 * np.abs(term) ** 2),
         dtype=np.float64,
     )
 

--- a/tests/noise_control/test_silencers.py
+++ b/tests/noise_control/test_silencers.py
@@ -6,7 +6,9 @@ Oracles: the simple-expansion-chamber closed form ``TL = 10 log10[1 + (1/4)
 (m = 2 -> 1.94, 4 -> 6.55, 8 -> 12.18, 16 -> 18.10 dB), the four-pole TL
 reducing to the side-branch closed form (Bies Eq. (8.73)), the quarter-wave
 tube tuning ``f = c/(4 l_e)`` (Example 8.1: 56.6 Hz), the Helmholtz resonance
-``f_0 = (c/2 pi) sqrt(S/(l_e V))``, matrix reciprocity, and limiting cases.
+``f_0 = (c/2 pi) sqrt(S/(l_e V))``, matrix reciprocity, the sudden-expansion
+limit ``TL = 10 log10[(1 + m)^2/(4 m)]`` of a zero-length element between
+unequal port areas (Munjal Eq. (3.27)), and limiting cases.
 """
 
 from __future__ import annotations
@@ -103,6 +105,44 @@ def test_insertion_loss_equals_tl_for_anechoic_reference() -> None:
     il = sl.insertion_loss(t, source_impedance=z, radiation_impedance=z)
     assert np.allclose(il, tl, atol=1e-9)
     assert il.max() > 3.0  # a real silencer gives a positive insertion loss
+
+
+def test_identity_element_is_sudden_expansion() -> None:
+    # A zero-length element (T = I) between unequal port areas is a sudden
+    # area change, with the classic TL = 10 log10[(1 + m)^2 / (4 m)],
+    # m = S_out / S_in: 0.512 dB for m = 2, and identical in both directions
+    # (the formula is invariant under m -> 1/m). Pins the Munjal Eq. (3.27)
+    # prefactor Zn/Z1; the misprinted Bies Eq. (8.141) gives 1.938 dB here
+    # and an inverted Z1/Zn prefactor gives 6.532 dB (see docs/ERRATA.md).
+    f = np.linspace(50.0, 500.0, 20)
+    ident = sl.duct_matrix(f, 0.0, 0.01)  # zero-length duct = identity
+    m = 2.0
+    oracle = 10.0 * np.log10((1.0 + m) ** 2 / (4.0 * m))
+    assert oracle == pytest.approx(0.512, abs=5e-4)
+    expansion = sl.transmission_loss(ident, inlet_area=0.01, outlet_area=0.02)
+    contraction = sl.transmission_loss(ident, inlet_area=0.02, outlet_area=0.01)
+    assert np.allclose(expansion, oracle, atol=1e-12)
+    assert np.allclose(contraction, oracle, atol=1e-12)
+
+
+def test_transmission_loss_reciprocity_unequal_ports() -> None:
+    # A lossless reciprocal two-port must show the same TL from either side.
+    # Reversing a two-port with det T = 1 exchanges T11 and T22; the port
+    # areas swap with it. Checks a chamber and an asymmetric two-duct cascade
+    # between unequal pipes, and that the TL of a passive element never goes
+    # negative.
+    f = np.linspace(50.0, 1500.0, 300)
+    chamber = sl.duct_matrix(f, 0.3, 0.04)
+    cascaded = sl.cascade(
+        sl.duct_matrix(f, 0.2, 0.03), sl.duct_matrix(f, 0.15, 0.05)
+    )
+    for t in (chamber, cascaded):
+        t_rev = t.copy()
+        t_rev[:, 0, 0], t_rev[:, 1, 1] = t[:, 1, 1].copy(), t[:, 0, 0].copy()
+        forward = sl.transmission_loss(t, inlet_area=0.01, outlet_area=0.02)
+        reverse = sl.transmission_loss(t_rev, inlet_area=0.02, outlet_area=0.01)
+        assert np.allclose(forward, reverse, atol=1e-9)
+        assert forward.min() > -1e-9
 
 
 def test_transfer_matrix_reciprocity() -> None:


### PR DESCRIPTION
## Summary

`noise_control.silencers.transmission_loss` computed the anechoic-termination transmission loss with the prefactor `Z1/Zn`; the correct form (Munjal, *Acoustics of Ducts and Mufflers* 2e, Eq. (3.27)) carries `Zn/Z1`. The error is `20 lg(S_out/S_in)`, so it only shows when the inlet and outlet port areas differ.

Two independent physics checks expose it:

- **Sudden-expansion limit.** A zero-length element (T = I) between S_in = 0.01 and S_out = 0.02 m2 is a sudden area expansion with the classic `TL = 10 lg[(1+m)^2/(4m)] = 0.512 dB`. The old prefactor gave 6.532 dB; the corrected form gives 0.512 dB exactly, in both directions.
- **Reciprocity.** A lossless reciprocal two-port must show the same TL from either side. For an expansion chamber between unequal pipes the old form gave 11.34 vs -0.70 dB (a negative loss for a passive element); the corrected form is symmetric.

While anchoring the citation, Bies 5e Eq. (8.141) as printed (printed p. 461) turned out to be wrong too: it puts the impedance ratios on T11 and T22 instead of the overall prefactor and gives 1.938 dB on the same oracle, even though it cites Munjal Eq. (3.27) as its source. Registered in `docs/ERRATA.md` with the 0.512 / 1.938 / 6.532 dB demonstration, and the module now carries a defensive note so the misprint is not transcribed back as a fix.

## Impact

- All four shipped silencer builders (expansion chamber, Helmholtz, quarter-wave, extended-tube) call `transmission_loss` with equal inlet/outlet areas, so shipped results, the conformance report and all 868 committed figures are unchanged (verified with `scripts/check_figures.py`, zero drift).
- Only the public `transmission_loss(...)` with `inlet_area != outlet_area` was affected.
- The insertion-loss note in the module header now states the IL = TL identity holds for equal port areas (with unequal areas the direct connection contains the same area jump, so its mismatch loss cancels from the IL).

## Tests

- New: zero-length identity element reproduces the sudden-expansion oracle (0.512 dB) in both directions.
- New: TL reciprocity for a chamber and an asymmetric two-duct cascade between unequal pipes, plus non-negativity.
- All pre-existing equal-area closed-form tests pass untouched, confirming shipped silencers were unaffected.

## Gates

ruff, mypy src scripts, bandit, pytest (noise_control + architecture + conformance, 449 passed), check_figures (868/868 match), api-docs regenerated (docstring drift committed).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

