### PR TITLE
Rotorcraft flow resistivity annotated for NumPy scalar-likes

### DIFF
--- a/site/src/content/docs/reference/api/aeroacoustics/rotorcraft-noise.md
+++ b/site/src/content/docs/reference/api/aeroacoustics/rotorcraft-noise.md
@@ -566,7 +566,7 @@ rotorcraft_event_level(
     path_angle: float | NDArray[np.float64] | list[float] | None = None,
     heading: float | NDArray[np.float64] | list[float] | None = None,
     bank_angle: float | NDArray[np.float64] | list[float] | None = None,
-    flow_resistivity: float | str = 'G',
+    flow_resistivity: float | str | np.floating[Any] | np.integer[Any] = 'G',
     temperature: float = 25.0,
     relative_humidity: float = 70.0,
     pressure: float = 101.325,

--- a/src/phonometry/aircraft/rotorcraft_noise.py
+++ b/src/phonometry/aircraft/rotorcraft_noise.py
@@ -1468,7 +1468,8 @@ def _event_setup(
     path_angle: float | NDArray[np.float64] | list[float] | None,
     heading: float | NDArray[np.float64] | list[float] | None,
     bank_angle: float | NDArray[np.float64] | list[float] | None,
-    flow_resistivity: float | str | NDArray[np.float64] | list[float] | list[list[float]],
+    flow_resistivity: float | str | np.floating[Any] | np.integer[Any]
+    | NDArray[np.float64] | list[float] | list[list[float]],
     temperature: float,
     relative_humidity: float,
     pressure: float,
@@ -1528,7 +1529,8 @@ def _section_spacing(
 
 
 def _setup_resistivity(
-    flow_resistivity: float | str | NDArray[np.float64] | list[float] | list[list[float]],
+    flow_resistivity: float | str | np.floating[Any] | np.integer[Any]
+    | NDArray[np.float64] | list[float] | list[list[float]],
     dem: tuple[NDArray[np.float64], NDArray[np.float64], NDArray[np.float64]] | None,
 ) -> float | NDArray[np.float64]:
     """The scalar (or per-receiver) flow resistivity of an event run."""
@@ -1834,7 +1836,7 @@ def rotorcraft_event_level(
     path_angle: float | NDArray[np.float64] | list[float] | None = None,
     heading: float | NDArray[np.float64] | list[float] | None = None,
     bank_angle: float | NDArray[np.float64] | list[float] | None = None,
-    flow_resistivity: float | str = "G",
+    flow_resistivity: float | str | np.floating[Any] | np.integer[Any] = "G",
     temperature: float = 25.0,
     relative_humidity: float = 70.0,
     pressure: float = 101.325,

--- a/tests/aircraft/test_rotorcraft_noise.py
+++ b/tests/aircraft/test_rotorcraft_noise.py
@@ -1100,10 +1100,10 @@ def test_event_numpy_scalar_flow_resistivity_is_scalar() -> None:
                                   flow_resistivity=2.0e5)
     for sigma in (np.float32(2.0e5), np.int64(200_000), np.array(2.0e5)):
         res = rotorcraft_event_level(hems, spd, ang, t, pos, (300.0, 0.0),
-                                     flow_resistivity=sigma)  # type: ignore[arg-type]
+                                     flow_resistivity=sigma)
         assert np.allclose(res.a_levels, base.a_levels, atol=1e-9)
     with_dem = rotorcraft_event_level(hems, spd, ang, t, pos, (300.0, 0.0),
-                                      flow_resistivity=np.float32(2.0e5),  # type: ignore[arg-type]
+                                      flow_resistivity=np.float32(2.0e5),
                                       terrain=dem, terrain_resolution=100.0)
     assert with_dem.sel == pytest.approx(base.sel, abs=1e-9)
 


### PR DESCRIPTION
## Summary

Follow-up to #411: the runtime already treats np.float32, np.int64 and 0-d arrays as scalar flow resistivities; the annotations of `rotorcraft_event_level` and the event setup chain now advertise it, and the regression test drops its type suppressions. No behavior change.

## Test plan

- mypy src scripts, ruff, rotorcraft unit suite: green.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

