### PR TITLE
docs(site): promote Materials and surfaces to a top-level guide group

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -432,16 +432,16 @@ export default defineConfig({
                 'guides/dynamic-stiffness',
               ],
             },
-            {
-              label: 'Materials and surfaces',
-              translations: { es: 'Materiales y superficies' },
-              items: [
-                { slug: 'guides/sections/materials-surfaces', attrs: { 'data-group-link': true } },
-                'guides/materials',
-                'guides/porous-absorbers',
-                'guides/surface-scattering',
-              ],
-            },
+          ],
+        },
+        {
+          label: 'Materials and surfaces',
+          translations: { es: 'Materiales y superficies' },
+          items: [
+            { slug: 'guides/sections/materials-surfaces', attrs: { 'data-group-link': true } },
+            'guides/materials',
+            'guides/porous-absorbers',
+            'guides/surface-scattering',
           ],
         },
         {

--- a/site/src/content/docs/es/guides/sections/rooms-buildings.md
+++ b/site/src/content/docs/es/guides/sections/rooms-buildings.md
@@ -1,6 +1,6 @@
 ---
 title: "Salas y edificación"
-description: "El sonido dentro de las salas y a través de los edificios: medición y predicción acústica de salas (ISO 3382, EN 12354-6), aislamiento acústico medido en campo y en laboratorio y predicho con EN 12354, y la caracterización de materiales y superficies acústicas."
+description: "El sonido dentro de las salas y a través de los edificios: medición y predicción acústica de salas (ISO 3382, EN 12354-6), y aislamiento acústico medido en campo y en laboratorio y predicho con EN 12354."
 ---
 
 Esta sección cubre el sonido en el entorno construido, y se divide por una
@@ -15,14 +15,10 @@ sonido aéreo y de impacto transmiten una partición y sus caminos de flancos,
 medido en campo (ISO 16283) o en laboratorio (ISO 10140) y predicho a partir
 de datos de elemento (EN 12354).
 
-Ambas mitades descansan sobre los mismos datos de material. Las páginas de
-**materiales y superficies** caracterizan lo que muros, absorbentes y
-pavimentos hacen realmente con el sonido: coeficientes de absorción y sus
-índices globales, resistencia al flujo de aire, impedancia superficial,
-dispersión y difusión. Esos coeficientes son las entradas que consumen las
-predicciones de sala, y los índices de elemento son las entradas que consumen
-las predicciones de aislamiento, así que la sección forma un bucle: medir el
-material, predecir el edificio, verificar en campo.
+Ambas mitades consumen coeficientes medidos en otro lugar: la sección de
+[Materiales y superficies](/phonometry/es/guides/sections/materials-surfaces/)
+caracteriza los datos de absorción, impedancia y dispersión en los que se
+apoyan las predicciones de sala y de aislamiento de esta sección.
 
 Empieza por [Acústica de salas](/phonometry/es/guides/room-acoustics/): la
 respuesta al impulso que adquiere y los parámetros que deriva son el
@@ -71,15 +67,3 @@ laboratorio y predicho a partir de datos de elemento.
 - [Rigidez dinámica de materiales resilientes (EN 29052-1)](/phonometry/es/guides/dynamic-stiffness/):
   la medición por resonancia de placa de carga detrás de toda predicción de
   suelo flotante.
-
-## [Materiales y superficies](/phonometry/es/guides/sections/materials-surfaces/)
-
-Lo que materiales y superficies hacen con el sonido, medido en laboratorio e
-in situ.
-
-- [Materiales acústicos](/phonometry/es/guides/materials/): el índice
-  ponderado de absorción de ISO 11654, la resistencia al flujo de aire
-  (ISO 9053-1/-2) y el tubo de impedancia (ISO 10534-1/-2, ASTM E2611).
-- [Dispersión superficial, difusión y absorción in situ](/phonometry/es/guides/surface-scattering/):
-  coeficientes de dispersión (ISO 17497-1) y difusión (ISO 17497-2), y
-  absorción in situ de pavimentos (ISO 13472-1/-2).

--- a/site/src/content/docs/guides/sections/rooms-buildings.md
+++ b/site/src/content/docs/guides/sections/rooms-buildings.md
@@ -1,6 +1,6 @@
 ---
 title: "Rooms and buildings"
-description: "Sound inside rooms and through buildings: room-acoustic measurement and prediction (ISO 3382, EN 12354-6), sound insulation measured in the field and the laboratory and predicted with EN 12354, and the laboratory characterisation of acoustic materials and surfaces."
+description: "Sound inside rooms and through buildings: room-acoustic measurement and prediction (ISO 3382, EN 12354-6), and sound insulation measured in the field and the laboratory and predicted with EN 12354."
 ---
 
 This section covers sound in the built environment, and it splits along a
@@ -14,13 +14,10 @@ airborne and impact sound a partition and its flanking paths transmit, measured
 in the field (ISO 16283) or the laboratory (ISO 10140) and predicted from
 element data (EN 12354).
 
-Both halves rest on the same material data. The **materials and surfaces**
-pages characterise what walls, absorbers and pavements actually do to sound:
-absorption coefficients and their single-number ratings, airflow resistance,
-surface impedance, scattering and diffusion. Those coefficients are the inputs
-the room predictions consume, and the element ratings are the inputs the
-insulation predictions consume, so the section forms a loop: measure the
-material, predict the building, verify in the field.
+Both halves consume coefficients measured elsewhere: the
+[Materials and surfaces](/phonometry/guides/sections/materials-surfaces/)
+section characterises the absorption, impedance and scattering data that the
+room and insulation predictions here rely on.
 
 Start with [Room Acoustics](/phonometry/guides/room-acoustics/): the impulse
 response it acquires and the parameters it derives are the vocabulary the rest
@@ -63,15 +60,3 @@ laboratory, and predicted from element data.
   and outdoor radiation (EN 12354-3/4).
 - [Dynamic stiffness of resilient materials (EN 29052-1)](/phonometry/guides/dynamic-stiffness/):
   the load-plate resonance measurement behind every floating-floor prediction.
-
-## [Materials and surfaces](/phonometry/guides/sections/materials-surfaces/)
-
-What materials and surfaces do to sound, measured in the laboratory and in
-situ.
-
-- [Acoustic Materials](/phonometry/guides/materials/): the ISO 11654 weighted
-  absorption rating, airflow resistance (ISO 9053-1/-2) and the impedance tube
-  (ISO 10534-1/-2, ASTM E2611).
-- [Surface Scattering, Diffusion and In-situ Absorption](/phonometry/guides/surface-scattering/):
-  scattering (ISO 17497-1) and diffusion (ISO 17497-2) coefficients, and
-  in-situ road-surface absorption (ISO 13472-1/-2).


### PR DESCRIPTION
## What

Moves the **Materials and surfaces** subgroup out of the *Rooms and buildings* guide sidebar group and makes it a top-level group of its own, placed immediately after Rooms and buildings and before Vibration and structure-borne sound.

- `site/astro.config.mjs`: the new group is flat (landing + `guides/materials`, `guides/porous-absorbers`, `guides/surface-scattering`), following the same pattern as Underwater acoustics, with the landing as `data-group-link` first item.
- `guides/sections/rooms-buildings.md` (EN + ES): drops the materials paragraph and the `## Materials and surfaces` block, tightens the frontmatter description, and adds one sentence pointing at the new top-level section as the source of the coefficients the room and insulation predictions consume.
- `guides/sections/materials-surfaces.md` (EN + ES): unchanged; the prose already reads standalone and works as a top-level landing.

## Why

The materials pages (absorption ratings and impedance-tube methods, porous and multilayer absorber models, scattering/diffusion and in-situ road-surface absorption) feed room predictions, insulation models and outdoor-noise work alike; buried two levels deep inside Rooms and buildings they were easy to miss. The API reference already treats `materials` as its own section, so the guide sidebar now matches it.

`guides/dynamic-stiffness` deliberately stays under Sound insulation: its module lives in `phonometry.materials`, but its sole consumer is the floating-floor prediction chain.

## URL impact

None. Every guide page and both landings keep their URLs; the redirects table is untouched.

## Checks

- `astro build` green, starlight-links-validator: all internal links valid (403 pages)
- `node scripts/check-i18n-parity.mjs`: 90/90 EN pages have an ES twin
- `html-validate` on the built site: clean for all touched pages (the only findings are a pre-existing long title on `guides/junction-transmission` EN/ES, unrelated to this change)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the English and Spanish room-and-building guides with clearer scope descriptions.
  - Added links to the consolidated “Materials and surfaces” documentation for relevant acoustic coefficients.
  - Removed duplicated “Materials and surfaces” sections from the room-and-building guides.
  - Corrected the documentation sidebar structure so the “Materials and surfaces” section appears correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->