### PR TITLE
docs: regenerate llms-full.txt after the latest merges

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -93,9 +93,10 @@ pip install phonometry
 Optional extras:
 
 ```bash
-pip install phonometry[plot]   # matplotlib, for filter response plots and result .plot() methods
-pip install phonometry[perf]  # numba, faster 'impulse' time weighting
-pip install phonometry[full]  # both
+pip install phonometry[plot]    # matplotlib, for filter response plots and result .plot() methods
+pip install phonometry[perf]    # numba, faster 'impulse' time weighting
+pip install phonometry[report]  # reportlab + svglib, so result .report() methods render normative PDF fiches
+pip install phonometry[full]    # all of the above
 ```
 
 **Option 2: Cloning and Installing**
@@ -207,8 +208,18 @@ safe to pass `wavfile.read` output directly.
 
 ## Where to go next
 
+The octave analysis above uses the `metrology` core, one of fifteen domain
+namespaces; the documentation index walks through the rest, from
+psychoacoustics and room, building and vibration acoustics to environmental,
+aircraft and underwater noise, electroacoustics and FDTD wave simulation.
+Every result object exposes a one-line `.plot(language="en"|"es")` figure and,
+where a standard defines a reporting format, a `.report()` method that renders
+the normative PDF fiche.
+
 - [Filter Banks](https://jmrplens.github.io/phonometry/guides/filter-banks/): choose an architecture and inspect responses
 - [Calibration and dBFS](https://jmrplens.github.io/phonometry/guides/calibration/): get real-world SPL values
+- [Why phonometry](https://jmrplens.github.io/phonometry/reference/why-phonometry/): the conformance-first design philosophy
+- [Conformance report](CONFORMANCE.md): the expected and computed value of all 371 checks
 - [API Reference](https://jmrplens.github.io/phonometry/reference/api/): every parameter of every function
 - [Bibliography](references.md): the books and papers behind every guide, each with a verified link
 


### PR DESCRIPTION
Two recent pull requests regenerated `llms-full.txt` concurrently in their own branches, so the committed copy missed whichever branch merged first. Regenerated from current main; `make llms` is now drift-free. Generated file only.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

