### PR TITLE
Add a security policy and a pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,54 @@
+<!--
+Keep it short. The checklist below is this repository's CI gates written out, so
+working through it honestly is the quickest route to a green build. Tick what
+applies and delete the lines that do not.
+-->
+
+## What and why
+
+<!-- One or two sentences: what changes, and the problem it solves. Link the
+     issue or discussion it came from. -->
+
+## Validation
+
+<!-- Required for any new normative implementation, and the rule this project is
+     built on: name the numeric oracle each new method is checked against (a
+     published worked example, a printed table, or an exact closed form) and
+     confirm it was obtained independently of the code in this pull request,
+     never by running the implementation. Cite the source in the test docstring
+     too. Write "no new computation" if that is the case. -->
+
+## Checklist
+
+Ran locally, same as CI:
+
+- [ ] `ruff check .` and `ruff format --check .`
+- [ ] `mypy src scripts`
+- [ ] `bandit -r src` (any finding fails, including Low)
+- [ ] `pytest -q`
+
+Regenerated where this change touches them:
+
+- [ ] `make conformance`, with `docs/CONFORMANCE.md` committed
+- [ ] `make api-docs`, with `site/src/content/docs/reference/api/` and
+      `site/src/generated/api-sidebar.mjs` committed
+- [ ] `make llms`, with `llms.txt`, `llms-full.txt` and the shards under
+      `site/public/llms/` committed
+- [ ] `make graphs`, with `python scripts/check_figures.py` passing
+      (figures come from `scripts/generate_graphs.py`, never by hand)
+- [ ] `make pypi-readme` after editing `README.md`
+
+Applies to new API:
+
+- [ ] New modules registered in `scripts/api_taxonomy.py`
+- [ ] `docs/api-reference.md` covers every new `__all__` name
+      (`python scripts/check_api_reference.py`)
+- [ ] Result objects expose `.plot()`, with shared plotting code in
+      `src/phonometry/_plot/`
+- [ ] New package paths added to `.github/labeler.yml`
+
+Always:
+
+- [ ] Documentation updated in English and Spanish, kept in step
+- [ ] Any defect found in a published source recorded in `docs/ERRATA.md`
+- [ ] CHANGELOG entry under `[Unreleased]`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,7 +22,7 @@ applies and delete the lines that do not.
 
 Ran locally, same as CI:
 
-- [ ] `ruff check .` and `ruff format --check .`
+- [ ] `ruff check .`, plus `ruff format --check` on the files you touched
 - [ ] `mypy src scripts`
 - [ ] `bandit -r src` (any finding fails, including Low)
 - [ ] `pytest -q`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   "From the near field to the far field" section in the FDTD guide, in
   English and Spanish.
 
