### PR TITLE
Literature oracles pinned as tests across nine domains

### DIFF
--- a/tests/building/test_building_prediction.py
+++ b/tests/building/test_building_prediction.py
@@ -608,3 +608,133 @@ def test_impact_non_finite_rejected() -> None:
         ValueError, match="'ln_w_eq' must be a finite number"
     ):
         predicted_impact_insulation(ln_w_eq=float("nan"))
+
+
+# --------------------------------------------------------------------------
+# Annex E junction Kij — independent literature oracles
+# --------------------------------------------------------------------------
+
+
+def test_kij_rigid_t_vigran_aerated_concrete_example() -> None:
+    # Vigran, Building Acoustics (Taylor & Francis, 2008), Sec. 9.3.2.3,
+    # p. 353: aerated-concrete test building, 125 mm walls and a 150 mm floor
+    # at 600 kg/m3 (m' = 75 and 90 kg/m2). For the wall-floor-wall path Ff
+    # across the rigid T-junction, "using the expression for a T-junction in
+    # EN 12354-1 we arrive at the value 6.9 dB for Kij". The book prints one
+    # decimal; the exact Annex E value is 6.85 dB, so 0.05 dB covers the
+    # rounding.
+    assert junction_vibration_reduction(
+        "rigid_t", "through", 90.0 / 75.0
+    ) == pytest.approx(6.9, abs=0.05)
+
+
+def test_kij_rigid_t_equal_masses_alba() -> None:
+    # Alba, Escuder, Ramis, del Rey and Segovia, J. Vib. Acoust. 134 (2012)
+    # 021009, Table 1: "The standard gives a fixed value of 5.7 for the
+    # vibration [reduction] index in a rigid T-junction when the surface
+    # densities of the elements forming the junction are equal"
+    # (K12354 = 5.7 dB). Exact value, no rounding involved.
+    assert junction_vibration_reduction(
+        "rigid_t", "corner", 1.0
+    ) == pytest.approx(5.7, abs=1e-9)
+
+
+@pytest.mark.parametrize(
+    ("frequency", "expected"),
+    [
+        # Alba et al. (2012) Table 1, T-junction with elastic interlayer and
+        # equal surface densities: K12 = 10 lg f - 10 lg f1 + 5.7 dB for
+        # f > f1, evaluated by hand from the paper's expression with the
+        # f1 = 125 Hz the paper uses for its theoretical curve, over the
+        # paper's fitted range 200-1250 Hz. Hand values to 0.01 dB.
+        (200.0, 7.74),
+        (500.0, 11.72),
+        (1250.0, 15.70),
+    ],
+)
+def test_kij_flexible_t_alba_frequency_law(
+    frequency: float, expected: float
+) -> None:
+    assert junction_vibration_reduction(
+        "flexible_t", "corner", 1.0, frequency=frequency, f1=125.0
+    ) == pytest.approx(expected, abs=0.005)
+
+
+# Schiavi & Astolfi, Applied Acoustics 71 (2010) 523-530, Table 3: measured
+# average vibration reduction index (one-third-octave bands, in-situ per
+# EN ISO 10848-1) for junctions between beam-and-block floors and brickwork
+# walls in Southern-European buildings. CB = concrete beam-brick wall,
+# BB = ribbed slab with brick blocks-brick wall.
+_SCHIAVI_TABLE3_FREQS = (
+    100.0, 125.0, 160.0, 200.0, 250.0, 315.0, 400.0, 500.0, 630.0,
+    800.0, 1000.0, 1250.0, 1600.0, 2000.0, 2500.0, 3150.0, 4000.0, 5000.0,
+)
+_SCHIAVI_TABLE3_CB = (
+    18.0, 17.5, 17.0, 16.5, 16.0, 15.5, 15.0, 14.5, 14.0,
+    14.0, 14.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0,
+)
+_SCHIAVI_TABLE3_BB = (
+    17.0, 16.5, 16.0, 15.5, 15.0, 14.5, 14.0, 13.5, 13.0,
+    12.5, 12.0, 11.5, 12.0, 12.5, 13.0, 13.5, 14.0, 14.5,
+)
+# Table 3 "Single number (average)" row.
+_SCHIAVI_SINGLE_CB = 16.0
+_SCHIAVI_SINGLE_BB = 14.0
+# Table 1, mwall/mfloor of the 13 BB junctions (junction numbers 3, 5, 7, 11,
+# 13, 14, 15, 16, 17, 18, 19, 21, 29); all are cross junctions.
+_SCHIAVI_BB_RATIOS = (
+    0.4, 0.4, 0.2, 0.3, 0.3, 0.3, 0.4, 0.3, 0.3, 0.2, 0.3, 0.4, 0.2
+)
+# Table 2, "essential" mass ratios mEwall/mEfloor of the 19 CB junctions
+# (junction numbers 1, 2, 4, 6, 8, 9, 10, 12, 20, 22, 23, 24, 25, 26, 27,
+# 28, 30, 31, 32).
+_SCHIAVI_CB_RATIOS = (
+    0.1, 0.1, 0.1, 0.2, 0.1, 0.2, 0.2, 0.2, 0.2, 0.1,
+    0.2, 0.1, 0.1, 0.1, 0.2, 0.2, 0.1, 0.1, 0.2,
+)
+
+
+def test_schiavi_table3_transcription_matches_single_numbers() -> None:
+    # The paper's single-number rows are "obtained from the frequency
+    # averaging from 100 Hz to 5 kHz" and printed as integers: pin the
+    # transcribed per-band columns to them (0.5 dB integer rounding).
+    n_bands = len(_SCHIAVI_TABLE3_FREQS)
+    assert len(_SCHIAVI_TABLE3_CB) == len(_SCHIAVI_TABLE3_BB) == n_bands
+    assert sum(_SCHIAVI_TABLE3_CB) / n_bands == pytest.approx(
+        _SCHIAVI_SINGLE_CB, abs=0.5
+    )
+    assert sum(_SCHIAVI_TABLE3_BB) / n_bands == pytest.approx(
+        _SCHIAVI_SINGLE_BB, abs=0.5
+    )
+
+
+@pytest.mark.parametrize(
+    ("ratios", "measured"),
+    [
+        (_SCHIAVI_BB_RATIOS, _SCHIAVI_SINGLE_BB),
+        (_SCHIAVI_CB_RATIOS, _SCHIAVI_SINGLE_CB),
+    ],
+    ids=["bb-junctions", "cb-junctions"],
+)
+def test_schiavi_measured_kij_anchors_annex_e_prediction(
+    ratios: tuple[float, ...], measured: float
+) -> None:
+    # Schiavi & Astolfi compare their measured Kij with the EN 12354-1
+    # Annex E rigid-cross corner formula (their Eq. (5), chosen "due to the
+    # prevalence of cross junctions in the full set of data") and report that
+    # the differences "are normally distributed, with an average value of
+    # 3.4 dB" (Sec. 5.1); the essential-mass CB comparison of Sec. 4.2 gives
+    # "about 4 dB". This is a tolerance anchor, not a digit oracle: the
+    # library prediction evaluated at the junctions' mean mass ratio must sit
+    # within 4.5 dB (the Sec. 4.2 "about 4 dB" figure plus the paper's
+    # ~0.5 dB standard deviation of the mean) of the measured single-number
+    # Kij. It fixes the
+    # sign convention of M and the Annex E constants against real data.
+    mean_ratio = sum(ratios) / len(ratios)
+    predicted = junction_vibration_reduction("rigid_cross", "corner", mean_ratio)
+    assert abs(measured - predicted) <= 4.5
+    # And the corner branch must be direction-symmetric (the paper notes the
+    # choice of the mass ratio for M is arbitrary for corner transmission).
+    assert junction_vibration_reduction(
+        "rigid_cross", "corner", 1.0 / mean_ratio
+    ) == pytest.approx(predicted, abs=1e-9)

