### PR TITLE
GPU runner scaffolding for the FDTD animation fields

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@ PHONO_GPU_HOST=192.168.1.100
 PHONO_GPU_USER=gpuuser
 
 # Human label used in runner messages and benchmark reports.
-PHONO_GPU_NAME=lab GPU
+PHONO_GPU_NAME="lab GPU"
 
 # Docker image providing python3 + CuPy with CUDA support. The default is
 # verified against NVIDIA driver 570 on an RTX 4060.

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,26 @@
+# Remote GPU runner for the animation FDTD fields (scripts/fdtd_gpu_remote.py).
+# Copy to .env (gitignored) and adjust; real environment variables take
+# precedence over this file. Leave PHONO_GPU_HOST empty (or omit the file)
+# to run everything locally on NumPy.
+#
+# The host needs: SSH key access for PHONO_GPU_USER, Docker with the NVIDIA
+# runtime (docker run --gpus all) and enough disk in PHONO_GPU_WORKDIR for
+# per-job directories (created and removed automatically per run).
+#
+# The values below are placeholders; replace them with your own machine.
+
+# SSH host name or address of the CUDA machine.
+PHONO_GPU_HOST=192.168.1.100
+
+# SSH user on the host (key-based, no password prompts).
+PHONO_GPU_USER=gpuuser
+
+# Human label used in runner messages and benchmark reports.
+PHONO_GPU_NAME=lab GPU
+
+# Docker image providing python3 + CuPy with CUDA support. The default is
+# verified against NVIDIA driver 570 on an RTX 4060.
+PHONO_GPU_DOCKER_IMAGE=cupy/cupy:v13.6.0
+
+# Remote directory for per-job staging (created if missing).
+PHONO_GPU_WORKDIR=/srv/phonometry-gpu

--- a/scripts/fdtd_gpu.py
+++ b/scripts/fdtd_gpu.py
@@ -58,6 +58,14 @@ def _integer(name: str, value: int) -> int:
     return int(value)
 
 
+def _resolve_cfl(cfl: float) -> float:
+    """Validate the Courant number into a float strictly inside (0, 1)."""
+    out = float(cfl)
+    if not np.isfinite(out) or not 0.0 < out < 1.0:
+        raise ValueError("cfl must lie in (0, 1)")
+    return out
+
+
 def _positive_map(name: str, field: Field2D) -> None:
     """Validate that every cell of *field* is strictly positive and finite."""
     if not np.all(np.isfinite(field)) or bool(np.any(field <= 0.0)):
@@ -109,6 +117,21 @@ def _resolve_rho_map(rho: float | Field2D, ny: int, nx: int) -> Field2D:
     return rho_map
 
 
+def _resolve_damping(damping: float | NDArray[np.float64],
+                     ny: int, nx: int) -> NDArray[np.float64]:
+    """Validate the damping spec into a non-negative 0D or ``(ny, nx)`` array."""
+    damping_map = np.asarray(damping, dtype=np.float64)
+    if damping_map.ndim not in (0, 2):
+        raise ValueError("damping must be a scalar or an (ny, nx) map")
+    if not np.all(np.isfinite(damping_map)) or np.any(damping_map < 0.0):
+        raise ValueError("damping must be non-negative and finite")
+    if damping_map.ndim == 2 and damping_map.shape != (ny, nx):
+        raise ValueError(
+            f"damping map shape {damping_map.shape} does not match the "
+            f"grid {(ny, nx)}")
+    return damping_map
+
+
 def _resolve_sponge_sides(sponge_sides: Any) -> tuple[str, ...]:
     """Normalise the sponge-side spec into a validated tuple of side names."""
     if sponge_sides is None:
@@ -137,6 +160,53 @@ def _edge_impedance_profile(side: str, value: float | NDArray[np.float64],
         raise ValueError(f"impedance for side {side!r} must be "
                          "strictly positive and finite")
     return z
+
+
+def _resolve_edge_impedance(
+    edge_impedance: dict[str, float | NDArray[np.float64]] | None,
+    sponge_width: int,
+    sponge_sides: tuple[str, ...],
+    ny: int,
+    nx: int,
+) -> dict[str, Field2D]:
+    """Validate the per-side impedance spec into 1D per-edge-cell profiles.
+
+    Rejects unknown side names and sides that are absorbing (sponge) at the
+    same time; scalars are broadcast to the edge length. The returned dict
+    iterates in the deterministic ``_SIDES`` order.
+    """
+    if not edge_impedance:
+        return {}
+    unknown = set(edge_impedance) - set(_SIDES)
+    if unknown:
+        raise ValueError(f"unknown impedance sides: {sorted(unknown)}")
+    absorbing = set(sponge_sides) if sponge_width > 0 else set()
+    profiles: dict[str, Field2D] = {}
+    for side in _SIDES:                          # deterministic order
+        if side not in edge_impedance:
+            continue
+        if side in absorbing:
+            raise ValueError(f"side {side!r} cannot be both absorbing "
+                             "and an impedance boundary")
+        n_edge = ny if side in ("left", "right") else nx
+        profiles[side] = _edge_impedance_profile(side, edge_impedance[side],
+                                                 n_edge)
+    return profiles
+
+
+def _resolve_obstacle_mask(obstacle_mask: NDArray[np.bool_] | None,
+                           ny: int, nx: int) -> NDArray[np.bool_] | None:
+    """Validate the obstacle spec into a boolean ``(ny, nx)`` map (or None)."""
+    if obstacle_mask is None:
+        return None
+    mask = np.asarray(obstacle_mask)
+    if mask.shape != (ny, nx):
+        raise ValueError("obstacle_mask must match the grid shape")
+    if mask.dtype != np.bool_:
+        raise ValueError("obstacle_mask must be a boolean array")
+    if bool(mask.all()):
+        raise ValueError("obstacle_mask must leave open cells")
+    return mask
 
 
 class _ImpedanceEdge:
@@ -224,8 +294,7 @@ class GpuFDTD2D:
         obstacle_mask: NDArray[np.bool_] | None = None,
     ) -> None:
         c_map = _resolve_c_map(c, shape)
-        if not np.isfinite(cfl) or not 0.0 < cfl < 1.0:
-            raise ValueError("cfl must lie in (0, 1)")
+        cfl = _resolve_cfl(cfl)
         ny, nx = c_map.shape
         rho_map = _resolve_rho_map(rho, ny, nx)
         sponge_width = _integer("sponge_width", sponge_width)
@@ -237,15 +306,7 @@ class GpuFDTD2D:
         if not 0.0 < sponge_reflection < 1.0:
             raise ValueError("sponge_reflection must lie strictly between "
                              "0 and 1")
-        damping_map = np.asarray(damping, dtype=np.float64)
-        if damping_map.ndim not in (0, 2):
-            raise ValueError("damping must be a scalar or an (ny, nx) map")
-        if not np.all(np.isfinite(damping_map)) or np.any(damping_map < 0.0):
-            raise ValueError("damping must be non-negative and finite")
-        if damping_map.ndim == 2 and damping_map.shape != (ny, nx):
-            raise ValueError(
-                f"damping map shape {damping_map.shape} does not match the "
-                f"grid {(ny, nx)}")
+        damping_map = _resolve_damping(damping, ny, nx)
 
         self._xp = xp
         self.dx = _positive_finite("dx", dx)
@@ -298,42 +359,21 @@ class GpuFDTD2D:
         nx: int,
     ) -> list[_ImpedanceEdge]:
         """Validate the per-side impedance spec into edge updaters."""
-        edges: list[_ImpedanceEdge] = []
-        if not edge_impedance:
-            return edges
-        unknown = set(edge_impedance) - set(_SIDES)
-        if unknown:
-            raise ValueError(f"unknown impedance sides: {sorted(unknown)}")
-        absorbing = set(sponge_sides) if sponge_width > 0 else set()
+        profiles = _resolve_edge_impedance(edge_impedance, sponge_width,
+                                           sponge_sides, ny, nx)
         rho_edges = {"left": rho_map[:, 0], "right": rho_map[:, -1],
                      "top": rho_map[0, :], "bottom": rho_map[-1, :]}
-        for side in _SIDES:                      # deterministic order
-            if side not in edge_impedance:
-                continue
-            if side in absorbing:
-                raise ValueError(f"side {side!r} cannot be both absorbing "
-                                 "and an impedance boundary")
-            n_edge = ny if side in ("left", "right") else nx
-            z = _edge_impedance_profile(side, edge_impedance[side], n_edge)
-            edges.append(_ImpedanceEdge(self._xp, side, z, rho_edges[side],
-                                        self.dt, self.dx))
-        return edges
+        return [_ImpedanceEdge(self._xp, side, z, rho_edges[side],
+                               self.dt, self.dx)
+                for side, z in profiles.items()]
 
     def _init_obstacle(self, obstacle_mask: NDArray[np.bool_] | None,
                        ny: int, nx: int) -> None:
         """Validate the obstacle mask into closed-face velocity factors."""
         self._vx_open: XPArray | None = None
         self._vy_open: XPArray | None = None
-        if obstacle_mask is None:
-            return
-        mask = np.asarray(obstacle_mask)
-        if mask.shape != (ny, nx):
-            raise ValueError("obstacle_mask must match the grid shape")
-        if mask.dtype != np.bool_:
-            raise ValueError("obstacle_mask must be a boolean array")
-        if bool(mask.all()):
-            raise ValueError("obstacle_mask must leave open cells")
-        if bool(mask.any()):
+        mask = _resolve_obstacle_mask(obstacle_mask, ny, nx)
+        if mask is not None and bool(mask.any()):
             xp = self._xp
             self._vx_open = xp.asarray(
                 (~(mask[:, 1:] | mask[:, :-1])).astype(np.float64))

