### PR TITLE
chore(i18n): flatten the last nested plot string tables and fix ES Anexo 16 wording

### DIFF
--- a/site/src/content/docs/es/guides/aircraft-noise.mdx
+++ b/site/src/content/docs/es/guides/aircraft-noise.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Ruido de aeronaves: nivel efectivo de ruido percibido"
-description: "El nivel efectivo de ruido percibido (EPNL) de la ICAO Anexo 16 Vol. I Apéndice 2: la molestia percibida y el PNL, la corrección tonal por el método de pendientes, la corrección por duración de 10 dB por debajo, y el verificador de sistema de medida IEC 61265."
+description: "El nivel efectivo de ruido percibido (EPNL) del Anexo 16 de la ICAO, Vol. I, Apéndice 2: la molestia percibida y el PNL, la corrección tonal por el método de pendientes, la corrección por duración de 10 dB por debajo, y el verificador de sistema de medida IEC 61265."
 references:
   - type: standard
     organization: "International Civil Aviation Organization"
@@ -150,7 +150,7 @@ aircraft.effective_perceived_noise_level(spectra, dt).plot()
 
 `EPNLResult.report(path)` renderiza una ficha PDF de una página con el formato de
 una hoja de datos de certificación de ruido de aeronaves: la línea de base
-normativa (ICAO Annex 16 Vol. I Apéndice 2), un bloque opcional de metadatos de
+normativa (Anexo 16 de la ICAO, Vol. I, Apéndice 2), un bloque opcional de metadatos de
 cabecera al estilo TCDSN (aeronave, fabricante / titular del certificado de tipo,
 solicitante, punto de medida), una tabla de métricas de las magnitudes
 intermedias informativas (el máximo `PNLTM`, la corrección por duración `D`, la
@@ -194,9 +194,9 @@ el repositorio; pulsa la vista previa para abrir el PDF.
 
 <ReportPreview
 	name="icao_epnl_example"
-	title="Informe de ejemplo EPNL de ICAO Annex 16 (PDF)"
+	title="Informe de ejemplo EPNL del Anexo 16 de la ICAO (PDF)"
 	description="Ficha de certificación de ruido de aeronaves de una página: una cabecera de metadatos, una franja de condiciones de referencia, una tabla de métricas con el máximo PNLTM y la corrección por duración D y la ventana de registros de 10 dB por debajo, la gráfica temporal PNL/PNLT a todo el ancho con el PNLTM marcado y la ventana de integración sombreada, el resultado de un solo número EPNL = 98.3 EPNdB en caja y una fila de veredicto CUMPLE frente a un límite de certificación de 101 EPNdB."
-	caption="Ficha de certificación EPNL de ICAO Annex 16 (EPNLResult.report), EPNL en EPNdB con PNLTM y la corrección por duración D."
+	caption="Ficha de certificación EPNL del Anexo 16 de la ICAO (EPNLResult.report), EPNL en EPNdB con PNLTM y la corrección por duración D."
 />
 
 ## Verificación del sistema de medida (IEC 61265)

--- a/src/phonometry/_plot/aircraft.py
+++ b/src/phonometry/_plot/aircraft.py
@@ -32,97 +32,58 @@ if TYPE_CHECKING:
         TerrainScreeningResult,
     )
 