--- a/tests/building/test_facade_prediction.py
+++ b/tests/building/test_facade_prediction.py
@@ -457,3 +457,61 @@ def test_radiated_power_plot() -> None:
     ax = _annex_g_side1_with_door().plot()
     assert ax.get_ylabel() != ""
     assert len(ax.patches) == len(ref.EN12354_4_ANNEX_G_BANDS)
+
+
+# ---------------------------------------------------------------------------
+# Element compositing — independent literature oracles
+# ---------------------------------------------------------------------------
+
+# The area-weighted transmission-factor sum (Formula 15) is unit-free in the
+# area ratio, so Long's foot-pound examples apply as printed. The receiving
+# volume is not part of R', so a nominal volume is passed.
+
+
+def test_composite_r_long_window_in_wall() -> None:
+    # Long, Architectural Acoustics 2e (Academic Press, 2014), Ch. 10 p. 385:
+    # a 12 ft2 window of TL 25 dB in a 160 ft2 wall of TL 45 dB gives
+    # R = 10 lg[160 / (12*0.0034 + 148*0.00003)] = 35.5 dB. Long rounds the
+    # transmission factors to two significant figures (0.0034 for 10^-2.5 =
+    # 0.00316), which moves the printed result by up to 0.3 dB; the exact
+    # compositing gives 35.74 dB.
+    res = facade_sound_reduction(
+        [
+            FacadeElement("wall", area=148.0, r=45.0),
+            FacadeElement("window", area=12.0, r=25.0),
+        ],
+        area=160.0,
+        volume=50.0,
+    )
+    assert res.r_prime[0] == pytest.approx(35.5, abs=0.3)
+
+
+def test_composite_r_long_slot_under_door() -> None:
+    # Long (2014), Ch. 10 p. 385: a 20 ft2 door of TL 30 dB with a 0.5 in
+    # slot (0.125 ft2, TL 0 dB) beneath it composites to
+    # R = 10 lg[20.125 / (20*0.001 + 0.125*1)] = 21.4 dB (printed to 0.1 dB).
+    res = facade_sound_reduction(
+        [
+            FacadeElement("door", area=20.0, r=30.0),
+            FacadeElement("slot", area=0.125, r=0.0),
+        ],
+        area=20.125,
+        volume=50.0,
+    )
+    assert res.r_prime[0] == pytest.approx(21.4, abs=0.05)
+
+
+def test_composite_r_manual_es_facade() -> None:
+    # Aviles Lopez & Perera Martin, Manual de acustica ambiental y
+    # arquitectonica (Paraninfo), Ejemplo 7.5 (p. 410): 8 m2 facade with a
+    # 2 m2 window; blind part RA = 40 dBA, window RA = 26 dBA ->
+    # Rg = 10 lg[8 / (6*10^-4.0 + 2*10^-2.6)] = 31.5 dBA (printed to 0.1 dB).
+    res = facade_sound_reduction(
+        [
+            FacadeElement("blind part", area=6.0, r=40.0),
+            FacadeElement("window", area=2.0, r=26.0),
+        ],
+        area=8.0,
+        volume=50.0,
+    )
+    assert res.r_prime[0] == pytest.approx(31.5, abs=0.05)

