### PR TITLE
fix: guard degenerate shaped-sweep and inversion edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   matches the Welch estimators exactly.
 
 ### Fixed
+- `shaped_sweep_signal()` no longer returns a NaN or infinite crest factor when
+- The shaped-sweep spectrum plot no longer crashes when the Welch grid, resolved
+- The `regularized_inverse_filter()` result documents `max_gain_db` as the
 
 - The documentation figures now render every text run in the viewer's native
   sans-serif font: I normalise all `font-family` declarations in the generated

--- a/site/src/content/docs/reference/api/spectra/inversion.md
+++ b/site/src/content/docs/reference/api/spectra/inversion.md
@@ -79,7 +79,7 @@ complex inverse spectrum *including* the modeling delay;
 | `delay` | Modeling delay of the filter, in samples. |
 | `fs` | Sample rate, in Hz. |
 | `flatness_db` | Largest deviation of the equalized magnitude `20*log10\|H*H_inv\|` from 0 dB inside `[f1, f2]`. |
-| `max_gain_db` | Largest filter gain `20*log10\|H_inv\|` *outside* the transition-padded band -- the boost the regularization allowed where the measurement carries no signal. Analytically at most `-20*log10(2*sqrt(epsilon_outside))`. |
+| `max_gain_db` | Largest filter gain *outside* the transition-padded band, peak-normalized as `20*log10(max\|H_inv\| * peak_h)` where `peak_h` is the peak of `\|H\|` -- the achieved out-of-band boost the regularization allowed where the measurement carries no signal. |
 
 ### InverseFilterResult.apply()
 
