### PR TITLE
docs: cite structure-borne sources on the vibration theory page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1802,6 +1802,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   integers, matching the existing field-validation style.
 
 ### Changed
+- Docs theory reference: the Vibration page now lists in its `references`
+  frontmatter the four structure-borne sources cited on the point-mobility and
+  radiation-efficiency section (Cremer, Heckl and Petersson, Structure-borne
+  sound, 3rd ed.; Hopkins, Sound insulation; ISO 7626-1:2011; and
+  ISO/TS 7849-1:2009 and ISO/TS 7849-2:2009), and the theory index gains the
+  two missing table-of-contents anchors for that page (the point-mobility
+  section and the multiple-shock subsection). Both changes are mirrored in the
+  Spanish pages.
 - Raised the `scipy` floor in `pyproject.toml` to `scipy>=1.18.0`, the minimum
   supported scipy version, matching the floor `requirements.txt` already
   carried. The

--- a/site/src/content/docs/es/reference/theory/index.md
+++ b/site/src/content/docs/es/reference/theory/index.md
@@ -50,3 +50,5 @@ La referencia de teoría explica las normas, las matemáticas y las decisiones d
 ## [Vibración](/phonometry/es/reference/theory/vibration/)
 
 - [Vibración en humanos (ISO 8041-1, ISO 2631-1/2, ISO 5349-1/2, Directiva 2002/44/CE)](/phonometry/es/reference/theory/vibration/#vibración-en-humanos-iso-8041-1-iso-2631-12-iso-5349-12-directiva-200244ce)
+- [Choques múltiples (ISO 2631-5)](/phonometry/es/reference/theory/vibration/#choques-múltiples-iso-2631-5)
+- [Movilidades puntuales y eficiencia de radiación (Cremer 5, Hopkins 2.9)](/phonometry/es/reference/theory/vibration/#movilidades-puntuales-y-eficiencia-de-radiación-cremer-5-hopkins-29)

--- a/site/src/content/docs/es/reference/theory/vibration.md
+++ b/site/src/content/docs/es/reference/theory/vibration.md
@@ -16,6 +16,42 @@ references:
     publisher: "CRC Press"
     url: "https://www.routledge.com/Human-Response-to-Vibration/Mansfield/p/book/9780415282390"
     note: "ISBN 978-0-415-28239-0. Un recorrido moderno y compacto por las cadenas de evaluación de cuerpo completo de ISO 2631-1 y mano-brazo de ISO 5349 resumidas en esta página."
+  - type: book
+    authors: ["Cremer, L.", "Heckl, M.", "Petersson, B. A. T."]
+    year: 2005
+    title: "Structure-borne sound: Structural vibrations and sound radiation at audio frequencies"
+    edition: "3.ª ed."
+    publisher: "Springer"
+    url: "https://link.springer.com/book/10.1007/b137728"
+    note: "ISBN 978-3-540-22696-3. La potencia en el punto de excitación W = (1/2) |F|^2 Re{Y} (Ec. 5.23) y las movilidades e impedancias en forma cerrada de estructuras infinitas (Tabla 5.1) de la sección de movilidades puntuales."
+  - type: book
+    authors: ["Hopkins, C."]
+    year: 2007
+    title: "Sound insulation"
+    publisher: "Butterworth-Heinemann"
+    url: "https://www.routledge.com/Sound-Insulation/Hopkins/p/book/9780750665261"
+    note: "ISBN 978-0-7506-6526-1. La teoría de la eficiencia de radiación de placas en flexión (Ecs. 2.227-2.230, el límite de alta frecuencia de Leppington/Maidanik) que sustenta la sección de eficiencia de radiación."
+  - type: standard
+    organization: "International Organization for Standardization"
+    year: 2011
+    title: "Mechanical vibration and shock — Experimental determination of mechanical mobility — Part 1: Basic terms and definitions, and transducer specifications"
+    designation: "ISO 7626-1:2011"
+    url: "https://www.iso.org/standard/50426.html"
+    note: "Las movilidades medidas en el punto de excitación de las que los resultados en forma cerrada de estructuras infinitas de la sección de movilidades puntuales son las contrapartes teóricas."
+  - type: standard
+    organization: "International Organization for Standardization"
+    year: 2009
+    title: "Acoustics — Determination of airborne sound power levels emitted by machinery using vibration measurement — Part 1: Survey method using a fixed radiation factor"
+    designation: "ISO/TS 7849-1:2009"
+    url: "https://www.iso.org/standard/40537.html"
+    note: "El factor de radiación que coincide con la eficiencia de radiación, cerrando la cadena de potencia acústica a partir de la vibración de la sección de eficiencia de radiación (método de sondeo, factor de radiación fijo)."
+  - type: standard
+    organization: "International Organization for Standardization"
+    year: 2009
+    title: "Acoustics — Determination of airborne sound power levels emitted by machinery using vibration measurement — Part 2: Engineering method including determination of the adequate radiation factor"
+    designation: "ISO/TS 7849-2:2009"
+    url: "https://www.iso.org/standard/40538.html"
+    note: "El método de ingeniería de la misma cadena de potencia acústica a partir de la vibración, que determina el factor de radiación adecuado a partir de la medida."
 ---
 
 Esta página reúne la teoría de la vibración en humanos: las ponderaciones frecuenciales de ISO 8041-1, las métricas de cuerpo entero y mano-brazo de ISO 2631-1 e ISO 5349, los valores de acción y límite de la Directiva 2002/44/CE, y el modelo espinal de choques múltiples de ISO 2631-5. Forma parte de la [referencia de teoría](/phonometry/es/reference/theory/).

--- a/site/src/content/docs/reference/theory/index.md
+++ b/site/src/content/docs/reference/theory/index.md
@@ -50,3 +50,5 @@ The theory reference explains the standards, the mathematics and the design deci
 ## [Vibration](/phonometry/reference/theory/vibration/)
 
 - [Human vibration (ISO 8041-1, ISO 2631-1/2, ISO 5349-1/2, Directive 2002/44/EC)](/phonometry/reference/theory/vibration/#human-vibration-iso-8041-1-iso-2631-12-iso-5349-12-directive-200244ec)
+- [Multiple shocks (ISO 2631-5)](/phonometry/reference/theory/vibration/#multiple-shocks-iso-2631-5)
+- [Point mobilities and radiation efficiency (Cremer 5, Hopkins 2.9)](/phonometry/reference/theory/vibration/#point-mobilities-and-radiation-efficiency-cremer-5-hopkins-29)

--- a/site/src/content/docs/reference/theory/vibration.md
+++ b/site/src/content/docs/reference/theory/vibration.md
@@ -16,6 +16,42 @@ references:
     publisher: "CRC Press"
     url: "https://www.routledge.com/Human-Response-to-Vibration/Mansfield/p/book/9780415282390"
     note: "ISBN 978-0-415-28239-0. A compact modern walkthrough of the ISO 2631-1 whole-body and ISO 5349 hand-arm evaluation chains summarised on this page."
+  - type: book
+    authors: ["Cremer, L.", "Heckl, M.", "Petersson, B. A. T."]
+    year: 2005
+    title: "Structure-borne sound: Structural vibrations and sound radiation at audio frequencies"
+    edition: "3rd ed."
+    publisher: "Springer"
+    url: "https://link.springer.com/book/10.1007/b137728"
+    note: "ISBN 978-3-540-22696-3. The driving-point power W = (1/2) |F|^2 Re{Y} (Eq. 5.23) and the closed-form infinite-structure mobilities and impedances (Table 5.1) of the point-mobility section."
+  - type: book
+    authors: ["Hopkins, C."]
+    year: 2007
+    title: "Sound insulation"
+    publisher: "Butterworth-Heinemann"
+    url: "https://www.routledge.com/Sound-Insulation/Hopkins/p/book/9780750665261"
+    note: "ISBN 978-0-7506-6526-1. The bending-plate radiation-efficiency theory (Eqs 2.227-2.230, the Leppington/Maidanik high-frequency limit) behind the radiation-efficiency section."
+  - type: standard
+    organization: "International Organization for Standardization"
+    year: 2011
+    title: "Mechanical vibration and shock — Experimental determination of mechanical mobility — Part 1: Basic terms and definitions, and transducer specifications"
+    designation: "ISO 7626-1:2011"
+    url: "https://www.iso.org/standard/50426.html"
+    note: "The measured driving-point mobilities that the closed-form infinite-structure results of the point-mobility section are the theoretical companions of."
+  - type: standard
+    organization: "International Organization for Standardization"
+    year: 2009
+    title: "Acoustics — Determination of airborne sound power levels emitted by machinery using vibration measurement — Part 1: Survey method using a fixed radiation factor"
+    designation: "ISO/TS 7849-1:2009"
+    url: "https://www.iso.org/standard/40537.html"
+    note: "The radiation factor that equals the radiation efficiency, closing the sound-power-from-vibration chain of the radiation-efficiency section (survey method, fixed radiation factor)."
+  - type: standard
+    organization: "International Organization for Standardization"
+    year: 2009
+    title: "Acoustics — Determination of airborne sound power levels emitted by machinery using vibration measurement — Part 2: Engineering method including determination of the adequate radiation factor"
+    designation: "ISO/TS 7849-2:2009"
+    url: "https://www.iso.org/standard/40538.html"
+    note: "The engineering method of the same sound-power-from-vibration chain, determining the adequate radiation factor from measurement."
 ---
 
 This page collects the theory behind human vibration: the ISO 8041-1 frequency weightings, the whole-body and hand-arm metrics of ISO 2631-1 and ISO 5349, the action and limit values of Directive 2002/44/EC, and the ISO 2631-5 multiple-shock spinal model. It is part of the [theory reference](/phonometry/reference/theory/).


### PR DESCRIPTION
## What

The second half of the Vibration theory page (`reference/theory/vibration`) derives point mobilities and radiation efficiency but its `references` frontmatter only listed Griffin 1996 and Mansfield 2004, so the works actually cited in that section rendered nowhere in the References list. This adds the missing bibliography entries and fills two gaps in the theory index table of contents.

## Changes

- `reference/theory/vibration.md`: added five `references` entries for the sources cited on the point-mobility and radiation-efficiency section:
  - Cremer, Heckl and Petersson (2005), Structure-borne sound, 3rd ed. (Springer) - the driving-point power Eq. 5.23 and the Table 5.1 infinite-structure mobilities.
  - Hopkins (2007), Sound insulation (Butterworth-Heinemann) - the bending-plate radiation-efficiency theory (Eqs 2.227-2.230).
  - ISO 7626-1:2011 - the measured mechanical mobility the closed forms are companions of.
  - ISO/TS 7849-1:2009 and ISO/TS 7849-2:2009 - the radiation factor that equals the radiation efficiency.
- `reference/theory/index.md`: added the two missing table-of-contents anchors for the vibration page (the point-mobility section and the multiple-shock subsection).
- Mirrored both changes into the Spanish pages with translated notes and labels; the standard titles and organisation stay in the canonical English form, matching the sibling theory pages.
- CHANGELOG: one note under `### Changed`.

Standards go in the frontmatter here, matching the convention on `environment-transport` and `signal-analysis`. Official standard titles keep their em-dashes, as the existing entries do.

## Checks

- `node site/scripts/check-i18n-parity.mjs`: parity OK (100 EN pages, all with ES).
- Site build: succeeds; the links validator reports all internal links valid, so both new anchor sets resolve in EN and ES.
- `html-validate` on the four affected built pages: clean.
- `ruff check .`: clean (no Python touched).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Vibration theory documentation with references covering structure-borne sound, point mobility, radiation efficiency, multiple shocks, and related ISO standards.
  * Added missing theory topic links and table-of-contents anchors for improved navigation.
  * Updated both English and Spanish documentation pages with the corresponding citations and localized reference details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->