### PR TITLE
Reduce cognitive complexity in loudness_zwicker and fluctuation_strength

### DIFF
--- a/src/phonometry/psychoacoustics/fluctuation_strength.py
+++ b/src/phonometry/psychoacoustics/fluctuation_strength.py
@@ -264,29 +264,114 @@ def _bark_center_hz(z: NDArray[np.float64] | float) -> Any:
     return np.interp(z, _INV_GRID_BARK, _INV_GRID_HZ)
 
 
-def _analyze(sig: NDArray[np.float64]) -> tuple[NDArray[np.float64], NDArray[np.float64], NDArray[np.float64]]:
-    """Un-calibrated Osses 2016 sum (``C_FS = 1``) of a model-rate signal.
+def _band_envelopes(
+    frame: NDArray[np.float64],
+    z_axis: NDArray[np.float64],
+    band_center_hz: NDArray[np.float64],
+) -> NDArray[np.float64]:
+    """Excitation-pattern envelopes of one frame, shape ``(47, n)``.
 
-    Runs the full front-end -- ear transmission, 47-band excitation filter bank,
-    generalised modulation depth ``m*``, neighbour cross-covariance ``k`` and the
-    weighted sum of Eq. (1) without the ``C_FS`` scale -- over 2 s frames with
-    50 % overlap. Returns the per-frame raw sums, the frame-averaged raw specific
-    pattern and the Bark axis. The public :func:`fluctuation_strength` multiplies
-    these by :func:`_c_fs`; keeping the scale out here lets the calibration be
-    derived from this same path without recursion.
+    Excitation front-end of Osses 2016 §2.1.1/2.1.2: Hann-windowed spectrum,
+    per-component level after the ear transmission, relative component and
+    excitation floors, triangular excitation spread onto the 47 observation
+    points and the inverse FFT back to band time signals.
+    """
+    n = frame.size
+    fs_v = float(_FS_SAMPLE_RATE)
+    p_ref = 2e-5
+    # Excitation patterns in the frequency domain.
+    spec = np.fft.rfft(frame * np.hanning(n))
+    freqs = np.asarray(np.fft.rfftfreq(n, d=1.0 / fs_v), dtype=np.float64)
+    mag = np.abs(spec) * 2.0 / n
+    # Per-component level (dB SPL) after the ear transmission.
+    with np.errstate(divide="ignore"):
+        lvl = 20.0 * np.log10(np.maximum(mag, 1e-12) / p_ref)
+    lvl = lvl + _terhardt_a0_db(freqs)
+    z_comp = _hz_to_bark(freqs)
+
+    # Only components above a floor contribute.
+    active = np.where(mag > mag.max() * 1e-4)[0] if mag.size else np.array([], int)
+    f_act = freqs[active]
+    lvl_act = lvl[active]
+    z_act = z_comp[active]
+    spec_act = spec[active]
+    inv_mag_act = 1.0 / np.maximum(mag[active], 1e-12)
+    s2_act = 24.0 + 230.0 / np.maximum(f_act, 1.0) - 0.2 * lvl_act
+    lvl_floor = lvl_act.max() - 60.0 if active.size else 0.0
+
+    # Build the 47 band time signals from the triangular excitation,
+    # vectorising the inverse FFT across all bands in one call.
+    band_spec = np.zeros((_N_FILTERS, freqs.size), dtype=np.complex128)
+    for i, zi in enumerate(z_axis):
+        # Excitation contribution of each active component to band i.
+        dz = zi - z_act
+        contrib_db = np.where(
+            f_act < band_center_hz[i],
+            lvl_act - s2_act * dz,  # component below observation point
+            lvl_act + _S1 * dz,  # component above (dz<0): -S1|dz|
+        )
+        weight = 10.0 ** (contrib_db / 20.0)
+        weight[contrib_db < lvl_floor] = 0.0
+        band_spec[i, active] = spec_act * (weight * inv_mag_act)
+    return np.abs(np.fft.irfft(band_spec, n=n, axis=1))
+
+
+def _modulation_depth(
+    band_env: NDArray[np.float64], env_sos: Any
+) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+    """Generalised modulation depth m* per band (Osses 2016 §2.1.3).
+
+    Returns ``(m_star, h_bp)`` with ``h_bp`` the band-pass-filtered envelopes
+    (needed again for the neighbour cross-covariance).
     """
     from scipy import signal as sp_signal
 
+    h0 = band_env.mean(axis=1)
+    h_bp = np.asarray(sp_signal.sosfilt(env_sos, band_env, axis=1))
+    rms_bp = np.sqrt(np.mean(h_bp**2, axis=1))
+    with np.errstate(divide="ignore", invalid="ignore"):
+        m_star = np.where(h0 > 0.0, rms_bp / h0, 0.0)
+    # 3:1 compression above the knee.
+    over = m_star > _COMPRESSION_THRESHOLD
+    m_star[over] = _COMPRESSION_THRESHOLD + (m_star[over] - _COMPRESSION_THRESHOLD) / _COMPRESSION_RATIO
+    return m_star, h_bp
+
+
+def _neighbour_covariance(h_bp: NDArray[np.float64]) -> NDArray[np.float64]:
+    """Cross covariance |k_{i-2}·k_{i+2}| with the bands two indices away
+    (Osses 2016 Eq. 9), with ``k = 1`` at the filter-bank edges."""
+    k = np.ones(_N_FILTERS)
+    for i in range(_N_FILTERS):
+        lo = i - 2
+        hi = i + 2
+        k_lo = _cross_covariance(h_bp[lo], h_bp[i]) if lo >= 0 else 1.0
+        k_hi = _cross_covariance(h_bp[i], h_bp[hi]) if hi < _N_FILTERS else 1.0
+        k[i] = abs(k_lo * k_hi)
+    return k
+
+
+def _analyze(sig: NDArray[np.float64]) -> tuple[NDArray[np.float64], NDArray[np.float64], NDArray[np.float64]]:
+    """Un-calibrated Osses 2016 sum (``C_FS = 1``) of a model-rate signal.
+
+    Runs the full front-end -- ear transmission, 47-band excitation filter bank
+    (:func:`_band_envelopes`), generalised modulation depth ``m*``
+    (:func:`_modulation_depth`), neighbour cross-covariance ``k``
+    (:func:`_neighbour_covariance`) and the weighted sum of Eq. (1) without the
+    ``C_FS`` scale -- over 2 s frames with 50 % overlap. Returns the per-frame
+    raw sums, the frame-averaged raw specific pattern and the Bark axis. The
+    public :func:`fluctuation_strength` multiplies these by :func:`_c_fs`;
+    keeping the scale out here lets the calibration be derived from this same
+    path without recursion.
+    """
     # Observation points (centre frequencies) of the 47 filters.
     z_axis = np.arange(1, _N_FILTERS + 1, dtype=np.float64) * _BARK_SPACING
     g_z = _g_weight(z_axis)
     band_center_hz = np.asarray(_bark_center_hz(z_axis), dtype=np.float64)
 
     env_sos = _bandpass_envelope_filter(float(_FS_SAMPLE_RATE))
-    fs_v = float(_FS_SAMPLE_RATE)
 
     # 2 s frames, 50 % overlap.
-    frame_len = round(2.0 * fs_v)
+    frame_len = round(2.0 * float(_FS_SAMPLE_RATE))
     frame_len = min(frame_len, sig.size)
     hop = max(1, frame_len // 2)
     starts = list(range(0, max(1, sig.size - frame_len + 1), hop))
@@ -296,66 +381,13 @@ def _analyze(sig: NDArray[np.float64]) -> tuple[NDArray[np.float64], NDArray[np.
     fs_frames: list[float] = []
     specific_accum = np.zeros(_N_FILTERS)
 
-    p_ref = 2e-5
     for start in starts:
         frame = sig[start : start + frame_len]
-        n = frame.size
-        if n < 16:
+        if frame.size < 16:
             continue
-        # Excitation patterns in the frequency domain.
-        spec = np.fft.rfft(frame * np.hanning(n))
-        freqs = np.asarray(np.fft.rfftfreq(n, d=1.0 / fs_v), dtype=np.float64)
-        mag = np.abs(spec) * 2.0 / n
-        # Per-component level (dB SPL) after the ear transmission.
-        with np.errstate(divide="ignore"):
-            lvl = 20.0 * np.log10(np.maximum(mag, 1e-12) / p_ref)
-        lvl = lvl + _terhardt_a0_db(freqs)
-        z_comp = _hz_to_bark(freqs)
-
-        # Only components above a floor contribute.
-        active = np.where(mag > mag.max() * 1e-4)[0] if mag.size else np.array([], int)
-        f_act = freqs[active]
-        lvl_act = lvl[active]
-        z_act = z_comp[active]
-        spec_act = spec[active]
-        inv_mag_act = 1.0 / np.maximum(mag[active], 1e-12)
-        s2_act = 24.0 + 230.0 / np.maximum(f_act, 1.0) - 0.2 * lvl_act
-        lvl_floor = lvl_act.max() - 60.0 if active.size else 0.0
-
-        # Build the 47 band time signals from the triangular excitation,
-        # vectorising the inverse FFT across all bands in one call.
-        band_spec = np.zeros((_N_FILTERS, freqs.size), dtype=np.complex128)
-        for i, zi in enumerate(z_axis):
-            # Excitation contribution of each active component to band i.
-            dz = zi - z_act
-            contrib_db = np.where(
-                f_act < band_center_hz[i],
-                lvl_act - s2_act * dz,  # component below observation point
-                lvl_act + _S1 * dz,  # component above (dz<0): -S1|dz|
-            )
-            weight = 10.0 ** (contrib_db / 20.0)
-            weight[contrib_db < lvl_floor] = 0.0
-            band_spec[i, active] = spec_act * (weight * inv_mag_act)
-        band_env = np.abs(np.fft.irfft(band_spec, n=n, axis=1))
-
-        # Generalised modulation depth m* per band.
-        h0 = band_env.mean(axis=1)
-        h_bp = sp_signal.sosfilt(env_sos, band_env, axis=1)
-        rms_bp = np.sqrt(np.mean(h_bp**2, axis=1))
-        with np.errstate(divide="ignore", invalid="ignore"):
-            m_star = np.where(h0 > 0.0, rms_bp / h0, 0.0)
-        # 3:1 compression above the knee.
-        over = m_star > _COMPRESSION_THRESHOLD
-        m_star[over] = _COMPRESSION_THRESHOLD + (m_star[over] - _COMPRESSION_THRESHOLD) / _COMPRESSION_RATIO
-
-        # Cross covariance with the bands two indices away.
-        k = np.ones(_N_FILTERS)
-        for i in range(_N_FILTERS):
-            lo = i - 2
-            hi = i + 2
-            k_lo = _cross_covariance(h_bp[lo], h_bp[i]) if lo >= 0 else 1.0
-            k_hi = _cross_covariance(h_bp[i], h_bp[hi]) if hi < _N_FILTERS else 1.0
-            k[i] = abs(k_lo * k_hi)
+        band_env = _band_envelopes(frame, z_axis, band_center_hz)
+        m_star, h_bp = _modulation_depth(band_env, env_sos)
+        k = _neighbour_covariance(h_bp)
 
         f_specific = (m_star**_P_M) * (k**_P_K) * g_z
         specific_accum += f_specific

--- a/src/phonometry/psychoacoustics/loudness_zwicker.py
+++ b/src/phonometry/psychoacoustics/loudness_zwicker.py
@@ -446,13 +446,94 @@ def _nonlinear_decay(core: np.ndarray, sample_rate: float) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _rns_index_of(core_l: float) -> int:
+    """Specific-loudness range index of a core loudness value (Table A.9)."""
+    idx_rns = 0
+    while idx_rns < _N_RNS and _RNS[idx_rns] >= core_l:
+        idx_rns += 1
+    return idx_rns
+
+
+def _next_rns_index(idx_rns: int, n2: float) -> int:
+    """Advance to the specific-loudness range of the segment end ``n2``."""
+    while idx_rns < _N_RNS - 1 and n2 <= _RNS[idx_rns]:
+        idx_rns += 1
+    return min(idx_rns, _N_RNS - 1)
+
+
+def _masked_segment(
+    ns: list[float],
+    state: tuple[float, float, float, int],
+    core_l: float,
+    zup: float,
+    usl: float,
+    idx_rns: int,
+) -> tuple[float, float, float, float, int, bool]:
+    """Extend the masking slope of the previous band by one segment.
+
+    The slope from the previous band still masks this band: extend it with
+    steepness ``usl`` until it meets the core loudness, a range limit RNS or
+    the band edge ZUP, return its trapezoidal ``area`` contribution and write
+    its 0.1-Bark samples into ``ns``.
+
+    :param ns: Specific-loudness samples, written in place.
+    :param state: Current ``(n1, z, z1, idx_ns)`` sampling state.
+    :return: ``(n2, z2, area, z, idx_ns, next_band)``.
+    """
+    n1, z, z1, idx_ns = state
+    n2 = max(_RNS[idx_rns], core_l)
+    dz = (n1 - n2) / usl
+    z2 = z1 + dz
+    next_band = False
+    if z2 > zup:
+        next_band = True
+        z2 = zup
+        dz = z2 - z1
+        n2 = n1 - dz * usl
+    area = dz * (n1 + n2) / 2.0
+    zk = z
+    while zk <= z2:
+        ns[idx_ns] = n1 - (zk - z1) * usl
+        idx_ns += 1
+        zk += 0.1
+    return n2, z2, area, zk, idx_ns, next_band
+
+
+def _flat_segment(
+    ns: list[float],
+    state: tuple[float, float, float, int],
+    core_l: float,
+    zup: float,
+) -> tuple[float, float, float, float, int]:
+    """Take the unmasked core loudness flat up to the band edge ``zup``.
+
+    Returns the rectangular ``area`` contribution and writes the 0.1-Bark
+    samples into ``ns``.
+
+    :param ns: Specific-loudness samples, written in place.
+    :param state: Current ``(n1, z, z1, idx_ns)`` sampling state.
+    :return: ``(n2, z2, area, z, idx_ns)``.
+    """
+    _, z, z1, idx_ns = state
+    z2 = zup
+    n2 = core_l
+    area = n2 * (z2 - z1)
+    zk = z
+    while zk <= z2:
+        ns[idx_ns] = n2
+        idx_ns += 1
+        zk += 0.1
+    return n2, z2, area, zk, idx_ns
+
+
 def _calc_slopes(core: list[float]) -> tuple[float, list[float]]:
     """Specific loudness pattern with upper slopes for one time step.
 
     Attaches the masking slopes towards higher frequencies to the core
     loudness values (steepness USL per specific-loudness range RNS,
     Table A.9; critical-band limits ZUP, Table A.8), integrates the total