--- a/tests/building/test_insulation.py
+++ b/tests/building/test_insulation.py
@@ -445,3 +445,49 @@ def test_impact_one_decimal_reference_floor() -> None:
     assert res.rating == pytest.approx(77.6)
     assert res.ci == pytest.approx(-10.3)
     assert res.core.rating == 78 and res.core.ci == -11
+
+
+# ---------------------------------------------------------------------------
+# ISO 717-1 rating of a published Spanish field test report (CTE DB-HR chain)
+# ---------------------------------------------------------------------------
+
+# Aviles Lopez & Perera Martin, "Manual de acustica ambiental y
+# arquitectonica" (Paraninfo, ISBN 978-84-283-3814-1), Ejemplo 7.2
+# (pp. 394-395): apparent sound reduction index R' of a separating wall from a
+# real field test report, one-third-octave bands 100 Hz - 3150 Hz (the report
+# extends to 5 kHz; the 16 ISO 717-1 rating bands are used here).
+_MANUAL_ES_R_PRIME = (
+    36.2, 41.5, 36.9, 40.4, 44.7, 42.4, 45.7, 46.1,
+    47.1, 52.3, 54.3, 57.5, 57.8, 57.3, 59.0, 62.8,
+)
+
+# Ejercicio 7.1 (p. 395): standardized facade level difference D2m,nT of the
+# same building's facade, same band layout.
+_MANUAL_ES_D_2M_NT = (
+    28.5, 28.5, 18.9, 23.7, 30.7, 31.3, 37.8, 35.2,
+    34.7, 38.5, 37.7, 43.1, 42.3, 44.2, 41.9, 37.5,
+)
+
+
+def test_weighted_rating_manual_es_field_report() -> None:
+    # Ejemplo 7.1 (pp. 391-392) publishes the report's ISO 717-1 statement for
+    # this curve: R'w = 52 dB with C = -1 and Ctr = -5, hence the CTE DB-HR
+    # global indices R'A = R'w + C = 51 dBA (pink noise) and
+    # R'A,tr = R'w + Ctr = 47 dBA (traffic). All integers by definition.
+    res = weighted_rating(_MANUAL_ES_R_PRIME)
+    assert res.rating == 52
+    assert res.c == -1
+    assert res.ctr == -5
+    # The published global indices 51 dBA and 47 dBA follow as 52 - 1 and
+    # 52 - 5 from the three values asserted above.
+
+
+def test_weighted_rating_manual_es_facade_traffic_index() -> None:
+    # Ejercicio 7.1 evaluates the CTE DB-HR facade index directly with the
+    # one-decimal formula D2m,nT,Atr = -10 lg sum 10^((LAtr,i - Di)/10) and
+    # publishes 32.8 dBA. The ISO 717-1 route implemented here yields the
+    # integer pair D2m,nT,w + Ctr; the two definitions agree to within the
+    # C-term's integer rounding, so 1.0 dB is the definitional tolerance
+    # (0.5 dB rounding of Ctr plus 0.5 dB of the printed one-decimal value).
+    res = weighted_rating(_MANUAL_ES_D_2M_NT)
+    assert res.rating + res.ctr == pytest.approx(32.8, abs=1.0)

--- a/tests/emission/test_vibration_sound_power.py
+++ b/tests/emission/test_vibration_sound_power.py
@@ -177,3 +177,18 @@ def test_plot_returns_axes() -> None:
         np.array([70.0, 75.0, 72.0]), 1.5, frequencies=np.array([250.0, 500.0, 1000.0])
     )
     assert res.plot() is not None