-#: English and Spanish text for every fixed label/title/legend drawn by this
-#: module's renderers.  English entries are byte-for-byte the original strings.
-_STRINGS: dict[str, dict[str, str]] = {
-    "en": {
-        "win_10db": "10 dB-down window",
-        "time_s": "Time [s]",
-        "level_pndb": "Level [PNdB]",
-        "sae_band": "SAE band",
-        "puretone_midband": "Pure-tone mid-band (ISO 9613-1)",
-        "freq_hz": "Frequency [Hz]",
-        "atten_db": "Attenuation [dB]",
-        "aircraft_abs_title": "Aircraft atmospheric absorption (SAE ARP 5534)",
-        "tabulated": "Tabulated",
-        "slant_distance": "Slant distance [m]",
-        "event_level": "Event level [dB]",
-        "npd_title": "Noise-power-distance curve (ECAC Doc 29)",
-        "segment_index": "Segment index",
-        "segment_metric": "Segment {metric} [dB]",
-        "flyover_title": "Single-event segment contributions (ECAC Doc 29)",
-        "polar_angle": "Polar angle θ [°]  (0° forward → 180° rearward)",
-        "source_level_60m": "Source level at 60 m [dB]",
-        "hemisphere_title": "Rotorcraft noise hemisphere directivity (ECAC Doc 32)",
-        "contour_title": "Aircraft noise contour (ECAC Doc 29)",
-        "airspeed": "Airspeed $V_A$",
-        "ground_speed": "Ground speed $V_g$",
-        "speed_ms": "Speed [m/s]",
-        "path_angle": "Path angle $\\gamma$",
-        "bank_angle": "Bank angle $\\Phi$",
-        "angle_deg": "Angle [°]",
-        "kinematics_title": "Rotorcraft flight-path kinematics (ECAC Doc 32)",
-        "recorded_time": "Recorded time [s]",
-        "a_level": "A-weighted level [dB(A)]",
-        "rotor_event_title": "Rotorcraft flyover time history (ECAC Doc 32)",
-        "rotor_contour_title": "Rotorcraft noise contour (ECAC Doc 32)",
-        "terrain_profile": "Terrain profile",
-        "mean_ground_plane": "Mean ground plane",
-        "section_distance": "Section distance [m]",
-        "height_m": "Height [m]",
-        "mgp_title": "Mean ground plane (NORAH2 guidance Eq. 36-40)",
-        "line_of_sight": "Line of sight",
-        "diffracted_path": "Diffracted path",
-        "diffraction_edges": "Diffraction edges",
-        "screening_title": "Terrain screening (ECAC Doc 32 / NORAH2 guidance)",
-    },
-    "es": {
-        "win_10db": "Ventana 10 dB por debajo",
-        "time_s": "Tiempo [s]",
-        "level_pndb": "Nivel [PNdB]",
-        "sae_band": "Banda SAE",
-        "puretone_midband": "Banda media de tono puro (ISO 9613-1)",
-        "freq_hz": "Frecuencia [Hz]",
-        "atten_db": "Atenuación [dB]",
-        "aircraft_abs_title": "Absorción atmosférica de aeronaves (SAE ARP 5534)",
-        "tabulated": "Tabulados",
-        "slant_distance": "Distancia oblicua [m]",
-        "event_level": "Nivel del evento [dB]",
-        "npd_title": "Curva ruido-potencia-distancia (ECAC Doc 29)",
-        "segment_index": "Índice de segmento",
-        "segment_metric": "{metric} por segmento [dB]",
-        "flyover_title": "Contribuciones por segmento de un evento único (ECAC Doc 29)",
-        "polar_angle": "Ángulo polar θ [°]  (0° adelante → 180° atrás)",
-        "source_level_60m": "Nivel de fuente a 60 m [dB]",
-        "hemisphere_title": "Directividad del hemisferio de ruido de rotorcraft (ECAC Doc 32)",
-        "contour_title": "Curvas de ruido de aeronaves (ECAC Doc 29)",
-        "airspeed": "Velocidad del aire $V_A$",
-        "ground_speed": "Velocidad respecto al suelo $V_g$",
-        "speed_ms": "Velocidad [m/s]",
-        "path_angle": "Ángulo de trayectoria $\\gamma$",
-        "bank_angle": "Ángulo de alabeo $\\Phi$",
-        "angle_deg": "Ángulo [°]",
-        "kinematics_title": "Cinemática de la trayectoria de rotorcraft (ECAC Doc 32)",
-        "recorded_time": "Tiempo registrado [s]",
-        "a_level": "Nivel ponderado A [dB(A)]",
-        "rotor_event_title": "Historia temporal de sobrevuelo de rotorcraft (ECAC Doc 32)",
-        "rotor_contour_title": "Curvas de ruido de rotorcraft (ECAC Doc 32)",
-        "terrain_profile": "Perfil del terreno",
-        "mean_ground_plane": "Plano medio del suelo",
-        "section_distance": "Distancia de la sección [m]",
-        "height_m": "Altura [m]",
-        "mgp_title": "Plano medio del suelo (guía NORAH2 Ec. 36-40)",
-        "line_of_sight": "Línea de visión",
-        "diffracted_path": "Trayectoria difractada",
-        "diffraction_edges": "Bordes de difracción",
-        "screening_title": "Apantallamiento por terreno (ECAC Doc 32 / guía NORAH2)",
-    },
+#: Spanish translations of the fixed strings rendered by the aircraft
+#: ``.plot()`` renderers, keyed by their verbatim English text.  ``_t``
+#: returns the English key unchanged for any language other than ``"es"``,
+#: so the English output is byte-for-byte identical to the pre-i18n
+#: renderers.
+_STRINGS: dict[str, str] = {
+    "10 dB-down window": "Ventana 10 dB por debajo",
+    "Time [s]": "Tiempo [s]",
+    "Level [PNdB]": "Nivel [PNdB]",
+    "SAE band": "Banda SAE",
+    "Pure-tone mid-band (ISO 9613-1)": "Banda media de tono puro (ISO 9613-1)",
+    "Frequency [Hz]": "Frecuencia [Hz]",
+    "Attenuation [dB]": "Atenuación [dB]",
+    "Aircraft atmospheric absorption (SAE ARP 5534)": "Absorción atmosférica de aeronaves (SAE ARP 5534)",
+    "Tabulated": "Tabulados",
+    "Slant distance [m]": "Distancia oblicua [m]",
+    "Event level [dB]": "Nivel del evento [dB]",
+    "Noise-power-distance curve (ECAC Doc 29)": "Curva ruido-potencia-distancia (ECAC Doc 29)",
+    "Segment index": "Índice de segmento",
+    "Segment {metric} [dB]": "{metric} por segmento [dB]",
+    "Single-event segment contributions (ECAC Doc 29)": "Contribuciones por segmento de un evento único (ECAC Doc 29)",
+    "Polar angle θ [°]  (0° forward → 180° rearward)": "Ángulo polar θ [°]  (0° adelante → 180° atrás)",
+    "Source level at 60 m [dB]": "Nivel de fuente a 60 m [dB]",
+    "Rotorcraft noise hemisphere directivity (ECAC Doc 32)": "Directividad del hemisferio de ruido de rotorcraft (ECAC Doc 32)",
+    "Aircraft noise contour (ECAC Doc 29)": "Curvas de ruido de aeronaves (ECAC Doc 29)",
+    "Airspeed $V_A$": "Velocidad del aire $V_A$",
+    "Ground speed $V_g$": "Velocidad respecto al suelo $V_g$",
+    "Speed [m/s]": "Velocidad [m/s]",
+    "Path angle $\\gamma$": "Ángulo de trayectoria $\\gamma$",
+    "Bank angle $\\Phi$": "Ángulo de alabeo $\\Phi$",
+    "Angle [°]": "Ángulo [°]",
+    "Rotorcraft flight-path kinematics (ECAC Doc 32)": "Cinemática de la trayectoria de rotorcraft (ECAC Doc 32)",
+    "Recorded time [s]": "Tiempo registrado [s]",
+    "A-weighted level [dB(A)]": "Nivel ponderado A [dB(A)]",
+    "Rotorcraft flyover time history (ECAC Doc 32)": "Historia temporal de sobrevuelo de rotorcraft (ECAC Doc 32)",
+    "Rotorcraft noise contour (ECAC Doc 32)": "Curvas de ruido de rotorcraft (ECAC Doc 32)",
+    "Terrain profile": "Perfil del terreno",
+    "Mean ground plane": "Plano medio del suelo",
+    "Section distance [m]": "Distancia de la sección [m]",
+    "Height [m]": "Altura [m]",
+    "Mean ground plane (NORAH2 guidance Eq. 36-40)": "Plano medio del suelo (guía NORAH2 Ec. 36-40)",
+    "Line of sight": "Línea de visión",
+    "Diffracted path": "Trayectoria difractada",
+    "Diffraction edges": "Bordes de difracción",
+    "Terrain screening (ECAC Doc 32 / NORAH2 guidance)": "Apantallamiento por terreno (ECAC Doc 32 / guía NORAH2)",
 }
 
 
-def _t(key: str, language: str) -> str:
-    """Localised fixed string for ``key`` (English is the byte-identical default)."""
-    return _STRINGS[language][key]
+def _t(text: str, language: str = "en", **fmt: Any) -> str:
+    """Localise a fixed string; English is returned verbatim (byte-identical)."""
+    s = _STRINGS.get(text, text) if language == "es" else text
+    return s.format(**fmt) if fmt else s
 
 
 def plot_epnl(result: "EPNLResult", ax: Axes | None = None, *, language: str = "en",
@@ -149,14 +110,14 @@ def plot_epnl(result: "EPNLResult", ax: Axes | None = None, *, language: str = "
     # (svglib) does not preserve alpha, so a translucent fill would render solid
     # and hide the PNL/PNLT traces. A light face keeps both curves readable.
     ax.axvspan(t[kf], t[kl], facecolor="#d7eccb", edgecolor="none", zorder=0,
-               label=_t("win_10db", language))
+               label=_t("10 dB-down window", language))
     ax.plot(t, np.asarray(result.pnl), color=_C_MUTED, lw=1.0, ls="--", label="PNL")
     ax.plot(t, np.asarray(result.pnlt), **{"color": _C_PRIMARY, "lw": 1.4, "label": "PNLT", **kwargs})
     km = int(np.argmax(np.asarray(result.pnlt)))
     ax.plot([t[km]], [result.pnltm], "o", color=_C_REFERENCE,
             label=f"PNLTM = {format_number(result.pnltm, language)} PNdB")
-    ax.set_xlabel(_t("time_s", language))
-    ax.set_ylabel(_t("level_pndb", language))
+    ax.set_xlabel(_t("Time [s]", language))
+    ax.set_ylabel(_t("Level [PNdB]", language))
     ax.set_title(
         f"ICAO EPNL = {format_number(result.epnl, language)} EPNdB "
         f"(D = {decimal_comma(f'{result.duration_correction:+.1f}', language)} dB)"
@@ -183,15 +144,15 @@ def plot_aircraft_band_attenuation(
 
     ax = ax if ax is not None else _new_axes()
     f = np.asarray(result.frequency, dtype=np.float64)
-    label = f"{_t('sae_band', language)} ({format_number(result.path_length, language, decimals=0)} m)"
+    label = f"{_t('SAE band', language)} ({format_number(result.path_length, language, decimals=0)} m)"
     ax.plot(f, np.asarray(result.band_attenuation),
             **{"color": _C_PRIMARY, "lw": 1.6, "marker": "o", "ms": 3, "label": label, **kwargs})
     ax.plot(f, np.asarray(result.midband_attenuation), color=_C_SECONDARY, lw=1.0, ls="--",
-            label=_t("puretone_midband", language))
+            label=_t("Pure-tone mid-band (ISO 9613-1)", language))
     ax.set_xscale("log")
-    ax.set_xlabel(_t("freq_hz", language))
-    ax.set_ylabel(_t("atten_db", language))
-    ax.set_title(_t("aircraft_abs_title", language))
+    ax.set_xlabel(_t("Frequency [Hz]", language))
+    ax.set_ylabel(_t("Attenuation [dB]", language))
+    ax.set_title(_t("Aircraft atmospheric absorption (SAE ARP 5534)", language))
     ax.grid(True, which="both", alpha=0.3)
     ax.legend(loc="upper left", fontsize="small")
     format_frequency_axis(ax, float(f.min()), float(f.max()))
@@ -217,11 +178,11 @@ def plot_npd_level(result: "NpdLevelResult", ax: Axes | None = None, *, language
     tl = np.asarray(result.table_levels, dtype=np.float64)
     label = f"NPD (P = {decimal_comma(f'{result.power:g}', language)})"
     ax.plot(d, lvl, **{"color": _C_PRIMARY, "lw": 1.6, "label": label, **kwargs})
-    ax.plot(td, tl, "o", color=_C_REFERENCE, ms=4, label=_t("tabulated", language))
+    ax.plot(td, tl, "o", color=_C_REFERENCE, ms=4, label=_t("Tabulated", language))
     ax.set_xscale("log")
-    ax.set_xlabel(_t("slant_distance", language))
-    ax.set_ylabel(_t("event_level", language))
-    ax.set_title(_t("npd_title", language))
+    ax.set_xlabel(_t("Slant distance [m]", language))
+    ax.set_ylabel(_t("Event level [dB]", language))
+    ax.set_title(_t("Noise-power-distance curve (ECAC Doc 29)", language))
     ax.grid(True, which="both", alpha=0.3)
     ax.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
     localize_axes(ax, language)
@@ -253,9 +214,9 @@ def plot_flyover(result: "FlyoverResult", ax: Axes | None = None, *, language: s
     if np.isfinite(result.level):
         ax.axhline(result.level, color=_C_REFERENCE, ls="--", lw=1.2,
                    label=f"Total {metric} = {format_number(result.level, language)} dB")
-    ax.set_xlabel(_t("segment_index", language))
-    ax.set_ylabel(_t("segment_metric", language).format(metric=metric))
-    ax.set_title(_t("flyover_title", language))
+    ax.set_xlabel(_t("Segment index", language))
+    ax.set_ylabel(_t("Segment {metric} [dB]", language, metric=metric))
+    ax.set_title(_t("Single-event segment contributions (ECAC Doc 29)", language))
     ax.grid(True, axis="y", alpha=0.3)
     if np.isfinite(result.level):
         ax.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
@@ -288,9 +249,9 @@ def plot_rotorcraft_hemisphere(
         np.nanargmax(np.nansum(10.0 ** (grid / 10.0), axis=0)))
     ax.plot(theta, grid[:, idx], **{"color": _C_PRIMARY, "lw": 1.8,
             "label": f"{format_number(freqs[idx], language, decimals=0)} Hz (φ = 0°)", **kwargs})
-    ax.set_xlabel(_t("polar_angle", language))
-    ax.set_ylabel(_t("source_level_60m", language))
-    ax.set_title(_t("hemisphere_title", language))
+    ax.set_xlabel(_t("Polar angle θ [°]  (0° forward → 180° rearward)", language))
+    ax.set_ylabel(_t("Source level at 60 m [dB]", language))
+    ax.set_title(_t("Rotorcraft noise hemisphere directivity (ECAC Doc 32)", language))
     ax.grid(True, alpha=0.3)
     ax.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
     localize_axes(ax, language)
@@ -322,7 +283,7 @@ def plot_noise_contour(result: "NoiseContourResult", ax: Axes | None = None, *,
     ax.figure.colorbar(cf, ax=ax, label=f"{'SEL' if result.metric == 'exposure' else 'LAmax'} [dB]")
     ax.set_xlabel("x [km]")
     ax.set_ylabel("y [km]")
-    ax.set_title(_t("contour_title", language))
+    ax.set_title(_t("Aircraft noise contour (ECAC Doc 29)", language))
     ax.set_aspect("equal", adjustable="box")
     localize_axes(ax, language)
     return ax
@@ -348,21 +309,21 @@ def plot_flight_path_kinematics(
     ax = ax if ax is not None else _new_axes()
     t = np.asarray(result.times, dtype=np.float64)
     ax.plot(t, result.airspeed, **{"color": _C_PRIMARY, "lw": 1.8,
-            "label": _t("airspeed", language), **kwargs})
+            "label": _t("Airspeed $V_A$", language), **kwargs})
     ax.plot(t, result.ground_speed, **{"color": _C_SECONDARY, "lw": 1.4,
-            "ls": "--", "label": _t("ground_speed", language), **kwargs})
-    ax.set_xlabel(_t("time_s", language))
-    ax.set_ylabel(_t("speed_ms", language))
+            "ls": "--", "label": _t("Ground speed $V_g$", language), **kwargs})
+    ax.set_xlabel(_t("Time [s]", language))
+    ax.set_ylabel(_t("Speed [m/s]", language))
     ax2 = ax.twinx()
     ax2.plot(t, result.path_angle, color=_C_TERTIARY, lw=1.4,
-             label=_t("path_angle", language))
+             label=_t("Path angle $\\gamma$", language))
     ax2.plot(t, result.bank_angle, color=_C_MUTED, lw=1.4, ls=":",
-             label=_t("bank_angle", language))
-    ax2.set_ylabel(_t("angle_deg", language))
+             label=_t("Bank angle $\\Phi$", language))
+    ax2.set_ylabel(_t("Angle [°]", language))
     lines = [*ax.get_lines(), *ax2.get_lines()]
     ax.legend(lines, [str(ln.get_label()) for ln in lines],
               loc=_LEGEND_UPPER_RIGHT, fontsize="small")
-    ax.set_title(_t("kinematics_title", language))
+    ax.set_title(_t("Rotorcraft flight-path kinematics (ECAC Doc 32)", language))
     ax.grid(True, alpha=0.3)
     localize_axes(ax, language)
     return ax
@@ -400,10 +361,10 @@ def plot_rotorcraft_event(
     if np.any(window):
         idx = np.nonzero(window)[0]
         ax.axvspan(t[idx[0]], t[idx[-1]], color=_C_PRIMARY, alpha=0.08,
-                   label=_t("win_10db", language))
-    ax.set_xlabel(_t("recorded_time", language))
-    ax.set_ylabel(_t("a_level", language))
-    ax.set_title(_t("rotor_event_title", language))
+                   label=_t("10 dB-down window", language))
+    ax.set_xlabel(_t("Recorded time [s]", language))
+    ax.set_ylabel(_t("A-weighted level [dB(A)]", language))
+    ax.set_title(_t("Rotorcraft flyover time history (ECAC Doc 32)", language))
     ax.grid(True, alpha=0.3)
     ax.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
     localize_axes(ax, language)
@@ -439,7 +400,7 @@ def plot_rotorcraft_noise_contour(
     ax.figure.colorbar(cf, ax=ax, label=f"{metric} [dB(A)]")
     ax.set_xlabel("x [km]")
     ax.set_ylabel("y [km]")
-    ax.set_title(_t("rotor_contour_title", language))
+    ax.set_title(_t("Rotorcraft noise contour (ECAC Doc 32)", language))
     ax.set_aspect("equal", adjustable="box")
     localize_axes(ax, language)
     return ax
@@ -462,15 +423,15 @@ def plot_mean_ground_plane(
     ax = ax if ax is not None else _new_axes()
     d = np.asarray(result.distances, dtype=np.float64)
     z = np.asarray(result.heights, dtype=np.float64)
-    ax.plot(d, z, **{"color": _C_PRIMARY, "lw": 1.8, "label": _t("terrain_profile", language),
+    ax.plot(d, z, **{"color": _C_PRIMARY, "lw": 1.8, "label": _t("Terrain profile", language),
             **kwargs})
     ax.fill_between(d, z, z.min() - 0.05 * np.ptp(z) - 0.5, color=_C_PRIMARY,
                     alpha=0.08)
     ax.plot(d, result.height(d), color=_C_SECONDARY, lw=1.6, ls="--",
-            label=f"{_t('mean_ground_plane', language)} (a = {format_number(result.slope, language, decimals=3)})")
-    ax.set_xlabel(_t("section_distance", language))
-    ax.set_ylabel(_t("height_m", language))
-    ax.set_title(_t("mgp_title", language))
+            label=f"{_t('Mean ground plane', language)} (a = {format_number(result.slope, language, decimals=3)})")
+    ax.set_xlabel(_t("Section distance [m]", language))
+    ax.set_ylabel(_t("Height [m]", language))
+    ax.set_title(_t("Mean ground plane (NORAH2 guidance Eq. 36-40)", language))
     ax.grid(True, alpha=0.3)
     ax.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
     localize_axes(ax, language)
@@ -495,28 +456,28 @@ def plot_terrain_screening(
     d = np.asarray(result.distances, dtype=np.float64)
     z = np.asarray(result.heights, dtype=np.float64)
     src, rcv = result.source, result.receiver
-    ax.plot(d, z, **{"color": _C_MUTED, "lw": 1.8, "label": _t("terrain_profile", language),
+    ax.plot(d, z, **{"color": _C_MUTED, "lw": 1.8, "label": _t("Terrain profile", language),
             **kwargs})
     floor = min(z.min(), src[1], rcv[1]) - 0.05 * max(np.ptp(z), 1.0) - 0.5
     ax.fill_between(d, z, floor, color=_C_MUTED, alpha=0.12)
     ax.plot([src[0], rcv[0]], [src[1], rcv[1]], color=_C_REFERENCE, lw=1.2,
-            ls=":", label=_t("line_of_sight", language))
+            ls=":", label=_t("Line of sight", language))
     if result.screened and result.diffraction_points.size:
         pts = np.vstack([[src[0], src[1]], result.diffraction_points,
                          [rcv[0], rcv[1]]])
         ax.plot(pts[:, 0], pts[:, 1], color=_C_PRIMARY, lw=1.8,
-                label=f"{_t('diffracted_path', language)} (δ = {format_number(result.path_difference, language, decimals=2)} m)")
+                label=f"{_t('Diffracted path', language)} (δ = {format_number(result.path_difference, language, decimals=2)} m)")
         ax.plot(result.diffraction_points[:, 0], result.diffraction_points[:, 1],
-                "v", color=_C_SECONDARY, ms=6, label=_t("diffraction_edges", language))
+                "v", color=_C_SECONDARY, ms=6, label=_t("Diffraction edges", language))
     ax.plot(*src, "o", color=_C_PRIMARY, ms=7)
     ax.annotate("S", src, textcoords="offset points", xytext=(0, 8),
                 ha="center", fontsize=10)
     ax.plot(*rcv, "s", color=_C_SECONDARY, ms=6)
     ax.annotate("R", rcv, textcoords="offset points", xytext=(0, 8),
                 ha="center", fontsize=10)
-    ax.set_xlabel(_t("section_distance", language))
-    ax.set_ylabel(_t("height_m", language))
-    ax.set_title(_t("screening_title", language))
+    ax.set_xlabel(_t("Section distance [m]", language))
+    ax.set_ylabel(_t("Height [m]", language))
+    ax.set_title(_t("Terrain screening (ECAC Doc 32 / NORAH2 guidance)", language))
     ax.grid(True, alpha=0.3)
     ax.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
     localize_axes(ax, language)

--- a/src/phonometry/_plot/environmental.py
+++ b/src/phonometry/_plot/environmental.py
@@ -37,101 +37,59 @@ if TYPE_CHECKING:
     from ..environmental.impulse_prominence import ImpulseProminenceResult
     from ..environmental.wind_turbine_noise import WindTurbineTonalityResult
 
-#: English and Spanish text for every fixed label/title/legend drawn by this
-#: module's renderers.  English entries are byte-for-byte the original strings.
-_STRINGS: dict[str, dict[str, str]] = {
-    "en": {
-        "narrowband": "Narrowband spectrum",
-        "critical_band": "Critical band",
-        "masking_level": "Masking level",
-        "tone": "Tone",
-        "freq_hz": "Frequency [Hz]",
-        "level_db": "Level [dB]",
-        "wt_prefix": "IEC 61400-11 tonal audibility",
-        "threshold": "threshold",
-        "impulses": "Impulses",
-        "governing": "Governing",
-        "predicted_prominence": "Predicted prominence $P$",
-        "adjustment_ki": "Adjustment $K_I$ [dB]",
-        "impulse_title": "NT ACOU 112 — impulse adjustment to $L_{Aeq}$",
-        "knees": "knees $\\Delta L_{ta}=4,\\,10$ dB",
-        "tonal_audibility_x": "Tonal audibility $\\Delta L_{ta}$ [dB]",
-        "tonal_adjustment_y": "Tonal adjustment $K_t$ [dB]",
-        "tonal_title": "ISO 1996-2 tonal adjustment",
-        "a_div": "$A_{div}$ — divergence",
-        "a_atm": "$A_{atm}$ — atmospheric",
-        "a_gr": "$A_{gr}$ — ground",
-        "a_bar": "$A_{bar}$ — barrier",
-        "a_total": "$A$ — total",
-        "atten_a": "Attenuation A [dB]",
-        "outdoor_title": "ISO 9613-2 attenuation breakdown",
-        "excess_atten": "Excess attenuation $\\Delta L$",
-        "free_field": "Free field (0 dB)",
-        "hard_ground": "Hard-ground limit (+6 dB)",
-        "level_re_ff": "Level re free field [dB]",
-        "spherical_title": "Spherical-wave ground effect (Weyl-Van der Pol)",
-        "insertion_loss": "Insertion loss",
-        "ground_word": "ground",
-        "grazing_limit": "Grazing limit (5 dB)",
-        "insertion_loss_db": "Insertion loss [dB]",
-        "barrier_title": "Barrier insertion loss",
-        "eff_sound_speed": "Effective sound speed [m/s]",
-        "height_m": "Height [m]",
-        "range_m": "Range [m]",
-        "eff_profile_title": "Effective sound-speed profile",
-        "source": "Source",
-        "rays_title": "Atmospheric ray paths",
-        "gfpe_prefix": "GFPE relative sound level",
-    },
-    "es": {
-        "narrowband": "Espectro de banda estrecha",
-        "critical_band": "Banda crítica",
-        "masking_level": "Nivel de enmascaramiento",
-        "tone": "Tono",
-        "freq_hz": "Frecuencia [Hz]",
-        "level_db": "Nivel [dB]",
-        "wt_prefix": "Audibilidad tonal IEC 61400-11",
-        "threshold": "umbral",
-        "impulses": "Impulsos",
-        "governing": "Determinante",
-        "predicted_prominence": "Prominencia prevista $P$",
-        "adjustment_ki": "Ajuste $K_I$ [dB]",
-        "impulse_title": "NT ACOU 112 — ajuste por impulsos a $L_{Aeq}$",
-        "knees": "codos $\\Delta L_{ta}=4,\\,10$ dB",
-        "tonal_audibility_x": "Audibilidad tonal $\\Delta L_{ta}$ [dB]",
-        "tonal_adjustment_y": "Ajuste tonal $K_t$ [dB]",
-        "tonal_title": "Ajuste tonal ISO 1996-2",
-        "a_div": "$A_{div}$ — divergencia",
-        "a_atm": "$A_{atm}$ — atmosférica",
-        "a_gr": "$A_{gr}$ — suelo",
-        "a_bar": "$A_{bar}$ — barrera",
-        "a_total": "$A$ — total",
-        "atten_a": "Atenuación A [dB]",
-        "outdoor_title": "Desglose de atenuación ISO 9613-2",
-        "excess_atten": "Atenuación en exceso $\\Delta L$",
-        "free_field": "Campo libre (0 dB)",
-        "hard_ground": "Límite de suelo duro (+6 dB)",
-        "level_re_ff": "Nivel re campo libre [dB]",
-        "spherical_title": "Efecto de suelo de onda esférica (Weyl-Van der Pol)",
-        "insertion_loss": "Pérdida por inserción",
-        "ground_word": "suelo",
-        "grazing_limit": "Límite rasante (5 dB)",
-        "insertion_loss_db": "Pérdida por inserción [dB]",
-        "barrier_title": "Pérdida por inserción de barrera",
-        "eff_sound_speed": "Velocidad efectiva del sonido [m/s]",
-        "height_m": "Altura [m]",
-        "range_m": "Distancia [m]",
-        "eff_profile_title": "Perfil de velocidad efectiva del sonido",
-        "source": "Fuente",
-        "rays_title": "Trayectorias de rayos atmosféricos",
-        "gfpe_prefix": "Nivel sonoro relativo GFPE",
-    },
+#: Spanish translations of the fixed strings rendered by the environmental
+#: ``.plot()`` renderers, keyed by their verbatim English text.  ``_t``
+#: returns the English key unchanged for any language other than ``"es"``,
+#: so the English output is byte-for-byte identical to the pre-i18n
+#: renderers.
+_STRINGS: dict[str, str] = {
+    "Narrowband spectrum": "Espectro de banda estrecha",
+    "Critical band": "Banda crítica",
+    "Masking level": "Nivel de enmascaramiento",
+    "Tone": "Tono",
+    "Frequency [Hz]": "Frecuencia [Hz]",
+    "Level [dB]": "Nivel [dB]",
+    "IEC 61400-11 tonal audibility": "Audibilidad tonal IEC 61400-11",
+    "threshold": "umbral",
+    "Impulses": "Impulsos",
+    "Governing": "Determinante",
+    "Predicted prominence $P$": "Prominencia prevista $P$",
+    "Adjustment $K_I$ [dB]": "Ajuste $K_I$ [dB]",
+    "NT ACOU 112 — impulse adjustment to $L_{Aeq}$": "NT ACOU 112 — ajuste por impulsos a $L_{Aeq}$",
+    "knees $\\Delta L_{ta}=4,\\,10$ dB": "codos $\\Delta L_{ta}=4,\\,10$ dB",
+    "Tonal audibility $\\Delta L_{ta}$ [dB]": "Audibilidad tonal $\\Delta L_{ta}$ [dB]",
+    "Tonal adjustment $K_t$ [dB]": "Ajuste tonal $K_t$ [dB]",
+    "ISO 1996-2 tonal adjustment": "Ajuste tonal ISO 1996-2",
+    "$A_{div}$ — divergence": "$A_{div}$ — divergencia",
+    "$A_{atm}$ — atmospheric": "$A_{atm}$ — atmosférica",
+    "$A_{gr}$ — ground": "$A_{gr}$ — suelo",
+    "$A_{bar}$ — barrier": "$A_{bar}$ — barrera",
+    "$A$ — total": "$A$ — total",
+    "Attenuation A [dB]": "Atenuación A [dB]",
+    "ISO 9613-2 attenuation breakdown": "Desglose de atenuación ISO 9613-2",
+    "Excess attenuation $\\Delta L$": "Atenuación en exceso $\\Delta L$",
+    "Free field (0 dB)": "Campo libre (0 dB)",
+    "Hard-ground limit (+6 dB)": "Límite de suelo duro (+6 dB)",
+    "Level re free field [dB]": "Nivel re campo libre [dB]",
+    "Spherical-wave ground effect (Weyl-Van der Pol)": "Efecto de suelo de onda esférica (Weyl-Van der Pol)",
+    "Insertion loss": "Pérdida por inserción",
+    "ground": "suelo",
+    "Grazing limit (5 dB)": "Límite rasante (5 dB)",
+    "Insertion loss [dB]": "Pérdida por inserción [dB]",
+    "Barrier insertion loss": "Pérdida por inserción de barrera",
+    "Effective sound speed [m/s]": "Velocidad efectiva del sonido [m/s]",
+    "Height [m]": "Altura [m]",
+    "Range [m]": "Distancia [m]",
+    "Effective sound-speed profile": "Perfil de velocidad efectiva del sonido",
+    "Source": "Fuente",
+    "Atmospheric ray paths": "Trayectorias de rayos atmosféricos",
+    "GFPE relative sound level": "Nivel sonoro relativo GFPE",
 }
 
 
-def _t(key: str, language: str) -> str:
-    """Localised fixed string for ``key`` (English is the byte-identical default)."""
-    return _STRINGS[language][key]
+def _t(text: str, language: str = "en") -> str:
+    """Localise a fixed string; English is returned verbatim (byte-identical)."""
+    return _STRINGS.get(text, text) if language == "es" else text
 
 
 def plot_wind_turbine_tonality(
@@ -154,15 +112,15 @@ def plot_wind_turbine_tonality(
     levels = np.asarray(result.levels, dtype=np.float64)
     fc = result.tone_frequency
     lo, hi = _critical_band_edges(fc)
-    ax.plot(freqs, levels, **{"color": _C_PRIMARY, "lw": 1.0, "label": _t("narrowband", language), **kwargs})
-    ax.axvspan(lo, hi, color=_C_TERTIARY, alpha=0.12, label=_t("critical_band", language))
+    ax.plot(freqs, levels, **{"color": _C_PRIMARY, "lw": 1.0, "label": _t("Narrowband spectrum", language), **kwargs})
+    ax.axvspan(lo, hi, color=_C_TERTIARY, alpha=0.12, label=_t("Critical band", language))
     ax.axhline(result.masking_level, color=_C_MUTED, ls="--", lw=1.0,
-               label=f"{_t('masking_level', language)} ({format_number(result.masking_level, language)} dB)")
+               label=f"{_t('Masking level', language)} ({format_number(result.masking_level, language)} dB)")
     ax.plot([fc], [result.tone_level], "o", color=_C_REFERENCE,
-            label=f"{_t('tone', language)} ({format_number(result.tone_level, language)} dB)")
-    ax.set_xlabel(_t("freq_hz", language))
-    ax.set_ylabel(_t("level_db", language))
-    ax.set_title(f"{_t('wt_prefix', language)} ΔLₐ = {format_number(result.tonal_audibility, language)} dB")
+            label=f"{_t('Tone', language)} ({format_number(result.tone_level, language)} dB)")
+    ax.set_xlabel(_t("Frequency [Hz]", language))
+    ax.set_ylabel(_t("Level [dB]", language))
+    ax.set_title(f"{_t('IEC 61400-11 tonal audibility', language)} ΔLₐ = {format_number(result.tonal_audibility, language)} dB")
     ax.grid(True, alpha=0.3)
     ax.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
     localize_axes(ax, language)
@@ -195,14 +153,14 @@ def plot_impulse_prominence(
 
     kwargs.setdefault("color", _C_PRIMARY_LIGHT)
     kwargs.setdefault("zorder", 3)
-    ax.scatter(per, impulse_adjustment(per), label=_t("impulses", language), **kwargs)
+    ax.scatter(per, impulse_adjustment(per), label=_t("Impulses", language), **kwargs)
     ax.scatter([result.prominence], [result.adjustment], color=_C_REFERENCE,
                zorder=4, s=90, marker="*",
-               label=f"{_t('governing', language)}  P = {format_number(result.prominence, language, decimals=2)},  "
+               label=f"{_t('Governing', language)}  P = {format_number(result.prominence, language, decimals=2)},  "
                      f"$K_I$ = {format_number(result.adjustment, language)} dB")
-    ax.set_xlabel(_t("predicted_prominence", language))
-    ax.set_ylabel(_t("adjustment_ki", language))
-    ax.set_title(_t("impulse_title", language))
+    ax.set_xlabel(_t("Predicted prominence $P$", language))
+    ax.set_ylabel(_t("Adjustment $K_I$ [dB]", language))
+    ax.set_title(_t("NT ACOU 112 — impulse adjustment to $L_{Aeq}$", language))
     ax.set_ylim(bottom=0.0)
     ax.legend(loc="upper left", fontsize="small")
     ax.grid(True, alpha=0.3)
@@ -230,7 +188,7 @@ def plot_tonal_adjustment(
     grid = np.linspace(0.0, top, 200)
     curve = np.array([tonal_adjustment(d) for d in grid], dtype=np.float64)
     ax.plot(grid, curve, color=_C_PRIMARY, label=r"$K_t(\Delta L_{ta})$")
-    ax.axvline(4.0, color=_C_MUTED, ls=":", label=_t("knees", language))
+    ax.axvline(4.0, color=_C_MUTED, ls=":", label=_t("knees $\\Delta L_{ta}=4,\\,10$ dB", language))
     ax.axvline(10.0, color=_C_MUTED, ls=":")
 
     kwargs.setdefault("color", _C_REFERENCE)
@@ -240,9 +198,9 @@ def plot_tonal_adjustment(
     ax.scatter([result.audibility], [result.adjustment],
                label=rf"$\Delta L_{{ta}}$ = {format_number(result.audibility, language)} dB,  "
                      rf"$K_t$ = {format_number(result.adjustment, language)} dB", **kwargs)
-    ax.set_xlabel(_t("tonal_audibility_x", language))
-    ax.set_ylabel(_t("tonal_adjustment_y", language))
-    ax.set_title(_t("tonal_title", language))
+    ax.set_xlabel(_t("Tonal audibility $\\Delta L_{ta}$ [dB]", language))
+    ax.set_ylabel(_t("Tonal adjustment $K_t$ [dB]", language))
+    ax.set_title(_t("ISO 1996-2 tonal adjustment", language))
     ax.set_ylim(bottom=0.0)
     ax.legend(loc="upper left", fontsize="small")
     ax.grid(True, alpha=0.3)
@@ -280,10 +238,10 @@ def plot_outdoor_attenuation(
     pos_bottom = np.zeros(n)
     neg_bottom = np.zeros(n)
     terms = (
-        (result.a_div, _C_PRIMARY, _t("a_div", language)),
-        (result.a_atm, _C_TERTIARY, _t("a_atm", language)),
-        (result.a_gr, _C_QUATERNARY, _t("a_gr", language)),
-        (result.a_bar, _C_SECONDARY, _t("a_bar", language)),
+        (result.a_div, _C_PRIMARY, _t("$A_{div}$ — divergence", language)),
+        (result.a_atm, _C_TERTIARY, _t("$A_{atm}$ — atmospheric", language)),
+        (result.a_gr, _C_QUATERNARY, _t("$A_{gr}$ — ground", language)),
+        (result.a_bar, _C_SECONDARY, _t("$A_{bar}$ — barrier", language)),
     )
     for values, color, label in terms:
         term = np.asarray(values, dtype=np.float64)
@@ -294,12 +252,12 @@ def plot_outdoor_attenuation(
 
     kwargs.setdefault("color", _C_REFERENCE)
     kwargs.setdefault("marker", "D")
-    kwargs.setdefault("label", _t("a_total", language))
+    kwargs.setdefault("label", _t("$A$ — total", language))
     ax.plot(positions, np.asarray(result.a_total, dtype=np.float64),
             zorder=4, **kwargs)
     ax.axhline(0.0, color=_C_MUTED, lw=0.8)
-    ax.set_ylabel(_t("atten_a", language))
-    ax.set_title(_t("outdoor_title", language))
+    ax.set_ylabel(_t("Attenuation A [dB]", language))
+    ax.set_title(_t("ISO 9613-2 attenuation breakdown", language))
     ax.legend(loc="best", fontsize="small")
     ax.grid(True, axis="y", alpha=0.3)
     localize_axes(ax, language)
@@ -329,14 +287,14 @@ def plot_spherical_ground(
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     d_l = np.asarray(result.excess_attenuation, dtype=np.float64)
     ax.plot(freqs, d_l, **{"color": _C_PRIMARY, "lw": 1.4, "marker": "o",
-                           "ms": 3.0, "label": _t("excess_atten", language),
+                           "ms": 3.0, "label": _t("Excess attenuation $\\Delta L$", language),
                            **kwargs})
-    ax.axhline(0.0, color=_C_MUTED, lw=0.8, label=_t("free_field", language))
+    ax.axhline(0.0, color=_C_MUTED, lw=0.8, label=_t("Free field (0 dB)", language))
     ax.axhline(6.0, color=_C_REFERENCE, ls="--", lw=0.9,
-               label=_t("hard_ground", language))
+               label=_t("Hard-ground limit (+6 dB)", language))
     _freq_axis(ax, freqs, language=language)
-    ax.set_ylabel(_t("level_re_ff", language))
-    ax.set_title(_t("spherical_title", language))
+    ax.set_ylabel(_t("Level re free field [dB]", language))
+    ax.set_title(_t("Spherical-wave ground effect (Weyl-Van der Pol)", language))
     ax.legend(loc="best", fontsize="small")
     ax.grid(True, which="both", alpha=0.3)
     localize_axes(ax, language)
@@ -361,16 +319,16 @@ def plot_barrier_insertion_loss(
     ax = ax if ax is not None else _new_axes()
     freqs = np.asarray(result.frequencies, dtype=np.float64)
     il = np.asarray(result.insertion_loss, dtype=np.float64)
-    ground_frag = f", {_t('ground_word', language)}" if result.ground else ""
-    label = f"{_t('insertion_loss', language)} ({result.method}{ground_frag})"
+    ground_frag = f", {_t('ground', language)}" if result.ground else ""
+    label = f"{_t('Insertion loss', language)} ({result.method}{ground_frag})"
     ax.plot(freqs, il, **{"color": _C_SECONDARY, "lw": 1.4, "marker": "s",
                           "ms": 3.0, "label": label, **kwargs})
     ax.axhline(0.0, color=_C_MUTED, lw=0.8)
     ax.axhline(5.0, color=_C_MUTED, ls=":", lw=0.9,
-               label=_t("grazing_limit", language))
+               label=_t("Grazing limit (5 dB)", language))
     _freq_axis(ax, freqs, language=language)
-    ax.set_ylabel(_t("insertion_loss_db", language))
-    ax.set_title(_t("barrier_title", language))
+    ax.set_ylabel(_t("Insertion loss [dB]", language))
+    ax.set_title(_t("Barrier insertion loss", language))
     ax.legend(loc="best", fontsize="small")
     ax.grid(True, which="both", alpha=0.3)
     localize_axes(ax, language)
@@ -397,9 +355,9 @@ def plot_sound_speed_profile(
     c = np.asarray(profile.sound_speeds, dtype=np.float64)
     label = profile.description or "c_eff(z)"
     ax.plot(c, z, **{"color": _C_PRIMARY, "lw": 1.4, "label": label, **kwargs})
-    ax.set_xlabel(_t("eff_sound_speed", language))
-    ax.set_ylabel(_t("height_m", language))
-    ax.set_title(_t("eff_profile_title", language))
+    ax.set_xlabel(_t("Effective sound speed [m/s]", language))
+    ax.set_ylabel(_t("Height [m]", language))
+    ax.set_title(_t("Effective sound-speed profile", language))
     ax.grid(True, alpha=0.3)
     ax.legend(loc="best", fontsize="small")
     localize_axes(ax, language)
@@ -426,12 +384,12 @@ def plot_atmospheric_rays(
     z = np.asarray(result.heights, dtype=np.float64)
     for i in range(r.shape[0]):
         ax.plot(r[i], z[i], **{"color": _C_PRIMARY, "lw": 0.7, "alpha": 0.7, **kwargs})
-    ax.plot([0.0], [result.source_height], "o", color=_C_REFERENCE, label=_t("source", language))
+    ax.plot([0.0], [result.source_height], "o", color=_C_REFERENCE, label=_t("Source", language))
     ax.axhline(0.0, color=_C_MUTED, lw=1.0)
-    ax.set_xlabel(_t("range_m", language))
-    ax.set_ylabel(_t("height_m", language))
+    ax.set_xlabel(_t("Range [m]", language))
+    ax.set_ylabel(_t("Height [m]", language))
     ax.set_ylim(bottom=0.0)
-    ax.set_title(_t("rays_title", language))
+    ax.set_title(_t("Atmospheric ray paths", language))
     ax.grid(True, alpha=0.3)
     ax.legend(loc="upper right", fontsize="small")
     localize_axes(ax, language)
@@ -478,11 +436,11 @@ def plot_atmospheric_pe(
             **kwargs,
         },
     )
-    ax.figure.colorbar(img, ax=ax, label=_t("level_re_ff", language))
-    ax.plot([0.0], [result.source_height], "o", color="k", ms=4.0, label=_t("source", language))
-    ax.set_xlabel(_t("range_m", language))
-    ax.set_ylabel(_t("height_m", language))
-    ax.set_title(f"{_t('gfpe_prefix', language)} ({format_number(result.frequency, language, decimals=0)} Hz)")
+    ax.figure.colorbar(img, ax=ax, label=_t("Level re free field [dB]", language))
+    ax.plot([0.0], [result.source_height], "o", color="k", ms=4.0, label=_t("Source", language))
+    ax.set_xlabel(_t("Range [m]", language))
+    ax.set_ylabel(_t("Height [m]", language))
+    ax.set_title(f"{_t('GFPE relative sound level', language)} ({format_number(result.frequency, language, decimals=0)} Hz)")
     ax.legend(loc="upper right", fontsize="small")
     localize_axes(ax, language)
     return ax

--- a/src/phonometry/_plot/underwater.py
+++ b/src/phonometry/_plot/underwater.py
@@ -35,113 +35,65 @@ if TYPE_CHECKING:
     from ..underwater.ocean_ambient_noise import AmbientNoiseResult
     from ..underwater.ship_traffic_noise import ShipTrafficSpectrum
 
-#: English and Spanish text for every fixed label/title/legend drawn by this
-#: module's renderers.  English entries are byte-for-byte the original strings.
-_STRINGS: dict[str, dict[str, str]] = {
-    "en": {
-        "source_level_ls": "Source level Ls",
-        "radiated_noise": "Radiated noise level",
-        "freq_hz": "Frequency [Hz]",
-        "level_upam": "Level [dB re 1 µPa·m]",
-        "surface_corr_legend": "Surface correction ΔL",
-        "surface_corr_ylabel": "Surface correction ΔL [dB]",
-        "source_level_title": "ISO 17208-2 equivalent monopole source level",
-        "peak": "Peak",
-        "pressure_pa": "Pressure [Pa]",
-        "time_s": "Time [s]",
-        "pile_title": "ISO 18406 pile strike",
-        "cumulative_energy": "Cumulative energy",
-        "cumulative_energy_norm": "Cumulative energy (norm.)",
-        "pulse_duration": "90 % pulse duration",
-        "sound_speed_ms": "Sound speed [m/s]",
-        "depth_m": "Depth [m]",
-        "sound_speed_title": "Sea-water sound-speed profile",
-        "total_tl": "Total TL",
-        "spreading": "Spreading",
-        "absorption": "Absorption",
-        "range_m": "Range [m]",
-        "tl_db": "Transmission loss [dB]",
-        "underwater_tl_title": "Underwater transmission loss",
-        "signal_excess": "Signal excess",
-        "detection_limit": "Detection limit (SE = 0)",
-        "figure_of_merit": "Figure of merit",
-        "signal_excess_db": "Signal excess [dB]",
-        "sonar_title": "Sonar equation",
-        "bottom_loss": "Bottom loss",
-        "critical_angle": "Critical angle",
-        "grazing_angle": "Grazing angle [°]",
-        "bottom_loss_db": "Bottom loss [dB]",
-        "seabed_title": "Seabed reflection loss",
-        "total": "Total",
-        "wind": "Wind",
-        "thermal": "Thermal",
-        "shipping": "Shipping",
-        "spectrum_level": "Spectrum level [dB re 1 µPa²/Hz]",
-        "ambient_title": "Ocean ambient noise",
-        "source_psd_ylabel": "Source spectral density [dB re 1 µPa²/Hz at 1 m]",
-        "traffic_title": "Ship traffic source level",
-        "modes_word": "modes",
-        "range_km": "Range [km]",
-        "modes_title": "Normal-mode transmission loss",
-        "source": "Source",
-        "raytrace_title": "Ray trace",
-        "pe_title": "Parabolic-equation transmission loss",
-    },
-    "es": {
-        "source_level_ls": "Nivel de fuente Ls",
-        "radiated_noise": "Nivel de ruido radiado",
-        "freq_hz": "Frecuencia [Hz]",
-        "level_upam": "Nivel [dB re 1 µPa·m]",
-        "surface_corr_legend": "Corrección de superficie ΔL",
-        "surface_corr_ylabel": "Corrección de superficie ΔL [dB]",
-        "source_level_title": "Nivel de fuente monopolar equivalente ISO 17208-2",
-        "peak": "Pico",
-        "pressure_pa": "Presión [Pa]",
-        "time_s": "Tiempo [s]",
-        "pile_title": "Golpe de pilote ISO 18406",
-        "cumulative_energy": "Energía acumulada",
-        "cumulative_energy_norm": "Energía acumulada (norm.)",
-        "pulse_duration": "Duración del pulso al 90 %",
-        "sound_speed_ms": "Velocidad del sonido [m/s]",
-        "depth_m": "Profundidad [m]",
-        "sound_speed_title": "Perfil de velocidad del sonido en agua de mar",
-        "total_tl": "TL total",
-        "spreading": "Divergencia",
-        "absorption": "Absorción",
-        "range_m": "Distancia [m]",
-        "tl_db": "Pérdida por transmisión [dB]",
-        "underwater_tl_title": "Pérdida por transmisión submarina",
-        "signal_excess": "Exceso de señal",
-        "detection_limit": "Límite de detección (SE = 0)",
-        "figure_of_merit": "Cifra de mérito",
-        "signal_excess_db": "Exceso de señal [dB]",
-        "sonar_title": "Ecuación del sonar",
-        "bottom_loss": "Pérdida en el fondo",
-        "critical_angle": "Ángulo crítico",
-        "grazing_angle": "Ángulo rasante [°]",
-        "bottom_loss_db": "Pérdida en el fondo [dB]",
-        "seabed_title": "Pérdida por reflexión en el fondo marino",
-        "total": "Total",
-        "wind": "Viento",
-        "thermal": "Térmico",
-        "shipping": "Tráfico marítimo",
-        "spectrum_level": "Nivel espectral [dB re 1 µPa²/Hz]",
-        "ambient_title": "Ruido ambiental oceánico",
-        "source_psd_ylabel": "Densidad espectral de la fuente [dB re 1 µPa²/Hz a 1 m]",
-        "traffic_title": "Nivel de fuente del tráfico marítimo",
-        "modes_word": "modos",
-        "range_km": "Distancia [km]",
-        "modes_title": "Pérdida por transmisión por modos normales",
-        "source": "Fuente",
-        "raytrace_title": "Trazado de rayos",
-        "pe_title": "Pérdida por transmisión por ecuación parabólica",
-    },
+#: Spanish translations of the fixed strings rendered by the underwater
+#: ``.plot()`` renderers, keyed by their verbatim English text.  ``_t``
+#: returns the English key unchanged for any language other than ``"es"``,
+#: so the English output is byte-for-byte identical to the pre-i18n
+#: renderers.
+_STRINGS: dict[str, str] = {
+    "Source level Ls": "Nivel de fuente Ls",
+    "Radiated noise level": "Nivel de ruido radiado",
+    "Frequency [Hz]": "Frecuencia [Hz]",
+    "Level [dB re 1 µPa·m]": "Nivel [dB re 1 µPa·m]",
+    "Surface correction ΔL": "Corrección de superficie ΔL",
+    "Surface correction ΔL [dB]": "Corrección de superficie ΔL [dB]",
+    "ISO 17208-2 equivalent monopole source level": "Nivel de fuente monopolar equivalente ISO 17208-2",
+    "Peak": "Pico",
+    "Pressure [Pa]": "Presión [Pa]",
+    "Time [s]": "Tiempo [s]",
+    "ISO 18406 pile strike": "Golpe de pilote ISO 18406",
+    "Cumulative energy": "Energía acumulada",
+    "Cumulative energy (norm.)": "Energía acumulada (norm.)",
+    "90 % pulse duration": "Duración del pulso al 90 %",
+    "Sound speed [m/s]": "Velocidad del sonido [m/s]",
+    "Depth [m]": "Profundidad [m]",
+    "Sea-water sound-speed profile": "Perfil de velocidad del sonido en agua de mar",
+    "Total TL": "TL total",
+    "Spreading": "Divergencia",
+    "Absorption": "Absorción",
+    "Range [m]": "Distancia [m]",
+    "Transmission loss [dB]": "Pérdida por transmisión [dB]",
+    "Underwater transmission loss": "Pérdida por transmisión submarina",
+    "Signal excess": "Exceso de señal",
+    "Detection limit (SE = 0)": "Límite de detección (SE = 0)",
+    "Figure of merit": "Cifra de mérito",
+    "Signal excess [dB]": "Exceso de señal [dB]",
+    "Sonar equation": "Ecuación del sonar",
+    "Bottom loss": "Pérdida en el fondo",
+    "Critical angle": "Ángulo crítico",
+    "Grazing angle [°]": "Ángulo rasante [°]",
+    "Bottom loss [dB]": "Pérdida en el fondo [dB]",
+    "Seabed reflection loss": "Pérdida por reflexión en el fondo marino",
+    "Total": "Total",
+    "Wind": "Viento",
+    "Thermal": "Térmico",
+    "Shipping": "Tráfico marítimo",
+    "Spectrum level [dB re 1 µPa²/Hz]": "Nivel espectral [dB re 1 µPa²/Hz]",
+    "Ocean ambient noise": "Ruido ambiental oceánico",
+    "Source spectral density [dB re 1 µPa²/Hz at 1 m]": "Densidad espectral de la fuente [dB re 1 µPa²/Hz a 1 m]",
+    "Ship traffic source level": "Nivel de fuente del tráfico marítimo",
+    "modes": "modos",
+    "Range [km]": "Distancia [km]",
+    "Normal-mode transmission loss": "Pérdida por transmisión por modos normales",
+    "Source": "Fuente",
+    "Ray trace": "Trazado de rayos",
+    "Parabolic-equation transmission loss": "Pérdida por transmisión por ecuación parabólica",
 }
 
 
-def _t(key: str, language: str) -> str:
-    """Localised fixed string for ``key`` (English is the byte-identical default)."""
-    return _STRINGS[language][key]
+def _t(text: str, language: str = "en") -> str:
+    """Localise a fixed string; English is returned verbatim (byte-identical)."""
+    return _STRINGS.get(text, text) if language == "es" else text
 
 
 def plot_ship_source_level(
@@ -169,17 +121,17 @@ def plot_ship_source_level(
     dl = np.asarray(result.surface_correction, dtype=np.float64)
 
     kwargs.setdefault("color", _C_PRIMARY)
-    kwargs.setdefault("label", _t("source_level_ls", language))
+    kwargs.setdefault("label", _t("Source level Ls", language))
     ax.semilogx(freqs, ls, "o-", **kwargs)
-    ax.semilogx(freqs, rnl, "s--", color=_C_REFERENCE, label=_t("radiated_noise", language))
-    ax.set_xlabel(_t("freq_hz", language))
-    ax.set_ylabel(_t("level_upam", language))
+    ax.semilogx(freqs, rnl, "s--", color=_C_REFERENCE, label=_t("Radiated noise level", language))
+    ax.set_xlabel(_t("Frequency [Hz]", language))
+    ax.set_ylabel(_t("Level [dB re 1 µPa·m]", language))
     ax.grid(True, which="both", alpha=0.3)
     ax.set_axisbelow(True)
 
     twin = ax.twinx()
-    twin.semilogx(freqs, dl, ":", color=_C_TERTIARY, label=_t("surface_corr_legend", language))
-    twin.set_ylabel(_t("surface_corr_ylabel", language))
+    twin.semilogx(freqs, dl, ":", color=_C_TERTIARY, label=_t("Surface correction ΔL", language))
+    twin.set_ylabel(_t("Surface correction ΔL [dB]", language))
     # After twinx() (it re-initialises the shared x-axis with the default log
     # locator) so the octave-band labelling is not reset back to 10^n ticks.
     format_frequency_axis(ax, float(freqs.min()), float(freqs.max()))
@@ -188,7 +140,7 @@ def plot_ship_source_level(
     tlines, tlabels = twin.get_legend_handles_labels()
     ax.legend(lines + tlines, labels + tlabels, loc="best", fontsize="small")
     ax.set_title(
-        f"{_t('source_level_title', language)} "
+        f"{_t('ISO 17208-2 equivalent monopole source level', language)} "
         f"(d_s = {format_number(result.source_depth, language)} m, "
         f"c = {format_number(result.sound_speed, language, decimals=0)} m/s)"
     )
@@ -226,29 +178,29 @@ def plot_pile_strike(
     def _waveform(axw: Axes) -> None:
         axw.plot(t, pressure, color=color, lw=0.8, **kwargs)
         axw.plot([t[peak_idx]], [pressure[peak_idx]], "o", color=_C_REFERENCE,
-                 label=f"{_t('peak', language)} ({format_number(result.peak_spl, language, decimals=0)} dB re 1 µPa)")
-        axw.set_ylabel(_t("pressure_pa", language))
+                 label=f"{_t('Peak', language)} ({format_number(result.peak_spl, language, decimals=0)} dB re 1 µPa)")
+        axw.set_ylabel(_t("Pressure [Pa]", language))
         axw.grid(True, alpha=0.3)
         axw.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
 
     if ax is not None:
         _waveform(ax)
-        ax.set_xlabel(_t("time_s", language))
-        ax.set_title(f"{_t('pile_title', language)} (SEL_ss = {format_number(result.single_strike_sel, language, decimals=0)} dB)")
+        ax.set_xlabel(_t("Time [s]", language))
+        ax.set_title(f"{_t('ISO 18406 pile strike', language)} (SEL_ss = {format_number(result.single_strike_sel, language, decimals=0)} dB)")
         localize_axes(ax, language)
         return ax
 
     axes = _new_axes_column(2, sharex=True, figsize=(8.0, 6.0))
     _waveform(axes[0])
     axes[0].set_title(
-        f"{_t('pile_title', language)} (SEL_ss = {format_number(result.single_strike_sel, language, decimals=0)} dB re 1 µPa²·s)"
+        f"{_t('ISO 18406 pile strike', language)} (SEL_ss = {format_number(result.single_strike_sel, language, decimals=0)} dB re 1 µPa²·s)"
     )
-    axes[1].plot(t, cum, color=_C_TERTIARY, label=_t("cumulative_energy", language))
+    axes[1].plot(t, cum, color=_C_TERTIARY, label=_t("Cumulative energy", language))
     for frac in (0.05, 0.95):
         axes[1].axhline(frac, color=_C_MUTED, ls="--", lw=0.8)
-    axes[1].set_ylabel(_t("cumulative_energy_norm", language))
-    axes[1].set_xlabel(_t("time_s", language))
-    axes[1].set_title(f"{_t('pulse_duration', language)} = {format_number(result.pulse_duration * 1e3, language, decimals=0)} ms")
+    axes[1].set_ylabel(_t("Cumulative energy (norm.)", language))
+    axes[1].set_xlabel(_t("Time [s]", language))
+    axes[1].set_title(f"{_t('90 % pulse duration', language)} = {format_number(result.pulse_duration * 1e3, language, decimals=0)} ms")
     axes[1].grid(True, alpha=0.3)
     localize_axes(axes[0], language)
     localize_axes(axes[1], language)
@@ -275,9 +227,9 @@ def plot_sound_speed_profile(
     ax.plot(speed, depth, **{"color": _C_PRIMARY, "lw": 1.4, "label": label, **kwargs})
     if not ax.yaxis_inverted():
         ax.invert_yaxis()
-    ax.set_xlabel(_t("sound_speed_ms", language))
-    ax.set_ylabel(_t("depth_m", language))
-    ax.set_title(_t("sound_speed_title", language))
+    ax.set_xlabel(_t("Sound speed [m/s]", language))
+    ax.set_ylabel(_t("Depth [m]", language))
+    ax.set_title(_t("Sea-water sound-speed profile", language))
     ax.grid(True, alpha=0.3)
     ax.legend(loc="lower left", fontsize="small")
     localize_axes(ax, language)
@@ -301,15 +253,15 @@ def plot_transmission_loss(
 
     ax = ax if ax is not None else _new_axes()
     r = np.asarray(result.range_m, dtype=np.float64)
-    label = f"{_t('total_tl', language)} ({decimal_comma(f'{result.frequency / 1000.0:.3g}', language)} kHz)"
+    label = f"{_t('Total TL', language)} ({decimal_comma(f'{result.frequency / 1000.0:.3g}', language)} kHz)"
     ax.plot(r, np.asarray(result.tl), **{"color": _C_PRIMARY, "lw": 1.6, "label": label, **kwargs})
     ax.plot(r, np.asarray(result.spreading), color=_C_MUTED, lw=1.0, ls="--",
-            label=f"{_t('spreading', language)} ({result.law})")
+            label=f"{_t('Spreading', language)} ({result.law})")
     ax.plot(r, np.asarray(result.absorption), color=_C_SECONDARY, lw=1.0, ls=":",
-            label=f"{_t('absorption', language)} ({decimal_comma(f'{result.absorption_coefficient:.3g}', language)} dB/km)")
-    ax.set_xlabel(_t("range_m", language))
-    ax.set_ylabel(_t("tl_db", language))
-    ax.set_title(f"{_t('underwater_tl_title', language)} ({result.model})")
+            label=f"{_t('Absorption', language)} ({decimal_comma(f'{result.absorption_coefficient:.3g}', language)} dB/km)")
+    ax.set_xlabel(_t("Range [m]", language))
+    ax.set_ylabel(_t("Transmission loss [dB]", language))
+    ax.set_title(f"{_t('Underwater transmission loss', language)} ({result.model})")
     if not ax.yaxis_inverted():
         ax.invert_yaxis()
     ax.grid(True, alpha=0.3)
@@ -335,14 +287,14 @@ def plot_sonar_equation(
     tl = np.asarray(result.transmission_loss, dtype=np.float64)
     se = np.asarray(result.signal_excess, dtype=np.float64)
     order = np.argsort(tl)
-    label = f"{_t('signal_excess', language)} ({result.mode})"
+    label = f"{_t('Signal excess', language)} ({result.mode})"
     ax.plot(tl[order], se[order], **{"color": _C_PRIMARY, "lw": 1.6, "label": label, **kwargs})
-    ax.axhline(0.0, color=_C_REFERENCE, ls="--", lw=1.0, label=_t("detection_limit", language))
+    ax.axhline(0.0, color=_C_REFERENCE, ls="--", lw=1.0, label=_t("Detection limit (SE = 0)", language))
     ax.axvline(result.figure_of_merit, color=_C_MUTED, ls=":", lw=1.0,
-               label=f"{_t('figure_of_merit', language)} = {format_number(result.figure_of_merit, language)} dB")
-    ax.set_xlabel(_t("tl_db", language))
-    ax.set_ylabel(_t("signal_excess_db", language))
-    ax.set_title(_t("sonar_title", language))
+               label=f"{_t('Figure of merit', language)} = {format_number(result.figure_of_merit, language)} dB")
+    ax.set_xlabel(_t("Transmission loss [dB]", language))
+    ax.set_ylabel(_t("Signal excess [dB]", language))
+    ax.set_title(_t("Sonar equation", language))
     ax.grid(True, alpha=0.3)
     ax.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
     localize_axes(ax, language)
@@ -365,13 +317,13 @@ def plot_bottom_loss(
     ax = ax if ax is not None else _new_axes()
     phi = np.asarray(result.grazing_angle, dtype=np.float64)
     loss = np.asarray(result.reflection_loss, dtype=np.float64)
-    ax.plot(phi, loss, **{"color": _C_PRIMARY, "lw": 1.6, "label": _t("bottom_loss", language), **kwargs})
+    ax.plot(phi, loss, **{"color": _C_PRIMARY, "lw": 1.6, "label": _t("Bottom loss", language), **kwargs})
     if result.critical_angle is not None:
         ax.axvline(result.critical_angle, color=_C_REFERENCE, ls="--", lw=1.0,
-                   label=f"{_t('critical_angle', language)} = {format_number(result.critical_angle, language)}°")
-    ax.set_xlabel(_t("grazing_angle", language))
-    ax.set_ylabel(_t("bottom_loss_db", language))
-    ax.set_title(_t("seabed_title", language))
+                   label=f"{_t('Critical angle', language)} = {format_number(result.critical_angle, language)}°")
+    ax.set_xlabel(_t("Grazing angle [°]", language))
+    ax.set_ylabel(_t("Bottom loss [dB]", language))
+    ax.set_title(_t("Seabed reflection loss", language))
     ax.grid(True, alpha=0.3)
     ax.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
     localize_axes(ax, language)
@@ -393,18 +345,18 @@ def plot_ambient_noise(
 
     ax = ax if ax is not None else _new_axes()
     f = np.asarray(result.frequency, dtype=np.float64)
-    label = f"{_t('total', language)} ({format_number(result.wind_speed_knots, language)} kn)"
+    label = f"{_t('Total', language)} ({format_number(result.wind_speed_knots, language)} kn)"
     ax.plot(f, np.asarray(result.spectrum_level),
             **{"color": _C_PRIMARY, "lw": 1.8, "label": label, **kwargs})
-    ax.plot(f, np.asarray(result.wind), color=_C_SECONDARY, lw=1.0, ls="--", label=_t("wind", language))
-    ax.plot(f, np.asarray(result.thermal), color=_C_TERTIARY, lw=1.0, ls=":", label=_t("thermal", language))
+    ax.plot(f, np.asarray(result.wind), color=_C_SECONDARY, lw=1.0, ls="--", label=_t("Wind", language))
+    ax.plot(f, np.asarray(result.thermal), color=_C_TERTIARY, lw=1.0, ls=":", label=_t("Thermal", language))
     if result.shipping is not None:
         ax.plot(f, np.asarray(result.shipping), color=_C_REFERENCE, lw=1.0, ls="-.",
-                label=_t("shipping", language))
+                label=_t("Shipping", language))
     ax.set_xscale("log")
-    ax.set_xlabel(_t("freq_hz", language))
-    ax.set_ylabel(_t("spectrum_level", language))
-    ax.set_title(_t("ambient_title", language))
+    ax.set_xlabel(_t("Frequency [Hz]", language))
+    ax.set_ylabel(_t("Spectrum level [dB re 1 µPa²/Hz]", language))
+    ax.set_title(_t("Ocean ambient noise", language))
     ax.grid(True, which="both", alpha=0.3)
     ax.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
     format_frequency_axis(ax, float(f.min()), float(f.max()))
@@ -434,9 +386,9 @@ def plot_ship_traffic_spectrum(
         label = result.model
     ax.plot(f, psd, **{"color": _C_PRIMARY, "lw": 1.6, "label": label, **kwargs})
     ax.set_xscale("log")
-    ax.set_xlabel(_t("freq_hz", language))
-    ax.set_ylabel(_t("source_psd_ylabel", language))
-    ax.set_title(_t("traffic_title", language))
+    ax.set_xlabel(_t("Frequency [Hz]", language))
+    ax.set_ylabel(_t("Source spectral density [dB re 1 µPa²/Hz at 1 m]", language))
+    ax.set_title(_t("Ship traffic source level", language))
     ax.grid(True, which="both", alpha=0.3)
     ax.legend(loc=_LEGEND_UPPER_RIGHT, fontsize="small")
     format_frequency_axis(ax, float(f.min()), float(f.max()))
@@ -460,11 +412,11 @@ def plot_normal_modes(
     ax = ax if ax is not None else _new_axes()
     r = np.asarray(result.ranges, dtype=np.float64)
     tl = np.asarray(result.transmission_loss, dtype=np.float64)
-    label = f"{result.wavenumbers.size} {_t('modes_word', language)} ({format_number(result.frequency, language, decimals=0)} Hz)"
+    label = f"{result.wavenumbers.size} {_t('modes', language)} ({format_number(result.frequency, language, decimals=0)} Hz)"
     ax.plot(r / 1000.0, tl, **{"color": _C_PRIMARY, "lw": 1.2, "label": label, **kwargs})
-    ax.set_xlabel(_t("range_km", language))
-    ax.set_ylabel(_t("tl_db", language))
-    ax.set_title(_t("modes_title", language))
+    ax.set_xlabel(_t("Range [km]", language))
+    ax.set_ylabel(_t("Transmission loss [dB]", language))
+    ax.set_title(_t("Normal-mode transmission loss", language))
     if not ax.yaxis_inverted():
         ax.invert_yaxis()
     ax.grid(True, alpha=0.3)
@@ -489,10 +441,10 @@ def plot_ray_trace(result: "RayTraceResult", ax: Axes | None = None, *, language
     z = np.asarray(result.depths, dtype=np.float64)
     for i in range(r.shape[0]):
         ax.plot(r[i] / 1000.0, z[i], **{"color": _C_PRIMARY, "lw": 0.7, "alpha": 0.7, **kwargs})
-    ax.plot([0.0], [result.source_depth], "o", color=_C_REFERENCE, label=_t("source", language))
-    ax.set_xlabel(_t("range_km", language))
-    ax.set_ylabel(_t("depth_m", language))
-    ax.set_title(_t("raytrace_title", language))
+    ax.plot([0.0], [result.source_depth], "o", color=_C_REFERENCE, label=_t("Source", language))
+    ax.set_xlabel(_t("Range [km]", language))
+    ax.set_ylabel(_t("Depth [m]", language))
+    ax.set_title(_t("Ray trace", language))
     if not ax.yaxis_inverted():
         ax.invert_yaxis()
     ax.grid(True, alpha=0.3)
@@ -539,9 +491,9 @@ def plot_parabolic_equation(
             **kwargs,
         },
     )
-    ax.figure.colorbar(img, ax=ax, label=_t("tl_db", language))
-    ax.set_xlabel(_t("range_km", language))
-    ax.set_ylabel(_t("depth_m", language))
-    ax.set_title(_t("pe_title", language))
+    ax.figure.colorbar(img, ax=ax, label=_t("Transmission loss [dB]", language))
+    ax.set_xlabel(_t("Range [km]", language))
+    ax.set_ylabel(_t("Depth [m]", language))
+    ax.set_title(_t("Parabolic-equation transmission loss", language))
     localize_axes(ax, language)
     return ax


### PR DESCRIPTION
## What

Two small internationalization cleanups.

### Flat string tables for the aircraft, environmental and underwater plots

These three renderer modules still carried the nested `{"en": {...}, "es": {...}}` string tables with slug keys and a strict `_STRINGS[language][key]` lookup, a leftover from before the plot i18n tables were collapsed. They now use the same flat `_STRINGS: dict[str, str]` form as the other fifteen plot modules: keys are the verbatim English display text and `_t` returns the key unchanged for any language other than `"es"`, so language validation stays centralized in `_i18n`. The aircraft table keeps its `{metric}` placeholder through the fmt-forwarding `_t` variant already used by the electroacoustics and metrology renderers. 127 strings converted (39 aircraft, 41 environmental, 47 underwater); every call site passes a literal, so no runtime value is ever looked up against the tables.

English output is byte-identical and the Spanish translations are unchanged: the three domain plot i18n suites pass and `scripts/check_figures.py` reports all 868 committed figures matching after a full `make graphs` regeneration.

### ES terminology: Anexo 16

The Spanish aircraft-noise guide mixed the untranslated "ICAO Annex 16" into prose that elsewhere uses "Anexo 16", and its description used the "la ICAO Anexo 16" word order. The four occurrences now follow the "Anexo 16 de la ICAO, Vol. I, Apendice 2" register used by the rest of the ES pages. The official English title in the references block, the bibliography citation and the `measurement_standard` code string (the standard designation rendered on the fiche) are intentionally untouched. EN pages untouched; `check-i18n-parity.mjs` passes.

## Checks

- `ruff check .`, `mypy src scripts`, `bandit -r src` clean
- `pytest tests/aircraft/test_aircraft_plot_i18n.py tests/environmental/test_environmental_plot_i18n.py tests/underwater/test_underwater_plot_i18n.py tests/test_package_architecture.py` (34 passed)
- `scripts/check_figures.py`: all 868 figures match (zero diff)
- api-docs regeneration: no drift (no public signatures change)
- `node site/scripts/check-i18n-parity.mjs`: 90/90 pages

No changelog entry: internal refactor plus ES wording only.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