--- a/scripts/fdtd_gpu.py
+++ b/scripts/fdtd_gpu.py
@@ -1,0 +1,444 @@
+#  Copyright (c) 2026. Jose M. Requena-Plens
+"""GPU-portable 2D acoustic FDTD stepping engine for the animation renders.
+
+A backend-agnostic replica of the leapfrog scheme of
+``phonometry.simulation.fdtd.FDTD2D`` restricted to the feature subset the
+documentation animations use: per-cell sound-speed and density maps, rigid
+walls by construction, graded sponge layers, per-side real-impedance edges,
+scalar or per-cell bulk damping, rasterised rigid obstacles and the one-way
+plane-wave initial condition. The array module is injected (the ``xp``
+parameter, NumPy or CuPy), so the same stepping code runs on the CPU or on
+an NVIDIA GPU without any change.
+
+The module is deliberately self-contained (NumPy is its only import) so it
+can be copied as a single file into a bare CuPy container by the remote
+runner (``fdtd_gpu_remote.py``); it must not import ``phonometry``.
+
+Numerical contract: with ``xp=numpy`` every update expression is written in
+the exact operation order of the library engine, so the pressure history is
+bit-identical to ``FDTD2D`` for the supported subset (the parity test in
+``tests/test_fdtd_gpu_parity.py`` locks this). All grid setup (validation,
+time step, face densities, decay maps, sponge profiles) is computed in
+float64 NumPy and only then transferred to the backend, so a GPU run departs
+from the CPU run only through the floating-point reassociation of the
+backend's elementwise kernels, at the ULP level.
+
+Scheme reference: Attenborough & Van Renterghem, *Predicting Outdoor Sound*
+(2nd ed., CRC Press 2021), chapter 4; see the library module docstring for
+the equation-by-equation mapping.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+Field2D = NDArray[np.float64]
+#: Backend array: ``numpy.ndarray`` or ``cupy.ndarray`` depending on ``xp``.
+XPArray = Any
+
+_SIDES = ("left", "right", "top", "bottom")
+_SIDE_TRAVEL = ("down", "up", "left", "right")
+
+
+def _positive_finite(name: str, value: float) -> float:
+    """Validate that *value* is a strictly positive finite scalar."""
+    out = float(value)
+    if not np.isfinite(out) or out <= 0.0:
+        raise ValueError(f"{name} must be positive and finite")
+    return out
+
+
+def _integer(name: str, value: int) -> int:
+    """Validate that *value* is an integral scalar (bool is rejected)."""
+    if isinstance(value, bool) or not isinstance(value, (int, np.integer)):
+        raise ValueError(f"{name} must be an integer")  # noqa: TRY004 - ValueError keeps the module validation errors uniform
+    return int(value)
+
+
+def _positive_map(name: str, field: Field2D) -> None:
+    """Validate that every cell of *field* is strictly positive and finite."""
+    if not np.all(np.isfinite(field)) or bool(np.any(field <= 0.0)):
+        raise ValueError(f"{name} must be strictly positive and finite "
+                         "everywhere")
+
+
+def _sponge_profile(n: int, width: int, sides: tuple[bool, bool],
+                    sigma_max: float) -> Field2D:
+    """1D absorption rate sigma(i) [1/s]: quadratic ramp into each sponge side.
+
+    ``sides`` selects (low-index side, high-index side). Identical to the
+    library helper of the same name.
+    """
+    sigma = np.zeros(n, dtype=np.float64)
+    if width <= 0:
+        return sigma
+    depth = (width - np.arange(width, dtype=np.float64)) / width
+    ramp = sigma_max * depth**2
+    if sides[0]:
+        sigma[:width] = np.maximum(sigma[:width], ramp)
+    if sides[1]:
+        sigma[n - width:] = np.maximum(sigma[n - width:], ramp[::-1])
+    return sigma
+
+
+def _resolve_c_map(c: float | Field2D,
+                   shape: tuple[int, int] | None) -> Field2D:
+    """Broadcast/validate the sound-speed spec into a positive 2D map."""
+    if np.isscalar(c):
+        if shape is None:
+            raise ValueError("shape is required when c is a scalar")
+        c_map = np.full(shape, float(np.real(c)), dtype=np.float64)
+    else:
+        c_map = np.asarray(c, dtype=np.float64)
+    if c_map.ndim != 2:
+        raise ValueError("c must be a 2D (ny, nx) map")
+    _positive_map("c", c_map)
+    return c_map
+
+
+def _resolve_rho_map(rho: float | Field2D, ny: int, nx: int) -> Field2D:
+    """Broadcast/validate the density spec into a positive ``(ny, nx)`` map."""
+    rho_map = (np.full((ny, nx), float(np.real(rho)), dtype=np.float64)
+               if np.isscalar(rho) else np.asarray(rho, dtype=np.float64))
+    if rho_map.shape != (ny, nx):
+        raise ValueError("rho map must match the shape of c")
+    _positive_map("rho", rho_map)
+    return rho_map
+
+
+def _resolve_sponge_sides(sponge_sides: Any) -> tuple[str, ...]:
+    """Normalise the sponge-side spec into a validated tuple of side names."""
+    if sponge_sides is None:
+        sides: tuple[str, ...] = _SIDES
+    elif isinstance(sponge_sides, str):
+        sides = (sponge_sides,)
+    else:
+        sides = tuple(sponge_sides)
+    unknown = set(sides) - set(_SIDES)
+    if unknown:
+        raise ValueError(f"unknown sponge sides: {sorted(unknown)}")
+    return sides
+
+
+def _edge_impedance_profile(side: str, value: float | NDArray[np.float64],
+                            n_edge: int) -> Field2D:
+    """Broadcast/validate one side's impedance into a positive 1D profile."""
+    z = np.asarray(value, dtype=np.float64)
+    if z.ndim == 0:
+        z = np.full(n_edge, float(z), dtype=np.float64)
+    if z.shape != (n_edge,):
+        raise ValueError(
+            f"impedance for side {side!r} must be a scalar or a 1D "
+            f"array of length {n_edge}")
+    if not np.all(np.isfinite(z)) or bool(np.any(z <= 0.0)):
+        raise ValueError(f"impedance for side {side!r} must be "
+                         "strictly positive and finite")
+    return z
+
+
+class _ImpedanceEdge:
+    """One locally reacting boundary side with a real specific impedance.
+
+    Backend-portable replica of the library ``_ImpedanceEdge``: coefficients
+    ``c1 = (1 - a) / (1 + a)`` and ``c2 = (2 dt / (rho dx)) / (1 + a)`` with
+    ``a = dt Z / (rho dx)``, computed in NumPy and transferred to ``xp``.
+    """
+
+    __slots__ = ("c1", "c2", "side", "vb")
+
+    def __init__(self, xp: Any, side: str, impedance: Field2D,
+                 rho_edge: Field2D, dt: float, dx: float) -> None:
+        self.side = side
+        a = dt * impedance / (rho_edge * dx)
+        self.c1: XPArray = xp.asarray((1.0 - a) / (1.0 + a))
+        self.c2: XPArray = xp.asarray((2.0 * dt / (rho_edge * dx)) / (1.0 + a))
+        self.vb: XPArray = xp.zeros(impedance.shape, dtype=np.float64)
+
+    def update(self, p: XPArray) -> None:
+        """Advance the boundary-face velocity by one leapfrog step."""
+        if self.side == "left":
+            self.vb = self.c1 * self.vb - self.c2 * p[:, 0]
+        elif self.side == "right":
+            self.vb = self.c1 * self.vb + self.c2 * p[:, -1]
+        elif self.side == "top":
+            self.vb = self.c1 * self.vb - self.c2 * p[0, :]
+        else:                                          # bottom
+            self.vb = self.c1 * self.vb + self.c2 * p[-1, :]
+
+    def add_flux(self, div: XPArray) -> None:
+        """Add the boundary-face flux to the velocity divergence."""
+        if self.side == "left":
+            div[:, 0] -= self.vb
+        elif self.side == "right":
+            div[:, -1] += self.vb
+        elif self.side == "top":
+            div[0, :] -= self.vb
+        else:                                          # bottom
+            div[-1, :] += self.vb
+
+
+class GpuFDTD2D:
+    """2D acoustic FDTD stepping engine with an injectable array backend.
+
+    Same staggered grid as the library engine: pressure ``p`` at cell
+    centres, shape ``(ny, nx)``; ``vx`` at interior x-faces ``(ny, nx - 1)``;
+    ``vy`` at interior y-faces ``(ny - 1, nx)``. The domain boundary is
+    rigid by construction; sponges and impedance edges soften selected
+    sides. Time step: ``dt = cfl * dx / (c_max * sqrt(2))``.
+
+    :param c: Sound-speed map [m/s], shape ``(ny, nx)``, or a scalar with
+        an explicit ``shape``.
+    :param dx: Grid spacing [m] (square cells).
+    :param xp: Array module: ``numpy`` (default) or ``cupy``. All state
+        arrays (``p``, ``vx``, ``vy``, decay maps) live on this backend.
+    :param rho: Density map [kg/m3]; scalar or ``(ny, nx)`` array.
+    :param cfl: Courant number in ``(0, 1)``; default 0.6 as the library.
+    :param sponge_width: Absorbing-layer thickness in cells (0 = none).
+    :param sponge_sides: Side name or iterable of side names
+        (default: all four when ``sponge_width > 0``).
+    :param sponge_reflection: Target round-trip amplitude reflection.
+    :param damping: Bulk amplitude decay rate [1/s], scalar or map.
+    :param shape: Grid shape ``(ny, nx)``, required when ``c`` is scalar.
+    :param edge_impedance: Mapping side name -> real specific impedance
+        [Pa s/m], scalar or per-edge-cell 1D array.
+    :param obstacle_mask: Boolean ``(ny, nx)`` map of rigid cells.
+    """
+
+    def __init__(
+        self,
+        c: float | Field2D,
+        dx: float,
+        *,
+        xp: Any = np,
+        rho: float | Field2D = 1.2,
+        cfl: float = 0.6,
+        sponge_width: int = 0,
+        sponge_sides: Any = None,
+        sponge_reflection: float = 1e-4,
+        damping: float | NDArray[np.float64] = 0.0,
+        shape: tuple[int, int] | None = None,
+        edge_impedance: dict[str, float | NDArray[np.float64]] | None = None,
+        obstacle_mask: NDArray[np.bool_] | None = None,
+    ) -> None:
+        c_map = _resolve_c_map(c, shape)
+        if not np.isfinite(cfl) or not 0.0 < cfl < 1.0:
+            raise ValueError("cfl must lie in (0, 1)")
+        ny, nx = c_map.shape
+        rho_map = _resolve_rho_map(rho, ny, nx)
+        sponge_width = _integer("sponge_width", sponge_width)
+        if sponge_width < 0:
+            raise ValueError("sponge_width must be non-negative")
+        if sponge_width >= min(nx, ny):
+            raise ValueError("sponge_width must be narrower than the "
+                             "smallest grid side")
+        if not 0.0 < sponge_reflection < 1.0:
+            raise ValueError("sponge_reflection must lie strictly between "
+                             "0 and 1")
+        damping_map = np.asarray(damping, dtype=np.float64)
+        if damping_map.ndim not in (0, 2):
+            raise ValueError("damping must be a scalar or an (ny, nx) map")
+        if not np.all(np.isfinite(damping_map)) or np.any(damping_map < 0.0):
+            raise ValueError("damping must be non-negative and finite")
+        if damping_map.ndim == 2 and damping_map.shape != (ny, nx):
+            raise ValueError(
+                f"damping map shape {damping_map.shape} does not match the "
+                f"grid {(ny, nx)}")
+
+        self._xp = xp
+        self.dx = _positive_finite("dx", dx)
+        c_max = float(c_map.max())
+        #: Time step [s]: ``cfl * dx / (c_max * sqrt(2))``, as the library.
+        self.dt = cfl * self.dx / (c_max * float(np.sqrt(2.0)))
+        self._c_ref = float(c_map.mean())
+        kappa = rho_map * c_map**2               # bulk modulus at centres
+        rho_x = 0.5 * (rho_map[:, 1:] + rho_map[:, :-1])
+        rho_y = 0.5 * (rho_map[1:, :] + rho_map[:-1, :])
+
+        self.p: XPArray = xp.zeros((ny, nx), dtype=np.float64)
+        self.vx: XPArray = xp.zeros((ny, nx - 1), dtype=np.float64)
+        self.vy: XPArray = xp.zeros((ny - 1, nx), dtype=np.float64)
+        self._div: XPArray = xp.zeros((ny, nx), dtype=np.float64)
+        self.kappa: XPArray = xp.asarray(kappa)
+        self._rho_x: XPArray = xp.asarray(rho_x)
+        self._rho_x_np = rho_x                   # host copy for plane waves
+        self._rho_y: XPArray = xp.asarray(rho_y)
+        self._rho_y_np = rho_y
+        self.n = 0                               # completed steps
+
+        sides = _resolve_sponge_sides(sponge_sides)
+        sigma_max = 0.0
+        if sponge_width > 0:
+            sigma_max = (-3.0 * c_max * float(np.log(sponge_reflection))
+                         / (2.0 * sponge_width * self.dx))
+        sig_x = _sponge_profile(nx, sponge_width,
+                                ("left" in sides, "right" in sides), sigma_max)
+        sig_y = _sponge_profile(ny, sponge_width,
+                                ("top" in sides, "bottom" in sides), sigma_max)
+        sigma = sig_x[np.newaxis, :] + sig_y[:, np.newaxis] + damping_map
+        self._decay_p: XPArray = xp.asarray(np.exp(-sigma * self.dt))
+        self._decay_vx: XPArray = xp.asarray(np.exp(
+            -(0.5 * (sigma[:, 1:] + sigma[:, :-1])) * self.dt))
+        self._decay_vy: XPArray = xp.asarray(np.exp(
+            -(0.5 * (sigma[1:, :] + sigma[:-1, :])) * self.dt))
+
+        self._edges = self._build_edges(edge_impedance, sponge_width, sides,
+                                        rho_map, ny, nx)
+        self._init_obstacle(obstacle_mask, ny, nx)
+
+    def _build_edges(
+        self,
+        edge_impedance: dict[str, float | NDArray[np.float64]] | None,
+        sponge_width: int,
+        sponge_sides: tuple[str, ...],
+        rho_map: Field2D,
+        ny: int,
+        nx: int,
+    ) -> list[_ImpedanceEdge]:
+        """Validate the per-side impedance spec into edge updaters."""
+        edges: list[_ImpedanceEdge] = []
+        if not edge_impedance:
+            return edges
+        unknown = set(edge_impedance) - set(_SIDES)
+        if unknown:
+            raise ValueError(f"unknown impedance sides: {sorted(unknown)}")
+        absorbing = set(sponge_sides) if sponge_width > 0 else set()
+        rho_edges = {"left": rho_map[:, 0], "right": rho_map[:, -1],
+                     "top": rho_map[0, :], "bottom": rho_map[-1, :]}
+        for side in _SIDES:                      # deterministic order
+            if side not in edge_impedance:
+                continue
+            if side in absorbing:
+                raise ValueError(f"side {side!r} cannot be both absorbing "
+                                 "and an impedance boundary")
+            n_edge = ny if side in ("left", "right") else nx
+            z = _edge_impedance_profile(side, edge_impedance[side], n_edge)
+            edges.append(_ImpedanceEdge(self._xp, side, z, rho_edges[side],
+                                        self.dt, self.dx))
+        return edges
+
+    def _init_obstacle(self, obstacle_mask: NDArray[np.bool_] | None,
+                       ny: int, nx: int) -> None:
+        """Validate the obstacle mask into closed-face velocity factors."""
+        self._vx_open: XPArray | None = None
+        self._vy_open: XPArray | None = None
+        if obstacle_mask is None:
+            return
+        mask = np.asarray(obstacle_mask)
+        if mask.shape != (ny, nx):
+            raise ValueError("obstacle_mask must match the grid shape")
+        if mask.dtype != np.bool_:
+            raise ValueError("obstacle_mask must be a boolean array")
+        if bool(mask.all()):
+            raise ValueError("obstacle_mask must leave open cells")
+        if bool(mask.any()):
+            xp = self._xp
+            self._vx_open = xp.asarray(
+                (~(mask[:, 1:] | mask[:, :-1])).astype(np.float64))
+            self._vy_open = xp.asarray(
+                (~(mask[1:, :] | mask[:-1, :])).astype(np.float64))
+
+    @property
+    def time(self) -> float:
+        """Elapsed simulated time [s]."""
+        return self.n * self.dt
+
+    def add_plane_wave(
+        self,
+        direction: str,
+        *,
+        center: float,
+        width: float,
+        amplitude: float = 1.0,
+        wavelength: float | None = None,
+    ) -> None:
+        """Superimpose a one-way plane wave packet as an initial condition.
+
+        Replica of ``FDTD2D.add_plane_wave``: a Gaussian envelope
+        (optionally carrying a sine at ``wavelength``) written onto the
+        pressure, with the leapfrog-consistent particle velocity written a
+        half time step back (``profile(faces + sign * 0.5 * c_ref * dt)``,
+        divided by ``rho_face * c_ref`` with ``c_ref = mean(c)``), so the
+        packet propagates only toward ``direction``. Profiles are computed
+        in NumPy and added on the backend.
+
+        :param direction: ``"down"``, ``"up"``, ``"left"`` or ``"right"``.
+        :param center: Envelope centre along the travel axis [m].
+        :param width: Gaussian ``1/e`` half-width [m].
+        :param amplitude: Peak pressure of the envelope [Pa].
+        :param wavelength: Optional carrier wavelength [m].
+        """
+        if direction not in _SIDE_TRAVEL:
+            raise ValueError(
+                "'direction' must be 'down', 'up', 'left' or 'right'."
+            )
+        if width <= 0.0:
+            raise ValueError("'width' must be positive.")
+        if wavelength is not None and wavelength <= 0.0:
+            raise ValueError("'wavelength' must be positive.")
+
+        def profile(coord: NDArray[np.floating]) -> Field2D:
+            envelope = amplitude * np.exp(-(((coord - center) / width) ** 2))
+            if wavelength is not None:
+                envelope = envelope * np.sin(
+                    2.0 * np.pi * (coord - center) / wavelength
+                )
+            return np.asarray(envelope, dtype=np.float64)
+
+        xp = self._xp
+        ny, nx = self.p.shape
+        axis_y = direction in ("down", "up")
+        sign = 1.0 if direction in ("down", "right") else -1.0
+        c_ref = self._c_ref
+        if axis_y:
+            centres = (np.arange(ny) + 0.5) * self.dx
+            faces = np.arange(1, ny) * self.dx
+            self.p += xp.asarray(profile(centres)[:, np.newaxis])
+            v_prof = profile(faces + sign * 0.5 * c_ref * self.dt)
+            v_add = sign * v_prof[:, np.newaxis] / (self._rho_y_np * c_ref)
+            self.vy += xp.asarray(v_add)
+        else:
+            centres = (np.arange(nx) + 0.5) * self.dx
+            faces = np.arange(1, nx) * self.dx
+            self.p += xp.asarray(profile(centres)[np.newaxis, :])
+            v_prof = profile(faces + sign * 0.5 * c_ref * self.dt)
+            v_add = sign * v_prof[np.newaxis, :] / (self._rho_x_np * c_ref)
+            self.vx += xp.asarray(v_add)
+
+    def step(self) -> None:
+        """Advance the leapfrog scheme by one time step.
+
+        Update order is identical to the library engine: velocity from the
+        pressure gradient, obstacle face closure, velocity decay, impedance
+        edge update from the pre-step pressure, divergence scatter plus
+        edge flux, pressure update, pressure decay.
+        """
+        dt_dx = self.dt / self.dx
+        self.vx -= dt_dx / self._rho_x * (self.p[:, 1:] - self.p[:, :-1])
+        self.vy -= dt_dx / self._rho_y * (self.p[1:, :] - self.p[:-1, :])
+        if self._vx_open is not None and self._vy_open is not None:
+            self.vx *= self._vx_open
+            self.vy *= self._vy_open
+        self.vx *= self._decay_vx
+        self.vy *= self._decay_vy
+        for edge in self._edges:
+            edge.update(self.p)
+        div = self._div
+        div.fill(0.0)
+        div[:, :-1] += self.vx
+        div[:, 1:] -= self.vx
+        div[:-1, :] += self.vy
+        div[1:, :] -= self.vy
+        for edge in self._edges:
+            edge.add_flux(div)
+        self.p -= self.kappa * dt_dx * div
+        self.p *= self._decay_p
+        self.n += 1
+
+    def pressure(self) -> Field2D:
+        """The current pressure field as a host (NumPy) array copy."""
+        if hasattr(self.p, "get"):               # CuPy device array
+            return np.asarray(self.p.get(), dtype=np.float64)
+        return np.array(self.p, dtype=np.float64)