+
+
+def test_radiated_power_norton_diesel_engine_example() -> None:
+    # Norton & Karczub, Fundamentals of Noise and Vibration Analysis for
+    # Engineers 2e (CUP, 2003), problem 3.9 (p. 580) with the published
+    # answer (p. 611): a diesel engine approximated by a 1.2 m cube (five
+    # radiating faces, S = 7.2 m2) with v_rms = 12.2 mm/s in the 500 Hz
+    # octave band and radiation ratio sigma = 0.25 radiates W = 0.1112 W,
+    # i.e. Lw = 110.5 dB re 1 pW — the ISO/TS 7849-style vibration-velocity
+    # method. The book uses rho*c ~ 415 N.s/m3 against the standard's
+    # normalized 411 N.s/m3 (0.04 dB) and rounds to 0.1 dB, so 0.15 dB
+    # covers both.
+    lv = 20.0 * math.log10(12.2e-3 / 5e-8)  # dB re 5e-8 m/s
+    lw = radiated_sound_power_level(lv, 7.2, radiation_factor=0.25)
+    assert float(lw) == pytest.approx(110.5, abs=0.15)

--- a/tests/environmental/test_environmental.py
+++ b/tests/environmental/test_environmental.py
@@ -87,3 +87,11 @@ def test_composite_accepts_generator_and_rejects_empty() -> None:
 def test_composite_rejects_non_finite_hours() -> None:
     with pytest.raises(ValueError, match="finite"):
         composite_rating_level([(60.0, float("nan"), 0.0), (50.0, 12.0, 0.0)])
+
+
+def test_lden_manual_es_published_example() -> None:
+    # Aviles Lopez & Perera Martin, Manual de acustica ambiental y
+    # arquitectonica (Paraninfo), Ejemplo 1.7 (p. 27): Ld = 65, Le = 62,
+    # Ln = 54 dBA give Lden = 65.1 dB with the standard 12/4/8 h day.
+    # The book prints one decimal (exact value 65.12), so 0.05 covers it.
+    assert lden(65.0, 62.0, 54.0) == pytest.approx(65.1, abs=0.05)

--- a/tests/materials/test_dynamic_stiffness.py
+++ b/tests/materials/test_dynamic_stiffness.py
@@ -171,3 +171,32 @@ def test_plot_returns_axes() -> None:
     matplotlib.use("Agg")
     res = floating_floor_resonance(25.0, 200.0, 100.0)
     assert res.plot() is not None
+
+
+# ---------------------------------------------------------------------------
+# Floating-floor natural frequency — Vigran's published outcomes
+# ---------------------------------------------------------------------------
+
+# Vigran, Building Acoustics (2008), Sec. 8.4.4 "Examples" pp. 317-318,
+# prints the constructions and the resulting natural frequencies (~40 Hz and
+# ~90 Hz); the numeric inputs below are reconstructed from the same section:
+# the total dynamic stiffness s' = 8.0 MPa/m of the 25 mm mineral-wool layer
+# follows from the Table 8.3 dynamic E-modulus plus the enclosed-air
+# stiffness, and the plate masses per unit area are nominal values for the
+# stated build-ups.
+
+
+def test_natural_frequency_vigran_concrete_floating_floor() -> None:
+    # 50 mm concrete floating slab (nominal m' ~ 115 kg/m2) on the
+    # s' = 8.0 MPa/m layer: the book publishes f0 ~= 40 Hz, rounded to the
+    # nearest 10 Hz (the reconstruction gives 42.0 Hz exactly), so 3 Hz
+    # covers the rounding plus the nominal slab mass.
+    assert natural_frequency(8.0e6, 115.0) == pytest.approx(40.0, abs=3.0)
+
+
+def test_natural_frequency_vigran_lightweight_floating_floor() -> None:
+    # Same layer under a lightweight top plate of 22 mm chipboard + 13 mm
+    # plasterboard (nominal m' ~ 16.7 + 11.2 ~ 28 kg/m2): the book publishes
+    # f0 ~= 90 Hz, rounded to the nearest 10 Hz (the reconstruction gives
+    # 85.1 Hz), so 5.5 Hz covers the rounding plus the nominal plate masses.
+    assert natural_frequency(8.0e6, 28.0) == pytest.approx(90.0, abs=5.5)

--- a/tests/room/test_reverberation_prediction.py
+++ b/tests/room/test_reverberation_prediction.py
@@ -402,3 +402,41 @@ def test_plot_returns_axes() -> None:
     matplotlib.use("Agg")
     res = reverberation_time_models(DIMS, (0.2, 0.15, 0.3), frequencies=[125.0, 250.0])
     assert res.plot() is not None