+- `SECURITY.md`: a security policy written for what this library actually is,
+  a computation package with no service and no credentials. Supported versions
+  (fixes ship forward on the latest 3.x, no backports; Python 3.13 and 3.14 on
+  Ubuntu, macOS and Windows), private reporting through GitHub security
+  advisories with an acknowledgement and assessment window I can keep, a
+  coordinated-disclosure statement, and a scope section that names the real
+  attack surface (untrusted files reaching a reader, deserialisation, the
+  release supply chain, repository automation) while stating plainly that a
+  value disagreeing with a standard is a conformance defect for the issue form,
+  and a defect in the standard itself an entry in `docs/ERRATA.md`. Also
+  records the checks already running: CodeQL, bandit, GitGuardian, Dependabot,
+  the `snyk` target and the conformance staleness gate.
+
+- `.github/pull_request_template.md`: the repository's CI gates written out as a
+  compact checklist, so the recurring failures (a stale `docs/CONFORMANCE.md`,
+  an unregenerated API reference, a module missing from
+  `scripts/api_taxonomy.py`, a figure not produced by `generate_graphs.py`,
+  EN/ES drift) are visible before the build runs. It also asks, for any new
+  normative implementation, which numeric oracle validated it and confirmation
+  that the oracle is independent of the implementation.
+
 - `make lighthouse` (`site/scripts/lighthouse-audit.mjs`): Lighthouse over a
   fixed sample of built pages against a local preview server, with JSON
   reports under `site/lighthouse-results/` and a console summary listing the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ is the right place for anything that is not yet a defect or a pull request:
 | Give feedback on the guides, figures or animations | [Documentation & learning](https://github.com/jmrplens/phonometry/discussions/categories/documentation-learning) |
 | Share a measurement, study or tool you built | [Show and tell](https://github.com/jmrplens/phonometry/discussions/categories/show-and-tell) |
 | Report a reproducible failure with no standard in play, or work on an agreed change | [Issues](https://github.com/jmrplens/phonometry/issues) |
+| Report a suspected security vulnerability | Privately, following the [security policy](SECURITY.md) |
 
 A discrepancy against a standard or a reference implementation belongs in
 Standards & conformance even when it reproduces every time, because settling it
@@ -190,6 +191,22 @@ Pull requests are labelled automatically from the paths they touch, through
 3. **Commit** your changes with clear messages.
 4. **Verify** your code using the commands above (`pytest`, `mypy`, `ruff`).
 5. **Push** to your fork and **Open a Pull Request**.
+
+The pull request description is prefilled from
+[`.github/pull_request_template.md`](.github/pull_request_template.md). Its
+checklist is the CI gates written out, including the regeneration steps above
+and the rule that matters most here: a new normative implementation must name
+the numeric oracle it was validated against, and that oracle must be independent
+of the implementation.
+
+### Security
+
+A suspected vulnerability goes through
+[GitHub's private reporting](https://github.com/jmrplens/phonometry/security/advisories/new)
+rather than an issue or a discussion. The [security policy](SECURITY.md) sets
+out what is treated as a vulnerability, what is not (a value that disagrees with
+a standard is a conformance defect, not a security issue), and what response to
+expect.
 
 ## License
 By contributing to this project, you agree that your contributions will be licensed under the project's [LICENSE](LICENSE) file.

--- a/README.md
+++ b/README.md
@@ -166,6 +166,10 @@ See the
 [contributing guide](https://github.com/jmrplens/phonometry/blob/main/CONTRIBUTING.md)
 and the
 [changelog](https://github.com/jmrplens/phonometry/blob/main/CHANGELOG.md).
+Suspected vulnerabilities go through
+[GitHub's private reporting](https://github.com/jmrplens/phonometry/security/advisories/new),
+as set out in the
+[security policy](https://github.com/jmrplens/phonometry/blob/main/SECURITY.md).
 
 ## 📄 License
 

--- a/README_PYPI.md
+++ b/README_PYPI.md
@@ -173,6 +173,10 @@ See the
 [contributing guide](https://github.com/jmrplens/phonometry/blob/main/CONTRIBUTING.md)
 and the
 [changelog](https://github.com/jmrplens/phonometry/blob/main/CHANGELOG.md).
+Suspected vulnerabilities go through
+[GitHub's private reporting](https://github.com/jmrplens/phonometry/security/advisories/new),
+as set out in the
+[security policy](https://github.com/jmrplens/phonometry/blob/main/SECURITY.md).
 
 ## 📄 License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,7 +35,7 @@ directly at
 That opens a private advisory visible only to you and me, and keeps the report,
 the fix and any CVE in one place.
 
-If private reporting is not available to you, write to `jmrplens@gmail.com`, the
+If private reporting is not available to you, write to `mail@jmrp.io`, the
 maintainer address already published in [`CITATION.cff`](CITATION.cff) and
 [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md), with `phonometry security` in the
 subject. Please do not use a public issue, a discussion or a pull request for a

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,150 @@
+# Security policy
+
+## What this project is
+
+phonometry is a scientific Python library. It computes acoustic, vibration and
+psychoacoustic quantities from arrays and files you hand it, inside your own
+process. It runs no service, opens no socket, holds no credentials and executes
+nothing it did not ship with. That shapes what a vulnerability can be here, so
+this policy is written for this library rather than copied from a generic
+template.
+
+## Supported versions
+
+Fixes ship forward. There are no backports: a security fix is released as a new
+version from `main`, and the remedy for any older version is to upgrade.
+
+| Version | Supported |
+| :--- | :--- |
+| 3.3.x (latest release) | Yes |
+| 3.0.x to 3.2.x | Upgrade to the latest 3.x |
+| 2.x and earlier, including `PyOctaveBand` | No |
+
+The `PyOctaveBand` package on PyPI is a 2.1.0 stub that only redirects to
+`phonometry` and receives no fixes.
+
+Supported interpreters are the ones CI exercises: Python 3.13 and 3.14 on
+Ubuntu, macOS and Windows. A report that reproduces only on an interpreter or
+platform outside that matrix is handled as an ordinary bug.
+
+## Reporting a vulnerability
+
+Report privately through GitHub, with **Security > Report a vulnerability**, or
+directly at
+[github.com/jmrplens/phonometry/security/advisories/new](https://github.com/jmrplens/phonometry/security/advisories/new).
+That opens a private advisory visible only to you and me, and keeps the report,
+the fix and any CVE in one place.
+
+If private reporting is not available to you, write to `jmrplens@gmail.com`, the
+maintainer address already published in [`CITATION.cff`](CITATION.cff) and
+[`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md), with `phonometry security` in the
+subject. Please do not use a public issue, a discussion or a pull request for a
+suspected vulnerability.
+
+A useful report states the version and interpreter, a minimal reproduction, the
+input that triggers the behaviour, and what an attacker gains. If a standard is
+involved, cite the clause or table by number rather than pasting the text.
+Standards are copyrighted.
+
+### What to expect
+
+This library is maintained by one person alongside research work, so these are
+commitments I can keep rather than an enterprise service level:
+
+| Step | Target |
+| :--- | :--- |
+| Acknowledgement that the report arrived | 5 working days |
+| First assessment: accepted, more information needed, or out of scope | 15 working days |
+| Release containing the fix, once accepted | with the next release, sooner if the impact warrants it |
+
+If the acknowledgement window passes in silence, add a comment on the advisory.
+It means the notification was missed, not that the report was dismissed.
+
+## Coordinated disclosure
+
+I work to coordinated disclosure. Please give me a chance to publish a fixed
+release before going public. In return I keep the advisory updated while it is
+open, credit you unless you would rather stay anonymous, and publish the advisory
+(with a CVE where GitHub assigns one) once the fixed version is on PyPI.
+
+Ninety days from acknowledgement is a reasonable ceiling. If a fix is going to
+take longer than that I will say so on the advisory instead of letting it go
+quiet.
+
+## Scope
+
+### Treated as a vulnerability
+
+- **Untrusted input reaching a computation.** Measurement arrays, samples
+  decoded elsewhere and passed in, and above all the file readers: the aircraft
+  noise module reads ANP CSV exports from a directory you point it at. If a
+  crafted file causes anything worse than a clean exception, for example
+  unbounded memory growth, a path that escapes the directory it was given, or an
+  attempt to execute what was read, that is a vulnerability.
+- **Deserialisation.** The library deliberately never unpickles, evaluates or
+  imports anything derived from input. A code path that does is a defect worth
+  reporting even without a working exploit.
+- **Supply chain.** Anything that can place code into a published artefact: the
+  release workflow, the contents of the built wheel or sdist, package data
+  reaching outside the package, or a dependency declaration that resolves
+  somewhere unexpected.
+- **Repository automation.** A workflow in this repository that can be made to
+  run attacker-controlled code, leak a secret, or escalate its token
+  permissions.
+
+### Not treated as a vulnerability
+
+- **A value that disagrees with a standard.** This is the failure mode that
+  matters most in this library, and it is a conformance defect, not a security
+  issue. Once the disagreement has been established, usually in
+  [Standards & conformance](https://github.com/jmrplens/phonometry/discussions/categories/standards-conformance),
+  file it with the
+  [conformance defect form](https://github.com/jmrplens/phonometry/issues/new?template=02-conformance-defect.yml).
+  It is handled with the same seriousness as a security report, in public, where
+  the numbers can be checked.
+- **A defect in the published standard itself.** Misprints and worked examples
+  that contradict their own normative text are recorded in
+  [`docs/ERRATA.md`](docs/ERRATA.md) with the evidence and the reading the
+  library implements. Those entries are documentation, never security
+  advisories.
+- **Resource exhaustion you asked for**, such as requesting a transform over an
+  array that does not fit in memory. The library computes what it is told to
+  compute.
+- **Results from inputs outside the validity range of a method**, for instance a
+  temperature or a frequency beyond what the standard covers. The guides state
+  the ranges; a missing range check is a bug report.
+- **Vulnerabilities in numpy, scipy, matplotlib, reportlab or any other
+  dependency.** Report those upstream. If phonometry uses the dependency in a way
+  that exposes users to it, that use is in scope here.
+- **Scanner output with no demonstrated impact**, and hardening suggestions with
+  no exploit path. Both are welcome as ordinary issues.
+
+## What already runs
+
+Rather than describe a process I do not have, here is the tooling that runs on
+every pull request and on `main`:
+
+- **CodeQL** default setup, weekly and on change, over the Python,
+  JavaScript/TypeScript and GitHub Actions code.
+- **bandit** over `src/` in the `quality` job. Any finding fails the build,
+  including Low severity, so the source stays clean of `assert` in library code,
+  unreviewed subprocess use and hardcoded secrets.
+- **GitGuardian** secret scanning on every pull request.
+- **Dependabot** security and version updates for pip, npm and GitHub Actions,
+  grouped weekly.
+- **Snyk** through the `snyk` target in the `Makefile`, for an on-demand
+  dependency audit.
+
+Workflows declare `contents: read` at the top level and widen permissions only
+on the individual jobs that need them.
+
+Integrity of the numbers is gated too, which matters more here than in most
+libraries: `docs/CONFORMANCE.md` is regenerated in CI from the library's own
+computations against reference values and the build fails if the committed
+report drifts, so a change that quietly moves a standards-conformant result
+cannot reach a release unnoticed.
+
+## Credit
+
+Reporters are credited in the published advisory and in the changelog entry for
+the release that carries the fix, unless they ask not to be.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,10 +4,11 @@
 
 phonometry is a scientific Python library. It computes acoustic, vibration and
 psychoacoustic quantities from arrays and files you hand it, inside your own
-process. It runs no service, opens no socket, holds no credentials and executes
-nothing it did not ship with. That shapes what a vulnerability can be here, so
-this policy is written for this library rather than copied from a generic
-template.
+process. It runs no service, opens no socket, holds no credentials, and never
+executes code derived from what you pass it: it calls its own code and its
+declared dependencies, nothing else. That shapes what a vulnerability can be
+here, so this policy is written for this library rather than copied from a
+generic template.
 
 ## Supported versions
 
@@ -16,24 +17,26 @@ version from `main`, and the remedy for any older version is to upgrade.
 
 | Version | Supported |
 | :--- | :--- |
-| 3.3.x (latest release) | Yes |
-| 3.0.x to 3.2.x | Upgrade to the latest 3.x |
+| Latest 3.x release | Yes |
+| Earlier 3.x releases | Upgrade to the latest 3.x |
 | 2.x and earlier, including `PyOctaveBand` | No |
 
-The `PyOctaveBand` package on PyPI is a 2.1.0 stub that only redirects to
+The `PyOctaveBand` package on PyPI is a stub that only redirects to
 `phonometry` and receives no fixes.
 
-Supported interpreters are the ones CI exercises: Python 3.13 and 3.14 on
-Ubuntu, macOS and Windows. A report that reproduces only on an interpreter or
-platform outside that matrix is handled as an ordinary bug.
+Supported interpreters and platforms are whatever the test matrix in
+[`.github/workflows/python-app.yml`](.github/workflows/python-app.yml)
+exercises, at the time of writing Python 3.13 and 3.14 on Ubuntu, macOS and
+Windows. That workflow is the authority, not this paragraph. A report that
+reproduces only outside the matrix is handled as an ordinary bug.
 
 ## Reporting a vulnerability
 
 Report privately through GitHub, with **Security > Report a vulnerability**, or
 directly at
 [github.com/jmrplens/phonometry/security/advisories/new](https://github.com/jmrplens/phonometry/security/advisories/new).
-That opens a private advisory visible only to you and me, and keeps the report,
-the fix and any CVE in one place.
+That opens a private advisory visible only to you and the maintainers, and keeps
+the report, the fix and any CVE in one place.
 
 If private reporting is not available to you, write to `mail@jmrp.io`, the
 maintainer address already published in [`CITATION.cff`](CITATION.cff) and


### PR DESCRIPTION
Two community health files were missing: a security policy and a pull request template. This adds both, written from what the project actually is rather than from a template.

## `SECURITY.md`

A generic policy would be worse than none here, so the threat model is specific to a computation library that runs no service and holds no credentials:

- **Supported versions.** Fixes ship forward on the latest 3.x with no backports, on the interpreters CI actually exercises (3.13 and 3.14, Ubuntu/macOS/Windows). The `PyOctaveBand` stub is called out as unmaintained.
- **Reporting.** Private reporting through GitHub security advisories, with the maintainer address already published in `CITATION.cff` and `CODE_OF_CONDUCT.md` as the fallback. Acknowledgement in 5 working days, first assessment in 15, fix with the next release. Deliberately not a 24 hour SLA for a single-maintainer research library.
- **Coordinated disclosure**, with 90 days from acknowledgement as the ceiling and credit in the advisory and the changelog.
- **Scope.** In: untrusted input reaching a reader (the ANP CSV loader is the concrete case), deserialisation, the release supply chain, repository automation. Out: dependency CVEs, resource exhaustion you asked for, out-of-range inputs, scanner output with no impact, and most importantly a value that disagrees with a standard. That last one is a conformance defect, and the policy links the conformance defect form and the Standards & conformance discussion category for it. Defects in the published standard itself are pointed at `docs/ERRATA.md`, explicitly not security advisories.
- **What already runs**, described rather than invented: CodeQL default setup, bandit in the `quality` job (any finding fails, including Low), GitGuardian on every pull request, Dependabot for pip/npm/Actions, the `snyk` Makefile target, and the conformance staleness gate as an integrity control on the numbers themselves.

## `.github/pull_request_template.md`

This is the part with leverage, so the checklist is the CI gates written out: `ruff check .`, `mypy src scripts`, `bandit -r src`, `pytest -q`; the regeneration duties (`make conformance`, `make api-docs` with the sidebar fragment, `make llms` with the shards, `make graphs` verified by `check_figures.py`, `make pypi-readme`); registering new modules in `scripts/api_taxonomy.py` and new paths in `.github/labeler.yml`; `docs/api-reference.md` covering every new `__all__` name; `.plot()` on result objects; EN/ES parity; `docs/ERRATA.md`; and a CHANGELOG entry. The "Validation" section asks for the numeric oracle behind any new normative implementation and confirmation that it is independent of the implementation, which is the rule this library stands on. Guidance is in HTML comments so the rendered body stays clean.

**Single file rather than a `PULL_REQUEST_TEMPLATE/` directory.** A directory of named templates is only applied when the author appends `?template=name.md` to the compare URL, which is not what `gh pr create`, the fork banner or the normal UI flow does, so most pull requests would open with an empty body. The single file is prefilled unconditionally, and since the point is to stop the same gates being missed, unconditional is what it has to be. The gates are also common to every kind of change here, so there is nothing to split.

## Community profile

Verified against the API rather than assumed. `files.pull_request_template` is currently `null` and will point at the new file once this merges. `files.issue_template` stays `null`, and that is not a defect of our forms: the field only ever reports a legacy `ISSUE_TEMPLATE.md`, and numpy, scipy, matplotlib and ruff all show `null` there while using YAML forms exactly like ours, with numpy still scoring 100%. If you want that field non-null anyway, the one-line option is a legacy `.github/ISSUE_TEMPLATE.md` alongside the directory, which GitHub would then use to prefill blank issues (`blank_issues_enabled: true` in our `config.yml`). I have left it out on purpose: it would add a second, unstructured path into the tracker for a cosmetic API field. Say the word and I will add it.

One thing needs a settings change that a pull request cannot make: **private vulnerability reporting is currently disabled** on the repository (`gh api repos/jmrplens/phonometry/private-vulnerability-reporting` returns `{"enabled": false}`). The policy is written assuming it is on, so please enable it under Settings > Advanced Security before merging, otherwise the "Report a vulnerability" link 404s for reporters and only the email fallback works.

## Notes

`README_PYPI.md` is regenerated from the README edit. No documentation pages or site content changed, so the figure, conformance, API reference and llms outputs are all unchanged (verified: `check_conformance_claims.py`, `check_api_reference.py`, `generate_site_reports.py --check` and a fresh `generate_llms.py` all clean).

## Summary by Sourcery

Add a project-specific security policy and pull request template, and wire them into the contributing and user documentation.

New Features:
- Introduce a SECURITY.md policy tailored to the library’s threat model, supported versions, reporting process, and coordinated disclosure expectations.
- Add a prefilled pull request template with validation guidance and a checklist mirroring the project’s CI and regeneration requirements.

Enhancements:
- Reference the security policy and private vulnerability reporting flow from CONTRIBUTING, README, and README_PYPI to clarify how suspected vulnerabilities should be reported.
- Document the existing security tooling and integrity gates in CHANGELOG to make current protections visible to contributors and users.

Documentation:
- Update contributing and README documentation to point reporters to GitHub private vulnerability reporting and to clarify the distinction between security issues, conformance defects, and standard errata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive `SECURITY.md` security policy covering reporting channels, vulnerability scope/exclusions, supported versions, assessment timelines, and coordinated disclosure expectations.
  * Updated Development and contribution guidance in the main and PyPI READMEs to direct suspected vulnerabilities to private reporting.
  * Added security-related entries to the changelog.

* **Process / CI**
  * Introduced a structured pull request template with required validation steps and documentation/conformance checklists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->