### PR TITLE
Record the ISO 10848-1:2017 correction of the 2006 critical-frequency misprint

### DIFF
--- a/docs/ERRATA.md
+++ b/docs/ERRATA.md
@@ -202,8 +202,9 @@ to the issuing body, with date and reference).
   misprint note in the docstring.
 - **Status:** corrected upstream — ISO 10848-1:2017 (second edition) prints
   the π-free form in its Formula (5), fc = c0²/(1,8 h cL), confirming the
-  2006 print as a misprint. No report needed; recorded for the 2006 edition
-  the library cites alongside the 2017 confirmation.
+  2006 print as a misprint. No report is needed. The entry is retained
+  because the library cites the 2006 edition, whose print carries the
+  defect; the 2017 edition stands as the confirmation.
 
 ## ISO 12999-1:2020, Table 4 (missing 500 Hz row)
 

--- a/docs/ERRATA.md
+++ b/docs/ERRATA.md
@@ -200,7 +200,10 @@ to the issuing body, with date and reference).
 - **Library behaviour:** implements the π-free form
   (`phonometry.building.flanking_transmission.critical_frequency`), with a
   misprint note in the docstring.
-- **Status:** unreported.
+- **Status:** corrected upstream — ISO 10848-1:2017 (second edition) prints
+  the π-free form in its Formula (5), fc = c0²/(1,8 h cL), confirming the
+  2006 print as a misprint. No report needed; recorded for the 2006 edition
+  the library cites alongside the 2017 confirmation.
 
 ## ISO 12999-1:2020, Table 4 (missing 500 Hz row)
 

--- a/site/src/content/docs/reference/api/building/flanking-transmission.md
+++ b/site/src/content/docs/reference/api/building/flanking-transmission.md
@@ -123,8 +123,9 @@ mutually consistent this equals [`phonometry.coincidence_frequency`](/phonometry
 The printed ISO 10848-1:2006 Formula (20) carries a spurious extra
 `π` in the denominator (`1,8 cL · h · π`), which would misplace
 `fc` by a factor π; the π-free form implemented here is the one
-ISO 12354-1:2017 prints (`fc = c0²/(1,8 cL t)`) and Hopkins
-Eq. 2.201 derives. See `docs/ERRATA.md`.
+ISO 10848-1:2017 restores in its Formula (5), ISO 12354-1:2017
+prints in its symbol definitions (`fc = c0²/(1,8 cL t)`) and
+Hopkins Eq. 2.201 derives. See `docs/ERRATA.md`.
 :::
 
 **Parameters**

--- a/src/phonometry/building/flanking_transmission.py
+++ b/src/phonometry/building/flanking_transmission.py
@@ -858,8 +858,9 @@ def critical_frequency(
         The printed ISO 10848-1:2006 Formula (20) carries a spurious extra
         ``π`` in the denominator (``1,8 cL · h · π``), which would misplace
         ``fc`` by a factor π; the π-free form implemented here is the one
-        ISO 12354-1:2017 prints (``fc = c0²/(1,8 cL t)``) and Hopkins
-        Eq. 2.201 derives. See ``docs/ERRATA.md``.
+        ISO 10848-1:2017 restores in its Formula (5), ISO 12354-1:2017
+        prints in its symbol definitions (``fc = c0²/(1,8 cL t)``) and
+        Hopkins Eq. 2.201 derives. See ``docs/ERRATA.md``.
 
     :param longitudinal_wave_speed: Longitudinal wave speed ``cL``, in m/s.
     :param thickness: Element thickness ``h``, in m.


### PR DESCRIPTION
The second edition of ISO 10848-1 (2017), now available for verification, prints the thin-plate critical frequency without the spurious pi of the 2006 Formula (20): its Formula (5) reads fc = c0^2/(1,8 h cL), matching the form this library implements and the Hopkins derivation. The errata entry is updated to record the upstream correction (no report needed) and the critical_frequency docstring cites the 2017 formula alongside the existing evidence. Generated API page regenerated.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated errata records to reflect that the critical-frequency formula correction was addressed in later ISO editions.
  * Expanded API and code documentation with references to the corrected, π-free formulas in ISO 10848-1:2017 and ISO 12354-1:2017.
  * Clarified the relationship between the standards and the documented reference equation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->