+
+
+# ---------------------------------------------------------------------------
+# Sabine chain — published Spanish classroom example
+# ---------------------------------------------------------------------------
+
+
+def test_sabine_manual_es_classroom_chain() -> None:
+    # Aviles Lopez & Perera Martin, Manual de acustica ambiental y
+    # arquitectonica (Paraninfo), Ejemplos 8.1 (pp. 524-525, equivalent
+    # absorption areas) and 8.2 (p. 549, Sabine reverberation times) for a
+    # 6.0 x 10.2 m classroom: V = 214.2 m3 with the original plaster ceiling
+    # and 189.7 m3 with the absorbent false ceiling. Octave bands
+    # 125 Hz - 4 kHz. The book evaluates T = 0.16 V / A and rounds to
+    # 0.01 s; the library's exact 55.26/c0 constant (0.161) differs by 0.6 %,
+    # so 0.04 s covers both effects at the longest published time (4.31 s).
+    cases = [
+        # (volume m3, A per band m2, published T per band s)
+        (
+            214.2,
+            (34.83, 14.36, 9.74, 7.94, 10.39, 12.67),
+            (0.98, 2.39, 3.52, 4.31, 3.30, 2.71),
+        ),
+        (
+            189.7,
+            (34.74, 19.80, 25.00, 41.09, 58.44, 47.00),
+            (0.87, 1.53, 1.21, 0.74, 0.52, 0.65),
+        ),
+        (
+            189.7,
+            (38.34, 27.00, 42.70, 70.49, 92.34, 80.60),
+            (0.79, 1.12, 0.71, 0.43, 0.33, 0.38),
+        ),
+    ]
+    for volume, areas, expected in cases:
+        for area, t_published in zip(areas, expected, strict=True):
+            t = sabine_reverberation_time(volume, [(area, 1.0)])
+            assert t == pytest.approx(t_published, abs=0.04), (volume, area)

--- a/tests/room/test_room_noise.py
+++ b/tests/room/test_room_noise.py
@@ -270,3 +270,38 @@ def test_rc_plot_returns_axes() -> None:
     ax = rn.room_criterion(rn.rc_curve(35.0)).plot()
     assert isinstance(ax, plt.Axes)
     plt.close("all")
+
+
+# ---------------------------------------------------------------------------
+# Published NC-rating examples
+# ---------------------------------------------------------------------------
+
+
+def test_nc_rating_manual_es_measured_spectrum() -> None:
+    # Aviles Lopez & Perera Martin, Manual de acustica ambiental y
+    # arquitectonica (Paraninfo), Ejemplo 8.3 (p. 564): measured octave
+    # spectrum 46/44/38/31/27/22/24/21 dB at 63 Hz - 8 kHz. With the classic
+    # 5-step NC family the book rates it NC-30 by tangency and refines to
+    # NC-27 by sliding the curve down 3 dB. The interpolated ANSI S12.2
+    # tangency implemented here lands on the same refined value; 0.5 dB
+    # covers the book's whole-dB curve stepping against the interpolation.
+    res = rn.noise_criterion(
+        [46.0, 44.0, 38.0, 31.0, 27.0, 22.0, 24.0, 21.0],
+        [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0],
+    )
+    assert res.rating == pytest.approx(27.0, abs=0.5)
+    assert res.rating <= 30.0  # the book's unrefined tangency designation
+
+
+def test_nc_verdict_long_hvac_receiver_spectrum() -> None:
+    # Long, Architectural Acoustics 2e (2014), Table 14.9 (pp. 555-558): the
+    # combined supply-plus-return receiver spectrum of the worked HVAC duct
+    # path, 55/45/32/26/23/25/22/12 dB at 63 Hz - 8 kHz, "meets NC 30". The
+    # rating must therefore not exceed 30 (and the spectrum must lie inside
+    # the NC family).
+    res = rn.noise_criterion(
+        [55.0, 45.0, 32.0, 26.0, 23.0, 25.0, 22.0, 12.0],
+        [63.0, 125.0, 250.0, 500.0, 1000.0, 2000.0, 4000.0, 8000.0],
+    )
+    assert res.out_of_range is None
+    assert res.rating <= 30.0

--- a/tests/underwater/test_ocean_ambient_noise.py
+++ b/tests/underwater/test_ocean_ambient_noise.py
@@ -125,3 +125,13 @@ def test_ambient_plot_smoke() -> None:
     f = np.logspace(2, 5, 50)
     res = ocean_ambient_noise(f, wind_speed_knots=10.0, shipping=np.full(50, 60.0))
     assert res.plot() is not None
+
+
+def test_thermal_noise_ainslie_closed_form_spot_value() -> None:
+    # Ainslie, Principles of Sonar Performance Modelling (2010), Eq. (9.153)
+    # p. 485: thermal noise NLf = -14.7 + 20 lg F(kHz) dB re uPa2/Hz. At
+    # F = 100 kHz that is 25.3 dB re uPa2/Hz. Ainslie prints the constant to
+    # one decimal, so 0.1 dB covers the rounding against the library's exact
+    # Mellen physical form at its default conditions.
+    got = thermal_noise_spectrum([100000.0])
+    assert float(got[0]) == pytest.approx(-14.7 + 20.0 * 2.0, abs=0.1)