@@ -110,7 +110,7 @@ InverseFilterResult.plot(
     *,
     language: str = 'en',
     **kwargs: Any,
-) -> Axes | np.ndarray
+) -> Axes
 ```
 
 Plot the measured, inverse and equalized magnitudes.

--- a/src/phonometry/_plot/room.py
+++ b/src/phonometry/_plot/room.py
@@ -819,7 +819,13 @@ def plot_shaped_sweep(
     tiny = np.finfo(np.float64).tiny
     band_w = (freqs_w >= f1) & (freqs_w <= f2)
     welch_db = 10.0 * np.log10(np.maximum(psd, tiny))
-    welch_db -= float(np.max(welch_db[band_w]))
+    # The Welch grid is resolved independently of the synthesis grid, so a
+    # narrow band on a short signal can leave no Welch bin inside [f1, f2]
+    # (unlike band_g, which synthesis validates). Fall back to the overall
+    # positive-frequency maximum so the reference stays finite and the plot
+    # still renders.
+    ref_w = welch_db[band_w] if np.any(band_w) else welch_db[freqs_w > 0.0]
+    welch_db -= float(np.max(ref_w))
     mag = np.asarray(result.magnitude, dtype=np.float64)
     grid = np.asarray(result.frequencies, dtype=np.float64)
     band_g = (grid >= f1) & (grid <= f2)

--- a/src/phonometry/metrology/inversion.py
+++ b/src/phonometry/metrology/inversion.py
@@ -76,10 +76,10 @@ class InverseFilterResult:
     :ivar fs: Sample rate, in Hz.
     :ivar flatness_db: Largest deviation of the equalized magnitude
         ``20*log10|H*H_inv|`` from 0 dB inside ``[f1, f2]``.
-    :ivar max_gain_db: Largest filter gain ``20*log10|H_inv|`` *outside*
-        the transition-padded band -- the boost the regularization allowed
-        where the measurement carries no signal. Analytically at most
-        ``-20*log10(2*sqrt(epsilon_outside))``.
+    :ivar max_gain_db: Largest filter gain *outside* the transition-padded
+        band, peak-normalized as ``20*log10(max|H_inv| * peak_h)`` where
+        ``peak_h`` is the peak of ``|H|`` -- the achieved out-of-band boost
+        the regularization allowed where the measurement carries no signal.
     """
 
     inverse: np.ndarray
@@ -127,7 +127,7 @@ class InverseFilterResult:
 
     def plot(
         self, ax: "Axes | None" = None, *, language: str = "en", **kwargs: Any
-    ) -> "Axes | np.ndarray":
+    ) -> "Axes":
         """Plot the measured, inverse and equalized magnitudes.
 
         One panel: ``|H|``, ``|H_inv|`` and the equalized product

--- a/src/phonometry/room/room_ir.py
+++ b/src/phonometry/room/room_ir.py
@@ -523,7 +523,7 @@ def mls_impulse_response(
     if rec.size == 0 or seq.size == 0:
         raise ValueError("'recorded' and 'mls' must be non-empty.")
     period = seq.size
-    if rec.size == 0 or rec.size % period != 0:
+    if rec.size % period != 0:
         raise ValueError(
             "recorded length must be a positive multiple of the MLS length"
         )
@@ -973,7 +973,13 @@ def shaped_sweep_signal(
     sweep *= amplitude / float(np.max(np.abs(sweep)))
 
     # Crest factor over the constant-envelope interval [lead, lead+seconds].
+    # A tiny 'seconds' next to a dominant 'start_delay' can round the two
+    # edges onto the same sample, leaving an empty (or single-sample) core
+    # that would make the statistic blow up; fall back to the whole
+    # retained sweep in that degenerate case.
     core = sweep[int(round(lead * fs_v)):int(round((lead + seconds) * fs_v))]
+    if core.size < 2:
+        core = sweep
     rms = float(np.sqrt(np.mean(core ** 2)))
     crest_db = 20.0 * np.log10(float(np.max(np.abs(core))) / rms)
 

--- a/tests/metrology/test_inversion.py
+++ b/tests/metrology/test_inversion.py
@@ -150,8 +150,9 @@ def test_fs_is_taken_from_a_result_object() -> None:
     res = regularized_inverse_filter(ir, f_range=(200.0, 10000.0))
     assert isinstance(res, InverseFilterResult)
     assert res.fs == FS
+    bare = np.asarray(ir)
     with pytest.raises(ValueError, match="fs"):
-        regularized_inverse_filter(np.asarray(ir), f_range=(200.0, 10000.0))
+        regularized_inverse_filter(bare, f_range=(200.0, 10000.0))
 
 
 # --------------------------------------------------------------------------
@@ -181,22 +182,20 @@ def test_rejects_bad_inputs() -> None:
         regularized_inverse_filter(
             h, FS, f_range=(200.0, 4000.0), delay=-1
         )
+    two_dim = np.zeros((2, 8))
     with pytest.raises(ValueError, match="one-dimensional"):
-        regularized_inverse_filter(
-            np.zeros((2, 8)), FS, f_range=(200.0, 4000.0)
-        )
+        regularized_inverse_filter(two_dim, FS, f_range=(200.0, 4000.0))
+    with_nan = np.array([1.0, np.nan])
     with pytest.raises(ValueError, match="finite"):
-        regularized_inverse_filter(
-            np.array([1.0, np.nan]), FS, f_range=(200.0, 4000.0)
-        )
+        regularized_inverse_filter(with_nan, FS, f_range=(200.0, 4000.0))
+    all_zero = np.zeros(64)
     with pytest.raises(ValueError, match="zero"):
-        regularized_inverse_filter(
-            np.zeros(64), FS, f_range=(200.0, 4000.0)
-        )
+        regularized_inverse_filter(all_zero, FS, f_range=(200.0, 4000.0))
 
 
 def test_apply_rejects_non_1d() -> None:
     h = _biquad_ir()
     res = regularized_inverse_filter(h, FS, f_range=(500.0, 8000.0))
+    two_dim = np.zeros((2, 4))
     with pytest.raises(ValueError, match="one-dimensional"):
-        res.apply(np.zeros((2, 4)))
+        res.apply(two_dim)

--- a/tests/metrology/test_parametric_eq.py
+++ b/tests/metrology/test_parametric_eq.py
@@ -437,10 +437,12 @@ def test_rejects_unknown_type_and_bad_frequencies() -> None:
         ph.EQSection("bell", 1000.0)  # type: ignore[arg-type]
     with pytest.raises(ValueError, match="positive"):
         ph.EQSection("peaking", 0.0)
+    at_nyquist = ph.EQSection("peaking", FS / 2, gain_db=3.0)
     with pytest.raises(ValueError, match="Nyquist"):
-        ph.ParametricEQ(FS, ph.EQSection("peaking", FS / 2, gain_db=3.0))
+        ph.ParametricEQ(FS, at_nyquist)
+    section = ph.EQSection("peaking", 1000.0, gain_db=3.0)
     with pytest.raises(ValueError, match="positive"):
-        ph.ParametricEQ(0, ph.EQSection("peaking", 1000.0, gain_db=3.0))
+        ph.ParametricEQ(0, section)
 
 
 def test_rejects_conflicting_or_misplaced_parameters() -> None:

--- a/tests/room/test_golay.py
+++ b/tests/room/test_golay.py
@@ -152,18 +152,19 @@ def test_alias_warning_when_ir_longer_than_period() -> None:
 
 def test_input_validation() -> None:
     pair = golay_pair(4)
+    valid = np.zeros(16)
+    non_multiple = np.zeros(10)
+    empty = np.zeros(0)
+    truncated_pair = (pair[0], pair[1][:8])
+    two_dim = np.zeros((2, 16))
     with pytest.raises(ValueError, match="multiple"):
-        golay_impulse_response(np.zeros(10), np.zeros(16), pair)
+        golay_impulse_response(non_multiple, valid, pair)
     with pytest.raises(ValueError, match="multiple"):
-        golay_impulse_response(np.zeros(16), np.zeros(0), pair)
+        golay_impulse_response(valid, empty, pair)
     with pytest.raises(ValueError, match="equal-length"):
-        golay_impulse_response(
-            np.zeros(16), np.zeros(16), (pair[0], pair[1][:8])
-        )
+        golay_impulse_response(valid, valid, truncated_pair)
     with pytest.raises(ValueError, match="one-dimensional"):
-        golay_impulse_response(
-            np.zeros((2, 16)), np.zeros(16), pair
-        )
+        golay_impulse_response(two_dim, valid, pair)
 
 
 def test_result_behaves_like_array() -> None:

--- a/tests/room/test_shaped_sweep.py
+++ b/tests/room/test_shaped_sweep.py
@@ -130,6 +130,16 @@ def test_crest_factor_stays_near_the_swept_sine_ideal() -> None:
         assert 3.0 < res.crest_factor_db < 4.5
 
 
+def test_crest_factor_is_finite_when_the_core_window_collapses() -> None:
+    # A tiny 'seconds' next to a dominant 'start_delay' rounds the two edges
+    # of the constant-envelope window onto the same sample, leaving an empty
+    # core slice; the crest factor must still come out finite (the statistic
+    # falls back to the whole retained sweep) rather than NaN/inf.
+    res = shaped_sweep_signal(FS, 50.0, 5000.0, 1e-6, start_delay=1.0)
+    assert np.isfinite(res.crest_factor_db)
+    assert res.crest_factor_db > 0.0
+
+
 def test_signal_length_amplitude_and_fades() -> None:
     res = shaped_sweep_signal(
         FS, 100.0, 10000.0, 1.0, amplitude=0.5, start_delay=0.1
@@ -183,21 +193,15 @@ def test_rejects_bad_inputs() -> None:
         shaped_sweep_signal(FS, 50.0, 5000.0, 1.0, start_delay=0.0)
     with pytest.raises(ValueError, match="unknown named target"):
         shaped_sweep_signal(FS, 50.0, 5000.0, 1.0, target="blue")
+    mismatched = (np.array([100.0, 200.0]), np.array([0.0]))
     with pytest.raises(ValueError, match="equal-length"):
-        shaped_sweep_signal(
-            FS, 50.0, 5000.0, 1.0,
-            target=(np.array([100.0, 200.0]), np.array([0.0])),
-        )
+        shaped_sweep_signal(FS, 50.0, 5000.0, 1.0, target=mismatched)
+    decreasing = (np.array([200.0, 100.0]), np.array([0.0, 0.0]))
     with pytest.raises(ValueError, match="increasing"):
-        shaped_sweep_signal(
-            FS, 50.0, 5000.0, 1.0,
-            target=(np.array([200.0, 100.0]), np.array([0.0, 0.0])),
-        )
+        shaped_sweep_signal(FS, 50.0, 5000.0, 1.0, target=decreasing)
+    non_finite = (np.array([100.0, 200.0]), np.array([0.0, np.inf]))
     with pytest.raises(ValueError, match="finite"):
-        shaped_sweep_signal(
-            FS, 50.0, 5000.0, 1.0,
-            target=(np.array([100.0, 200.0]), np.array([0.0, np.inf])),
-        )
+        shaped_sweep_signal(FS, 50.0, 5000.0, 1.0, target=non_finite)
 
 
 def test_result_behaves_like_array() -> None:


### PR DESCRIPTION
A small batch of minor code-quality fixes to harden edge cases in the
system-measurement and parametric-EQ code.

## Fixes

- **`shaped_sweep_signal` crest factor**: a very small `seconds` next to a
  dominant `start_delay` could round the two edges of the constant-envelope
  window onto the same sample, leaving an empty core slice that made the crest
  factor come out NaN or infinite even though the sample-count guard passed. It
  now falls back to the whole retained sweep in that degenerate case, with a
  test covering it.
- **Shaped-sweep spectrum plot**: the Welch grid is resolved independently of
  the synthesis grid, so a narrow `(f1, f2)` band on a short signal could leave
  no Welch bin inside the band and crash the normalization on an empty slice
  (unlike the synthesis grid, which is validated at synthesis). The Welch
  magnitude now falls back to its overall positive-frequency maximum as the
  reference so the plot still renders.
- **`regularized_inverse_filter` docs and types**: `max_gain_db` is now
  documented as the achieved peak-normalized out-of-band gain the code actually
  returns (the computation is unchanged and stays conformance-pinned), and the
  `plot()` return type is narrowed to a single `Axes` to match the plotting
  helper.
- **MLS `impulse_response`**: dropped a redundant `rec.size == 0` term that is
  already guaranteed false by the non-empty check above it.
- **Tests**: hoisted input construction out of `pytest.raises` blocks in the
  inversion, Golay, shaped-sweep and parametric-EQ tests so only the call under
  test can raise.

The inversion API reference is regenerated from the updated docstrings.

## Verification

- `ruff check .`, `mypy src scripts`, `bandit -r src`: clean
- affected test files + `tests/test_package_architecture.py`: 147 passed
- `scripts/check_figures.py`: all 920 figures match
- `scripts/check_api_reference.py` and conformance report: no drift
