### PR TITLE
Use mail@jmrp.io as the maintainer contact address

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ title: "phonometry: acoustic measurement toolkit for Python (formerly PyOctaveBa
 authors:
   - family-names: "Requena-Plens"
     given-names: "José M."
-    email: "jmrplens@gmail.com"
+    email: "mail@jmrp.io"
     orcid: "https://orcid.org/0000-0003-1250-6212"
 repository-code: "https://github.com/jmrplens/phonometry"
 url: "https://jmrplens.github.io/phonometry/"

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-jmrplens@gmail.com.
+mail@jmrp.io.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "phonometry"
 dynamic = ["version"]
 authors = [
-  { name="José M. Requena-Plens", email="jmrplens@gmail.com" },
+  { name="José M. Requena-Plens", email="mail@jmrp.io" },
 ]
 description = "Acoustic measurement toolkit: fractional octave-band filters, A/C/Z and time weighting, and sound level metrology per IEC 61260-1 and IEC 61672-1."
 # The PyPI long description is generated from README.md (which uses

--- a/stub/pyproject.toml
+++ b/stub/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "PyOctaveBand"
 version = "2.1.0"
 authors = [
-  { name="Jose Manuel Requena Plens", email="jmrplens@gmail.com" },
+  { name="José M. Requena-Plens", email="mail@jmrp.io" },
 ]
 description = "PyOctaveBand is now phonometry. This transition package installs phonometry and keeps 'import pyoctaveband' working."
 readme = "README.md"


### PR DESCRIPTION
The contact address published across the project was a personal Gmail address. This replaces it with the domain address in every file that carries it:

- `CITATION.cff` (citation metadata, so it also reaches Zenodo and the JOSS submission)
- `CODE_OF_CONDUCT.md` (the enforcement contact)
- `pyproject.toml` and `stub/pyproject.toml` (package metadata on PyPI)

While in the stub manifest I also finished the author-name unification that the rest of the project went through earlier: it still read "Jose Manuel Requena Plens" where everywhere else now reads "José M. Requena-Plens".

`.zenodo.json` carries no email, so it needed no change. A repo-wide sweep confirms no other tracked file mentions the old address.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR replaces the personal Gmail address with a domain-based contact address (mail@jmrp.io) across project metadata and documentation files. The change affects citation metadata, the code of conduct enforcement contact, and package metadata published on PyPI. Additionally, the stub package author name is standardized to match the canonical format used throughout the project.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Updates CITATION.cff and pyproject.toml to use mail@jmrp.io as the maintainer contact email instead of the personal Gmail address</li>

<li>Updates CODE_OF_CONDUCT.md enforcement contact from Gmail to mail@jmrp.io domain address</li>

<li>Updates stub/pyproject.toml with both the email change and author name normalization from 'Jose Manuel Requena Plens' to 'José M. Requena-Plens'</li>

<li>Confirms .zenodo.json carries no email and required no changes</li>

</ul>
</details>

</div>