--- a/tests/underwater/test_ship_traffic_noise.py
+++ b/tests/underwater/test_ship_traffic_noise.py
@@ -177,3 +177,53 @@ def test_randi_reproduces_report_table_2(
     got = _randi(f, speed_kn, length_ft * 0.3048)
     for idx, (freq, ref) in enumerate(sorted(levels.items())):
         assert float(got[idx]) == pytest.approx(ref, abs=0.1), freq
+
+
+# ---------------------------------------------------------------------------
+# JOMOPANS-ECHO vs the classic Overseas Harriette measurement
+# ---------------------------------------------------------------------------
+
+# Ainslie, Principles of Sonar Performance Modelling (2010), Table 8.16
+# (p. 421): third-octave dipole source levels of the cargo ship M/V Overseas
+# Harriette (173 m bulk carrier) at three speeds, from the Arveson &
+# Vendittis (2000) measurements — the classic single-ship anchor for
+# class-average source-level models. dB re uPa2 m2.
+_HARRIETTE_FREQS = [50.0, 100.0, 200.0, 500.0, 1000.0, 2000.0]
+_HARRIETTE_LEVELS = {
+    16.0: [185.0, 180.0, 174.0, 168.0, 166.0, 163.0],
+    12.0: [178.0, 169.0, 164.0, 161.0, 159.0, 155.0],
+    8.0: [163.0, 154.0, 156.0, 157.0, 156.0, 152.0],
+}
+
+
+@pytest.mark.parametrize("speed_kn", [16.0, 12.0])
+def test_jomopans_echo_tracks_overseas_harriette_at_speed(
+    speed_kn: float,
+) -> None:
+    # At the vessel's service speeds the class-average bulker prediction must
+    # track the measured individual ship within the model's own class spread:
+    # MacGillivray & de Jong (2021) report within-class standard deviations of
+    # roughly 5 dB per band, so 8 dB per band (< 2 sigma) and
+    # 4 dB on the six-band mean are the tolerance. This is a cross-check
+    # anchor for the speed/length scaling and band conversion, not a digit
+    # oracle.
+    res = ship_source_spectrum(
+        speed_kn, 173.0, vessel_class="bulker",
+        frequency_hz=_HARRIETTE_FREQS,
+    )
+    diff = res.band_level - np.asarray(_HARRIETTE_LEVELS[speed_kn])
+    assert float(np.max(np.abs(diff))) <= 8.0
+    assert float(np.mean(np.abs(diff))) <= 4.0
+
+
+def test_jomopans_echo_overseas_harriette_low_speed_mean() -> None:
+    # At 8 kn the v^6 speed law of the class average under-predicts the
+    # machinery-dominated high bands of this particular ship (a documented
+    # limitation of speed-scaled class averages at low speed), so only the
+    # six-band mean deviation is constrained, at 6 dB (about one class
+    # standard deviation).
+    res = ship_source_spectrum(
+        8.0, 173.0, vessel_class="bulker", frequency_hz=_HARRIETTE_FREQS,
+    )
+    diff = res.band_level - np.asarray(_HARRIETTE_LEVELS[8.0])
+    assert float(np.mean(np.abs(diff))) <= 6.0

--- a/tests/underwater/test_sonar_equation.py
+++ b/tests/underwater/test_sonar_equation.py
@@ -85,3 +85,61 @@ def test_plot_smoke() -> None:
     res = passive_sonar_equation(150.0, np.linspace(40.0, 110.0, 40), 55.0,
                                  detection_threshold=8.0)
     assert res.plot() is not None
+
+
+# ---------------------------------------------------------------------------
+# Ainslie (2010) worked-example figure-of-merit oracles
+# ---------------------------------------------------------------------------
+
+# Ainslie, Principles of Sonar Performance Modelling (Springer, 2010),
+# publishes complete term tables for his sonar-equation worked examples. The
+# term balances below re-combine those printed values through the library's
+# equations; every expected number is the book's, so these anchor the sign
+# conventions of the SL/NL/DI/DT/TS combination against an independent source.
+
+
+def test_ainslie_passive_narrowband_fom() -> None:
+    # Table 3.1 (p. 76), passive narrowband example of Sec. 3.2.3.8:
+    # SL = 133.9 dB re uPa2 m2, NLf = 59.7 dB re uPa2/Hz, AG = 11.5 dB,
+    # DT = 13.8 dB, analysis bandwidth 0.25 Hz (the printed "BW = -6.0 dB"
+    # row) -> FOM = 78.0 dB re m2. The bandwidth term folds into the masking
+    # noise as NL = NLf + 10 lg(0.25 Hz) = 59.7 - 6.0 dB. Five printed
+    # terms, each rounded to 0.1 dB, give a 0.15 dB accumulation allowance.
+    res = passive_sonar_equation(
+        133.9, 0.0, 59.7 - 6.0,
+        directivity_index=11.5, detection_threshold=13.8,
+    )
+    assert res.figure_of_merit == pytest.approx(78.0, abs=0.15)
+
+
+def test_ainslie_passive_broadband_fom() -> None:
+    # Table 3.2 (p. 90), passive broadband example of Sec. 3.2.4.8 (spectral
+    # density form, no bandwidth term): SLf = 100.9 dB re uPa2 m2/Hz,
+    # NLf = 53.2 dB re uPa2/Hz, AGm = 12.8 dB, DT = -18.6 dB ->
+    # FOM = 79.0 dB re m2 (four printed 0.1 dB terms -> 0.15 dB allowance).
+    res = passive_sonar_equation(
+        100.9, 0.0, 53.2,
+        directivity_index=12.8, detection_threshold=-18.6,
+    )
+    assert res.figure_of_merit == pytest.approx(79.0, abs=0.15)
+
+
+def test_ainslie_active_orca_noise_limited_fom() -> None:
+    # Sec. 11.4.6 (orca vs salmon, Tables 11.6-11.7 pp. 620-624): SL(RMS) =
+    # 198.2 dB re uPa2 m2, TS(salmon, 0.8 m) = -29.0 dB re m2, wind noise
+    # NL = 75.0 dB re uPa2, AG = 16.5 dB, DT = 8.7 dB -> noise-limited
+    # FOM_NL = (SL + TS - (NL - AG) - DT)/2 = 51.0 dB re m2.
+    res = active_sonar_equation(
+        198.2, 0.0, -29.0, 75.0,
+        directivity_index=16.5, detection_threshold=8.7,
+    )
+    assert res.figure_of_merit == pytest.approx(51.0, abs=0.05)
+
+
+def test_ainslie_active_orca_hearing_threshold_fom() -> None:
+    # Same example: against the orca's hearing threshold at 50 kHz,
+    # HT = 51.2 dB re uPa2 (audiogram Eq. 11.159), the book's
+    # FOM_HT = (SL + TS - HT)/2 = 59.0 dB re m2; the threshold acts as the
+    # masking level with no array gain and no detection threshold.
+    res = active_sonar_equation(198.2, 0.0, -29.0, 51.2)
+    assert res.figure_of_merit == pytest.approx(59.0, abs=0.05)

--- a/tests/underwater/test_underwater_propagation.py
+++ b/tests/underwater/test_underwater_propagation.py
@@ -187,3 +187,18 @@ def test_ainslie_mccolm_table_i_oceans_within_ten_percent_of_fg() -> None:
                                  depth=z_km * 1000.0, ph=ph_v,
                                  model="ainslie-mccolm")
         assert float(np.max(np.abs(am - fg) / fg)) <= 0.10, (ph_v, s, t, z_km)
