### PR TITLE
Small plotting robustness fixes

### DIFF
--- a/site/src/content/docs/reference/api/electroacoustics/piston.md
+++ b/site/src/content/docs/reference/api/electroacoustics/piston.md
@@ -202,7 +202,7 @@ matplotlib (`pip install phonometry[plot]`).
 | :--- | :--- |
 | `ax` | Existing (polar) axes, or `None` to create a figure. |
 | `language` | Label language, `"en"` (default) or `"es"`. |
-| `kwargs` | Forwarded to the per-`ka` `Axes.plot` calls. |
+| `kwargs` | Forwarded to the `Axes.plot` call when the result holds a single `ka`; ignored for a multi-`ka` family so one user color or label cannot collapse the per-curve styling. |
 
 **Returns:** The axes.
 

--- a/site/src/content/docs/reference/api/underwater/seabed-reflection.md
+++ b/site/src/content/docs/reference/api/underwater/seabed-reflection.md
@@ -44,6 +44,10 @@ bottom_reflection_loss(
 
 Bottom reflection loss `BL = −20·lg|R|` versus grazing angle (dB).
 
+At an angle of intromission `R = 0` and the loss is `inf` (total
+transmission into the sediment); that is a legitimate bottom-loss value,
+returned without warning.
+
 **Parameters**
 
 | Name | Description |
@@ -176,7 +180,8 @@ fluid-fluid interface and bundles the complex `R`, its magnitude `|R|`,
 the bottom loss `BL = −20·lg|R|` and the interface parameters into a
 [`SeabedReflection`](/phonometry/reference/api/underwater/seabed-reflection/#seabedreflection) that exposes `.plot()`. The maths is unchanged;
 this is a thin, plottable wrapper around the existing function (the same
-`ValueError` cases apply).
+`ValueError` cases apply). At an angle of intromission `R = 0` and the
+bottom loss is `inf` (total transmission), returned without warning.
 
 **Parameters**
 

--- a/src/phonometry/_plot/electroacoustics.py
+++ b/src/phonometry/_plot/electroacoustics.py
@@ -359,7 +359,9 @@ def plot_piston_directivity(
         :class:`~phonometry.electroacoustics.piston.PistonDirectivity`.
     :param ax: Existing polar axes, or ``None`` to create a polar figure.
     :param language: Label language, ``"en"`` (default) or ``"es"``.
-    :param kwargs: Forwarded to the per-``ka`` ``Axes.plot`` calls.
+    :param kwargs: Forwarded to the ``Axes.plot`` call when the result holds a
+        single ``ka``; ignored for a multi-``ka`` family so one user color or
+        label cannot collapse the per-curve styling.
     :return: The (polar) axes.
     """
     from .._i18n import decimal_comma, localize_axes
@@ -383,7 +385,10 @@ def plot_piston_directivity(
         line_kwargs: dict[str, Any] = {
             "color": colors[i % len(colors)], "lw": 1.6, "label": label,
         }
-        line_kwargs.update(kwargs)
+        if ka.size == 1:
+            # User overrides (color, label, ...) apply only to a single-curve
+            # plot; with several ka they would collapse the family styling.
+            line_kwargs.update(kwargs)
         ax.plot(theta, levels[i], **line_kwargs)
     ax.set_ylim(-_POLAR_SPAN_PISTON_DB, 0.0)
     ax.set_yticks([-40.0, -30.0, -20.0, -10.0, 0.0])

--- a/src/phonometry/_plot/psychoacoustics.py
+++ b/src/phonometry/_plot/psychoacoustics.py
@@ -754,8 +754,9 @@ def plot_equal_loudness_contours(
     """Normal equal-loudness-level contour family (ISO 226:2023).
 
     Draws sound pressure level in dB against a logarithmic frequency axis: one
-    line per loudness level in ``result.phons`` (each annotated near 1 kHz) and
-    the threshold of hearing T_f. This is the iconic ISO 226 chart.
+    line per loudness level in ``result.phons`` (each annotated near 1 kHz when
+    the frequency range includes 1 kHz) and the threshold of hearing T_f. This
+    is the iconic ISO 226 chart.
 
     :param result: An
         :class:`~phonometry.loudness_contours.EqualLoudnessContours`.
@@ -772,21 +773,27 @@ def plot_equal_loudness_contours(
     kwargs.setdefault("color", _C_PRIMARY)
     kwargs.setdefault("linewidth", 1.5)
 
+    fmin, fmax = float(freqs.min()), float(freqs.max())
+    # The per-contour labels sit at the 1 kHz crossing (SPL = phon by
+    # definition); when a frequency subset excludes 1 kHz they would land
+    # outside the axes, so they are skipped.
+    annotate_phons = fmin <= 1000.0 <= fmax
     for phon, spl in zip(result.phons, contours, strict=True):
         ax.plot(freqs, spl, **kwargs)
-        # Annotate the contour where it crosses 1 kHz (SPL = phon by definition).
-        ax.annotate(
-            _t("{p} phon", language).format(p=format_number(phon, language, decimals=0, trim=True)),
-            xy=(1000.0, phon), xytext=(1180.0, phon + 1.0),
-            fontsize=9, color=kwargs["color"],
-        )
+        if annotate_phons:
+            ax.annotate(
+                _t("{p} phon", language).format(
+                    p=format_number(phon, language, decimals=0, trim=True)
+                ),
+                xy=(1000.0, phon), xytext=(1180.0, phon + 1.0),
+                fontsize=9, color=kwargs["color"],
+            )
     ax.plot(
         freqs, np.asarray(result.threshold, dtype=np.float64),
         color=_C_SECONDARY, linestyle="--",
         label=_t(r"Hearing threshold $T_f$", language),
     )
 
-    fmin, fmax = float(freqs.min()), float(freqs.max())
     ax.set_xlim(fmin, fmax)
     format_frequency_axis(ax, fmin, fmax)
     ax.set_xlabel(_t("Frequency [Hz]", language))

--- a/src/phonometry/electroacoustics/piston.py
+++ b/src/phonometry/electroacoustics/piston.py
@@ -192,7 +192,9 @@ class PistonDirectivity:
 
         :param ax: Existing (polar) axes, or ``None`` to create a figure.
         :param language: Label language, ``"en"`` (default) or ``"es"``.
-        :param kwargs: Forwarded to the per-``ka`` ``Axes.plot`` calls.
+        :param kwargs: Forwarded to the ``Axes.plot`` call when the result
+            holds a single ``ka``; ignored for a multi-``ka`` family so one
+            user color or label cannot collapse the per-curve styling.
         :return: The axes.
         """
         from .._i18n import check_language

--- a/src/phonometry/underwater/seabed_reflection.py
+++ b/src/phonometry/underwater/seabed_reflection.py
@@ -134,6 +134,10 @@ def bottom_reflection_loss(
 ) -> BottomLossResult:
     """Bottom reflection loss ``BL = −20·lg|R|`` versus grazing angle (dB).
 
+    At an angle of intromission ``R = 0`` and the loss is ``inf`` (total
+    transmission into the sediment); that is a legitimate bottom-loss value,
+    returned without warning.
+
     :param grazing_angle: Grazing angle(s) ``φ`` from the interface, in degrees.
     :param rho1: Water density ``ρ1`` (default 1000 kg/m³).
     :param c1: Sound speed in the water ``c1``, in m/s (default 1500).
@@ -144,7 +148,10 @@ def bottom_reflection_loss(
     """
     phi = np.atleast_1d(np.asarray(grazing_angle, dtype=np.float64))
     r = reflection_coefficient(phi, rho1=rho1, c1=c1, rho2=rho2, c2=c2)
-    loss = -20.0 * np.log10(np.abs(r))
+    # At an intromission angle |R| = 0 and the bottom loss is legitimately
+    # infinite (total transmission); silence the log10(0) warning.
+    with np.errstate(divide="ignore"):
+        loss = -20.0 * np.log10(np.abs(r))
     phi_c = critical_angle(c1, c2) if float(c2) > float(c1) else None
     return BottomLossResult(
         grazing_angle=phi,
@@ -223,7 +230,8 @@ def seabed_reflection(
     the bottom loss ``BL = −20·lg|R|`` and the interface parameters into a
     :class:`SeabedReflection` that exposes ``.plot()``. The maths is unchanged;
     this is a thin, plottable wrapper around the existing function (the same
-    ``ValueError`` cases apply).
+    ``ValueError`` cases apply). At an angle of intromission ``R = 0`` and the
+    bottom loss is ``inf`` (total transmission), returned without warning.
 
     :param grazing_angle: Grazing angle(s) ``φ`` from the interface, in degrees
         (``0`` grazing to ``90`` normal incidence).
@@ -237,7 +245,10 @@ def seabed_reflection(
     phi = np.atleast_1d(np.asarray(grazing_angle, dtype=np.float64))
     r = reflection_coefficient(phi, rho1=rho1, c1=c1, rho2=rho2, c2=c2)
     magnitude = np.abs(r)
-    loss = -20.0 * np.log10(magnitude)
+    # At an intromission angle |R| = 0 and the bottom loss is legitimately
+    # infinite (total transmission); silence the log10(0) warning.
+    with np.errstate(divide="ignore"):
+        loss = -20.0 * np.log10(magnitude)
     phi_c = critical_angle(c1, c2) if float(c2) > float(c1) else None
     return SeabedReflection(
         grazing_angle=phi,

--- a/tests/electroacoustics/test_piston.py
+++ b/tests/electroacoustics/test_piston.py
@@ -165,6 +165,24 @@ def test_directivity_pattern_plot() -> None:
         res.plot(language="xx")
 
 
+def test_directivity_pattern_plot_kwargs_single_ka_only() -> None:
+    # User plot kwargs restyle a single-ka curve, but are ignored for a
+    # multi-ka family: one color/label would collapse the per-curve styling.
+    import matplotlib
+
+    matplotlib.use("Agg")
+    single = piston_directivity_pattern(5.0)
+    ax = single.plot(color="crimson", label="mine")
+    assert ax.lines[0].get_color() == "crimson"
+    assert ax.lines[0].get_label() == "mine"
+
+    family = piston_directivity_pattern([2.0, 5.0, 10.0])
+    ax_family = family.plot(color="crimson")
+    colors = {line.get_color() for line in ax_family.lines}
+    assert "crimson" not in colors
+    assert len(colors) == 3
+
+
 def test_directivity_pattern_validation() -> None:
     # Build the arguments up front so only the throwing call sits in each block.
     ka_one = [1.0]

--- a/tests/psychoacoustics/test_loudness_contours.py
+++ b/tests/psychoacoustics/test_loudness_contours.py
@@ -175,6 +175,28 @@ def test_contours_plot_returns_axes() -> None:
     assert "isofónicas" in ax_es.get_title()
 
 
+def test_contours_plot_phon_labels_skipped_without_1khz() -> None:
+    # The per-contour phon labels sit at the 1 kHz crossing; on a frequency
+    # subset that excludes 1 kHz they must be skipped (they would render
+    # outside the axes), while a range including 1 kHz keeps them.
+    pytest.importorskip("matplotlib")
+    import matplotlib
+
+    matplotlib.use("Agg")
+    from matplotlib.text import Annotation
+
+    subset = equal_loudness_contours(
+        phons=(20.0, 40.0), frequencies=(63.0, 125.0, 250.0, 500.0)
+    )
+    ax = subset.plot()
+    assert not [t for t in ax.texts if isinstance(t, Annotation)]
+
+    full = equal_loudness_contours(phons=(20.0, 40.0))
+    ax_full = full.plot()
+    labels = [t for t in ax_full.texts if isinstance(t, Annotation)]
+    assert [t.get_text() for t in labels] == ["20 phon", "40 phon"]
+
+
 def test_contours_plot_rejects_unknown_language() -> None:
     pytest.importorskip("matplotlib")
     import matplotlib

--- a/tests/underwater/test_seabed_reflection.py
+++ b/tests/underwater/test_seabed_reflection.py
@@ -8,6 +8,8 @@ angle ``arccos(c1/c2)``; and total reflection (``|R| = 1``) below it.
 
 from __future__ import annotations
 
+import warnings
+
 import matplotlib
 
 matplotlib.use("Agg")
@@ -84,6 +86,37 @@ def test_zero_grazing_equal_speeds_no_nan() -> None:
     assert float(res.reflection_loss[0]) == pytest.approx(
         -20.0 * np.log10(abs(expected_r)), abs=1e-9
     )
+
+
+def test_intromission_angle_slow_bottom_closed_form() -> None:
+    # Slow mud bottom (rho2 = 1300, c2 = 1400): R = 0 at the angle of
+    # intromission. Closed form from R's numerator = 0 with Snell's law:
+    # sin(phi_I) = sqrt((z1^2 - (rho1 c2)^2) / (z2^2 - (rho1 c2)^2)),
+    # which gives phi_I = 27.585 deg for this pair. |R| vanishes there and the
+    # bottom loss blows up; no warning may leak.
+    rho1, c1, rho2, c2 = 1000.0, 1500.0, 1300.0, 1400.0
+    z1, z2, z12 = rho1 * c1, rho2 * c2, rho1 * c2
+    phi_i = float(np.degrees(np.arcsin(np.sqrt((z1**2 - z12**2) / (z2**2 - z12**2)))))
+    assert phi_i == pytest.approx(27.585, abs=1e-3)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        res = bottom_reflection_loss(phi_i, rho1=rho1, c1=c1, rho2=rho2, c2=c2)
+    assert float(np.abs(res.reflection_coefficient[0])) == pytest.approx(0.0, abs=1e-12)
+    assert float(res.reflection_loss[0]) > 100.0  # inf at the exact zero of R
+    assert res.critical_angle is None
+
+
+def test_exact_intromission_zero_gives_inf_loss_without_warning() -> None:
+    # When |R| underflows to exactly 0 the loss is legitimately +inf; the
+    # log10(0) RuntimeWarning must be silenced (identical media force R = 0
+    # exactly at every angle).
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        res = bottom_reflection_loss(30.0, rho1=1000.0, c1=1500.0, rho2=1000.0, c2=1500.0)
+        wrapped = seabed_reflection(30.0, rho1=1000.0, c1=1500.0, rho2=1000.0, c2=1500.0)
+    assert res.reflection_loss[0] == np.inf
+    assert wrapped.magnitude[0] == 0.0
+    assert wrapped.bottom_loss[0] == np.inf
 
 
 def test_grazing_angle_out_of_range_rejected() -> None:


### PR DESCRIPTION
Three small fixes in the plotting layer and the seabed reflection maths.

- **Seabed reflection**: at an angle of intromission the Rayleigh coefficient vanishes and `BL = -20 lg|R|` is legitimately infinite (total transmission). The unguarded `log10` emitted a `RuntimeWarning` when `|R|` hit exactly zero; both `bottom_reflection_loss` and `seabed_reflection` now silence the divide warning and document the `inf` value. Tests pin the closed-form intromission angle for a slow mud bottom (1300 kg/m3, 1400 m/s: 27.585 deg) and an exact `|R| = 0` case.
- **ISO 226 contours**: the per-contour phon labels sit at the 1 kHz crossing with text at 1180 Hz, so a frequency subset that excludes 1 kHz drew them outside the axes. They are now skipped unless the plotted range includes 1 kHz; the default full-range figure is unchanged.
- **Piston directivity**: user plot kwargs were applied to every `ka` curve, so a single color or label collapsed the family styling. They now restyle the curve only when the result holds a single `ka`, and both docstrings state the behavior.

No committed figure changes: the affected figures were regenerated and are byte-identical.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

