### PR TITLE
Skip the SonarCloud scan on Dependabot runs

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -280,7 +280,11 @@ jobs:
   sonar:
     needs: tests
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
+    # Dependabot runs with a restricted token and no access to repository secrets, so
+    # SONAR_TOKEN is empty there and the scan can only ever fail. Skip it for those runs.
+    if: >-
+      github.actor != 'dependabot[bot]' &&
+      (github.event_name == 'pull_request' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
     steps:
     - uses: actions/checkout@v7
       with:


### PR DESCRIPTION
Dependabot workflow runs execute with a restricted token and no access to repository secrets, so `SONAR_TOKEN` arrives empty and the scanner exits with `Not authorized or project not found`. The result is that every dependency bump carries a permanently failing `sonar` check that carries no information about the change, while all the real gates (quality, tests on five platform/version combinations, conformance, API reference, figures) pass.

This guards the `sonar` job on the actor so those runs skip it. Analysis of `main` and of ordinary pull requests is untouched.

Verified on the three currently open dependency PRs (#382, #383, #384): all of them are green except `sonar`, whose logs show `SONAR_TOKEN:` empty followed by `EXECUTION FAILURE`.

## Summary by Sourcery

CI:
- Skip the SonarCloud scan job when the workflow actor is Dependabot while preserving analysis for main branch and regular pull requests.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated code-quality checks to skip SonarCloud scans for Dependabot-triggered workflows.
  * Existing pull request and main-branch scan conditions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->