+
+
+def test_ainslie_mccolm_book_spot_value_300hz() -> None:
+    # Ainslie, Principles of Sonar Performance Modelling (Springer, 2010):
+    # the passive worked example of Sec. 3.2.3.8 quotes the seawater
+    # absorption at its 300 Hz tonal as 0.0086 dB/km (footnote, p. 78),
+    # computed for the book's representative conditions T = 10 C, S = 35,
+    # z = 0, pH = 8 (pp. 28-29). The book prints two significant figures
+    # (exact Ainslie-McColm value 0.00858 dB/km), so 1e-4 dB/km covers the
+    # rounding.
+    alpha = seawater_absorption(
+        300.0, temperature=10.0, salinity=35.0, depth=0.0, ph=8.0,
+        model="ainslie-mccolm",
+    )
+    assert float(alpha[0]) == pytest.approx(0.0086, abs=1e-4)

--- a/tests/vibration/test_mechanical_mobility.py
+++ b/tests/vibration/test_mechanical_mobility.py
@@ -277,3 +277,56 @@ def test_rigid_mass_plot_rejects_unknown_language() -> None:
     res = rigid_mass_calibration_check([0.1], [100.0], 10.0)
     with pytest.raises(ValueError, match="Unknown language"):
         res.plot(language="xx")