-    loudness and samples the pattern at 0.1-Bark steps.
+    loudness and samples the pattern at 0.1-Bark steps.  The two segment
+    kinds live in :func:`_masked_segment` and :func:`_flat_segment`.
 
     :param core: 21 core loudness values.
     :return: Total loudness in sone and 240 specific loudness values.
@@ -460,10 +541,8 @@ def _calc_slopes(core: list[float]) -> tuple[float, list[float]]:
     ns = [0.0] * _N_BARK
     total = 0.0
     n1 = 0.0  # specific loudness at the current lower band edge
-    n2 = 0.0
     z = 0.1  # next 0.1-Bark sampling position
     z1 = 0.0  # Bark position of the current lower band edge
-    z2 = 0.0
     idx_rns = 0
     idx_ns = 0
 
@@ -473,49 +552,21 @@ def _calc_slopes(core: list[float]) -> tuple[float, list[float]]:
         idx_cbn = min(idx_cl - 1, _N_CBR - 1)  # never used while negative
         while True:
             if n1 > core_l:
-                # The slope from the previous band still masks this band:
-                # extend it with steepness USL until it meets the core
-                # loudness, a range limit RNS or the band edge ZUP.
                 usl = _USL[idx_rns][idx_cbn]
-                n2 = max(_RNS[idx_rns], core_l)
-                dz = (n1 - n2) / usl
-                z2 = z1 + dz
-                next_band = False
-                if z2 > zup:
-                    next_band = True
-                    z2 = zup
-                    dz = z2 - z1
-                    n2 = n1 - dz * usl
-                # Trapezoidal contribution of the slope segment and its
-                # 0.1-Bark samples.
-                total += dz * (n1 + n2) / 2.0
-                zk = z
-                while zk <= z2:
-                    ns[idx_ns] = n1 - (zk - z1) * usl
-                    idx_ns += 1
-                    zk += 0.1
-                z = zk
+                n2, z2, area, z, idx_ns, next_band = _masked_segment(
+                    ns, (n1, z, z1, idx_ns), core_l, zup, usl, idx_rns
+                )
             else:
                 # Unmasked band: find the specific-loudness range of the
                 # core value, then take it flat up to the band edge.
                 if n1 < core_l:
-                    idx_rns = 0
-                    while idx_rns < _N_RNS and _RNS[idx_rns] >= core_l:
-                        idx_rns += 1
+                    idx_rns = _rns_index_of(core_l)
                 next_band = True
-                z2 = zup
-                n2 = core_l
-                total += n2 * (z2 - z1)
-                zk = z
-                while zk <= z2:
-                    ns[idx_ns] = n2
-                    idx_ns += 1
-                    zk += 0.1
-                z = zk
-            # Advance to the specific-loudness range of the segment end.
-            while idx_rns < _N_RNS - 1 and n2 <= _RNS[idx_rns]:
-                idx_rns += 1
-            idx_rns = min(idx_rns, _N_RNS - 1)
+                n2, z2, area, z, idx_ns = _flat_segment(
+                    ns, (n1, z, z1, idx_ns), core_l, zup
+                )
+            total += area
+            idx_rns = _next_rns_index(idx_rns, n2)
             z1 = z2
             n1 = n2
             if next_band:


### PR DESCRIPTION
Structural refactor of the two psychoacoustics functions SonarCloud flags for cognitive complexity (S3776), with zero behavior change. Both are oracle-validated implementations (ISO 532-1 loudness, Osses 2016 fluctuation strength), so no physics, constants or numerics were touched; the code was only decomposed into helpers that map to the conceptual stages of each algorithm.

