### PR TITLE
Give the Spanish diffusion cross-link an ASCII anchor so the audit passes

### DIFF
--- a/site/src/content/docs/es/guides/diffusers.mdx
+++ b/site/src/content/docs/es/guides/diffusers.mdx
@@ -72,7 +72,7 @@ Los dos coeficientes responden a preguntas distintas y no son
 intercambiables: la dispersión es *cuánta* energía abandona la dirección
 especular; la difusión es *cuán uniformemente* se reparte en ángulo la
 energía reflejada. La
-[sección final](#dispersión-o-difusión-dos-coeficientes-dos-trabajos)
+[sección final](#dispersion-o-difusion)
 precisa la distinción. Los parientes en sublongitud de onda profunda de los
 diseños de Schroeder tratados aquí, paneles de pocos centímetros que
 dispersan como pozos de decenas de centímetros, tienen su propia guía:
@@ -645,6 +645,8 @@ plt.show()
 ```
 
 </details>
+
+<span id="dispersion-o-difusion"></span>
 
 ## ¿Dispersión o difusión? Dos coeficientes, dos trabajos
 


### PR DESCRIPTION
The Deploy Docs job failed after #403: pa11y compares the percent-encoded href of the accented in-page anchor in the Spanish diffusers guide against the raw unicode heading id and reports a missing anchor. An explicit ASCII span anchor above the heading fixes the comparison without renaming the heading. Swept all 56 audited URLs: this was the only accented same-page anchor in the sample. Validated with a full local site build.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed the internal link to the “¿Dispersión o difusión?” section in the Spanish Diffusers guide.
  * Added a matching anchor to ensure the link navigates correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->