--- a/scripts/fdtd_gpu.py
+++ b/scripts/fdtd_gpu.py
@@ -117,6 +117,21 @@ def _resolve_rho_map(rho: float | Field2D, ny: int, nx: int) -> Field2D:
     return rho_map
 
 
+def _resolve_sponge(sponge_width: Any, sponge_reflection: float,
+                    ny: int, nx: int) -> tuple[int, float]:
+    """Validate the sponge configuration exactly as the library does."""
+    width = _integer("sponge_width", sponge_width)
+    if width < 0:
+        raise ValueError("sponge_width must be non-negative")
+    if width >= min(nx, ny):
+        raise ValueError("sponge_width must be narrower than the "
+                         "smallest grid side")
+    if not 0.0 < sponge_reflection < 1.0:
+        raise ValueError("sponge_reflection must lie strictly between "
+                         "0 and 1")
+    return width, float(sponge_reflection)
+
+
 def _resolve_damping(damping: float | NDArray[np.float64],
                      ny: int, nx: int) -> NDArray[np.float64]:
     """Validate the damping spec into a non-negative 0D or ``(ny, nx)`` array."""
@@ -297,15 +312,8 @@ class GpuFDTD2D:
         cfl = _resolve_cfl(cfl)
         ny, nx = c_map.shape
         rho_map = _resolve_rho_map(rho, ny, nx)
-        sponge_width = _integer("sponge_width", sponge_width)
-        if sponge_width < 0:
-            raise ValueError("sponge_width must be non-negative")
-        if sponge_width >= min(nx, ny):
-            raise ValueError("sponge_width must be narrower than the "
-                             "smallest grid side")
-        if not 0.0 < sponge_reflection < 1.0:
-            raise ValueError("sponge_reflection must lie strictly between "
-                             "0 and 1")
+        sponge_width, sponge_reflection = _resolve_sponge(
+            sponge_width, sponge_reflection, ny, nx)
         damping_map = _resolve_damping(damping, ny, nx)
 
         self._xp = xp

