### PR TITLE
Fix the metadiffuser reference schema so the docs deploy again

### DIFF
--- a/site/src/content/docs/es/guides/surface-scattering.mdx
+++ b/site/src/content/docs/es/guides/surface-scattering.mdx
@@ -14,7 +14,7 @@ references:
     authors: ["Jiménez, N.", "Cox, T. J.", "Romero-García, V.", "Groby, J.-P."]
     year: 2017
     title: "Metadiffusers: Deep-subwavelength sound diffusers"
-    container: "Scientific Reports"
+    journal: "Scientific Reports"
     volume: "7"
     pages: "5389"
     doi: "10.1038/s41598-017-05710-5"

--- a/site/src/content/docs/guides/surface-scattering.mdx
+++ b/site/src/content/docs/guides/surface-scattering.mdx
@@ -14,7 +14,7 @@ references:
     authors: ["Jiménez, N.", "Cox, T. J.", "Romero-García, V.", "Groby, J.-P."]
     year: 2017
     title: "Metadiffusers: Deep-subwavelength sound diffusers"
-    container: "Scientific Reports"
+    journal: "Scientific Reports"
     volume: "7"
     pages: "5389"
     doi: "10.1038/s41598-017-05710-5"


### PR DESCRIPTION
The metadiffuser reference entry used container instead of the journal field the docs content schema requires for articles, so astro's content sync failed both language variants and the Deploy Docs job has been red since #397. Validated locally with astro sync.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected citation metadata for a “Scientific Reports” article in the surface-scattering guide.
  * Applied the update to both English and Spanish documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->