### PR TITLE
docs(site): Signals and spectra subgroup and a sound level meter walk-through

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -331,6 +331,7 @@ export default defineConfig({
           translations: { es: 'Análisis de señal' },
           items: [
             { slug: 'guides/sections/core-signal-analysis', attrs: { 'data-group-link': true } },
+            'guides/sound-level-meter',
             {
               label: 'Octave filtering',
               translations: { es: 'Filtrado en octavas' },
@@ -352,14 +353,21 @@ export default defineConfig({
               ],
             },
             {
+              label: 'Signals and spectra',
+              translations: { es: 'Señales y espectros' },
+              items: [
+                { slug: 'guides/sections/signals-spectra', attrs: { 'data-group-link': true } },
+                'guides/spectral-analysis',
+                'guides/correlation-delay',
+              ],
+            },
+            {
               label: 'Calibration and uncertainty',
               translations: { es: 'Calibración e incertidumbre' },
               items: [
                 { slug: 'guides/sections/calibration-uncertainty', attrs: { 'data-group-link': true } },
                 'guides/calibration',
                 'guides/gum-uncertainty',
-                'guides/spectral-analysis',
-                'guides/correlation-delay',
               ],
             },
           ],

--- a/site/src/content/docs/es/guides/sections/calibration-uncertainty.md
+++ b/site/src/content/docs/es/guides/sections/calibration-uncertainty.md
@@ -30,13 +30,12 @@ que siguen siendo honestos cuando el modelo es no lineal o las entradas
 distan de ser gaussianas. La página muestra ambas sobre los mismos modelos,
 incluyendo dónde divergen y por qué.
 
-La misma disciplina se extiende al dominio de la frecuencia.
-[Análisis espectral calibrado](/phonometry/es/guides/spectral-analysis/)
-aplica el análisis de error de Bendat y Piersol a las estimaciones
-espectrales de Welch: cada PSD lleva su número efectivo de promedios, su
-error aleatorio normalizado y un intervalo de confianza chi-cuadrado, y el
-espectro de salida coherente separa una salida medida en señal y ruido con
-una SNR espectral.
+La misma disciplina se extiende al dominio de la frecuencia: las páginas de
+[Señales y espectros](/phonometry/es/guides/sections/signals-spectra/)
+aplican el análisis de error de Bendat y Piersol a las estimaciones
+espectrales de Welch, de modo que cada PSD lleva su número efectivo de
+promedios, su error aleatorio normalizado y un intervalo de confianza
+chi-cuadrado.
 
 Las páginas se encuentran en la práctica: un presupuesto de incertidumbre
 de una medición acústica casi siempre contiene un término de calibración, y
@@ -52,7 +51,3 @@ la maquinaria GUM descrita aquí.
 - [Incertidumbre de medida (GUM y Monte Carlo)](/phonometry/es/guides/gum-uncertainty/):
   la ley de propagación de la incertidumbre y el método de Monte Carlo,
   incertidumbre expandida e intervalos de cobertura.
-- [Análisis espectral calibrado](/phonometry/es/guides/spectral-analysis/):
-  PSD/CSD de Welch con intervalos de confianza chi-cuadrado, el espectro de
-  salida coherente y la SNR espectral, suavizado en 1/n de octava y
-  generadores de ruido de colores con pendiente exacta.

--- a/site/src/content/docs/es/guides/sections/core-signal-analysis.md
+++ b/site/src/content/docs/es/guides/sections/core-signal-analysis.md
@@ -1,6 +1,6 @@
 ---
 title: "Análisis de señal"
-description: "El núcleo de medición de phonometry: bancos de filtros de octava fraccional, ponderación frecuencial y temporal, niveles integrados y estadísticos, calibración física e incertidumbre de medida, y cómo esas piezas se encadenan en un sonómetro en código."
+description: "El núcleo de medición de phonometry: bancos de filtros de octava fraccional, ponderación frecuencial y temporal, niveles integrados y estadísticos, análisis espectral y de correlación calibrado, calibración física e incertidumbre de medida, y cómo esas piezas se encadenan en un sonómetro en código."
 ---
 
 Todo en phonometry empieza aquí. Esta sección cubre la cadena que convierte
@@ -13,11 +13,20 @@ funciones componibles, y todas las demás secciones de la documentación se
 apoyan en él: un modelo de sonoridad consume niveles de banda calibrados, un
 parámetro de sala parte de una respuesta al impulso filtrada, una valoración
 ambiental es un Leq ajustado.
+[Construye un sonómetro](/phonometry/es/guides/sound-level-meter/) monta esa
+cadena de principio a fin en una sola página ejecutable; es el mejor punto de
+partida si quieres ver el área entera en funcionamiento antes de abrir las
+guías de fondo.
 
-Dos preocupaciones transversales completan el núcleo. La **calibración**
-decide qué significan físicamente las muestras digitales: los resultados
-pueden referirse a un tono de calibrador medido o a una sensibilidad conocida
-(dB SPL), o quedarse en escala digital completa (dBFS). Y la **incertidumbre
+Alrededor de la cadena de niveles están las herramientas generales de
+análisis de señal: las **estimaciones espectrales calibradas** (PSD y
+densidad espectral cruzada de Welch con intervalos de confianza), la
+**correlación y la estimación de retardo** y la **envolvente de Hilbert**,
+todas expresadas con el análisis de error de Bendat y Piersol. Y dos
+preocupaciones transversales completan el núcleo. La **calibración** decide
+qué significan físicamente las muestras digitales: los resultados pueden
+referirse a un tono de calibrador medido o a una sensibilidad conocida
+(dB SPL), o quedarse en escala digital completa (dBFS). La **incertidumbre
 de medida** (la GUM y su suplemento de Monte Carlo) cualifica cualquier
 resultado calculado a partir de entradas inciertas, que es lo que hace
 defendible un número en un informe.
@@ -60,16 +69,11 @@ valoración.
   (IEC 61252), Lden y niveles de valoración (ISO 1996-1), y espectrogramas de
   octava.
 
-## [Calibración e incertidumbre](/phonometry/es/guides/sections/calibration-uncertainty/)
+## [Señales y espectros](/phonometry/es/guides/sections/signals-spectra/)
 
-Qué significan los números y cuánto fiarse de ellos.
+Análisis de grano fino en frecuencia y en tiempo, con cada estimación
+calibrada y acompañada de su calidad estadística.
 
-- [Calibración y dBFS](/phonometry/es/guides/calibration/): calibración SPL
-  física a partir de un tono de calibrador (IEC 60942) o de una sensibilidad
-  conocida, y el modo digital dBFS.
-- [Incertidumbre de medida (GUM y Monte Carlo)](/phonometry/es/guides/gum-uncertainty/):
-  la ley de propagación de la incertidumbre y el método de Monte Carlo de
-  ISO/IEC Guide 98-3, con incertidumbre expandida e intervalos de cobertura.
 - [Análisis espectral calibrado](/phonometry/es/guides/spectral-analysis/):
   los estimadores de Welch de Bendat y Piersol con su calidad estadística:
   PSD y densidad espectral cruzada con intervalos de confianza chi-cuadrado,
@@ -81,3 +85,14 @@ Qué significan los números y cuánto fiarse de ellos.
   del espectro cruzado y las ponderaciones GCC de Knapp y Carter, retardo
   submuestral y alineación de respuestas al impulso, y la envolvente de
   Hilbert.
+
+## [Calibración e incertidumbre](/phonometry/es/guides/sections/calibration-uncertainty/)
+
+Qué significan los números y cuánto fiarse de ellos.
+
+- [Calibración y dBFS](/phonometry/es/guides/calibration/): calibración SPL
+  física a partir de un tono de calibrador (IEC 60942) o de una sensibilidad
+  conocida, y el modo digital dBFS.
+- [Incertidumbre de medida (GUM y Monte Carlo)](/phonometry/es/guides/gum-uncertainty/):
+  la ley de propagación de la incertidumbre y el método de Monte Carlo de
+  ISO/IEC Guide 98-3, con incertidumbre expandida e intervalos de cobertura.

--- a/site/src/content/docs/es/guides/sections/signals-spectra.md
+++ b/site/src/content/docs/es/guides/sections/signals-spectra.md
@@ -1,0 +1,55 @@
+---
+title: "Señales y espectros"
+description: "Análisis de señal en frecuencia y en tiempo en phonometry: estimaciones espectrales de Welch calibradas con su calidad estadística, y correlación, estimación de retardo y la envolvente de Hilbert."
+---
+
+Los niveles de banda responden a *cuánto*; esta sección responde a *qué hay
+en la señal*. Donde el resto del núcleo trabaja en bandas de octava
+fraccional, estas páginas trabajan con los estimadores de grano fino del
+análisis de señal clásico: densidades espectrales, funciones de correlación,
+retardos y envolventes. Comparten una misma disciplina, tomada de Bendat y
+Piersol: cada estimación está **calibrada** (los mismos marcos de referencia
+dB SPL / dBFS que el resto de la biblioteca) y lleva consigo su **calidad
+estadística**, de modo que un espectro no es solo una curva, sino una curva
+con su intervalo de confianza.
+
+[Análisis espectral calibrado](/phonometry/es/guides/spectral-analysis/) es
+la mitad del dominio de la frecuencia. Los estimadores de Welch de densidad
+espectral de potencia y cruzada reportan su número efectivo de promedios, sus
+errores aleatorios normalizados y sus intervalos de confianza chi-cuadrado;
+el espectro de salida coherente separa una salida medida en la parte
+explicada por una entrada y la parte que es ruido, con una relación
+señal-ruido espectral; el suavizado en fracciones de octava tiende el puente
+de vuelta al mundo de bandas; y los generadores de ruido de colores
+sintetizan señales de prueba blancas, rosas, rojas, azules y violetas con
+pendiente exacta en ley de potencias.
+
+[Correlación, retardo y envolvente](/phonometry/es/guides/correlation-delay/)
+es la mitad del dominio del tiempo. La autocorrelación y la correlación
+cruzada vienen con las normalizaciones y los errores aleatorios de Bendat y
+Piersol; la estimación del retardo ofrece el correlador directo, la pendiente
+de fase del espectro cruzado y las ponderaciones de la correlación cruzada
+generalizada de Knapp y Carter (Roth, SCOT, PHAT, máxima verosimilitud); las
+respuestas al impulso pueden retardarse y alinearse con precisión
+submuestral; y la transformada de Hilbert produce la envolvente con fase y
+frecuencia instantáneas.
+
+Estos estimadores alimentan al resto de la biblioteca: las funciones de
+transferencia y el análisis de distorsión se apoyan en la maquinaria
+espectral cruzada, el trabajo con respuestas al impulso de sala descansa en
+la estimación de retardo y la alineación, y las
+[páginas de incertidumbre](/phonometry/es/guides/sections/calibration-uncertainty/)
+aportan el vocabulario de análisis de error en el que se expresan las
+estimaciones.
+
+## Páginas de esta sección
+
+- [Análisis espectral calibrado](/phonometry/es/guides/spectral-analysis/):
+  PSD/CSD de Welch con intervalos de confianza chi-cuadrado, el espectro de
+  salida coherente y la SNR espectral, suavizado en 1/n de octava y
+  generadores de ruido de colores con pendiente exacta.
+- [Correlación, retardo y envolvente](/phonometry/es/guides/correlation-delay/):
+  estimaciones de correlación con sus errores aleatorios, estimación del
+  retardo por correlación directa, pendiente de fase y ponderaciones GCC,
+  alineación submuestral de respuestas al impulso, y la envolvente de
+  Hilbert.

--- a/site/src/content/docs/es/guides/sound-level-meter.mdx
+++ b/site/src/content/docs/es/guides/sound-level-meter.mdx
@@ -1,0 +1,219 @@
+---
+title: "Construye un sonómetro"
+description: "Un recorrido de principio a fin que compone la API del núcleo en un sonómetro funcional: calibra con un tono IEC 60942, aplica las ponderaciones frecuencial y temporal de IEC 61672-1, integra en Leq, SEL y niveles percentiles, descompone en bandas de octava IEC 61260-1 y verifica la clase de cada etapa."
+references:
+  - type: standard
+    organization: "International Electrotechnical Commission"
+    year: 2013
+    title: "Electroacoustics — Sound level meters — Part 1: Specifications"
+    designation: "IEC 61672-1:2013"
+    url: "https://webstore.iec.ch/en/publication/5708"
+    note: "El plano del instrumento montado en esta página: la ponderación frecuencial A y la ponderación temporal exponencial Fast de la cadena de niveles, el pico con ponderación C y el nivel de exposición sonora, y los límites de aceptación de clase de la Tabla 3 que comprueba verify_weighting_class."
+  - type: standard
+    organization: "International Electrotechnical Commission"
+    year: 2014
+    title: "Electroacoustics — Octave-band and fractional-octave-band filters — Part 1: Specifications"
+    designation: "IEC 61260-1:2014"
+    url: "https://webstore.iec.ch/en/publication/5063"
+    note: "Los filtros de bandas de octava fraccional de la etapa de espectro, y los límites de aceptación de clase de la Tabla 1 que comprueba verify_filter_class."
+  - type: standard
+    organization: "International Electrotechnical Commission"
+    year: 2017
+    title: "Electroacoustics — Sound calibrators"
+    designation: "IEC 60942:2017"
+    url: "https://webstore.iec.ch/en/publication/30045"
+    note: "El calibrador acústico que asume la etapa de sensibilidad: el nivel principal de 94 dB y la comprobación de estabilidad a corto plazo aplicada a la grabación de referencia."
+---
+
+Un sonómetro no es un algoritmo, sino una breve cadena de ellos, e
+IEC 61672-1 especifica cada etapa. phonometry implementa cada etapa como una
+función independiente y componible; esta página las ensambla, en orden, en un
+sonómetro funcional. Todos los fragmentos se ejecutan tal cual (las señales
+se sintetizan para que la página sea autocontenida), y cada etapa enlaza con
+la guía de fondo que la explica por completo.
+
+```mermaid
+flowchart LR
+    A["Tono de calibrador\n(IEC 60942)"] --> B["sensitivity()"]
+    B --> C["Ponderación frecuencial\nweighting_filter('A')"]
+    C --> D["Ponderación temporal\ntime_weighting('fast')"]
+    D --> E["Pantalla + percentiles\nLAF(t), ln_levels"]
+    C --> F["Niveles integrados\nlaeq / sel / lc_peak"]
+    C -.-> G["Bandas de octava\noctave_filter (IEC 61260-1)"]
+    E --> H["Informe"]
+    F --> H
+    G --> H
+```
+
+Los fragmentos de esta página se apoyan unos en otros: ejecútalos de arriba
+abajo en una misma sesión (o pega la página entera en un script).
+
+## 1. El escenario
+
+Un sonómetro necesita dos grabaciones de la *misma* cadena de entrada: el
+tono de calibrador que ancla los números digitales a pascales, y la propia
+medición. Aquí ambas se sintetizan para que puedas ejecutar la página en
+cualquier parte; en una medición real proceden de tu micrófono.
+
+```python
+import numpy as np
+from phonometry import metrology
+
+fs = 48000
+
+# Tono de calibrador: 94 dB SPL = 1 Pa RMS a 1 kHz (IEC 60942).
+#   Sintetizado aquí; en campo, graba unos segundos de tu calibrador.
+calibrator = np.sqrt(2) * np.sin(2 * np.pi * 1000 * np.arange(3 * fs) / fs)
+
+# Medición "de calle": 10 s de ruido rosa de fondo más un evento de 1 s a
+#   1 kHz, tipo bocina, para que los niveles estadísticos tengan algo que separar.
+recording = metrology.noise_signal(fs, 10.0, color="pink", rms=0.02, seed=7)
+recording[4 * fs : 5 * fs] += 0.2 * np.sqrt(2) * np.sin(
+    2 * np.pi * 1000 * np.arange(fs) / fs
+)
+```
+
+## 2. Calibra: da significado físico a las muestras
+
+Las muestras digitales son adimensionales; el **factor de sensibilidad** las
+convierte a pascales. `sensitivity()` lo calcula a partir de la grabación del
+calibrador y, de paso, valida la estabilidad a corto plazo de la grabación
+igual que IEC 60942 cualifica el propio calibrador, de modo que un micrófono
+mal acoplado se detecta aquí en lugar de corromper todos los niveles
+posteriores.
+
+```python
+cal = metrology.sensitivity(calibrator, target_spl=94.0, fs=fs)
+# cal está en Pa por unidad digital; todas las funciones de nivel lo aceptan
+# como calibration_factor. Para este tono sintético vale ≈1,0.
+```
+
+Guía de fondo: [Calibración y dBFS](/phonometry/es/guides/calibration/), que
+cubre también la calibración desde una sensibilidad de micrófono conocida y
+el modo digital dBFS que se usa cuando no existe referencia física.
+
+## 3. Pondera: frecuencia y tiempo (IEC 61672-1)
+
+El sonómetro nunca muestra la presión en bruto. La señal pasa primero por la
+**ponderación frecuencial A** (la curva de respuesta del oído de
+IEC 61672-1), se eleva al cuadrado y se suaviza con el **detector
+exponencial Fast** (constante de tiempo de 125 ms). El resultado es el nivel
+móvil que sigue la pantalla de un sonómetro, LAF(t):
+
+```python
+pressure = cal * recording                          # unidades digitales -> Pa
+weighted = metrology.weighting_filter(pressure, fs, curve="A")
+envelope = metrology.time_weighting(weighted, fs, mode="fast")  # media cuadrática en Pa^2
+laf_t = 10 * np.log10(np.maximum(envelope, 1e-12) / (2e-5) ** 2)
+# laf_t alcanza unos 80 dB durante el evento y se asienta cerca de 55 dB entre medias.
+```
+
+Rara vez escribirás esta cadena a mano: todas las funciones de nivel del paso
+siguiente aplican la ponderación frecuencial internamente, y los niveles
+percentiles reconstruyen por ti esta envolvente Fast. Las métricas de energía
+(Leq, SEL) integran directamente la señal ponderada al cuadrado, sin
+balística, exactamente como hace un sonómetro. La cadena se muestra aquí
+porque *es* la pantalla del sonómetro.
+
+Guías de fondo:
+[Ponderación frecuencial (A, C, G, Z)](/phonometry/es/guides/weighting/) y
+[Ponderación temporal](/phonometry/es/guides/time-weighting/).
+
+## 4. Integra: los números que reporta un sonómetro
+
+Una sola pasada sobre la grabación calibrada produce las lecturas estándar:
+el **LAeq** equivalente en energía, los **niveles percentiles** que describen
+cómo fluctuó el nivel (L90 es el fondo, L10 los eventos), el **nivel de
+exposición sonora** que normaliza el evento a un segundo, y el **pico** con
+ponderación C para contenido impulsivo.
+
+```python
+la_eq = metrology.laeq(recording, fs, calibration_factor=cal)     # ≈70,2 dB
+ln = metrology.ln_levels(
+    recording, fs, n=(10, 50, 90), weighting="A", calibration_factor=cal
+)                                          # L10 ≈78,0, L50 ≈55,1, L90 ≈54,9
+lae = metrology.sel(recording, fs, weighting="A", calibration_factor=cal)  # ≈80,2
+lc_pk = metrology.lc_peak(recording, fs, calibration_factor=cal)           # ≈84,4
+
+print(f"LAeq {la_eq:.1f} dB | L10 {ln[10]:.1f} | L90 {ln[90]:.1f} "
+      f"| LAE {lae:.1f} | LCpeak {lc_pk:.1f}")
+```
+
+Fíjate en la aritmética que codifican los números: el evento de 1 s domina
+el LAeq (está 25 dB por encima del fondo, mucho más de los 10 dB que el
+fondo, nueve veces más largo, recupera por duración), el LAE es el LAeq más
+10 log10 de los 10 s de duración, y el L90 apenas nota el evento.
+
+Guía de fondo:
+[Niveles integrados y estadísticos](/phonometry/es/guides/levels/), que añade
+dosis de ruido, Lden y niveles de valoración, y espectrogramas de octava.
+
+## 5. Filtra en bandas: la vista de espectro (IEC 61260-1)
+
+Un sonómetro de clase 1 con juego de filtros reporta niveles por banda.
+`octave_filter` descompone la señal calibrada en bandas de octava fraccional
+cuyo diseño está anclado a los bordes de banda de IEC 61260-1;
+`nominal=True` las etiqueta con las frecuencias preferentes que leerías en un
+instrumento.
+
+```python
+spl, bands = metrology.octave_filter(
+    recording, fs, fraction=3, calibration_factor=cal, nominal=True
+)
+# 33 niveles de banda de tercio de octava en dB SPL, etiquetados '12.5' ... '20k'.
+# La banda '1k' contiene el evento: ≈70 dB, con sus vecinas ≈25 dB por debajo.
+print(dict(zip(bands, np.round(spl, 1))))
+```
+
+Guías de fondo: [Bancos de filtros](/phonometry/es/guides/filter-banks/) para
+las arquitecturas de filtro y el modo de fase cero,
+[Procesado por bloques](/phonometry/es/guides/block-processing/) para
+streaming, y [Multicanal y rendimiento](/phonometry/es/guides/multichannel/)
+para arrays.
+
+## 6. Verifica: ¿es este sonómetro de clase 1?
+
+Un instrumento real solo es un "sonómetro de clase 1" cuando sus
+ponderaciones y filtros superan los límites de aceptación de las normas. La
+biblioteca incluye los mismos verificadores que se aplica a sí misma en CI:
+`verify_weighting_class` barre un `WeightingFilter` contra los límites de la
+Tabla 3 de IEC 61672-1, y `verify_filter_class` barre un `OctaveFilterBank`
+contra los límites de la Tabla 1 de IEC 61260-1.
+
+```python
+wf = metrology.WeightingFilter(fs, curve="A")
+print(metrology.verify_weighting_class(wf)["overall_class"])   # 1
+
+bank = metrology.OctaveFilterBank(fs, fraction=3)
+print(metrology.verify_filter_class(bank)["overall_class"])    # 1
+```
+
+Los veredictos también llegan por banda, de modo que puedes ver exactamente
+dónde un diseño se saldría de su pasillo de clase. Guías de fondo:
+[Ponderación frecuencial](/phonometry/es/guides/weighting/) (sección de
+verificación de clase) y [Bancos de filtros](/phonometry/es/guides/filter-banks/)
+(conformidad de clase).
+
+## Adónde ir después
+
+El sonómetro construido aquí es el tronco; el resto del núcleo crece de él.
+
+- [Incertidumbre de medida (GUM y Monte Carlo)](/phonometry/es/guides/gum-uncertainty/):
+  acompaña de una incertidumbre el LAeq que acabas de calcular, término de
+  calibración incluido.
+- [Análisis espectral calibrado](/phonometry/es/guides/spectral-analysis/):
+  cuando las bandas se quedan cortas, la PSD de Welch con intervalos de
+  confianza.
+- [Correlación, retardo y envolvente](/phonometry/es/guides/correlation-delay/):
+  dos micrófonos en lugar de uno, y el retardo entre ellos.
+- [Procesado por bloques](/phonometry/es/guides/block-processing/): convierte
+  el sonómetro fuera de línea de esta página en uno en streaming con estado
+  de filtro arrastrado.
+
+## Véase también
+
+- Referencia de la API: [`metrology.calibration`](/phonometry/es/reference/api/levels/calibration/),
+  [`metrology.parametric_filters`](/phonometry/es/reference/api/filters/parametric-filters/),
+  [`metrology.levels`](/phonometry/es/reference/api/levels/levels/),
+  [`phonometry`](/phonometry/es/reference/api/filters/phonometry/) y
+  [`metrology.compliance`](/phonometry/es/reference/api/filters/compliance/).

--- a/site/src/content/docs/guides/sections/calibration-uncertainty.md
+++ b/site/src/content/docs/guides/sections/calibration-uncertainty.md
@@ -27,12 +27,11 @@ intervals that stay honest when the model is non-linear or the inputs are far
 from Gaussian. The page shows both on the same models, including where they
 diverge and why.
 
-The same discipline extends into the frequency domain.
-[Calibrated spectral analysis](/phonometry/guides/spectral-analysis/) applies
-the Bendat & Piersol error analysis to Welch spectral estimates: every PSD
-carries its effective number of averages, its normalized random error and a
-chi-square confidence interval, and the coherent output spectrum splits a
-measured output into signal and noise with a spectral SNR.
+The same discipline extends into the frequency domain: the
+[Signals and spectra](/phonometry/guides/sections/signals-spectra/) pages
+apply the Bendat & Piersol error analysis to Welch spectral estimates, so
+every PSD carries its effective number of averages, its normalized random
+error and a chi-square confidence interval.
 
 The pages meet in practice: an uncertainty budget for an acoustic
 measurement almost always contains a calibration term, and several standards
@@ -47,7 +46,3 @@ budgets that are specialisations of the GUM machinery described here.
 - [Measurement uncertainty (GUM and Monte Carlo)](/phonometry/guides/gum-uncertainty/):
   the law of propagation of uncertainty and the Monte Carlo method, expanded
   uncertainty and coverage intervals.
-- [Calibrated spectral analysis](/phonometry/guides/spectral-analysis/):
-  Welch PSD/CSD with chi-square confidence intervals, the coherent output
-  spectrum and spectral SNR, 1/n-octave smoothing and exact-slope
-  colored-noise generators.

--- a/site/src/content/docs/guides/sections/core-signal-analysis.md
+++ b/site/src/content/docs/guides/sections/core-signal-analysis.md
@@ -1,6 +1,6 @@
 ---
 title: "Core signal analysis"
-description: "The measurement core of phonometry: fractional octave filter banks, frequency and time weighting, integrated and statistical levels, physical calibration and measurement uncertainty, and how those pieces chain into a sound level meter in code."
+description: "The measurement core of phonometry: fractional octave filter banks, frequency and time weighting, integrated and statistical levels, calibrated spectral and correlation analysis, physical calibration and measurement uncertainty, and how those pieces chain into a sound level meter in code."
 ---
 
 Everything in phonometry starts here. This section covers the chain that turns
@@ -12,13 +12,20 @@ in effect, a sound level meter decomposed into composable functions, and every
 other section of the documentation builds on it: a loudness model consumes
 calibrated band levels, a room parameter starts from a filtered impulse
 response, an environmental rating is an adjusted Leq.
+[Build a sound level meter](/phonometry/guides/sound-level-meter/) assembles
+that chain end to end on a single runnable page; it is the best starting point
+if you want to see the whole area at work before opening the deep guides.
 
-Two transversal concerns complete the core. **Calibration** decides what the
-digital samples mean physically: results can be referenced to a measured
-calibrator tone or a known sensitivity (dB SPL), or stay in digital full scale
-(dBFS). And **measurement uncertainty** (the GUM and its Monte Carlo
-supplement) qualifies any result computed from uncertain inputs, which is what
-makes a number defensible in a report.
+Around the level chain sit the general signal-analysis tools:
+**calibrated spectral estimates** (Welch PSD and cross-spectral density with
+confidence intervals), **correlation and time-delay estimation** and the
+**Hilbert envelope**, all stated with the Bendat & Piersol error analysis.
+And two transversal concerns complete the core. **Calibration** decides what
+the digital samples mean physically: results can be referenced to a measured
+calibrator tone or a known sensitivity (dB SPL), or stay in digital full
+scale (dBFS). **Measurement uncertainty** (the GUM and its Monte Carlo
+supplement) qualifies any result computed from uncertain inputs, which is
+what makes a number defensible in a report.
 
 If you are new to the library, read
 [Filter Banks](/phonometry/guides/filter-banks/) first: it introduces the band
@@ -55,16 +62,11 @@ ballistics and the integrated, statistical and rating levels.
   LAeq, percentile levels L10/L50/L90, LCpeak and SEL, noise dose (IEC 61252),
   Lden and rating levels (ISO 1996-1), and octave spectrograms.
 
-## [Calibration and uncertainty](/phonometry/guides/sections/calibration-uncertainty/)
+## [Signals and spectra](/phonometry/guides/sections/signals-spectra/)
 
-What the numbers mean and how much to trust them.
+Fine-grained frequency- and time-domain analysis, every estimate calibrated
+and carrying its statistical quality.
 
-- [Calibration and dBFS](/phonometry/guides/calibration/): physical SPL
-  calibration from a calibrator tone (IEC 60942) or a known sensitivity, and
-  the digital dBFS mode.
-- [Measurement uncertainty (GUM and Monte Carlo)](/phonometry/guides/gum-uncertainty/):
-  the law of propagation of uncertainty and the Monte Carlo method of
-  ISO/IEC Guide 98-3, with expanded uncertainty and coverage intervals.
 - [Calibrated spectral analysis](/phonometry/guides/spectral-analysis/): the
   Bendat & Piersol Welch estimators with their statistical quality: PSD and
   cross-spectral density with chi-square confidence intervals, the coherent
@@ -75,3 +77,14 @@ What the numbers mean and how much to trust them.
   estimation by direct correlation, cross-spectrum phase slope and the
   Knapp & Carter GCC weightings, sub-sample impulse-response delay and
   alignment, and the Hilbert envelope.
+
+## [Calibration and uncertainty](/phonometry/guides/sections/calibration-uncertainty/)
+
+What the numbers mean and how much to trust them.
+
+- [Calibration and dBFS](/phonometry/guides/calibration/): physical SPL
+  calibration from a calibrator tone (IEC 60942) or a known sensitivity, and
+  the digital dBFS mode.
+- [Measurement uncertainty (GUM and Monte Carlo)](/phonometry/guides/gum-uncertainty/):
+  the law of propagation of uncertainty and the Monte Carlo method of
+  ISO/IEC Guide 98-3, with expanded uncertainty and coverage intervals.

--- a/site/src/content/docs/guides/sections/signals-spectra.md
+++ b/site/src/content/docs/guides/sections/signals-spectra.md
@@ -1,0 +1,48 @@
+---
+title: "Signals and spectra"
+description: "Frequency- and time-domain signal analysis in phonometry: calibrated Welch spectral estimates with their statistical quality, and correlation, time-delay estimation and the Hilbert envelope."
+---
+
+Band levels answer *how much*; this section answers *what is in the signal*.
+Where the rest of the core works in fractional octave bands, these pages work
+with the fine-grained estimators of classical signal analysis: spectral
+densities, correlation functions, delays and envelopes. They share one
+discipline, taken from Bendat & Piersol: every estimate is **calibrated** (the
+same dB SPL / dBFS reference frames as the rest of the library) and carries
+its **statistical quality**, so a spectrum is not just a curve but a curve
+with a confidence interval.
+
+[Calibrated spectral analysis](/phonometry/guides/spectral-analysis/) is the
+frequency-domain half. The Welch power and cross-spectral density estimators
+report their effective number of averages, normalized random errors and
+chi-square confidence intervals; the coherent output spectrum splits a
+measured output into the part explained by an input and the part that is
+noise, with a spectral signal-to-noise ratio; fractional-octave smoothing
+bridges back to the banded world; and the colored-noise generators synthesize
+white, pink, red, blue and violet test signals with an exact power-law slope.
+
+[Correlation, time delay and envelope](/phonometry/guides/correlation-delay/)
+is the time-domain half. Auto- and cross-correlation come with the
+Bendat & Piersol normalizations and random errors; time-delay estimation
+offers the direct correlator, the cross-spectrum phase slope and the
+Knapp & Carter generalized cross-correlation weightings (Roth, SCOT, PHAT,
+maximum likelihood); impulse responses can be delayed and aligned with
+sub-sample precision; and the Hilbert transform yields the envelope with
+instantaneous phase and frequency.
+
+These estimators feed the rest of the library: transfer functions and
+distortion analysis build on the cross-spectral machinery, room impulse
+response work leans on delay estimation and alignment, and the
+[uncertainty pages](/phonometry/guides/sections/calibration-uncertainty/)
+supply the error-analysis vocabulary the estimates are stated in.
+
+## Pages in this section
+
+- [Calibrated spectral analysis](/phonometry/guides/spectral-analysis/):
+  Welch PSD/CSD with chi-square confidence intervals, the coherent output
+  spectrum and spectral SNR, 1/n-octave smoothing and exact-slope
+  colored-noise generators.
+- [Correlation, time delay and envelope](/phonometry/guides/correlation-delay/):
+  correlation estimates with their random errors, time-delay estimation by
+  direct correlation, phase slope and GCC weightings, sub-sample
+  impulse-response alignment, and the Hilbert envelope.

--- a/site/src/content/docs/guides/sound-level-meter.mdx
+++ b/site/src/content/docs/guides/sound-level-meter.mdx
@@ -1,0 +1,210 @@
+---
+title: "Build a sound level meter"
+description: "An end-to-end walk-through that composes the core API into a working sound level meter: calibrate against an IEC 60942 tone, apply the IEC 61672-1 frequency and time weightings, integrate into Leq, SEL and percentile levels, split into IEC 61260-1 octave bands, and verify the class of every stage."
+references:
+  - type: standard
+    organization: "International Electrotechnical Commission"
+    year: 2013
+    title: "Electroacoustics — Sound level meters — Part 1: Specifications"
+    designation: "IEC 61672-1:2013"
+    url: "https://webstore.iec.ch/en/publication/5708"
+    note: "The blueprint of the instrument assembled on this page: the A frequency weighting and the Fast exponential time weighting of the level chain, the C-weighted peak and the sound exposure level, and the Table 3 class acceptance limits checked by verify_weighting_class."
+  - type: standard
+    organization: "International Electrotechnical Commission"
+    year: 2014
+    title: "Electroacoustics — Octave-band and fractional-octave-band filters — Part 1: Specifications"
+    designation: "IEC 61260-1:2014"
+    url: "https://webstore.iec.ch/en/publication/5063"
+    note: "The fractional-octave-band filters behind the spectrum stage, and the Table 1 class acceptance limits checked by verify_filter_class."
+  - type: standard
+    organization: "International Electrotechnical Commission"
+    year: 2017
+    title: "Electroacoustics — Sound calibrators"
+    designation: "IEC 60942:2017"
+    url: "https://webstore.iec.ch/en/publication/30045"
+    note: "The acoustic calibrator assumed by the sensitivity stage: the 94 dB principal level and the short-term stability check applied to the reference recording."
+---
+
+A sound level meter is not one algorithm but a short pipeline of them, and
+IEC 61672-1 specifies every stage. phonometry implements each stage as an
+independent, composable function; this page assembles them, in order, into a
+working meter. Every snippet runs as written (the signals are synthesized so
+the page is self-contained), and each stage links to the deep guide that
+explains it fully.
+
+```mermaid
+flowchart LR
+    A["Calibrator tone\n(IEC 60942)"] --> B["sensitivity()"]
+    B --> C["Frequency weighting\nweighting_filter('A')"]
+    C --> D["Time weighting\ntime_weighting('fast')"]
+    D --> E["Display + percentiles\nLAF(t), ln_levels"]
+    C --> F["Integrated levels\nlaeq / sel / lc_peak"]
+    C -.-> G["Octave bands\noctave_filter (IEC 61260-1)"]
+    E --> H["Report"]
+    F --> H
+    G --> H
+```
+
+The snippets on this page build on each other: run them top to bottom in one
+session (or paste the whole page into a script).
+
+## 1. The scenario
+
+A meter needs two recordings from the *same* input chain: the calibrator tone
+that anchors the digital numbers to pascals, and the measurement itself. Here
+both are synthesized so you can run the page anywhere; in a real measurement
+they come from your microphone.
+
+```python
+import numpy as np
+from phonometry import metrology
+
+fs = 48000
+
+# Calibrator tone: 94 dB SPL = 1 Pa RMS at 1 kHz (IEC 60942).
+#   Synthesized here; in the field, record a few seconds of your calibrator.
+calibrator = np.sqrt(2) * np.sin(2 * np.pi * 1000 * np.arange(3 * fs) / fs)
+
+# "Street" measurement: 10 s of pink background noise plus a 1 s horn-like
+#   1 kHz event, so the statistical levels have something to separate.
+recording = metrology.noise_signal(fs, 10.0, color="pink", rms=0.02, seed=7)
+recording[4 * fs : 5 * fs] += 0.2 * np.sqrt(2) * np.sin(
+    2 * np.pi * 1000 * np.arange(fs) / fs
+)
+```
+
+## 2. Calibrate: give the samples physical meaning
+
+Digital samples are dimensionless; the **sensitivity factor** converts them
+to pascals. `sensitivity()` computes it from the calibrator recording and, at
+the same time, validates the recording's short-term stability the way
+IEC 60942 qualifies the calibrator itself, so a badly coupled microphone is
+caught here instead of corrupting every level downstream.
+
+```python
+cal = metrology.sensitivity(calibrator, target_spl=94.0, fs=fs)
+# cal is in Pa per digital unit; every level function accepts it as
+# calibration_factor. For this synthetic tone it is ~1.0.
+```
+
+Deep guide: [Calibration and dBFS](/phonometry/guides/calibration/), which
+also covers calibrating from a known microphone sensitivity and the digital
+dBFS mode used when no physical reference exists.
+
+## 3. Weight: frequency and time (IEC 61672-1)
+
+The meter never shows raw pressure. The signal first passes the **A
+frequency weighting** (the ear-response curve of IEC 61672-1), is squared,
+and is then smoothed by the **Fast exponential detector** (time constant
+125 ms). The result is the moving level a meter's display follows, LAF(t):
+
+```python
+pressure = cal * recording                                # digital units -> Pa
+weighted = metrology.weighting_filter(pressure, fs, curve="A")
+envelope = metrology.time_weighting(weighted, fs, mode="fast")  # mean-square Pa^2
+laf_t = 10 * np.log10(np.maximum(envelope, 1e-12) / (2e-5) ** 2)
+# laf_t peaks near 80 dB during the event and settles near 55 dB between.
+```
+
+You rarely write this chain yourself: every level function of the next step
+applies the frequency weighting internally, and the percentile levels rebuild
+this Fast envelope for you. The energy metrics (Leq, SEL) integrate the
+squared weighted signal directly, with no ballistics, exactly as a meter
+does. The chain is shown here because it *is* the meter's display.
+
+Deep guides: [Frequency Weighting (A, C, G, Z)](/phonometry/guides/weighting/)
+and [Time Weighting](/phonometry/guides/time-weighting/).
+
+## 4. Integrate: the numbers a meter reports
+
+One pass over the calibrated recording yields the standard readouts: the
+energy-equivalent **LAeq**, the **percentile levels** that describe how the
+level fluctuated (L90 is the background, L10 the events), the
+**sound exposure level** that normalizes the event to one second, and the
+C-weighted **peak** for impulsive content.
+
+```python
+la_eq = metrology.laeq(recording, fs, calibration_factor=cal)     # ~70.2 dB
+ln = metrology.ln_levels(
+    recording, fs, n=(10, 50, 90), weighting="A", calibration_factor=cal
+)                                                # L10 ~78.0, L50 ~55.1, L90 ~54.9
+lae = metrology.sel(recording, fs, weighting="A", calibration_factor=cal)  # ~80.2
+lc_pk = metrology.lc_peak(recording, fs, calibration_factor=cal)           # ~84.4
+
+print(f"LAeq {la_eq:.1f} dB | L10 {ln[10]:.1f} | L90 {ln[90]:.1f} "
+      f"| LAE {lae:.1f} | LCpeak {lc_pk:.1f}")
+```
+
+Note the arithmetic the numbers encode: the 1 s event dominates LAeq (it sits
+25 dB above the background, far more than the 10 dB the nine-times-longer
+background gets back in duration), LAE is LAeq plus 10 log10 of the 10 s
+duration, and L90 barely notices the event at all.
+
+Deep guide: [Integrated and Statistical Levels](/phonometry/guides/levels/),
+which adds noise dose, Lden and rating levels, and octave spectrograms.
+
+## 5. Band-filter: the spectrum view (IEC 61260-1)
+
+A class 1 meter with a filter set reports band levels. `octave_filter`
+decomposes the calibrated signal into fractional-octave bands whose design is
+anchored to the IEC 61260-1 band edges; `nominal=True` labels them with the
+preferred frequencies you would read on an instrument.
+
+```python
+spl, bands = metrology.octave_filter(
+    recording, fs, fraction=3, calibration_factor=cal, nominal=True
+)
+# 33 one-third-octave band levels in dB SPL, labeled '12.5' ... '20k'.
+# The '1k' band holds the event: ~70 dB, while its neighbors stay ~25 dB below.
+print(dict(zip(bands, np.round(spl, 1))))
+```
+
+Deep guides: [Filter Banks](/phonometry/guides/filter-banks/) for the filter
+architectures and zero-phase mode,
+[Block Processing](/phonometry/guides/block-processing/) for streaming, and
+[Multichannel and Performance](/phonometry/guides/multichannel/) for arrays.
+
+## 6. Verify: is this meter class 1?
+
+A real instrument is only a "class 1 sound level meter" after its weightings
+and filters pass the acceptance limits of the standards. The library ships
+the same verifiers it applies to itself in CI: `verify_weighting_class`
+sweeps a `WeightingFilter` against the IEC 61672-1 Table 3 limits, and
+`verify_filter_class` sweeps an `OctaveFilterBank` against the IEC 61260-1
+Table 1 limits.
+
+```python
+wf = metrology.WeightingFilter(fs, curve="A")
+print(metrology.verify_weighting_class(wf)["overall_class"])   # 1
+
+bank = metrology.OctaveFilterBank(fs, fraction=3)
+print(metrology.verify_filter_class(bank)["overall_class"])    # 1
+```
+
+The verdicts also come per band, so you can see exactly where a design would
+leave its class corridor. Deep guides:
+[Frequency Weighting](/phonometry/guides/weighting/) (section on class
+verification) and [Filter Banks](/phonometry/guides/filter-banks/) (class
+compliance).
+
+## Where to go next
+
+The meter built here is the trunk; the rest of the core grows from it.
+
+- [Measurement uncertainty (GUM and Monte Carlo)](/phonometry/guides/gum-uncertainty/):
+  attach an uncertainty to the LAeq you just computed, calibration term
+  included.
+- [Calibrated spectral analysis](/phonometry/guides/spectral-analysis/): when
+  bands are too coarse, the Welch PSD with confidence intervals.
+- [Correlation, time delay and envelope](/phonometry/guides/correlation-delay/):
+  two microphones instead of one, and the delay between them.
+- [Block Processing](/phonometry/guides/block-processing/): turn this page's
+  offline meter into a streaming one with carried filter state.
+
+## See also
+
+- API reference: [`metrology.calibration`](/phonometry/reference/api/levels/calibration/),
+  [`metrology.parametric_filters`](/phonometry/reference/api/filters/parametric-filters/),
+  [`metrology.levels`](/phonometry/reference/api/levels/levels/),
+  [`phonometry`](/phonometry/reference/api/filters/phonometry/) and
+  [`metrology.compliance`](/phonometry/reference/api/filters/compliance/).


### PR DESCRIPTION
## Summary

Docs-only restructure of the Core signal analysis guide area, plus one new integrator guide. No library code changes and no URL changes.

### Sidebar restructure

- New **Signals and spectra** ("Señales y espectros") subgroup inside Core signal analysis, with its own overview-first landing page. It takes over the [Calibrated spectral analysis] and [Correlation, time delay and envelope] guides, which were parked under Calibration and uncertainty despite not being calibration topics. Only the sidebar grouping moves; every slug stays where it was.
- The Core signal analysis landing is rewritten around the resulting four subgroups (Octave filtering, Levels and weighting, Signals and spectra, Calibration and uncertainty), and the Calibration and uncertainty landing now points to the new subgroup instead of listing its pages.

### New guide: Build a sound level meter (EN + ES)

An end-to-end walk-through that composes the existing public API into a working meter, one stage per section, each linked to its deep guide:

1. calibrate against an IEC 60942 tone (`sensitivity`),
2. apply the IEC 61672-1 A-weighting and Fast detector (`weighting_filter`, `time_weighting`),
3. integrate into LAeq, percentile levels, SEL and LCpeak (`laeq`, `ln_levels`, `sel`, `lc_peak`),
4. split into IEC 61260-1 one-third-octave bands (`octave_filter`),
5. verify the class of the weighting and the bank (`verify_weighting_class`, `verify_filter_class`).

The signals are synthesized in the first snippet so the whole page runs as written, top to bottom, and the numeric comments match the actual output. Typed `references:` frontmatter covers IEC 61672-1:2013, IEC 61260-1:2014 and IEC 60942:2017.

## Verification

- Every Python snippet on both new pages executed (concatenated, in order) against `src/`; printed values match the inline comments.
- `node site/scripts/check-i18n-parity.mjs`: 93/93 EN pages paired with ES.
- Full `astro build`: 409 pages, all internal links valid (starlight-links-validator).
- `html-validate 'dist/**/*.html'`: clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a comprehensive guide for building a standards-based sound level meter, including calibration, weighting, metrics, octave-band analysis, and compliance checks.
  * Added a “Signals and spectra” documentation section covering spectral, correlation, delay, and envelope analysis.

* **Documentation**
  * Reorganized navigation and section pages to clarify the distinction between signal analysis and calibration topics.
  * Expanded guidance on Welch spectral estimates, statistical error, and confidence intervals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->