### PR TITLE
docs: cite Jiménez metamaterial-acoustics work on the materials reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1809,6 +1809,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   integers, matching the existing field-validation style.
 
 ### Changed
+- Docs materials reference: the Materials and Surfaces theory page now cites
+  three open-access works by Jiménez and co-workers alongside Cox & D'Antonio,
+  the metadiffuser paper (Jiménez, Cox, Romero-García and Groby, 2017,
+  Scientific Reports) on the surface-diffusion section and the two
+  critical-coupling perfect-absorption papers (Jiménez, Groby, Pagneux and
+  Romero-García, 2017, Applied Sciences; Jiménez, Romero-García and Groby,
+  2018, Acta Acustica) on the material-characterisation section, and the
+  `scattering_diffusion` and `porous_absorber` module docstrings reference the
+  same works. The bibliography page gains the edited volume Acoustic Waves in
+  Periodic Structures, Metamaterials, and Porous Media (Jiménez, Umnova and
+  Groby, Eds., 2021, Springer) as a metamaterials companion to Cox & D'Antonio.
+  Mirrored in the Spanish pages.
 - Docs theory reference: the Vibration page now lists in its `references`
   frontmatter the four structure-borne sources cited on the point-mobility and
   radiation-efficiency section (Cremer, Heckl and Petersson, Structure-borne

--- a/site/src/content/docs/es/reference/bibliography.md
+++ b/site/src/content/docs/es/reference/bibliography.md
@@ -339,6 +339,15 @@ que las guías incorporan sus secciones de Referencias.
   autores del método del coeficiente de difusión de ISO 17497-2.
   Citado por [Materiales acústicos](/phonometry/es/guides/materials/) y
   [Dispersión superficial, difusión y absorción in situ](/phonometry/es/guides/surface-scattering/).
+- Jiménez, N., Umnova, O. y Groby, J.-P. (Eds.). (2021). *Acoustic waves in
+  periodic structures, metamaterials, and porous media* (Topics in Applied
+  Physics, Vol. 143). Springer.
+  [doi:10.1007/978-3-030-84300-7](https://doi.org/10.1007/978-3-030-84300-7).
+  Un volumen editado que abarca las estructuras resonantes y periódicas que
+  absorben y difunden el sonido, desde la teoría de la matriz de transferencia
+  y el acoplamiento crítico de los absorbentes de metamaterial hasta los
+  difusores de sublongitud de onda profunda; el complemento moderno sobre
+  metamateriales de Cox & D'Antonio.
 - International Organization for Standardization. (2003). *Acoustics —
   Measurement of sound absorption in a reverberation room* (ISO 354:2003).
   [Catálogo iso.org](https://www.iso.org/standard/34545.html).

--- a/site/src/content/docs/es/reference/theory/materials-surfaces.md
+++ b/site/src/content/docs/es/reference/theory/materials-surfaces.md
@@ -18,6 +18,35 @@ references:
     publisher: "Wiley"
     doi: "10.1002/9780470747339"
     note: "ISBN 978-0-470-74661-5. La teoría del material poroso que enlaza las magnitudes de resistencia al flujo y de tubo de impedancia de la sección de caracterización."
+  - type: article
+    authors: ["Jiménez, N.", "Cox, T. J.", "Romero-García, V.", "Groby, J.-P."]
+    year: 2017
+    title: "Metadiffusers: Deep-subwavelength sound diffusers"
+    journal: "Scientific Reports"
+    volume: 7
+    pages: "5389"
+    doi: "10.1038/s41598-017-05710-5"
+    note: "Acceso abierto. Difusores de panel de sublongitud de onda profunda cuyas ranuras resonantes de sonido lento alcanzan la difusión de un difusor de Schroeder o de residuo cuadrático en una fracción del espesor; en coautoría con Cox, autor del método del coeficiente de difusión de ISO 17497-2."
+  - type: article
+    authors: ["Jiménez, N.", "Groby, J.-P.", "Pagneux, V.", "Romero-García, V."]
+    year: 2017
+    title: "Iridescent perfect absorption in critically-coupled acoustic metamaterials using the transfer matrix method"
+    journal: "Applied Sciences"
+    volume: 7
+    issue: 6
+    pages: "618"
+    doi: "10.3390/app7060618"
+    note: "Acceso abierto. Un tutorial del método de la matriz de transferencia para absorbentes resonantes con terminación rígida y la condición de acoplamiento crítico para la absorción perfecta, con la misma maquinaria por capas que la predicción multicapa del tubo de impedancia de aquí."
+  - type: article
+    authors: ["Jiménez, N.", "Romero-García, V.", "Groby, J.-P."]
+    year: 2018
+    title: "Perfect absorption of sound by rigidly-backed high-porous materials"
+    journal: "Acta Acustica united with Acustica"
+    volume: 104
+    issue: 3
+    pages: "396-409"
+    doi: "10.3813/AAA.919183"
+    note: "La condición de acoplamiento crítico aplicada a una capa de absorbente de alta porosidad con terminación rígida, que conecta los modelos de material poroso de la sección de caracterización con la absorción perfecta a una sola frecuencia."
   - type: standard
     organization: "International Organization for Standardization"
     year: 2004

--- a/site/src/content/docs/reference/api/materials/porous-absorber.md
+++ b/site/src/content/docs/reference/api/materials/porous-absorber.md
@@ -46,7 +46,13 @@ medium has `Im(k) < 0`):
   plate, limp membrane) enter as series transfer impedances
   `[[1, z],[0, 1]]`. The stack is closed by a rigid wall, by free air or
   by an arbitrary termination impedance, giving the surface impedance, the
-  oblique reflection factor and `alpha(theta)`.
+  oblique reflection factor and `alpha(theta)`. This same layer transfer
+  matrix underlies the critically-coupled perfect-absorber designs of Jiménez,
+  Groby, Pagneux & Romero-García (2017, *Applied Sciences* 7(6), 618,
+  doi:10.3390/app7060618) and, for a rigidly-backed high-porosity layer,
+  Jiménez, Romero-García & Groby (2018, *Acta Acustica united with Acustica*
+  104(3), 396-409, doi:10.3813/AAA.919183), where the critical-coupling
+  condition on the surface impedance yields total single-frequency absorption.
 
 * **Resonant sheets and random incidence**: the perforated-plate impedance
   uses the end-corrected air-plug mass and the visco-thermal surface

--- a/site/src/content/docs/reference/api/materials/scattering-diffusion.md
+++ b/site/src/content/docs/reference/api/materials/scattering-diffusion.md
@@ -39,6 +39,12 @@ Neither part of ISO 17497 contains a numeric worked example; the two methods
 are distinct measurements and the helpers are named per part so they are
 never mixed.
 
+The Part 2 diffusion coefficient is the design target of subwavelength diffuser
+panels such as the metadiffusers of Jiménez, Cox, Romero-García & Groby
+(2017, *Scientific Reports* 7, 5389, doi:10.1038/s41598-017-05710-5), whose
+slow-sound resonant slots reach the diffusion of a Schroeder or
+quadratic-residue diffuser in a fraction of the depth.
+
 ## absorption_coefficient_uncertainty
 
 ```python

--- a/site/src/content/docs/reference/bibliography.md
+++ b/site/src/content/docs/reference/bibliography.md
@@ -328,6 +328,14 @@ list grows as guides gain their References sections.
   authors behind the ISO 17497-2 diffusion-coefficient method.
   Cited by [Acoustic Materials](/phonometry/guides/materials/) and
   [Surface Scattering, Diffusion and In-situ Absorption](/phonometry/guides/surface-scattering/).
+- Jiménez, N., Umnova, O., & Groby, J.-P. (Eds.). (2021). *Acoustic waves in
+  periodic structures, metamaterials, and porous media* (Topics in Applied
+  Physics, Vol. 143). Springer.
+  [doi:10.1007/978-3-030-84300-7](https://doi.org/10.1007/978-3-030-84300-7).
+  An edited umbrella volume on resonant and periodic sound-absorbing and
+  sound-diffusing structures, from the transfer-matrix and critical-coupling
+  theory of metamaterial absorbers to deep-subwavelength diffusers; the modern
+  metamaterials companion to Cox & D'Antonio.
 - International Organization for Standardization. (2003). *Acoustics —
   Measurement of sound absorption in a reverberation room* (ISO 354:2003).
   [iso.org catalogue](https://www.iso.org/standard/34545.html).

--- a/site/src/content/docs/reference/theory/materials-surfaces.md
+++ b/site/src/content/docs/reference/theory/materials-surfaces.md
@@ -18,6 +18,35 @@ references:
     publisher: "Wiley"
     doi: "10.1002/9780470747339"
     note: "ISBN 978-0-470-74661-5. The porous-material theory linking the airflow-resistance and impedance-tube quantities of the characterisation section."
+  - type: article
+    authors: ["Jiménez, N.", "Cox, T. J.", "Romero-García, V.", "Groby, J.-P."]
+    year: 2017
+    title: "Metadiffusers: Deep-subwavelength sound diffusers"
+    journal: "Scientific Reports"
+    volume: 7
+    pages: "5389"
+    doi: "10.1038/s41598-017-05710-5"
+    note: "Open access. Deep-subwavelength panel diffusers whose slow-sound resonant slots reach the diffusion of a Schroeder or quadratic-residue diffuser in a fraction of the depth; co-authored with Cox, behind the ISO 17497-2 diffusion-coefficient method."
+  - type: article
+    authors: ["Jiménez, N.", "Groby, J.-P.", "Pagneux, V.", "Romero-García, V."]
+    year: 2017
+    title: "Iridescent perfect absorption in critically-coupled acoustic metamaterials using the transfer matrix method"
+    journal: "Applied Sciences"
+    volume: 7
+    issue: 6
+    pages: "618"
+    doi: "10.3390/app7060618"
+    note: "Open access. A transfer-matrix-method tutorial for rigidly-backed resonant absorbers with the critical-coupling condition for perfect absorption, using the same layer machinery as the multilayer impedance-tube prediction here."
+  - type: article
+    authors: ["Jiménez, N.", "Romero-García, V.", "Groby, J.-P."]
+    year: 2018
+    title: "Perfect absorption of sound by rigidly-backed high-porous materials"
+    journal: "Acta Acustica united with Acustica"
+    volume: 104
+    issue: 3
+    pages: "396-409"
+    doi: "10.3813/AAA.919183"
+    note: "The critical-coupling condition applied to a rigidly-backed layer of ordinary high-porosity absorber, connecting the porous-material models of the characterisation section to perfect single-frequency absorption."
   - type: standard
     organization: "International Organization for Standardization"
     year: 2004

--- a/src/phonometry/materials/porous_absorber.py
+++ b/src/phonometry/materials/porous_absorber.py
@@ -39,7 +39,13 @@ medium has ``Im(k) < 0``):
   plate, limp membrane) enter as series transfer impedances
   ``[[1, z],[0, 1]]``. The stack is closed by a rigid wall, by free air or
   by an arbitrary termination impedance, giving the surface impedance, the
-  oblique reflection factor and ``alpha(theta)``.
+  oblique reflection factor and ``alpha(theta)``. This same layer transfer
+  matrix underlies the critically-coupled perfect-absorber designs of Jiménez,
+  Groby, Pagneux & Romero-García (2017, *Applied Sciences* 7(6), 618,
+  doi:10.3390/app7060618) and, for a rigidly-backed high-porosity layer,
+  Jiménez, Romero-García & Groby (2018, *Acta Acustica united with Acustica*
+  104(3), 396-409, doi:10.3813/AAA.919183), where the critical-coupling
+  condition on the surface impedance yields total single-frequency absorption.
 
 * **Resonant sheets and random incidence**: the perforated-plate impedance
   uses the end-corrected air-plug mass and the visco-thermal surface

--- a/src/phonometry/materials/scattering_diffusion.py
+++ b/src/phonometry/materials/scattering_diffusion.py
@@ -31,6 +31,12 @@ implemented, each faithful to its own standard:
 Neither part of ISO 17497 contains a numeric worked example; the two methods
 are distinct measurements and the helpers are named per part so they are
 never mixed.
+
+The Part 2 diffusion coefficient is the design target of subwavelength diffuser
+panels such as the metadiffusers of Jiménez, Cox, Romero-García & Groby
+(2017, *Scientific Reports* 7, 5389, doi:10.1038/s41598-017-05710-5), whose
+slow-sound resonant slots reach the diffusion of a Schroeder or
+quadratic-residue diffuser in a fraction of the depth.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
The Materials and Surfaces theory page derives surface diffusion and porous-absorber prediction, yet its `references` frontmatter listed only Cox & D'Antonio and Allard & Atalla. This adds three open-access works by Jiménez and co-workers that the page already speaks to, matching the existing reference-entry schema and keeping EN/ES parity.

## What changed
- **Materials and Surfaces theory page** (EN + ES `references` frontmatter): three new article entries.
  - Jiménez, Cox, Romero-García & Groby (2017), "Metadiffusers: Deep-subwavelength sound diffusers", Scientific Reports 7, 5389, doi:10.1038/s41598-017-05710-5, on the surface-diffusion section (co-authored with Cox, behind the ISO 17497-2 method).
  - Jiménez, Groby, Pagneux & Romero-García (2017), "Iridescent perfect absorption in critically-coupled acoustic metamaterials using the transfer matrix method", Applied Sciences 7(6), 618, doi:10.3390/app7060618, on the material-characterisation section.
  - Jiménez, Romero-García & Groby (2018), "Perfect absorption of sound by rigidly-backed high-porous materials", Acta Acustica united with Acustica 104(3), 396-409, doi:10.3813/AAA.919183.
- **Module docstrings**: `scattering_diffusion.py` references the metadiffuser paper; `porous_absorber.py` references both perfect-absorption papers on its transfer-matrix section. The committed API reference is regenerated.
- **Bibliography page** (EN + ES): the edited volume "Acoustic Waves in Periodic Structures, Metamaterials, and Porous Media" (Jiménez, Umnova & Groby, Eds., 2021, Springer, doi:10.1007/978-3-030-84300-7) added as a metamaterials companion to Cox & D'Antonio.

All DOIs were verified against Crossref (title, venue, year, author order, volume/issue/pages). Docs-only enrichment; no prose rewrites.

## Verification
`ruff check .`, `mypy src scripts`, i18n parity (100 pages), `make api-docs` (idempotent), site build with link validation and html-validate, and the materials/api-docs test subset (505 passed) all green locally.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded materials and surfaces references with research on sound diffusion, metamaterials, and perfect absorption.
  * Added the 2021 edited volume *Acoustic Waves in Periodic Structures, Metamaterials, and Porous Media* to the bibliography.
  * Clarified documentation for porous absorbers, transfer-matrix methods, and ISO 17497-2 diffusion targets.
  * Applied corresponding reference updates to Spanish documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->