## Changes

**`loudness_zwicker.py` / `_calc_slopes`** (the clause 5.5 slope state machine, Tables A.8/A.9):
- `_masked_segment`: one segment of the masking slope from the previous band (steepness USL, trapezoidal area, 0.1-Bark sampling).
- `_flat_segment`: the unmasked flat band up to the ZUP band edge.
- `_rns_index_of` / `_next_rns_index`: the Table A.9 specific-loudness range searches.
- `_calc_slopes` itself keeps only the band loop and the branch between the two segment kinds.

**`fluctuation_strength.py` / `_analyze`** (the Osses 2016 signal model):
- `_band_envelopes`: per-frame excitation front-end (windowed spectrum, ear transmission, component floors, triangular excitation onto the 47 observation points, inverse FFT).
- `_modulation_depth`: generalised modulation depth m* with the 3:1 compression.
- `_neighbour_covariance`: cross covariance with the bands two indices away.
- `_analyze` keeps the framing loop and the Eq. (1) sum.

## Verification

- Representative signals (AM tone, AM noise, FM tone with resampling; stationary spectrum/signal and time-varying loudness in free and diffuse field, with calibration factor and time skip) were run through the public functions before and after the refactor: all 31 captured outputs (overall values, specific patterns, time traces, percentiles) are byte-for-byte identical.
- `pytest tests/psychoacoustics`: 436 passed, before and after.
- The committed `docs/CONFORMANCE.md` regenerates unchanged.
- `ruff check .` and `mypy src scripts` clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the internal processing of fluctuation strength analysis while preserving existing results and public interfaces.
  * Streamlined specific-loudness calculations used by Zwicker loudness analysis.
  * Existing calibration, resampling, caching, and frame-based result behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->