### PR TITLE
ci(site): disable pnpm's minimum-release-age gate for the docs build

### DIFF
--- a/site/pnpm-workspace.yaml
+++ b/site/pnpm-workspace.yaml
@@ -2,3 +2,9 @@ allowBuilds:
   esbuild: true
   sharp: true
   puppeteer: true
+
+# Disable pnpm 11's minimum-release-age supply-chain gate: the committed
+# lockfile is the trust root here, and the 24 h default kept blocking docs
+# deploys whenever a transitive dependency (e.g. the lightningcss platform
+# binaries) published shortly before a scheduled run.
+minimumReleaseAge: 0


### PR DESCRIPTION
The Deploy Docs job failed twice with `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`: pnpm 11 applies a 24 hour minimum-release-age supply-chain default, and the lightningcss 1.33.0 platform binaries had published minutes before the scheduled run's cutoff. The committed `pnpm-lock.yaml` is the trust root for this repository (installs run with `--frozen-lockfile`), so this sets `minimumReleaseAge: 0` in `site/pnpm-workspace.yaml` with a comment documenting the incident. Verified locally: `pnpm install --frozen-lockfile` now completes (previously blocked by the same policy).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

