### PR TITLE
feat(site): read the Person entity from its canonical source

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -161,56 +161,134 @@ const dateModified = (() => {
 
 const softwareRequirements = 'Python >= 3.13 with NumPy and SciPy (matplotlib and numba optional).';
 
+// --- Canonical identity --------------------------------------------------
+// The `#person` entity is no longer restated here; it is fetched from its
+// single source of truth on jmrp.io and spliced into the graph verbatim. Every
+// property this site used to hand-copy (jobTitle, description, image, sameAs,
+// alternateName) had to be kept in sync by hand across five project sites, and
+// it drifted: two ended up publishing values that contradicted the canonical
+// node, one an avatar URL that had started returning 404.
+//
+// Fetched from raw.githubusercontent.com rather than https://jmrp.io on
+// purpose: this build runs on a CI runner, and jmrp.io sits behind Cloudflare,
+// CrowdSec and a MikroTik bouncer, where a blocked runner IP would silently
+// degrade this site to a stale snapshot. GitHub serves the same bytes and is
+// already a hard dependency of the build — the checkout comes from it.
+const CANONICAL_IDENTITY_URL =
+  'https://raw.githubusercontent.com/jmrplens/jmrp.io/main/public/identity/person.jsonld';
+
+// Committed fallback, only reached if the fetch fails — which, given the URL is
+// on the same host as the checkout, effectively means GitHub is down and there
+// is no build anyway. The warning is deliberately loud so a stale identity
+// never ships unnoticed. Refresh with `pnpm run identity:sync`.
+const identitySnapshot = JSON.parse(
+  readFileSync(new URL('./identity/person.snapshot.json', import.meta.url), 'utf8'),
+);
+
+// `@context` is stripped: the document is standalone, but here it becomes one
+// node of a graph that already declares the context once.
+const { '@context': _identityContext, ...canonicalPerson } = await fetch(
+  CANONICAL_IDENTITY_URL,
+  { signal: AbortSignal.timeout(10_000) },
+)
+  .then((response) =>
+    response.ok
+      ? response.json()
+      : Promise.reject(new Error(`HTTP ${response.status}`)),
+  )
+  .catch((error) => {
+    console.warn(
+      `\n⚠ [identity] Could not fetch the canonical Person entity (${error.message}).\n` +
+        `  Falling back to the committed snapshot — this build may ship a stale identity.\n`,
+    );
+    return identitySnapshot;
+  });
+
+/**
+ * Topics specific to this project, kept alongside the canonical expertise list
+ * rather than replacing it. `knowsAbout` is multi-valued, so the two sets merge
+ * instead of conflicting — which is why these may stay local while the
+ * single-valued properties above may not. The full original set is listed, not
+ * just the entries the canonical lacks, so this site keeps asserting its own
+ * topics even if the canonical list changes.
+ */
+const projectTopics = [
+  {
+    '@type': 'Thing',
+    name: 'Acoustics',
+    '@id': 'http://www.wikidata.org/entity/Q82811',
+  },
+  {
+    '@type': 'Thing',
+    name: 'Signal processing',
+    '@id': 'http://www.wikidata.org/entity/Q208163',
+  },
+  {
+    '@type': 'Thing',
+    name: 'Psychoacoustics',
+    '@id': 'http://www.wikidata.org/entity/Q557399',
+  },
+  {
+    '@type': 'Thing',
+    name: 'Architectural acoustics',
+    '@id': 'http://www.wikidata.org/entity/Q2305951',
+  },
+  {
+    '@type': 'Thing',
+    name: 'Noise control',
+    '@id': 'http://www.wikidata.org/entity/Q1879301',
+  },
+  {
+    '@type': 'Thing',
+    name: 'Vibration',
+    '@id': 'http://www.wikidata.org/entity/Q3695508',
+  },
+  {
+    '@type': 'Thing',
+    name: 'Underwater acoustics',
+    '@id': 'http://www.wikidata.org/entity/Q1292425',
+  },
+  {
+    '@type': 'Thing',
+    name: 'Python',
+    '@id': 'http://www.wikidata.org/entity/Q28865',
+  },
+  {
+    '@type': 'Thing',
+    name: 'Embedded system',
+    '@id': 'http://www.wikidata.org/entity/Q193040',
+  },
+];
+
+/** Reads a `knowsAbout` entry's label, which may be a string or a Thing. */
+const topicName = (topic) =>
+  typeof topic === 'string' ? topic : (topic.name ?? '');
+
+/**
+ * Canonical topics first, then this project's own, de-duplicated by label
+ * (case-insensitively). Canonical entries win a collision because they carry a
+ * verified Wikidata `@id`.
+ */
+const personNode = (() => {
+  const canonical = canonicalPerson.knowsAbout ?? [];
+  const seen = new Set(canonical.map((t) => topicName(t).toLowerCase()));
+  return {
+    ...canonicalPerson,
+    knowsAbout: [
+      ...canonical,
+      ...projectTopics.filter((t) => !seen.has(topicName(t).toLowerCase())),
+    ],
+  };
+})();
+
 const jsonLd = JSON.stringify({
   '@context': 'https://schema.org',
   '@graph': [
-    {
-      '@type': 'Person',
-      '@id': authorId,
-      name: 'José Manuel Requena Plens',
-      alternateName: 'jmrplens',
-      // Matches the canonical node published at jmrp.io. Both sites claim the
-      // same `@id`, so where they disagreed a consumer merging them got two
-      // conflicting descriptions of one person; this side used to be the
-      // weaker of the two, missing the ORCID entirely.
-      jobTitle: 'R&D · Firmware & Software Engineer',
-      description:
-        'Firmware and software engineer in Valencia, Spain: industrial embedded systems, open-source tooling, and self-hosted infrastructure.',
-      url: authorUrl,
-      image: 'https://github.com/jmrplens.png',
-      identifier: {
-        '@type': 'PropertyValue',
-        propertyID: 'ORCID',
-        value: '0000-0003-1250-6212',
-        url: 'https://orcid.org/0000-0003-1250-6212',
-      },
-      // Wikidata-grounded rather than free text: a bare string leaves a model
-      // to guess which "Acoustics" is meant, an entity URI does not. Every QID
-      // below was checked against the Wikidata API.
-      knowsAbout: [
-        { '@type': 'Thing', name: 'Acoustics', '@id': 'http://www.wikidata.org/entity/Q82811' },
-        { '@type': 'Thing', name: 'Signal processing', '@id': 'http://www.wikidata.org/entity/Q208163' },
-        { '@type': 'Thing', name: 'Psychoacoustics', '@id': 'http://www.wikidata.org/entity/Q557399' },
-        { '@type': 'Thing', name: 'Architectural acoustics', '@id': 'http://www.wikidata.org/entity/Q2305951' },
-        { '@type': 'Thing', name: 'Noise control', '@id': 'http://www.wikidata.org/entity/Q1879301' },
-        { '@type': 'Thing', name: 'Vibration', '@id': 'http://www.wikidata.org/entity/Q3695508' },
-        { '@type': 'Thing', name: 'Underwater acoustics', '@id': 'http://www.wikidata.org/entity/Q1292425' },
-        { '@type': 'Thing', name: 'Python', '@id': 'http://www.wikidata.org/entity/Q28865' },
-        { '@type': 'Thing', name: 'Embedded system', '@id': 'http://www.wikidata.org/entity/Q193040' },
-      ],
-      sameAs: [
-        'https://github.com/jmrplens',
-        'https://www.linkedin.com/in/jmrplens',
-        'https://mstdn.jmrp.io/@jmrplens',
-        'https://bsky.app/profile/jmrp.io',
-        'https://matrix.to/#/@jmrplens:matrix.jmrp.io',
-        'https://keyoxide.org/0A993B268654DBBA52B7E8D3FCF653391E2C91FC',
-        'https://scholar.google.com/citations?user=9b0kPaUAAAAJ',
-        'https://orcid.org/0000-0003-1250-6212',
-        'https://www.researchgate.net/profile/Jose-Requena-Plens-2',
-        'https://www.mathworks.com/matlabcentral/profile/authors/5890853',
-      ],
-    },
+    // The canonical Person entity, fetched at build time — see the
+    // "Canonical identity" block above. Spliced verbatim so this document
+    // and jmrp.io describe the same node with the same values, instead of
+    // two hand-maintained copies that drift.
+    personNode,
     {
       '@type': 'WebSite',
       '@id': websiteId,
@@ -263,6 +341,10 @@ const jsonLd = JSON.stringify({
         priceCurrency: 'USD',
       },
       author: { '@id': authorId },
+      // Same three agents jmrp.io/projects/ emits for this @id, so the merged
+      // node states one consistent set instead of a partial one per document.
+      creator: { '@id': authorId },
+      maintainer: { '@id': authorId },
       sameAs: [
         'https://pypi.org/project/phonometry/',
         'https://doi.org/10.5281/zenodo.21215280',
@@ -279,6 +361,10 @@ const jsonLd = JSON.stringify({
       license: 'https://opensource.org/licenses/MIT',
       isPartOf: { '@id': softwareId },
       author: { '@id': authorId },
+      // Same three agents jmrp.io/projects/ emits for this @id, so the merged
+      // node states one consistent set instead of a partial one per document.
+      creator: { '@id': authorId },
+      maintainer: { '@id': authorId },
     },
   ],
 });

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -271,12 +271,25 @@ const topicName = (topic) =>
  */
 const personNode = (() => {
   const canonical = canonicalPerson.knowsAbout ?? [];
-  const seen = new Set(canonical.map((t) => topicName(t).toLowerCase()));
+  const seenNames = new Set(canonical.map((t) => topicName(t).toLowerCase()));
+  // De-duplicating on the label alone is not enough. This project lists
+  // "Embedded system" where the canonical says "Embedded Systems", and both
+  // carry Wikidata Q193040 — so a name comparison let both through and emitted
+  // two Thing nodes under one @id with conflicting names. That is the exact
+  // contradiction this change exists to remove, reintroduced one level down.
+  // The @id is the identity; the label is only how a document spells it.
+  const seenIds = new Set(
+    canonical
+      .map((t) => (typeof t === 'object' ? t['@id'] : undefined))
+      .filter(Boolean),
+  );
   return {
     ...canonicalPerson,
     knowsAbout: [
       ...canonical,
-      ...projectTopics.filter((t) => !seen.has(topicName(t).toLowerCase())),
+      ...projectTopics.filter(
+        (t) => !seenNames.has(topicName(t).toLowerCase()) && !seenIds.has(t['@id']),
+      ),
     ],
   };
 })();

--- a/site/identity/person.snapshot.json
+++ b/site/identity/person.snapshot.json
@@ -1,0 +1,179 @@
+{
+  "@context": "https://schema.org",
+  "@type": "Person",
+  "@id": "https://jmrp.io/#person",
+  "name": "José Manuel Requena Plens",
+  "alternateName": [
+    "jmrplens",
+    "José M. Requena-Plens",
+    "Jose M. Requena-Plens",
+    "José M. Requena Plens",
+    "Jose M. Requena Plens",
+    "José Manuel Requena-Plens",
+    "Jose Manuel Requena-Plens",
+    "Jose Manuel Requena Plens"
+  ],
+  "jobTitle": "R&D · Firmware & Software Engineer",
+  "description": "Firmware and software engineer in Valencia, Spain — industrial embedded systems, open-source tooling, and self-hosted infrastructure.",
+  "url": "https://jmrp.io/",
+  "image": {
+    "@type": "ImageObject",
+    "url": "https://github.com/jmrplens.png",
+    "width": "460",
+    "height": "460"
+  },
+  "knowsAbout": [
+    {
+      "@type": "Thing",
+      "name": "Embedded Systems",
+      "@id": "http://www.wikidata.org/entity/Q193040"
+    },
+    {
+      "@type": "Thing",
+      "name": "Firmware",
+      "@id": "http://www.wikidata.org/entity/Q104851"
+    },
+    {
+      "@type": "Thing",
+      "name": "STM32",
+      "@id": "http://www.wikidata.org/entity/Q7394773"
+    },
+    {
+      "@type": "Thing",
+      "name": "FreeRTOS",
+      "@id": "http://www.wikidata.org/entity/Q1186761"
+    },
+    {
+      "@type": "Thing",
+      "name": "Modbus",
+      "@id": "http://www.wikidata.org/entity/Q1135322"
+    },
+    {
+      "@type": "Thing",
+      "name": "Cryptography",
+      "@id": "http://www.wikidata.org/entity/Q8789"
+    },
+    {
+      "@type": "Thing",
+      "name": "Network Security",
+      "@id": "http://www.wikidata.org/entity/Q989632"
+    },
+    {
+      "@type": "Thing",
+      "name": "Nginx",
+      "@id": "http://www.wikidata.org/entity/Q306144"
+    },
+    {
+      "@type": "Thing",
+      "name": "MikroTik RouterOS",
+      "@id": "http://www.wikidata.org/entity/Q12036888"
+    },
+    {
+      "@type": "Thing",
+      "name": "WireGuard",
+      "@id": "http://www.wikidata.org/entity/Q28975568"
+    },
+    {
+      "@type": "Thing",
+      "name": "IPv6",
+      "@id": "http://www.wikidata.org/entity/Q2551624"
+    },
+    {
+      "@type": "Thing",
+      "name": "Acoustics",
+      "@id": "http://www.wikidata.org/entity/Q82811"
+    },
+    {
+      "@type": "Thing",
+      "name": "Signal Processing",
+      "@id": "http://www.wikidata.org/entity/Q208163"
+    },
+    {
+      "@type": "Thing",
+      "name": "Go",
+      "@id": "http://www.wikidata.org/entity/Q37227"
+    },
+    {
+      "@type": "Thing",
+      "name": "Model Context Protocol",
+      "@id": "http://www.wikidata.org/entity/Q133436854"
+    },
+    {
+      "@type": "Thing",
+      "name": "CI/CD",
+      "@id": "http://www.wikidata.org/entity/Q28136854"
+    },
+    {
+      "@type": "Thing",
+      "name": "DevSecOps",
+      "@id": "http://www.wikidata.org/entity/Q108525696"
+    },
+    {
+      "@type": "Thing",
+      "name": "Software Testing",
+      "@id": "http://www.wikidata.org/entity/Q188522"
+    },
+    {
+      "@type": "Thing",
+      "name": "ESP32",
+      "@id": "http://www.wikidata.org/entity/Q27921668"
+    }
+  ],
+  "owns": [
+    {
+      "@id": "https://github.com/jmrplens/gitlab-mcp-server#software"
+    },
+    {
+      "@id": "https://github.com/jmrplens/phonometry#software"
+    },
+    {
+      "@id": "https://github.com/jmrplens/cs-routeros-bouncer#software"
+    },
+    {
+      "@id": "https://github.com/jmrplens/Cloudflare-DNS-Updater#software"
+    },
+    {
+      "@id": "https://github.com/jmrplens/libgen-mcp#software"
+    },
+    {
+      "@id": "https://github.com/jmrplens/TFG-TFM_EPS#software"
+    },
+    {
+      "@id": "https://github.com/jmrplens/A-Lab#software"
+    },
+    {
+      "@id": "https://github.com/jmrplens/mastodon_official_profiles#software"
+    },
+    {
+      "@id": "https://github.com/jmrplens/SetFigPaper#software"
+    },
+    {
+      "@id": "https://github.com/jmrplens/LoVE-BASS#software"
+    },
+    {
+      "@id": "https://github.com/jmrplens/FDTDexamples#software"
+    }
+  ],
+  "identifier": {
+    "@type": "PropertyValue",
+    "propertyID": "ORCID",
+    "value": "0000-0003-1250-6212",
+    "url": "https://orcid.org/0000-0003-1250-6212"
+  },
+  "sameAs": [
+    "https://github.com/jmrplens",
+    "https://www.linkedin.com/in/jmrplens",
+    "https://mstdn.jmrp.io/@jmrplens",
+    "https://bsky.app/profile/jmrp.io",
+    "https://matrix.to/#/@jmrplens:matrix.jmrp.io",
+    "https://keyoxide.org/0A993B268654DBBA52B7E8D3FCF653391E2C91FC",
+    "https://scholar.google.com/citations?user=9b0kPaUAAAAJ",
+    "https://orcid.org/0000-0003-1250-6212",
+    "https://www.researchgate.net/profile/Jose-Requena-Plens-2",
+    "https://www.mathworks.com/matlabcentral/profile/authors/5890853",
+    "https://codeberg.org/jmrplens",
+    "https://gitlab.com/jmrp",
+    "https://pypi.org/user/jmrplens/",
+    "https://hub.docker.com/u/jmrplens"
+  ]
+}

--- a/site/package.json
+++ b/site/package.json
@@ -9,6 +9,7 @@
     "check:i18n": "node scripts/check-i18n-parity.mjs",
     "dev": "astro dev",
     "build": "astro build",
+    "identity:sync": "node scripts/sync-identity.mjs",
     "preview": "astro preview",
     "html-validate": "html-validate 'dist/**/*.html'",
     "pa11y": "astro preview & PREVIEW_PID=$!; sleep 3 && pa11y-ci; EXIT=$?; kill $PREVIEW_PID 2>/dev/null; exit $EXIT"

--- a/site/scripts/sync-identity.mjs
+++ b/site/scripts/sync-identity.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+/**
+ * Refreshes the committed snapshot of the canonical `#person` entity.
+ *
+ * The build fetches the live document (see `astro.config.mjs`); this snapshot
+ * is only the offline fallback. Refresh it deliberately — via this script, in
+ * its own commit — so the identity this site would ship without a network is
+ * visible in review rather than silently frozen at whatever it was on the day
+ * the file was first added.
+ *
+ * Usage:
+ *   node scripts/sync-identity.mjs           # write the snapshot
+ *   node scripts/sync-identity.mjs --check   # fail if it is stale
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import process from "node:process";
+
+const SOURCE =
+	"https://raw.githubusercontent.com/jmrplens/jmrp.io/main/public/identity/person.jsonld";
+const TARGET = new URL("../identity/person.snapshot.json", import.meta.url);
+
+const response = await fetch(SOURCE, { signal: AbortSignal.timeout(15_000) });
+if (!response.ok) {
+	console.error(`✗ Could not fetch ${SOURCE} — HTTP ${response.status}`);
+	process.exit(1);
+}
+const latest = `${JSON.stringify(await response.json(), null, 2)}\n`;
+
+if (process.argv.includes("--check")) {
+	const committed = readFileSync(TARGET, "utf8");
+	if (committed !== latest) {
+		console.error(
+			"✗ identity/person.snapshot.json is stale.\n" +
+				"  Refresh it with: pnpm run identity:sync",
+		);
+		process.exit(1);
+	}
+	console.log("✓ Identity snapshot matches the canonical document.");
+} else {
+	writeFileSync(TARGET, latest);
+	console.log("✓ Refreshed identity/person.snapshot.json");
+}

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -10,6 +10,14 @@ const text =
   lang === 'es'
     ? 'Creado y mantenido por'
     : 'Created and maintained by';
+
+// The maintainer's project index. Gives a reader — and a crawler — a path from
+// this project to the whole portfolio, where every #software node in the
+// identity graph is listed together. Not ` + String.fromCharCode(96) + `rel="me"` + String.fromCharCode(96) + `: it is a page, not an
+// identity profile.
+const projectsUrl =
+  lang === 'es' ? 'https://jmrp.io/es/projects/' : 'https://jmrp.io/projects/';
+const projectsText = lang === 'es' ? 'Todos los proyectos' : 'All projects';
 ---
 
 <Default><slot /></Default>
@@ -18,6 +26,7 @@ const text =
   <a href="https://jmrp.io" rel="author">José Manuel Requena Plens</a>
   · <a href="https://github.com/jmrplens/phonometry">GitHub</a>
   · <a href="https://pypi.org/project/phonometry/">PyPI</a>
+  · <a href={projectsUrl}>{projectsText}</a>
 </div>
 
 <style>

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -13,7 +13,7 @@ const text =
 
 // The maintainer's project index. Gives a reader — and a crawler — a path from
 // this project to the whole portfolio, where every #software node in the
-// identity graph is listed together. Not ` + String.fromCharCode(96) + `rel="me"` + String.fromCharCode(96) + `: it is a page, not an
+// identity graph is listed together. Not `rel="me"`: it is a page, not an
 // identity profile.
 const projectsUrl =
   lang === 'es' ? 'https://jmrp.io/es/projects/' : 'https://jmrp.io/projects/';


### PR DESCRIPTION
Completes the rollout across the six sites publishing `https://jmrp.io/#person`. This one was held back while the docs were being rewritten.

## The drift this found

The Person node here carried a comment stating it matched the canonical entity. **It did not.**

```
canonical : …in Valencia, Spain — industrial embedded systems…
this site : …in Valencia, Spain: industrial embedded systems…
```

A colon where the canonical has an em dash. Two documents claiming the same `@id` with different single-valued `description`s — invisible to the eye, sitting right underneath a comment asserting they agreed.

That is the **third** drift this hand-mirroring convention produced across five sites, and the most subtle. The others were a wrong job title and an avatar URL that had started returning 404.

## Change

The node is fetched at build time from the canonical document and spliced verbatim, so both documents describe the same entity **by construction** rather than by discipline.

```
raw.githubusercontent.com/jmrplens/jmrp.io/main/public/identity/person.jsonld
```

Fetched from GitHub rather than `https://jmrp.io` on purpose: this build runs on a CI runner, and jmrp.io sits behind Cloudflare, CrowdSec and a MikroTik bouncer — the one place a blocked runner IP would silently degrade this site to a stale snapshot. GitHub serves the same bytes and is already a hard dependency of the build.

## What it gains

| | Before | After |
| --- | --- | --- |
| `alternateName` | `"jmrplens"` | **8 observed variants**, including `José M. Requena-Plens` — the form **every published paper cites**, and one this site had particular reason to carry |
| `sameAs` | 9 | **14** |
| `owns` | absent | **11 projects** |
| `description` | diverged | canonical, by construction |

## Deliberate choices

- **The nine acoustics topics stay local and are merged, not replaced.** `knowsAbout` is multi-valued, so Psychoacoustics, Architectural acoustics, Noise control, Vibration and Underwater acoustics reinforce the canonical list rather than conflicting with it. Result: **26 topics, no duplicates**.
- **`creator` + `maintainer` added alongside `author`** on the software nodes, matching the three agents `jmrp.io/projects/` emits for those `@id`s.
- **Footer link to the project index**, localized. Not `rel="me"`: it is a page, not an identity profile.
- **`pnpm run identity:sync`** refreshes the committed snapshot deliberately, so the identity this site would ship without a network is visible in review.

## Verification

Built and re-parsed out of the built HTML:

```
props identical to canonical : YES
extra props                  : none
alternateName 8 · owns 11 · sameAs 14
knowsAbout 26 (canonical 19 + this project's 7), no duplicates
node inventory: Person, SoftwareApplication, SoftwareSourceCode, WebSite  (unchanged)
agents: author, creator, maintainer on both software nodes
footer link to /projects/: yes
```

The full node inventory was compared before and after — not just the `Person` — after an earlier attempt in this rollout silently deleted two sibling nodes while still producing a green build.

https://claude.ai/code/session_01Ecf6hESxYdc7f1UV1vHrQU

## Summary by Sourcery

Fetch the canonical Person entity from jmrp.io at build time, merge in project-specific topics, and use the shared node across the identity graph and UI.

New Features:
- Link the site footer to the maintainer’s localized project index page to expose the full project portfolio.
- Add a script and npm task to refresh or verify the committed offline snapshot of the canonical Person identity.

Enhancements:
- Replace the locally defined Person node with the canonical identity document, ensuring schema.org metadata stays in sync with jmrp.io by construction.
- Extend software nodes to include creator and maintainer agents alongside author for consistency with jmrp.io’s project metadata.
- Enrich the Person node’s knowsAbout list by merging canonical expertise topics with this project’s acoustics-related topics without duplicates.

Build:
- Integrate identity fetching and merging logic into the Astro build configuration, with a GitHub-backed fallback snapshot for offline or fetch-failure scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a localized Projects link and an additional maintainer hyperlink in the site footer.
  * Enhanced structured profile metadata by sourcing canonical identity data and merging topic coverage with deduplication.

* **Maintenance**
  * Added an offline identity snapshot to keep builds reliable when remote identity data is unavailable.
  * Introduced an `identity:sync` command to refresh and optionally verify the snapshot against freshly fetched JSON-LD.
  * Ensured consistent `creator`/`maintainer` identifiers across related software metadata nodes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->