+
+
+# ---------------------------------------------------------------------------
+# SDOF resonance — published tapping-machine/covering spot oracles
+# ---------------------------------------------------------------------------
+
+# These anchor the SDOF resonance relation f0 = (1/2pi) sqrt(k/m) on published
+# building-acoustics worked values for the ISO tapping-machine hammer
+# (m = 0.5 kg) resting on the contact stiffness of a floor covering — the
+# input side of the ISO 16251-1 / ISO 10140-3 improvement prediction models.
+
+
+def test_resonance_vigran_floor_covering_spot_values() -> None:
+    # Vigran, Building Acoustics (2008), Sec. 8.4.5 pp. 319-321 (Figs. 8.36
+    # and 8.37): hammer mass 0.5 kg on measured covering stiffnesses
+    # s = 3.2e5 N/m (carpet squares) -> f0 ~= 130 Hz, and s = 5.2e6 N/m
+    # (vinyl on felt) -> f0 ~= 510 Hz. The book quotes rounded frequencies
+    # (exact values 127.3 and 513.3 Hz), so 4 Hz covers the rounding.
+    # (The Fig. 8.37 caption prints the carpet stiffness as 3.2e6 N/m; the
+    # body text value 3.2e5 N/m is the one that reproduces 130 Hz — a book
+    # erratum, not one of the standard.)
+    assert resonance_frequency(0.5, 3.2e5) == pytest.approx(130.0, abs=4.0)
+    assert resonance_frequency(0.5, 5.2e6) == pytest.approx(510.0, abs=4.0)
+
+
+def test_resonance_hopkins_contact_stiffness_cutoffs() -> None:
+    # Hopkins, Sound Insulation (2007), Sec. 4.4.3.1 pp. 513-514 with the
+    # model of Sec. 3.6.3.1 (Eqs. 3.97/3.98/3.102): ISO tapping machine
+    # hammer m = 0.5 kg, contact radius r = 15 mm.
+    m_hammer = 0.5
+    r_contact = 0.015
+    # Covering No. 2, E/d = 2.8e8 N/m3: K = (E/d)*pi*r^2 (Eq. 3.98) and
+    # fco = (1/2pi) sqrt(K/m); Hopkins publishes fco = 100 Hz (exact
+    # 100.1 Hz).
+    k_covering_2 = 2.8e8 * math.pi * r_contact**2
+    assert resonance_frequency(m_hammer, k_covering_2) == pytest.approx(
+        100.0, abs=0.5
+    )
+    # Covering No. 1, E/d = 1.5e11 N/m3: Hopkins publishes fco ~= 2300 Hz
+    # (exact 2318 Hz; the book rounds to two significant figures).
+    k_covering_1 = 1.5e11 * math.pi * r_contact**2
+    assert resonance_frequency(m_hammer, k_covering_1) == pytest.approx(
+        2300.0, abs=25.0
+    )
+    # Bare 140 mm concrete slab: K = 2 r E / (1 - nu^2) (Eq. 3.97) with
+    # E = cL^2 rho (1 - nu^2) from cL = 3800 m/s, rho = 2200 kg/m3,
+    # nu = 0.2; Hopkins publishes fco ~= 7000 Hz (exact 6947 Hz, rounded to
+    # one significant figure in the book).
+    e_concrete = 3800.0**2 * 2200.0 * (1.0 - 0.2**2)
+    k_plate = 2.0 * r_contact * e_concrete / (1.0 - 0.2**2)
+    assert resonance_frequency(m_hammer, k_plate) == pytest.approx(
+        7000.0, abs=100.0
+    )


### PR DESCRIPTION
## Summary

27 new tests hard-pin published worked examples and measured tables from the acoustics literature against the existing functions, complementing the standard-clause conformance suite with independent book anchors:

- Junctions: Vigran's T-junction worked example (Kij 6.9 dB, EN 12354-1 path), Alba's rigid and elastic-interlayer expressions, and Schiavi's measured cross-junction Kij tables (with the paper's own deviation statistics as the bound, plus a transcription self-check).
- Floating floors and coverings: Hopkins' contact-stiffness cutoff frequencies, Vigran's covering resonances (with a figure-caption erratum noted where the correct value is used) and floating-floor natural frequencies via EN 29052-1.
- Building chains: the Spanish Manual's CTE DB-HR worked chains (R'w 52, C -1, Ctr -5, R'A 51 dBA, R'A,tr 47 dBA, D2m,nT,Atr 32.8 dBA), Long's composite facade TL examples, Sabine chains and NC ratings, and Lden.
- Emission: Norton's diesel-engine radiated sound power (ISO/TS 7849 route).
- Underwater: Ainslie's absorption spot value, passive and active sonar figure-of-merit tables, thermal noise law, and the Overseas Harriette measured source levels as a JOMOPANS-ECHO cross-check.

Every expected value is a hardcoded literal with a source citation and a tolerance justified by the source's rounding; nothing requiring new features was forced in (those went to the feature-candidate list).

## Test plan

- Full suite: 5735 passed, 79 skipped.
- mypy src scripts, ruff, bandit: green.
- A second reviewer spot-verified ~90 printed values against the sources by page (zero transcription mismatches), recomputed every library value, and audited tolerance honesty; its findings are applied.

## Summary by Sourcery

Add independent literature-based oracle tests across building acoustics, vibration, underwater acoustics, and environmental noise domains to hard-pin existing prediction and rating functions against published reference examples.

Tests:
- Add Annex E junction Kij tests using Vigran, Alba, and Schiavi & Astolfi data to anchor junction vibration reduction predictions against measured and worked examples.
- Add facade compositing tests based on Long and Spanish Manual examples to validate composite sound reduction index calculations and CTE DB-HR ratings.
- Add single-degree-of-freedom resonance and floating-floor natural frequency tests using Vigran and Hopkins values to verify mechanical mobility and floor resonance utilities.
- Add ISO 717-1 and CTE DB-HR chain tests from Spanish field reports to confirm weighted rating and facade traffic index computations.
- Add Sabine reverberation-time chain and NC-rating tests from Long and Spanish classroom/HVAC examples to validate room acoustics and noise-criterion implementations.
- Add underwater sonar-equation figure-of-merit, seawater absorption, thermal noise, ship source-spectrum, and ocean ambient-noise tests using Ainslie, JOMOPANS-ECHO, and classic measurement anchors.
- Add radiated sound power test based on Norton’s diesel-engine example to check vibration-velocity sound power level calculations.
- Add environmental Lden test from the Spanish Manual to verify day-evening-night level aggregation logic.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