--- a/scripts/fdtd_gpu_remote.py
+++ b/scripts/fdtd_gpu_remote.py
@@ -177,7 +177,8 @@ def build_job(
     rho_map = fdtd_gpu._resolve_rho_map(rho, ny, nx)
     cfl = fdtd_gpu._resolve_cfl(cfl)
     steps = fdtd_gpu._integer("steps", steps)
-    sponge_width = fdtd_gpu._integer("sponge_width", sponge_width)
+    sponge_width, sponge_reflection = fdtd_gpu._resolve_sponge(
+        sponge_width, sponge_reflection, ny, nx)
     sample_stride = fdtd_gpu._integer("sample_stride", sample_stride)
     if sample_stride < 1:
         raise ValueError("sample_stride must be >= 1")

--- a/scripts/fdtd_gpu_remote.py
+++ b/scripts/fdtd_gpu_remote.py
@@ -157,7 +157,12 @@ def build_job(
     ``add_plane_wave`` (``direction``, ``center``, ``width`` and optional
     ``amplitude``/``wavelength``). ``sample_steps`` lists the step counts
     at which a pressure frame is recorded (0 = the initial state); every
-    entry must lie in ``[0, steps]``. ``init_scale_x`` is an optional 1D
+    entry must lie in ``[0, steps]`` and duplicates are dropped, so the
+    stored schedule is strictly increasing with one frame per entry.
+    ``cfl``, ``damping``, ``edge_impedance`` and ``obstacle_mask`` are
+    validated here with the same helpers :class:`fdtd_gpu.GpuFDTD2D` uses,
+    so a malformed job fails eagerly at packing time instead of on the
+    remote machine. ``init_scale_x`` is an optional 1D
     window of length ``nx`` applied after the plane waves are laid down
     (``p *= w`` and ``vy *= w`` column-wise, ``vx`` untouched), giving the
     initial front a lateral taper that leaves the sponges alone.
@@ -170,6 +175,7 @@ def build_job(
     c_map = fdtd_gpu._resolve_c_map(c, shape)
     ny, nx = c_map.shape
     rho_map = fdtd_gpu._resolve_rho_map(rho, ny, nx)
+    cfl = fdtd_gpu._resolve_cfl(cfl)
     steps = fdtd_gpu._integer("steps", steps)
     sponge_width = fdtd_gpu._integer("sponge_width", sponge_width)
     sample_stride = fdtd_gpu._integer("sample_stride", sample_stride)
@@ -177,7 +183,7 @@ def build_job(
         raise ValueError("sample_stride must be >= 1")
     if sample_dtype not in ("float64", "float32"):
         raise ValueError("sample_dtype must be 'float64' or 'float32'")
-    sample_arr = np.asarray(sample_steps, dtype=np.int64)
+    sample_arr = np.unique(np.asarray(sample_steps, dtype=np.int64))
     if sample_arr.size and (int(sample_arr.min()) < 0
                             or int(sample_arr.max()) > steps):
         raise ValueError("sample_steps must lie within [0, steps]")
@@ -189,9 +195,11 @@ def build_job(
                                   if sponge_width > 0 else ())
     else:
         sides = fdtd_gpu._resolve_sponge_sides(sponge_sides)
-    edge_impedance = edge_impedance or {}
-    obstacle = (np.zeros((ny, nx), dtype=np.bool_) if obstacle_mask is None
-                else np.asarray(obstacle_mask, dtype=np.bool_))
+    damping_map = fdtd_gpu._resolve_damping(damping, ny, nx)
+    edge_profiles = fdtd_gpu._resolve_edge_impedance(
+        edge_impedance, sponge_width, sides, ny, nx)
+    mask = fdtd_gpu._resolve_obstacle_mask(obstacle_mask, ny, nx)
+    obstacle = np.zeros((ny, nx), dtype=np.bool_) if mask is None else mask
     job: dict[str, Any] = {
         "c": c_map,
         "rho": rho_map,
@@ -200,8 +208,8 @@ def build_job(
         "sponge_width": np.int64(sponge_width),
         "sponge_sides": np.asarray(sides, dtype=np.str_),
         "sponge_reflection": np.float64(sponge_reflection),
-        "damping": np.asarray(damping, dtype=np.float64),
-        "edge_sides": np.asarray(sorted(edge_impedance), dtype=np.str_),
+        "damping": damping_map,
+        "edge_sides": np.asarray(sorted(edge_profiles), dtype=np.str_),
         "obstacle": obstacle,
         "plane_waves": np.str_(json.dumps(plane_waves or [])),
         "steps": np.int64(steps),
@@ -209,8 +217,8 @@ def build_job(
         "sample_stride": np.int64(sample_stride),
         "sample_dtype": np.str_(sample_dtype),
     }
-    for side, z in edge_impedance.items():
-        job[f"edge_z_{side}"] = np.asarray(z, dtype=np.float64)
+    for side, z in edge_profiles.items():
+        job[f"edge_z_{side}"] = z
     if init_scale_x is not None:
         w = np.asarray(init_scale_x, dtype=np.float64)
         if w.ndim != 1 or w.shape[0] != nx:

--- a/scripts/fdtd_gpu_remote.py
+++ b/scripts/fdtd_gpu_remote.py
@@ -1,0 +1,440 @@
+#  Copyright (c) 2026. Jose M. Requena-Plens
+"""Remote GPU runner for the animation FDTD fields.
+
+Offloads a 2D acoustic FDTD run (the ``fdtd_gpu.GpuFDTD2D`` engine) to a
+CUDA machine over SSH and Docker, falling back to a local NumPy run when no
+remote is configured or reachable. The flow is file-based and stateless:
+
+1. :func:`build_job` packs the domain (c/rho maps, sponges, impedance
+   edges, damping, obstacles, plane-wave initial conditions) plus the step
+   count and the frame sampling schedule into a single ``.npz`` archive.
+2. :func:`submit` copies ``fdtd_gpu.py``, ``job_runner.py`` and the job
+   archive into a fresh per-job directory under the remote work directory,
+   executes ``docker run --rm --gpus all -v <jobdir>:/work <image>
+   python3 /work/job_runner.py`` over SSH, copies the resulting frames
+   archive back and removes the remote job directory.
+3. The result dict carries the sampled pressure frames, the backend that
+   actually ran (``"cupy"`` or ``"numpy"``) and the device-synchronised
+   stepping time, so callers can report throughput honestly.
+
+Configuration comes from environment variables, optionally loaded from the
+repository ``.env`` (never committed; see ``.env.example``): PHONO_GPU_HOST,
+PHONO_GPU_USER, PHONO_GPU_NAME, PHONO_GPU_DOCKER_IMAGE, PHONO_GPU_WORKDIR.
+Real environment variables take precedence over the file, dotenv-style; the
+parser is self-contained so python-dotenv is not a dependency.
+
+If the remote host does not answer (or the transfer/run fails), the runner
+prints a clear notice and finishes the job locally instead of raising, so
+an unplugged GPU box never breaks a render.
+
+``--benchmark`` runs a medium representative case (default 1200 x 1600
+cells, 500 steps: heterogeneous rho with a dense block, three sponge sides,
+one impedance edge, a damping map and a sine-carrier plane wave) once
+locally and once remotely, and reports cell updates per second for both.
+Verified end to end against a Docker + CuPy host: the committed default
+image ``cupy/cupy:v13.6.0`` runs as-is on an NVIDIA driver 570 machine.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+_SCRIPTS = Path(__file__).resolve().parent
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import fdtd_gpu
+import job_runner
+
+_REPO_ROOT = _SCRIPTS.parent
+_ENV_FILE = _REPO_ROOT / ".env"
+
+_CONNECT_TIMEOUT_S = 8
+_DEFAULT_JOB_TIMEOUT_S = 900.0
+
+
+def load_env(path: Path = _ENV_FILE) -> dict[str, str]:
+    """Read ``KEY=VALUE`` lines from *path* into the process environment.
+
+    Comments (``#``) and blank lines are skipped, surrounding quotes are
+    stripped, and variables already present in ``os.environ`` are left
+    untouched (real environment wins, as python-dotenv does). Returns the
+    mapping that was read (before precedence), for inspection.
+    """
+    values: dict[str, str] = {}
+    if not path.is_file():
+        return values
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip().strip("'\"")
+        if key:
+            values[key] = value
+            os.environ.setdefault(key, value)
+    return values
+
+
+@dataclass(frozen=True)
+class RemoteConfig:
+    """Connection settings of the remote GPU box.
+
+    :ivar host: SSH host name or address; empty disables the remote path.
+    :ivar user: SSH user.
+    :ivar name: Human label of the machine/GPU, used only in messages.
+    :ivar image: Docker image with CUDA-enabled CuPy and Python 3.
+    :ivar workdir: Remote directory where per-job directories are created.
+    """
+
+    host: str
+    user: str
+    name: str
+    image: str
+    workdir: str
+
+    @classmethod
+    def from_env(cls) -> RemoteConfig:
+        """Build the config from PHONO_GPU_* (after :func:`load_env`)."""
+        return cls(
+            host=os.environ.get("PHONO_GPU_HOST", ""),
+            user=os.environ.get("PHONO_GPU_USER", "root"),
+            name=os.environ.get("PHONO_GPU_NAME", "remote GPU"),
+            image=os.environ.get("PHONO_GPU_DOCKER_IMAGE",
+                                 "cupy/cupy:v13.6.0"),
+            workdir=os.environ.get("PHONO_GPU_WORKDIR",
+                                   "/tmp/phonometry-gpu"),
+        )
+
+    @property
+    def target(self) -> str:
+        """The ``user@host`` SSH target."""
+        return f"{self.user}@{self.host}"
+
+
+class RemoteRunError(RuntimeError):
+    """A remote stage (ssh, scp or docker) failed or timed out."""
+
+
+def build_job(
+    c: float | NDArray[np.float64],
+    dx: float,
+    *,
+    steps: int,
+    sample_steps: list[int] | NDArray[np.int_],
+    shape: tuple[int, int] | None = None,
+    rho: float | NDArray[np.float64] = 1.2,
+    cfl: float = 0.6,
+    sponge_width: int = 0,
+    sponge_sides: Any = None,
+    sponge_reflection: float = 1e-4,
+    damping: float | NDArray[np.float64] = 0.0,
+    edge_impedance: dict[str, float | NDArray[np.float64]] | None = None,
+    obstacle_mask: NDArray[np.bool_] | None = None,
+    plane_waves: list[dict[str, Any]] | None = None,
+    init_scale_x: NDArray[np.float64] | None = None,
+    sample_stride: int = 1,
+    sample_dtype: str = "float64",
+) -> dict[str, Any]:
+    """Pack one simulation into the flat job payload of ``job_runner``.
+
+    Parameters mirror :class:`fdtd_gpu.GpuFDTD2D` (same names, same
+    semantics); ``plane_waves`` is a list of keyword dicts for
+    ``add_plane_wave`` (``direction``, ``center``, ``width`` and optional
+    ``amplitude``/``wavelength``). ``sample_steps`` lists the step counts
+    at which a pressure frame is recorded (0 = the initial state); every
+    entry must lie in ``[0, steps]``. ``init_scale_x`` is an optional 1D
+    window of length ``nx`` applied after the plane waves are laid down
+    (``p *= w`` and ``vy *= w`` column-wise, ``vx`` untouched), giving the
+    initial front a lateral taper that leaves the sponges alone.
+    ``sample_stride`` subsamples each
+    recorded frame spatially (``frame[::stride, ::stride]``, applied on
+    the compute device before the transfer) and ``sample_dtype``
+    (``"float64"`` or ``"float32"``) is the dtype the frames are cast to,
+    also on the device, so a coarse animation grid ships fewer bytes.
+    """
+    c_map = fdtd_gpu._resolve_c_map(c, shape)
+    ny, nx = c_map.shape
+    rho_map = fdtd_gpu._resolve_rho_map(rho, ny, nx)
+    steps = fdtd_gpu._integer("steps", steps)
+    sponge_width = fdtd_gpu._integer("sponge_width", sponge_width)
+    sample_stride = fdtd_gpu._integer("sample_stride", sample_stride)
+    if sample_stride < 1:
+        raise ValueError("sample_stride must be >= 1")
+    if sample_dtype not in ("float64", "float32"):
+        raise ValueError("sample_dtype must be 'float64' or 'float32'")
+    sample_arr = np.asarray(sample_steps, dtype=np.int64)
+    if sample_arr.size and (int(sample_arr.min()) < 0
+                            or int(sample_arr.max()) > steps):
+        raise ValueError("sample_steps must lie within [0, steps]")
+    # None is the "not given" sentinel (all four sides when a sponge is
+    # active, as the library); an explicit iterable, including the empty
+    # tuple, is resolved and stored literally.
+    if sponge_sides is None:
+        sides: tuple[str, ...] = (fdtd_gpu._resolve_sponge_sides(None)
+                                  if sponge_width > 0 else ())
+    else:
+        sides = fdtd_gpu._resolve_sponge_sides(sponge_sides)
+    edge_impedance = edge_impedance or {}
+    obstacle = (np.zeros((ny, nx), dtype=np.bool_) if obstacle_mask is None
+                else np.asarray(obstacle_mask, dtype=np.bool_))
+    job: dict[str, Any] = {
+        "c": c_map,
+        "rho": rho_map,
+        "dx": np.float64(dx),
+        "cfl": np.float64(cfl),
+        "sponge_width": np.int64(sponge_width),
+        "sponge_sides": np.asarray(sides, dtype=np.str_),
+        "sponge_reflection": np.float64(sponge_reflection),
+        "damping": np.asarray(damping, dtype=np.float64),
+        "edge_sides": np.asarray(sorted(edge_impedance), dtype=np.str_),
+        "obstacle": obstacle,
+        "plane_waves": np.str_(json.dumps(plane_waves or [])),
+        "steps": np.int64(steps),
+        "sample_steps": sample_arr,
+        "sample_stride": np.int64(sample_stride),
+        "sample_dtype": np.str_(sample_dtype),
+    }
+    for side, z in edge_impedance.items():
+        job[f"edge_z_{side}"] = np.asarray(z, dtype=np.float64)
+    if init_scale_x is not None:
+        w = np.asarray(init_scale_x, dtype=np.float64)
+        if w.ndim != 1 or w.shape[0] != nx:
+            raise ValueError(
+                f"init_scale_x must be a 1D array of length nx = {nx}")
+        if not np.all(np.isfinite(w)):
+            raise ValueError("init_scale_x must be finite everywhere")
+        job["init_scale_x"] = w
+    return job
+
+
+def _ssh(config: RemoteConfig, command: str,
+         timeout: float) -> subprocess.CompletedProcess[str]:
+    """Run one remote command over SSH (BatchMode, no prompts)."""
+    return subprocess.run(
+        ["ssh", "-o", "BatchMode=yes",
+         "-o", f"ConnectTimeout={_CONNECT_TIMEOUT_S}",
+         "--", config.target, command],
+        capture_output=True, text=True, timeout=timeout, check=False,
+    )
+
+
+def _scp(sources: list[str], dest: str, timeout: float) -> None:
+    """Copy files with scp; raise :class:`RemoteRunError` on failure."""
+    proc = subprocess.run(
+        ["scp", "-q", "-o", "BatchMode=yes",
+         "-o", f"ConnectTimeout={_CONNECT_TIMEOUT_S}", "--", *sources, dest],
+        capture_output=True, text=True, timeout=timeout, check=False,
+    )
+    if proc.returncode != 0:
+        raise RemoteRunError(f"scp failed: {proc.stderr.strip()}")
+
+
+def remote_available(config: RemoteConfig) -> bool:
+    """True when the configured host answers an SSH no-op."""
+    if not config.host:
+        return False
+    try:
+        proc = _ssh(config, "true", timeout=_CONNECT_TIMEOUT_S + 4)
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return proc.returncode == 0
+
+
+def run_remote(job: dict[str, Any], config: RemoteConfig,
+               timeout: float = _DEFAULT_JOB_TIMEOUT_S) -> dict[str, Any]:
+    """Execute one job on the remote GPU and return the result payload.
+
+    Creates a unique job directory under ``config.workdir``, ships the
+    engine, the runner and the job archive, runs the container and fetches
+    the frames back. The remote directory is removed afterwards, also on
+    failure. Raises :class:`RemoteRunError` on any remote-stage failure
+    (transport-level ``OSError``/``subprocess.TimeoutExpired`` from the
+    scp/ssh steps propagate as-is); use :func:`submit` for the version
+    with the local fallback.
+    """
+    job_dir = f"{config.workdir.rstrip('/')}/job-{int(time.time())}-{os.getpid()}"
+    q_dir = shlex.quote(job_dir)
+    with tempfile.TemporaryDirectory(prefix="phono-gpu-") as tmp:
+        job_path = Path(tmp) / "job.npz"
+        np.savez_compressed(job_path, **job)
+        mkdir = _ssh(config, f"mkdir -p {q_dir}", timeout=30.0)
+        if mkdir.returncode != 0:
+            raise RemoteRunError(
+                f"cannot create {job_dir} on {config.target}: "
+                f"{mkdir.stderr.strip()}")
+        try:
+            _scp([str(_SCRIPTS / "fdtd_gpu.py"),
+                  str(_SCRIPTS / "job_runner.py"),
+                  str(job_path)],
+                 f"{config.target}:{q_dir}/", timeout=120.0)
+            docker_cmd = (
+                f"docker run --rm --gpus all -v {q_dir}:/work "
+                f"{shlex.quote(config.image)} "
+                "python3 /work/job_runner.py /work/job.npz /work/frames.npz"
+            )
+            try:
+                run = _ssh(config, docker_cmd, timeout=timeout)
+            except subprocess.TimeoutExpired as exc:
+                raise RemoteRunError(
+                    f"remote job exceeded {timeout:.0f} s") from exc
+            if run.returncode != 0:
+                raise RemoteRunError(
+                    f"remote docker run failed: {run.stderr.strip()[-800:]}")
+            frames_path = Path(tmp) / "frames.npz"
+            _scp([f"{config.target}:{q_dir}/frames.npz"],
+                 str(frames_path), timeout=300.0)
+            with np.load(frames_path, allow_pickle=False) as data:
+                return {key: (data[key].copy() if data[key].ndim
+                              else data[key][()])
+                        for key in data.files}
+        finally:
+            try:
+                _ssh(config, f"rm -rf {q_dir}", timeout=30.0)
+            except (OSError, subprocess.TimeoutExpired):
+                pass                             # best-effort cleanup
+
+
+def submit(job: dict[str, Any], config: RemoteConfig | None = None,
+           timeout: float = _DEFAULT_JOB_TIMEOUT_S) -> dict[str, Any]:
+    """Run one job remotely when possible, locally (NumPy) otherwise.
+
+    The local fallback is a message, not an exception: a missing .env, an
+    unreachable host or any remote failure degrades to the same result
+    computed on the CPU.
+    """
+    if config is None:
+        load_env()
+        config = RemoteConfig.from_env()
+    if config.host:
+        if remote_available(config):
+            try:
+                return run_remote(job, config, timeout=timeout)
+            except (RemoteRunError, subprocess.TimeoutExpired,
+                    OSError) as exc:
+                print(f"[fdtd-gpu] remote run on {config.name} "
+                      f"({config.target}) failed: {exc}", file=sys.stderr)
+                print("[fdtd-gpu] falling back to a local NumPy run",
+                      file=sys.stderr)
+        else:
+            print(f"[fdtd-gpu] {config.name} ({config.target}) does not "
+                  "answer; running locally on NumPy", file=sys.stderr)
+    else:
+        print("[fdtd-gpu] no PHONO_GPU_HOST configured; running locally "
+              "on NumPy", file=sys.stderr)
+    return job_runner.run_job(job)
+
+
+def _benchmark_job(ny: int, nx: int, steps: int) -> dict[str, Any]:
+    """A representative medium case exercising every engine feature."""
+    dx = 0.01
+    c_map = np.full((ny, nx), 343.0)
+    rho_map = np.full((ny, nx), 1.2)
+    # Dense rigid-like block (a 1000:1 density contrast scatterer).
+    rho_map[ny // 2:ny // 2 + ny // 10, nx // 3:nx // 3 + nx // 5] = 1200.0
+    damping = np.zeros((ny, nx))
+    damping[:, -nx // 8:] = 40.0                 # lossy sample at the right
+    return build_job(
+        c_map, dx,
+        rho=rho_map,
+        sponge_width=40,
+        sponge_sides=("left", "right", "bottom"),
+        damping=damping,
+        edge_impedance={"top": 413.0},
+        plane_waves=[{"direction": "down", "center": (ny // 4) * dx,
+                      "width": (ny // 12) * dx, "wavelength": 30 * dx}],
+        steps=steps,
+        sample_steps=[0, steps // 2, steps],
+    )
+
+
+def _report(label: str, result: dict[str, Any], wall: float) -> float:
+    """Print one benchmark line; return the stepping cells/s."""
+    cells = int(result["cells"])
+    steps = int(result["steps"])
+    elapsed = float(result["elapsed"])
+    rate = cells * steps / elapsed
+    print(f"  {label:24s} backend={result['backend']!s:6s} "
+          f"stepping={elapsed:7.2f} s  wall={wall:7.2f} s  "
+          f"rate={rate / 1e6:8.1f} Mcells/s")
+    return rate
+
+
+def _run_benchmark(args: argparse.Namespace) -> int:
+    """Local-vs-remote throughput comparison on the medium case."""
+    load_env()
+    config = RemoteConfig.from_env()
+    ny, nx, steps = args.ny, args.nx, args.steps
+    print(f"FDTD GPU benchmark: {ny} x {nx} cells, {steps} steps "
+          f"({ny * nx * steps / 1e9:.1f} Gcell-updates)")
+    job = _benchmark_job(ny, nx, steps)
+
+    t0 = time.perf_counter()
+    local = job_runner.run_job(job)
+    local_rate = _report("local", local, time.perf_counter() - t0)
+
+    if args.local_only:
+        return 0
+    if not config.host or not remote_available(config):
+        print(f"  remote {config.name} ({config.target or 'unset'}) is not "
+              "reachable; no GPU numbers")
+        return 1
+    t0 = time.perf_counter()
+    try:
+        remote = run_remote(job, config, timeout=args.timeout)
+    except RemoteRunError as exc:
+        print(f"  remote run failed: {exc}")
+        return 1
+    remote_rate = _report(f"remote ({config.name})", remote,
+                          time.perf_counter() - t0)
+    print(f"  speedup (stepping): {remote_rate / local_rate:.1f}x")
+    ref = np.asarray(local["frames"][-1])
+    got = np.asarray(remote["frames"][-1])
+    peak = float(np.max(np.abs(ref))) or 1.0
+    print(f"  max frame deviation: {np.max(np.abs(got - ref)) / peak:.2e} "
+          "(relative to peak)")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Run animation FDTD fields on a remote GPU over "
+                    "SSH + Docker, with a local NumPy fallback.")
+    parser.add_argument("--benchmark", action="store_true",
+                        help="time a medium case locally and remotely and "
+                             "report cell updates per second")
+    parser.add_argument("--ny", type=int, default=1200,
+                        help="benchmark grid rows (default 1200)")
+    parser.add_argument("--nx", type=int, default=1600,
+                        help="benchmark grid columns (default 1600)")
+    parser.add_argument("--steps", type=int, default=500,
+                        help="benchmark time steps (default 500)")
+    parser.add_argument("--local-only", action="store_true",
+                        help="benchmark only the local NumPy path")
+    parser.add_argument("--timeout", type=float,
+                        default=_DEFAULT_JOB_TIMEOUT_S,
+                        help="remote job timeout in seconds")
+    args = parser.parse_args(argv)
+    if args.benchmark:
+        return _run_benchmark(args)
+    parser.print_help()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/job_runner.py
+++ b/scripts/job_runner.py
@@ -1,0 +1,169 @@
+#  Copyright (c) 2026. Jose M. Requena-Plens
+"""Executable payload of the remote GPU FDTD runner.
+
+Runs inside the CuPy container (or on any plain Python with NumPy): loads a
+job archive produced by ``fdtd_gpu_remote.py``, builds the backend-agnostic
+:class:`fdtd_gpu.GpuFDTD2D` engine on CuPy when a GPU is reachable (NumPy
+otherwise), steps the simulation and writes the requested pressure frames
+back to a result archive.
+
+Usage: ``python3 job_runner.py <job.npz> <frames.npz>``.
+
+Job archive keys (all produced by ``fdtd_gpu_remote.build_job``):
+
+* ``c``, ``rho``: float64 ``(ny, nx)`` maps.
+* ``dx``, ``cfl``, ``sponge_reflection``: scalars.
+* ``sponge_width``: int scalar; ``sponge_sides``: array of side names.
+* ``damping``: scalar or ``(ny, nx)`` map.
+* ``edge_sides``: array of side names; per side an ``edge_z_<side>`` array.
+* ``obstacle``: boolean ``(ny, nx)`` map (all-False when unused).
+* ``plane_waves``: JSON string, list of ``add_plane_wave`` keyword dicts.
+* ``init_scale_x`` (optional): 1D window of length ``nx``, multiplied into
+  ``p`` and ``vy`` column-wise after the plane waves (``vx`` untouched).
+* ``steps``: total leapfrog steps; ``sample_steps``: sorted step counts at
+  which the pressure field is recorded (0 records the initial state).
+* ``sample_stride``: spatial subsampling of the recorded frames
+  (``frame[::stride, ::stride]``); ``sample_dtype``: dtype of the returned
+  frames (``"float64"`` or ``"float32"``). Both are applied on the compute
+  device before the host transfer, so they shrink the shipped archive.
+
+Result archive keys: ``frames`` ``(n_frames, ceil(ny / stride),
+ceil(nx / stride))`` in ``sample_dtype``, ``sample_steps``,
+``sample_stride``, ``sample_dtype``, ``backend`` (``"cupy"`` or
+``"numpy"``), ``elapsed`` (stepping wall time in seconds,
+device-synchronised), ``steps`` and ``cells``.
+
+The file is self-contained next to ``fdtd_gpu.py``; both are copied into
+the container work directory, so no package installation is needed.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from typing import Any
+
+import fdtd_gpu
+import numpy as np
+
+
+def _pick_backend() -> tuple[Any, str]:
+    """Return (array module, name): CuPy with a usable GPU, else NumPy."""
+    try:
+        import cupy
+
+        cupy.cuda.runtime.getDeviceCount()       # raises without a GPU
+        cupy.arange(1).sum()                     # force a real kernel launch
+    except Exception:                            # noqa: BLE001 - any CUDA/import failure means CPU
+        return np, "numpy"
+    return cupy, "cupy"
+
+
+def _build_engine(job: Any, xp: Any) -> fdtd_gpu.GpuFDTD2D:
+    """Instantiate the engine from the job archive on backend *xp*."""
+    damping = job["damping"]
+    edge_impedance: dict[str, Any] = {
+        str(side): job[f"edge_z_{side}"] for side in job["edge_sides"]
+    }
+    obstacle = np.asarray(job["obstacle"], dtype=np.bool_)
+    sim = fdtd_gpu.GpuFDTD2D(
+        np.asarray(job["c"], dtype=np.float64),
+        float(job["dx"]),
+        xp=xp,
+        rho=np.asarray(job["rho"], dtype=np.float64),
+        cfl=float(job["cfl"]),
+        sponge_width=int(job["sponge_width"]),
+        # build_job stores the fully resolved sponge sides, so an empty
+        # array is the library's explicit "()" (no sponge sides), never
+        # "not given": pass the tuple through and keep None strictly as
+        # the never-stored "not given" sentinel.
+        sponge_sides=tuple(str(s) for s in job["sponge_sides"]),
+        sponge_reflection=float(job["sponge_reflection"]),
+        damping=(float(damping) if damping.ndim == 0
+                 else np.asarray(damping, dtype=np.float64)),
+        edge_impedance=edge_impedance or None,
+        obstacle_mask=obstacle if bool(obstacle.any()) else None,
+    )
+    for spec in json.loads(str(job["plane_waves"])):
+        sim.add_plane_wave(
+            spec["direction"],
+            center=float(spec["center"]),
+            width=float(spec["width"]),
+            amplitude=float(spec.get("amplitude", 1.0)),
+            wavelength=(None if spec.get("wavelength") is None
+                        else float(spec["wavelength"])),
+        )
+    if "init_scale_x" in job:
+        # Lateral taper of the initial front: column-wise window on the
+        # pressure and the y-velocity (vx keeps its (ny, nx - 1) columns).
+        w = xp.asarray(np.asarray(job["init_scale_x"],
+                                  dtype=np.float64)[np.newaxis, :])
+        sim.p *= w
+        sim.vy *= w
+    return sim
+
+
+def _sample_frame(sim: fdtd_gpu.GpuFDTD2D, stride: int,
+                  dtype: np.dtype[Any]) -> np.ndarray:
+    """Subsample and cast the pressure on the device, then transfer it."""
+    frame = sim.p[::stride, ::stride].astype(dtype, copy=True)
+    if hasattr(frame, "get"):                    # CuPy device array
+        return np.asarray(frame.get())
+    return np.asarray(frame)
+
+
+def run_job(job: Any) -> dict[str, Any]:
+    """Run one job dict/archive and return the result payload."""
+    xp, backend = _pick_backend()
+    sim = _build_engine(job, xp)
+    steps = int(job["steps"])
+    stride = int(job["sample_stride"]) if "sample_stride" in job else 1
+    if stride < 1:
+        raise ValueError("sample_stride must be >= 1")
+    dtype = np.dtype(str(job["sample_dtype"]) if "sample_dtype" in job
+                     else "float64")
+    sample_steps = sorted(int(s) for s in np.asarray(job["sample_steps"]))
+    wanted = set(sample_steps)
+    frames: list[np.ndarray] = []
+    if 0 in wanted:
+        frames.append(_sample_frame(sim, stride, dtype))
+    if backend == "cupy":
+        xp.cuda.Stream.null.synchronize()
+    t0 = time.perf_counter()
+    for i in range(steps):
+        sim.step()
+        if (i + 1) in wanted:
+            frames.append(_sample_frame(sim, stride, dtype))
+    if backend == "cupy":
+        xp.cuda.Stream.null.synchronize()
+    elapsed = time.perf_counter() - t0
+    ny, nx = sim.p.shape
+    return {
+        "frames": (np.stack(frames) if frames
+                   else np.zeros((0, 0, 0), dtype=dtype)),
+        "sample_steps": np.asarray(sample_steps, dtype=np.int64),
+        "sample_stride": stride,
+        "sample_dtype": str(dtype),
+        "backend": backend,
+        "elapsed": elapsed,
+        "steps": steps,
+        "cells": ny * nx,
+    }
+
+
+def main(argv: list[str]) -> int:
+    """CLI entry point: ``job_runner.py <job.npz> <frames.npz>``."""
+    if len(argv) != 3:
+        print("usage: job_runner.py <job.npz> <frames.npz>", file=sys.stderr)
+        return 2
+    with np.load(argv[1], allow_pickle=False) as job:
+        result = run_job(job)
+    np.savez_compressed(argv[2], **result)
+    print(f"backend={result['backend']} steps={result['steps']} "
+          f"cells={result['cells']} elapsed={result['elapsed']:.3f}s")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/job_runner.py
+++ b/scripts/job_runner.py
@@ -20,8 +20,10 @@ Job archive keys (all produced by ``fdtd_gpu_remote.build_job``):
 * ``plane_waves``: JSON string, list of ``add_plane_wave`` keyword dicts.
 * ``init_scale_x`` (optional): 1D window of length ``nx``, multiplied into
   ``p`` and ``vy`` column-wise after the plane waves (``vx`` untouched).
-* ``steps``: total leapfrog steps; ``sample_steps``: sorted step counts at
-  which the pressure field is recorded (0 records the initial state).
+* ``steps``: total leapfrog steps; ``sample_steps``: step counts at which
+  the pressure field is recorded (0 records the initial state). The runner
+  sorts them and drops duplicates, so the result carries one frame per
+  unique step.
 * ``sample_stride``: spatial subsampling of the recorded frames
   (``frame[::stride, ::stride]``); ``sample_dtype``: dtype of the returned
   frames (``"float64"`` or ``"float32"``). Both are applied on the compute
@@ -123,7 +125,11 @@ def run_job(job: Any) -> dict[str, Any]:
         raise ValueError("sample_stride must be >= 1")
     dtype = np.dtype(str(job["sample_dtype"]) if "sample_dtype" in job
                      else "float64")
-    sample_steps = sorted(int(s) for s in np.asarray(job["sample_steps"]))
+    # Deduplicate defensively (build_job already stores unique steps, but
+    # the archive may come from elsewhere): ascending order, one recorded
+    # frame per reported step, so frames[i] always belongs to
+    # sample_steps[i].
+    sample_steps = sorted({int(s) for s in np.asarray(job["sample_steps"])})
     wanted = set(sample_steps)
     frames: list[np.ndarray] = []
     if 0 in wanted:

--- a/tests/test_fdtd_gpu_parity.py
+++ b/tests/test_fdtd_gpu_parity.py
@@ -303,25 +303,27 @@ def test_build_job_validation() -> None:
         fdtd_gpu_remote.build_job(343.0, _DX, cfl=1.5, **ok)
     with pytest.raises(ValueError, match="damping"):
         fdtd_gpu_remote.build_job(343.0, _DX, damping=-1.0, **ok)
+    bad_damping = np.zeros((_NY + 1, _NX))
     with pytest.raises(ValueError, match="damping"):
-        fdtd_gpu_remote.build_job(343.0, _DX,
-                                  damping=np.zeros((_NY + 1, _NX)), **ok)
+        fdtd_gpu_remote.build_job(343.0, _DX, damping=bad_damping, **ok)
     with pytest.raises(ValueError, match="impedance sides"):
         fdtd_gpu_remote.build_job(343.0, _DX,
                                   edge_impedance={"front": 413.0}, **ok)
     with pytest.raises(ValueError, match="absorbing"):
         fdtd_gpu_remote.build_job(343.0, _DX, sponge_width=10,
                                   edge_impedance={"top": 413.0}, **ok)
+    bad_profile = {"top": np.ones(_NX + 2)}
     with pytest.raises(ValueError, match="impedance"):
-        fdtd_gpu_remote.build_job(
-            343.0, _DX, edge_impedance={"top": np.ones(_NX + 2)}, **ok)
+        fdtd_gpu_remote.build_job(343.0, _DX, edge_impedance=bad_profile,
+                                  **ok)
+    bad_mask_shape = np.zeros((_NY + 1, _NX), np.bool_)
     with pytest.raises(ValueError, match="obstacle_mask"):
-        fdtd_gpu_remote.build_job(
-            343.0, _DX, obstacle_mask=np.zeros((_NY + 1, _NX), np.bool_),
-            **ok)
+        fdtd_gpu_remote.build_job(343.0, _DX, obstacle_mask=bad_mask_shape,
+                                  **ok)
+    bad_mask_dtype = np.zeros((_NY, _NX), np.int64)
     with pytest.raises(ValueError, match="obstacle_mask"):
-        fdtd_gpu_remote.build_job(
-            343.0, _DX, obstacle_mask=np.zeros((_NY, _NX), np.int64), **ok)
+        fdtd_gpu_remote.build_job(343.0, _DX, obstacle_mask=bad_mask_dtype,
+                                  **ok)
     with pytest.raises(ValueError, match="sample_steps"):
         fdtd_gpu_remote.build_job(343.0, _DX, shape=(_NY, _NX), steps=100,
                                   sample_steps=[50, 150])
@@ -340,12 +342,20 @@ def test_build_job_validation() -> None:
         fdtd_gpu_remote.build_job(343.0, _DX, sponge_width=3.5, **ok)
     with pytest.raises(ValueError, match="sponge_width"):
         fdtd_gpu.GpuFDTD2D(343.0, _DX, shape=(_NY, _NX), sponge_width=2.5)
+    with pytest.raises(ValueError, match="smallest grid side"):
+        fdtd_gpu_remote.build_job(343.0, _DX, sponge_width=min(_NY, _NX),
+                                  **ok)
+    with pytest.raises(ValueError, match="sponge_reflection"):
+        fdtd_gpu_remote.build_job(343.0, _DX, sponge_width=4,
+                                  sponge_reflection=1.5, **ok)
+    bad_scale_length = np.ones(_NX + 1)
     with pytest.raises(ValueError, match="init_scale_x"):
-        fdtd_gpu_remote.build_job(343.0, _DX,
-                                  init_scale_x=np.ones(_NX + 1), **ok)
+        fdtd_gpu_remote.build_job(343.0, _DX, init_scale_x=bad_scale_length,
+                                  **ok)
+    bad_scale_nan = np.full(_NX, np.nan)
     with pytest.raises(ValueError, match="init_scale_x"):
-        fdtd_gpu_remote.build_job(343.0, _DX,
-                                  init_scale_x=np.full(_NX, np.nan), **ok)
+        fdtd_gpu_remote.build_job(343.0, _DX, init_scale_x=bad_scale_nan,
+                                  **ok)
 
 
 def test_sample_steps_deduplicated_local_and_remote_contract() -> None:

--- a/tests/test_fdtd_gpu_parity.py
+++ b/tests/test_fdtd_gpu_parity.py
@@ -342,9 +342,9 @@ def test_build_job_validation() -> None:
         fdtd_gpu_remote.build_job(343.0, _DX, sponge_width=3.5, **ok)
     with pytest.raises(ValueError, match="sponge_width"):
         fdtd_gpu.GpuFDTD2D(343.0, _DX, shape=(_NY, _NX), sponge_width=2.5)
+    too_wide = min(_NY, _NX)
     with pytest.raises(ValueError, match="smallest grid side"):
-        fdtd_gpu_remote.build_job(343.0, _DX, sponge_width=min(_NY, _NX),
-                                  **ok)
+        fdtd_gpu_remote.build_job(343.0, _DX, sponge_width=too_wide, **ok)
     with pytest.raises(ValueError, match="sponge_reflection"):
         fdtd_gpu_remote.build_job(343.0, _DX, sponge_width=4,
                                   sponge_reflection=1.5, **ok)

--- a/tests/test_fdtd_gpu_parity.py
+++ b/tests/test_fdtd_gpu_parity.py
@@ -1,0 +1,324 @@
+#  Copyright (c) 2026. Jose M. Requena-Plens
+"""Parity tests: ``scripts/fdtd_gpu.py`` versus the library FDTD engine.
+
+``GpuFDTD2D`` is a backend-injectable replica of
+:class:`phonometry.simulation.fdtd.FDTD2D` for the feature subset the
+documentation animations use. These tests lock the replica to the library
+step by step on small grids: with ``xp=numpy`` every recorded pressure
+field must match the reference within 1e-12 of the field peak (in practice
+the NumPy path is bit-identical because the update expressions share the
+exact operation order). When CuPy and a CUDA device are available the same
+scenarios run with ``xp=cupy`` under a looser (ULP-scale reassociation)
+tolerance; on machines without a GPU those cases skip.
+
+The job-packaging round trip of ``fdtd_gpu_remote.build_job`` through
+``job_runner.run_job`` is covered too, since the remote runner feeds the
+engine only through that path.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+from typing import Any
+
+import numpy as np
+import pytest
+
+from phonometry.simulation.fdtd import FDTD2D
+
+_SCRIPTS = str(pathlib.Path(__file__).resolve().parent.parent / "scripts")
+if _SCRIPTS not in sys.path:
+    sys.path.insert(0, _SCRIPTS)
+
+import fdtd_gpu
+import fdtd_gpu_remote
+import job_runner
+
+
+def _cupy_or_none() -> Any:
+    """CuPy with a working CUDA device, else None."""
+    try:
+        import cupy
+
+        cupy.cuda.runtime.getDeviceCount()
+        cupy.arange(1).sum()
+    except Exception:  # noqa: BLE001 - any import/CUDA failure means no GPU
+        return None
+    return cupy
+
+
+_CUPY = _cupy_or_none()
+
+BACKENDS = [
+    pytest.param(np, 1e-12, id="numpy"),
+    pytest.param(_CUPY, 1e-10, id="cupy", marks=pytest.mark.skipif(
+        _CUPY is None, reason="CuPy with a CUDA device is not available")),
+]
+
+_NY, _NX = 60, 80
+_DX = 0.01
+_STEPS = 200
+
+
+def _scenarios() -> dict[str, dict[str, Any]]:
+    """Constructor kwargs of every parity scenario (library names).
+
+    An optional ``"c"`` entry replaces the default scalar sound speed.
+    """
+    rho_obstacle = np.full((_NY, _NX), 1.2)
+    rho_obstacle[24:36, 30:44] = 6000.0          # dense block scatterer
+    damping_map = np.zeros((_NY, _NX))
+    damping_map[:, _NX - 16:] = 35.0             # lossy slab at the right
+    mask = np.zeros((_NY, _NX), dtype=np.bool_)
+    mask[40:46, 10:70] = True                    # rigid slat obstacle
+    c_hetero = np.full((_NY, _NX), 343.0)        # air over a water layer
+    c_hetero[_NY // 2:, :] = 1500.0
+    rho_hetero = np.full((_NY, _NX), 1.2)
+    rho_hetero[_NY // 2:, :] = 1000.0
+    return {
+        "rigid_box": {},
+        "dense_rho_obstacle": {"rho": rho_obstacle},
+        "heterogeneous_c": {"c": c_hetero, "rho": rho_hetero},
+        "sponge": {"sponge_width": 12,
+                   "sponge_sides": ("left", "right", "bottom"),
+                   "sponge_reflection": 1e-3},
+        "sponge_side_string": {"sponge_width": 12, "sponge_sides": "top"},
+        "impedance_edges": {"edge_impedance": {
+            "top": 413.0,
+            "left": np.linspace(200.0, 800.0, _NY),
+        }},
+        "impedance_right_bottom": {"edge_impedance": {
+            "right": 620.0,
+            "bottom": np.linspace(300.0, 900.0, _NX),
+        }},
+        "damping_scalar": {"damping": 25.0},
+        "damping_map": {"damping": damping_map},
+        "obstacle_mask": {"obstacle_mask": mask},
+        "combined": {"rho": rho_obstacle,
+                     "sponge_width": 10,
+                     "sponge_sides": ("left", "right"),
+                     "damping": damping_map,
+                     "edge_impedance": {"top": 413.0}},
+    }
+
+
+_WAVES: dict[str, dict[str, Any]] = {
+    "down": {"center": 0.12, "width": 0.05},
+    "up": {"center": 0.45, "width": 0.05, "wavelength": 0.08},
+    "left": {"center": 0.60, "width": 0.06, "amplitude": 0.7},
+    "right": {"center": 0.20, "width": 0.05, "wavelength": 0.10},
+}
+
+
+def _split_c(kwargs: dict[str, Any]) -> tuple[Any, dict[str, Any]]:
+    """Pop the optional ``"c"`` entry (default scalar 343) from *kwargs*."""
+    rest = dict(kwargs)
+    return rest.pop("c", 343.0), rest
+
+
+def _reference(kwargs: dict[str, Any], wave: dict[str, Any],
+               direction: str) -> list[np.ndarray]:
+    """Library-engine pressure fields every 50 steps."""
+    c, rest = _split_c(kwargs)
+    ref = FDTD2D(c, _DX, shape=(_NY, _NX), **rest)
+    ref.add_plane_wave(direction, **wave)
+    fields = []
+    for i in range(_STEPS):
+        ref.step()
+        if (i + 1) % 50 == 0:
+            fields.append(ref.p.copy())
+    return fields
+
+
+def _assert_parity(fields: list[np.ndarray], got: list[np.ndarray],
+                   rtol_peak: float) -> None:
+    """Every recorded field matches within *rtol_peak* of the run peak."""
+    peak = max(float(np.max(np.abs(f))) for f in fields)
+    assert peak > 0.0
+    for ref_f, got_f in zip(fields, got, strict=True):
+        np.testing.assert_allclose(got_f, ref_f, rtol=0.0,
+                                   atol=rtol_peak * peak)
+
+
+@pytest.mark.parametrize("xp,tol", BACKENDS)
+@pytest.mark.parametrize("direction", list(_WAVES))
+def test_plane_wave_directions_match_library(xp: Any, tol: float,
+                                             direction: str) -> None:
+    """A plane packet in each travel direction reproduces the library."""
+    wave = _WAVES[direction]
+    fields = _reference({}, wave, direction)
+    sim = fdtd_gpu.GpuFDTD2D(343.0, _DX, shape=(_NY, _NX), xp=xp)
+    sim.add_plane_wave(direction, **wave)
+    got = []
+    for i in range(_STEPS):
+        sim.step()
+        if (i + 1) % 50 == 0:
+            got.append(sim.pressure())
+    _assert_parity(fields, got, tol)
+    assert sim.n == _STEPS
+    assert sim.dt == pytest.approx(0.6 * _DX / (343.0 * np.sqrt(2.0)))
+    assert sim.time == pytest.approx(_STEPS * sim.dt)
+
+
+@pytest.mark.parametrize("xp,tol", BACKENDS)
+@pytest.mark.parametrize("scenario", list(_scenarios()))
+def test_scenarios_match_library(xp: Any, tol: float, scenario: str) -> None:
+    """Each engine feature (and their combination) reproduces the library."""
+    kwargs = _scenarios()[scenario]
+    wave = {"center": 0.15, "width": 0.06, "wavelength": 0.09}
+    fields = _reference(kwargs, wave, "down")
+    c, rest = _split_c(kwargs)
+    sim = fdtd_gpu.GpuFDTD2D(c, _DX, shape=(_NY, _NX), xp=xp, **rest)
+    sim.add_plane_wave("down", **wave)
+    got = []
+    for i in range(_STEPS):
+        sim.step()
+        if (i + 1) % 50 == 0:
+            got.append(sim.pressure())
+    _assert_parity(fields, got, tol)
+
+
+def test_numpy_path_is_bit_identical() -> None:
+    """With xp=numpy the replica is exactly the library, bit for bit."""
+    kwargs = _scenarios()["combined"]
+    wave = {"center": 0.15, "width": 0.06, "wavelength": 0.09}
+    ref = FDTD2D(343.0, _DX, shape=(_NY, _NX), **kwargs)
+    ref.add_plane_wave("down", **wave)
+    sim = fdtd_gpu.GpuFDTD2D(343.0, _DX, shape=(_NY, _NX), xp=np, **kwargs)
+    sim.add_plane_wave("down", **wave)
+    for _ in range(_STEPS):
+        ref.step()
+        sim.step()
+    assert np.array_equal(sim.p, ref.p)
+
+
+def test_job_round_trip_matches_library() -> None:
+    """build_job -> job_runner.run_job reproduces the library fields."""
+    kwargs = _scenarios()["combined"]
+    wave = {"center": 0.15, "width": 0.06, "wavelength": 0.09}
+    fields = _reference(kwargs, wave, "down")
+    job = fdtd_gpu_remote.build_job(
+        343.0, _DX, shape=(_NY, _NX), steps=_STEPS,
+        sample_steps=[50, 100, 150, 200],
+        plane_waves=[{"direction": "down", **wave}], **kwargs)
+    result = job_runner.run_job(job)
+    assert result["backend"] in ("numpy", "cupy")
+    assert int(result["cells"]) == _NY * _NX
+    tol = 1e-12 if result["backend"] == "numpy" else 1e-10
+    _assert_parity(fields, list(np.asarray(result["frames"])), tol)
+
+
+def test_job_round_trip_edge_array_and_obstacle() -> None:
+    """Per-cell 1D edge impedance and a non-trivial obstacle survive the npz."""
+    mask = np.zeros((_NY, _NX), dtype=np.bool_)
+    mask[18:22, 8:36] = True                     # horizontal slat
+    mask[30:52, 44:48] = True                    # vertical baffle
+    kwargs = {
+        "edge_impedance": {"left": np.linspace(220.0, 760.0, _NY)},
+        "obstacle_mask": mask,
+    }
+    wave = {"center": 0.15, "width": 0.06, "wavelength": 0.09}
+    fields = _reference(kwargs, wave, "down")
+    job = fdtd_gpu_remote.build_job(
+        343.0, _DX, shape=(_NY, _NX), steps=_STEPS,
+        sample_steps=[50, 100, 150, 200],
+        plane_waves=[{"direction": "down", **wave}], **kwargs)
+    result = job_runner.run_job(job)
+    tol = 1e-12 if result["backend"] == "numpy" else 1e-10
+    _assert_parity(fields, list(np.asarray(result["frames"])), tol)
+
+
+def test_job_round_trip_empty_sponge_sides() -> None:
+    """An explicit sponge_sides=() with sponge_width > 0 stays empty.
+
+    The library treats the empty tuple as "no sponge anywhere" even when a
+    width is given; the job archive must not turn it back into the
+    all-four-sides default.
+    """
+    kwargs: dict[str, Any] = {"sponge_width": 12, "sponge_sides": ()}
+    wave = {"center": 0.15, "width": 0.06, "wavelength": 0.09}
+    fields = _reference(kwargs, wave, "down")
+    job = fdtd_gpu_remote.build_job(
+        343.0, _DX, shape=(_NY, _NX), steps=_STEPS,
+        sample_steps=[50, 100, 150, 200],
+        plane_waves=[{"direction": "down", **wave}], **kwargs)
+    assert job["sponge_sides"].size == 0
+    result = job_runner.run_job(job)
+    tol = 1e-12 if result["backend"] == "numpy" else 1e-10
+    _assert_parity(fields, list(np.asarray(result["frames"])), tol)
+
+
+def test_job_round_trip_init_scale_x() -> None:
+    """A cosine taper on the initial front matches the manual scaling."""
+    window = 0.5 * (1.0 - np.cos(2.0 * np.pi * np.arange(_NX) / (_NX - 1)))
+    wave = {"center": 0.15, "width": 0.06, "wavelength": 0.09}
+    sim = fdtd_gpu.GpuFDTD2D(343.0, _DX, shape=(_NY, _NX), xp=np)
+    sim.add_plane_wave("down", **wave)
+    sim.p *= window[np.newaxis, :]
+    sim.vy *= window[np.newaxis, :]
+    fields = []
+    for i in range(_STEPS):
+        sim.step()
+        if (i + 1) % 50 == 0:
+            fields.append(sim.pressure())
+    job = fdtd_gpu_remote.build_job(
+        343.0, _DX, shape=(_NY, _NX), steps=_STEPS,
+        sample_steps=[50, 100, 150, 200],
+        plane_waves=[{"direction": "down", **wave}],
+        init_scale_x=window)
+    result = job_runner.run_job(job)
+    tol = 1e-12 if result["backend"] == "numpy" else 1e-10
+    _assert_parity(fields, list(np.asarray(result["frames"])), tol)
+
+
+def test_job_round_trip_subsampled_frames() -> None:
+    """sample_stride=4 + float32 equals the full frames subsampled locally."""
+    kwargs = _scenarios()["combined"]
+    wave = {"center": 0.15, "width": 0.06, "wavelength": 0.09}
+    common: dict[str, Any] = dict(
+        shape=(_NY, _NX), steps=_STEPS, sample_steps=[0, 100, 200],
+        plane_waves=[{"direction": "down", **wave}], **kwargs)
+    full = job_runner.run_job(
+        fdtd_gpu_remote.build_job(343.0, _DX, **common))
+    sub = job_runner.run_job(
+        fdtd_gpu_remote.build_job(343.0, _DX, sample_stride=4,
+                                  sample_dtype="float32", **common))
+    full_frames = np.asarray(full["frames"])
+    sub_frames = np.asarray(sub["frames"])
+    assert full_frames.dtype == np.float64
+    assert sub_frames.dtype == np.float32
+    assert sub_frames.shape == (3, (_NY + 3) // 4, (_NX + 3) // 4)
+    assert sub_frames.nbytes * 32 == full_frames.nbytes
+    np.testing.assert_array_equal(
+        sub_frames, full_frames[:, ::4, ::4].astype(np.float32))
+
+
+def test_build_job_validation() -> None:
+    """build_job rejects inconsistent sampling and non-integer widths."""
+    ok: dict[str, Any] = {"shape": (_NY, _NX), "steps": 100,
+                          "sample_steps": [50]}
+    with pytest.raises(ValueError, match="sample_steps"):
+        fdtd_gpu_remote.build_job(343.0, _DX, shape=(_NY, _NX), steps=100,
+                                  sample_steps=[50, 150])
+    with pytest.raises(ValueError, match="sample_steps"):
+        fdtd_gpu_remote.build_job(343.0, _DX, shape=(_NY, _NX), steps=100,
+                                  sample_steps=[-1, 50])
+    with pytest.raises(ValueError, match="sample_stride"):
+        fdtd_gpu_remote.build_job(343.0, _DX, sample_stride=0, **ok)
+    with pytest.raises(ValueError, match="sample_stride"):
+        fdtd_gpu_remote.build_job(343.0, _DX, sample_stride=2.0, **ok)
+    with pytest.raises(ValueError, match="sample_dtype"):
+        fdtd_gpu_remote.build_job(343.0, _DX, sample_dtype="int16", **ok)
+    with pytest.raises(ValueError, match="sponge_width"):
+        fdtd_gpu_remote.build_job(343.0, _DX, sponge_width=True, **ok)
+    with pytest.raises(ValueError, match="sponge_width"):
+        fdtd_gpu_remote.build_job(343.0, _DX, sponge_width=3.5, **ok)
+    with pytest.raises(ValueError, match="sponge_width"):
+        fdtd_gpu.GpuFDTD2D(343.0, _DX, shape=(_NY, _NX), sponge_width=2.5)
+    with pytest.raises(ValueError, match="init_scale_x"):
+        fdtd_gpu_remote.build_job(343.0, _DX,
+                                  init_scale_x=np.ones(_NX + 1), **ok)
+    with pytest.raises(ValueError, match="init_scale_x"):
+        fdtd_gpu_remote.build_job(343.0, _DX,
+                                  init_scale_x=np.full(_NX, np.nan), **ok)

--- a/tests/test_fdtd_gpu_parity.py
+++ b/tests/test_fdtd_gpu_parity.py
@@ -18,6 +18,7 @@ engine only through that path.
 
 from __future__ import annotations
 
+import os
 import pathlib
 import sys
 from typing import Any
@@ -298,6 +299,29 @@ def test_build_job_validation() -> None:
     """build_job rejects inconsistent sampling and non-integer widths."""
     ok: dict[str, Any] = {"shape": (_NY, _NX), "steps": 100,
                           "sample_steps": [50]}
+    with pytest.raises(ValueError, match="cfl"):
+        fdtd_gpu_remote.build_job(343.0, _DX, cfl=1.5, **ok)
+    with pytest.raises(ValueError, match="damping"):
+        fdtd_gpu_remote.build_job(343.0, _DX, damping=-1.0, **ok)
+    with pytest.raises(ValueError, match="damping"):
+        fdtd_gpu_remote.build_job(343.0, _DX,
+                                  damping=np.zeros((_NY + 1, _NX)), **ok)
+    with pytest.raises(ValueError, match="impedance sides"):
+        fdtd_gpu_remote.build_job(343.0, _DX,
+                                  edge_impedance={"front": 413.0}, **ok)
+    with pytest.raises(ValueError, match="absorbing"):
+        fdtd_gpu_remote.build_job(343.0, _DX, sponge_width=10,
+                                  edge_impedance={"top": 413.0}, **ok)
+    with pytest.raises(ValueError, match="impedance"):
+        fdtd_gpu_remote.build_job(
+            343.0, _DX, edge_impedance={"top": np.ones(_NX + 2)}, **ok)
+    with pytest.raises(ValueError, match="obstacle_mask"):
+        fdtd_gpu_remote.build_job(
+            343.0, _DX, obstacle_mask=np.zeros((_NY + 1, _NX), np.bool_),
+            **ok)
+    with pytest.raises(ValueError, match="obstacle_mask"):
+        fdtd_gpu_remote.build_job(
+            343.0, _DX, obstacle_mask=np.zeros((_NY, _NX), np.int64), **ok)
     with pytest.raises(ValueError, match="sample_steps"):
         fdtd_gpu_remote.build_job(343.0, _DX, shape=(_NY, _NX), steps=100,
                                   sample_steps=[50, 150])
@@ -322,3 +346,69 @@ def test_build_job_validation() -> None:
     with pytest.raises(ValueError, match="init_scale_x"):
         fdtd_gpu_remote.build_job(343.0, _DX,
                                   init_scale_x=np.full(_NX, np.nan), **ok)
+
+
+def test_sample_steps_deduplicated_local_and_remote_contract() -> None:
+    """Repeated sample_steps collapse to one frame per unique step.
+
+    build_job stores the unique ascending schedule and run_job dedups on
+    its own too, so a hand-built archive with duplicates yields the same
+    frames/sample_steps contract as the packed job.
+    """
+    job = fdtd_gpu_remote.build_job(
+        343.0, _DX, shape=(_NY, _NX), steps=100,
+        sample_steps=[100, 0, 50, 50, 0, 100])
+    np.testing.assert_array_equal(job["sample_steps"], [0, 50, 100])
+    job["sample_steps"] = np.asarray([100, 0, 50, 50, 0, 100],
+                                     dtype=np.int64)
+    result = job_runner.run_job(job)
+    np.testing.assert_array_equal(result["sample_steps"], [0, 50, 100])
+    assert np.asarray(result["frames"]).shape[0] == 3
+
+
+def test_submit_falls_back_to_local_numpy_run(
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str]) -> None:
+    """A reachable remote whose run fails degrades to a local NumPy run."""
+    config = fdtd_gpu_remote.RemoteConfig(
+        host="203.0.113.9", user="gpuuser", name="test GPU",
+        image="cupy/cupy:v13.6.0", workdir="/tmp/phonometry-gpu")
+    monkeypatch.setattr(fdtd_gpu_remote, "remote_available",
+                        lambda config: True)
+
+    def _boom(job: dict[str, Any], config: Any,
+              timeout: float = 0.0) -> dict[str, Any]:
+        raise fdtd_gpu_remote.RemoteRunError("docker run failed")
+
+    monkeypatch.setattr(fdtd_gpu_remote, "run_remote", _boom)
+    monkeypatch.setattr(job_runner, "_pick_backend",
+                        lambda: (np, "numpy"))
+    job = fdtd_gpu_remote.build_job(
+        343.0, _DX, shape=(20, 24), steps=10, sample_steps=[0, 10])
+    result = fdtd_gpu_remote.submit(job, config)
+    assert result["backend"] == "numpy"
+    assert int(result["steps"]) == 10
+    assert np.asarray(result["frames"]).shape == (2, 20, 24)
+    err = capsys.readouterr().err
+    assert "docker run failed" in err
+    assert "falling back to a local NumPy run" in err
+
+
+def test_load_env_real_environment_wins(
+        monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path) -> None:
+    """An exported variable beats the .env file; missing ones are loaded."""
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "# comment line\n"
+        "PHONO_GPU_HOST=file-host\n"
+        'PHONO_GPU_NAME="lab GPU"\n',
+        encoding="utf-8")
+    monkeypatch.setenv("PHONO_GPU_HOST", "env-host")
+    # Guarantee the variable is absent and restored either way.
+    monkeypatch.setenv("PHONO_GPU_NAME", "sentinel")
+    monkeypatch.delenv("PHONO_GPU_NAME")
+    values = fdtd_gpu_remote.load_env(env_file)
+    assert values == {"PHONO_GPU_HOST": "file-host",
+                      "PHONO_GPU_NAME": "lab GPU"}
+    assert os.environ["PHONO_GPU_HOST"] == "env-host"    # real env wins
+    assert os.environ["PHONO_GPU_NAME"] == "lab GPU"     # quotes stripped


### PR DESCRIPTION
Add a backend-injectable replica of the FDTD2D leapfrog engine
(scripts/fdtd_gpu.py) that runs the same stepping code on NumPy or CuPy
for the subset the animations use: per-cell c/rho maps, rigid walls,
sponge layers, per-side real-impedance edges, scalar or per-cell
damping, rasterised obstacles and the one-way plane-wave initial
condition. With xp=numpy the pressure history is bit-identical to the
library engine; tests/test_fdtd_gpu_parity.py locks parity per feature
and per travel direction (including heterogeneous c maps, right/bottom
impedance edges, a bare-string sponge side and the explicit empty
sponge_sides tuple), and the CuPy cases run automatically when a CUDA
device is present.

scripts/fdtd_gpu_remote.py packs a job (maps, parameters and a frame
sampling schedule) into a single npz, ships it with the engine to a
CUDA host over SSH and runs it there with Docker (--gpus all) through
scripts/job_runner.py, fetching the sampled frames back and cleaning
the per-job directory. Jobs can request device-side frame subsampling
(sample_stride) and float32 casting (sample_dtype) before the transfer,
plus an optional init_scale_x window that tapers the initial front
laterally (p and vy column-wise). build_job validates its inputs like
the library (strict integers, sample_steps within [0, steps], stride
and dtype checks); the scp/ssh invocations quote remote paths and
end-of-options the targets, and any transport failure (RemoteRunError,
timeout or OSError) degrades to a local NumPy run with a notice instead
of an exception. Configuration comes from PHONO_GPU_* variables,
optionally read from the gitignored .env (placeholder template
committed as .env.example).

Verified end to end against the reference host (RTX 4060, driver 570,
image cupy/cupy:v13.6.0): the 1200 x 1600 cell, 500 step benchmark
runs at 444 Mcell/s on the GPU versus 14.5 Mcell/s on local NumPy, a
30.7x stepping speedup with bit-identical returned frames; a stride 10
float32 job returns exactly the locally subsampled frames while cutting
the fetched frames archive from 4.84 MB to 27 kB.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GPU-accelerated 2D acoustic FDTD engine with damping/material maps, sponge layers, obstacles, impedance boundaries, and plane-wave injection.
  * Added a job-based runner that executes locally (NumPy/CuPy autodetect), samples frames, and packages results.
  * Added remote GPU submission via SSH + Docker with automatic local fallback, plus an optional benchmark/verification mode.
* **Documentation**
  * Introduced a `.env.example` template for remote configuration.
* **Tests**
  * Added parity and round-trip verification tests covering GPU/CPU consistency, job pipeline behavior, and environment loading/fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->