### PR TITLE
Reflow multi-equation display formulas on narrow screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Documentation site: a display formula that states several equations on one
+  line now reflows on narrow screens instead of scrolling sideways. A build-time
+  pass splits such a block at the author's own widest top-level separator
+  (`\quad` or `\qquad`), makes each equation a part of a wrapping row and
+  re-expresses the separator as the row's column gap, so a wide screen renders
+  the identical single centred row while a phone stacks one equation per line,
+  each centred. It reaches the 232 blocks on 120 pages (60 English, 60 Spanish)
+  that state more than one equation per block, needs no change to the markdown,
+  and leaves the TeX, the accessible label and the page anchors untouched.
+
 - The home page meta description now fits the ~160-character window search
   engines display (Bing flagged the old 318-character one): the one-sentence
   definition plus the conformance-check claim, in both languages. The full

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -9,6 +9,7 @@ import rehypeKatex from 'rehype-katex';
 import { sidebar } from './src/data/sidebar.mjs';
 import { basePath, siteUrl } from './src/data/site.mjs';
 import { isOurMedia, mediaUrl, REMOTE_PREFIXES } from './src/lib/media.mjs';
+import { rehypeWrappableMath } from './src/lib/wrappable-math.mjs';
 import {
   featureList,
   keywords,
@@ -439,7 +440,13 @@ export default defineConfig({
     remarkPlugins: [remarkMath],
     // rehypeSingleTextMath must run after rehypeKatex: it rewrites the
     // elements KaTeX has just produced.
-    rehypePlugins: [rehypeKatex, rehypeSingleTextMath, rehypeLocalMedia, rehypeTableAlign],
+    rehypePlugins: [
+      rehypeKatex,
+      rehypeSingleTextMath,
+      rehypeWrappableMath,
+      rehypeLocalMedia,
+      rehypeTableAlign,
+    ],
   },
   integrations: [
     mermaid({

--- a/site/src/lib/wrappable-math.mjs
+++ b/site/src/lib/wrappable-math.mjs
@@ -1,0 +1,123 @@
+/**
+ * Lets a display formula that carries several equations on one line reflow.
+ *
+ * Theory pages routinely state two or three related equations in a single
+ * display block, separated by the author's own \quad or \qquad, because on a
+ * wide screen they belong together. KaTeX lays that row out as one unbreakable
+ * line, so on a phone the reader has to scroll the formula sideways to reach
+ * the last equation, and the block is centred, which means the first equation
+ * starts off-screen too.
+ *
+ * KaTeX already chops the row into unbreakable chunks (it breaks after every
+ * top-level relation and binary operator, as the TeXbook prescribes), but those
+ * are not equation boundaries: letting them wrap would strand an "=" at the end
+ * of a line. So the split is made at the author's own widest top-level spacer
+ * instead, which is exactly where one equation ends and the next begins, and
+ * each equation becomes a flex item. The separator is then re-expressed as the
+ * row's column gap, and a column gap is only drawn *between* items on the same
+ * line: a wide viewport gets the identical single centred row it got before,
+ * and a narrow one stacks one equation per line, each centred, with no dangling
+ * 2 em space hanging off the line ends.
+ *
+ * Nothing here depends on the page, the language or the theme, and the source
+ * markdown keeps stating the equations the way they read best: one line.
+ */
+export function rehypeWrappableMath() {
+  const classesOf = (node) =>
+    node?.type === 'element' && Array.isArray(node.properties?.className)
+      ? node.properties.className
+      : [];
+  const hasClass = (node, name) => classesOf(node).includes(name);
+  // KaTeX renamed its layout classes in 0.18 (`base` -> `katex-base`,
+  // `strut` -> `katex-strut`) to stop colliding with page styles. rehype-katex
+  // still renders with the 0.16 line, so both spellings are accepted rather
+  // than tying this pass to whichever one is installed.
+  const isChunk = (node) => hasClass(node, 'katex-base') || hasClass(node, 'base');
+  const isStrut = (node) => hasClass(node, 'katex-strut') || hasClass(node, 'strut');
+  // KaTeX writes horizontal space as a right margin on an empty span.
+  const spacerEm = (node) => {
+    const match = /margin-right:\s*([\d.]+)em/.exec(node.properties?.style ?? '');
+    return match ? Number(match[1]) : 0;
+  };
+  // The struts carry the chunk's height and depth, so every piece a chunk is
+  // split into needs its own copy.
+  const cloneStrut = (strut) =>
+    strut && { ...strut, properties: { ...strut.properties } };
+
+  return (tree) => {
+    (function visit(node) {
+      if (!hasClass(node, 'katex-display')) {
+        node.children?.forEach(visit);
+        return;
+      }
+      const katex = node.children?.find((c) => hasClass(c, 'katex'));
+      const html = katex?.children?.find((c) => hasClass(c, 'katex-html'));
+      const chunks = html?.children ?? [];
+      // A tagged or explicitly line-broken formula puts a tag or a newline
+      // among the chunks and already controls its own layout.
+      if (!chunks.length || !chunks.every(isChunk)) return;
+
+      // The widest top-level spacer is the author's own outermost separator:
+      // in `a = b \quad (b > 0), \qquad c = d` the \quad ties the condition to
+      // its equation and only the \qquad separates equations.
+      let gap = 0;
+      for (const chunk of chunks) {
+        for (const child of chunk.children ?? []) {
+          if (hasClass(child, 'mspace')) gap = Math.max(gap, spacerEm(child));
+        }
+      }
+      if (gap < 1) return; // No \quad-sized separator: a single equation.
+
+      const parts = [];
+      let part = [];
+      for (const chunk of chunks) {
+        const children = chunk.children ?? [];
+        // KaTeX always opens a chunk with its strut, but do not assume it: a
+        // first child taken for a strut it is not would be copied into every
+        // piece the chunk is split into.
+        const strut = isStrut(children[0]) ? children[0] : null;
+        const rest = strut ? children.slice(1) : children;
+        const piece = [];
+        const emit = () => {
+          if (!piece.length) return;
+          part.push({
+            ...chunk,
+            properties: { ...chunk.properties },
+            children: [cloneStrut(strut), ...piece].filter(Boolean),
+          });
+          piece.length = 0;
+        };
+        for (const child of rest) {
+          // Only the separator itself is taken out, and the column gap puts it
+          // back. Everything else stays exactly where it was, including the
+          // thin inter-atom space KaTeX writes next to it, so the row keeps its
+          // original width to the pixel while it fits on one line.
+          if (hasClass(child, 'mspace') && spacerEm(child) >= gap) {
+            emit();
+            if (part.length) {
+              parts.push(part);
+              part = [];
+            }
+            continue;
+          }
+          piece.push(child);
+        }
+        emit();
+      }
+      if (part.length) parts.push(part);
+      if (parts.length < 2) return;
+
+      html.children = parts.map((children) => ({
+        type: 'element',
+        tagName: 'span',
+        properties: { className: ['katex-eq-part'] },
+        children,
+      }));
+      html.properties = {
+        ...html.properties,
+        className: [...classesOf(html), 'katex-eq-row'],
+        style: `${html.properties?.style ? `${html.properties.style};` : ''}--katex-eq-gap:${gap}em`,
+      };
+    })(tree);
+  };
+}

--- a/site/src/styles/katex.css
+++ b/site/src/styles/katex.css
@@ -7,3 +7,25 @@
   overflow-y: hidden;
   padding-block: 0.25rem;
 }
+
+/* A display block stating several equations on one line is rebuilt at build
+   time (rehypeWrappableMath in src/lib/wrappable-math.mjs) as one part per
+   equation, with the author's \quad or \qquad carried in --katex-eq-gap.
+   Laying the parts out as a wrapping flex row makes the separation a gap, which
+   the browser draws only between parts that share a line: a wide screen keeps
+   the single centred row the formula was written as, and a narrow one stacks
+   one equation per line without a stray gap dangling at the line ends. Each
+   flex line is centred on its own, so no equation starts off-screen.
+
+   `safe center` keeps a part that is wider than the box reachable from the
+   left edge of the scroll container instead of overflowing both ways; the
+   plain `center` before it is what browsers without safe alignment apply. */
+.katex-display > .katex > .katex-html.katex-eq-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: center;
+  justify-content: safe center;
+  column-gap: var(--katex-eq-gap, 2em);
+  row-gap: 0.7em;
+}


### PR DESCRIPTION
## Summary

- Display formulas that state several equations on one line, separated by my own `\quad` or `\qquad`, were laid out by KaTeX as a single unbreakable row. On a phone the reader had to scroll the formula sideways to reach the last equation and, because the row is centred, the first one started off-screen as well. 232 blocks on 120 pages (60 English, 60 Spanish) are written that way; at 390 px, 185 of them rendered wider than the text column, the worst by 608 px.
- A build-time rehype pass (`site/src/lib/wrappable-math.mjs`) splits such a block at its widest top-level separator, wraps each equation in its own part and carries the separator width in a custom property. The layout is a wrapping flex row (`site/src/styles/katex.css`): a column gap is only painted between parts that share a line, so a row that fits renders exactly as before and a row that does not fit stacks one equation per line, each line centred on its own, with no 2 em space dangling at a line end.
- No markdown changes, so it reaches both languages, every existing page and every future one, and it does not diverge from the `docs/` mirror that GitHub renders on its own.
- The split is made only at the widest top-level spacer of each block, which is my own hierarchy: in `f_m = 1000\,G^{x/b} \quad (b\ \text{odd}), \qquad f_1 = \ldots` the `\quad` binds the condition to its equation, so only the `\qquad` becomes a break. 208 blocks split on `\qquad`, 24 on `\quad`.
- Blocks with an explicit line break or a tag are left alone by construction, and a block with no `\quad`-sized separator (one long equation) keeps the scroll box it has today.

## Why this shape and not the others

- **Letting the KaTeX row wrap with `white-space: normal`.** The only break opportunities KaTeX leaves are its own chunk boundaries, which sit after every top-level relation and binary operator, so a narrow line ends in a stranded `=` instead of at an equation boundary. It also leaves the separator hanging at the end of the wrapped line, which pulls the centring of that line off by half the separator width.
- **A media or container query that turns separators into line breaks below a threshold.** It stacks whether or not the row actually fits, and no single threshold is right for a phone, a tablet and a narrow laptop with the sidebar open at the same time. The flex row wraps exactly when the row does not fit, at every width, with no breakpoint to keep in sync with the layout.
- **A scroll container with a fade affordance.** It keeps the sideways scrolling and only advertises it better; the content fits the screen perfectly well once it is allowed to wrap. The scroll box stays as the fallback for a single equation that is genuinely wider than a phone.
- **Rewriting the sources into `aligned` or `gather`.** That stacks the equations on wide screens too, losing the side-by-side reading they were written for, and the same markdown is mirrored under `docs/`, so all 232 blocks would have to be edited and then kept in sync by hand in two languages.

## Test plan

- `pnpm run check:i18n` (140 EN pages each with an ES translation), `pnpm run build` and `pnpm run html-validate`: green.
- Formula text unchanged: the text of every display formula compared between a build before and after the change, over 530 pages, is identical on every page. The formula root keeps `role="math"` and the `aria-label` carrying its TeX, and the visual layer keeps `aria-hidden="true"`, so the accessible name and the extracted text are untouched. No page in the corpus uses `\tag` or an explicit `\\`, and such blocks are skipped in any case.
- Desktop parity: an element screenshot of a three-equation block at 1280 px, before against after, is pixel-identical (maximum channel difference 0).
- Headless sweep over all 120 affected pages counting rows wider than their box:

  | viewport | before | after |
  | --- | --- | --- |
  | 360 px | 202 | 58 |
  | 390 px | 185 | 40 |
  | 1280 px | 30 | 4 |

  What remains is single equations that are themselves wider than the viewport; those keep the scroll box.
- No JavaScript is involved and no rule is theme-dependent, so the theme toggle is unaffected.

## Screenshots

Same block, before and after, at a phone width, English, light theme (`/guides/impedance-tube/`, 390 px):

![English, 390 px, light](https://raw.githubusercontent.com/jmrplens/phonometry/evidence/responsive-display-equations/pair-en-390-light.png)

The same block in dark theme:

![English, 390 px, dark](https://raw.githubusercontent.com/jmrplens/phonometry/evidence/responsive-display-equations/pair-en-390-dark.png)

Spanish, 360 px, light theme (`/es/guides/impedance-tube/`):

![Spanish, 360 px, light](https://raw.githubusercontent.com/jmrplens/phonometry/evidence/responsive-display-equations/pair-es-360-light.png)

A three-equation block separated by `\quad` (`/guides/facade-insulation/`, 390 px, dark):

![English, 390 px, dark, facade](https://raw.githubusercontent.com/jmrplens/phonometry/evidence/responsive-display-equations/pair-en-390-dark-facade.png)

Desktop, 1280 px: a row that fits is untouched, and this pair is pixel-identical,

![English, 1280 px, light](https://raw.githubusercontent.com/jmrplens/phonometry/evidence/responsive-display-equations/pair-en-1280-light-block.png)

while a row wider than the 45 rem text column now wraps there too instead of being clipped at both ends:

![Spanish, 1280 px, dark](https://raw.githubusercontent.com/jmrplens/phonometry/evidence/responsive-display-equations/pair-es-1280-dark-block.png)

The screenshots live on the `evidence/responsive-display-equations` branch, which carries nothing else and can be deleted once this is reviewed.

## Summary by Sourcery

Enable multi-equation display formulas to reflow responsively on narrow screens while preserving their appearance on wider viewports.

New Features:
- Introduce a rehype build-time transform that splits multi-equation KaTeX display blocks into individually wrappable parts based on author-provided spacing commands.

Enhancements:
- Lay out transformed multi-equation display formulas as a wrapping flex row with responsive gaps so equations stack cleanly on small screens without changing desktop rendering.
- Wire the new wrappable-math rehype plugin into the Astro markdown/HTML pipeline to apply the behavior across the documentation site.

Documentation:
- Document the new responsive behavior of multi-equation display formulas in the changelog, including scope, impact, and accessibility guarantees. 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR introduces a build-time HTML transform that allows KaTeX display formulas stating multiple equations on one line to reflow responsively on narrow screens while preserving their desktop layout. A new rehype plugin (`rehypeWrappableMath`) splits multi-equation blocks at the author's own widest top-level separator (`\quad` or `\qquad`) and renders them as a wrapping flex row with the separator expressed as a CSS column gap, so wide screens produce identical single-row output and narrow screens stack equations with each line centred independently.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Added `site/src/lib/wrappable-math.mjs`: a rehype build-time transform that identifies KaTeX display blocks with top-level separators, splits them at the widest separator, wraps each equation part in `katex-eq-part` spans and marks the container with `katex-eq-row` class and `--katex-eq-gap` custom property.</li>

<li>Added CSS rules in `site/src/styles/katex.css` for `.katex-eq-row` that apply `display: flex; flex-wrap: wrap; justify-content: safe center; column-gap: var(--katex-eq-gap)` to enable responsive stacking while preserving desktop layout as column gaps only appear between items on the same line.</li>

<li>Integrated the new plugin into the Astro markdown pipeline in `site/astro.config.mjs` by importing `rehypeWrappableMath` and adding it to the rehypePlugins array between `rehypeSingleTextMath` and `rehypeLocalMedia`.</li>

<li>Documented the new behavior in `CHANGELOG.md` under the Unreleased Changed section, noting the scope (232 blocks on 120 pages in both languages), the mechanism (build-time split at `\quad`/`\qquad`), and the guarantees (TeX, accessible labels, and page anchors untouched).</li>

</ul>
</details>

</div>