### PR TITLE
Fail the build on unresolved merge-conflict markers

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -17,6 +17,18 @@ jobs:
       contents: read
     steps:
     - uses: actions/checkout@v7
+    # A conflict resolved carelessly during a rebase can leave markers behind in
+    # a file no other gate reads. CHANGELOG.md is the usual victim: it collides
+    # on every parallel branch and nothing lints it, so the markers ride a fully
+    # green pull request all the way to main. Only the opening and closing
+    # markers are matched, never a bare row of "=", because that is legitimate
+    # Markdown (a setext heading underline).
+    - name: Check for merge-conflict markers
+      run: |
+        if git grep -nE '^(<{7} |>{7} )' -- . ; then
+          echo "::error::Unresolved merge-conflict markers found in the files listed above."
+          exit 1
+        fi
     - name: Set up Python 3.13
       uses: actions/setup-python@v7
       with:


### PR DESCRIPTION
A conflict resolved carelessly during a rebase can leave markers behind in a file that no other gate reads. `CHANGELOG.md` is the usual victim: it collides on every parallel branch, and nothing lints it, so the markers ride a fully green pull request all the way to `main`.

This is not hypothetical. An open pull request in flight right now carries `<<<<<<< HEAD` at line 12 of `CHANGELOG.md` and `>>>>>>> 9839e23f` at line 136, with every check green, because no gate reads that file.

The step matches only the opening and closing markers (`<<<<<<< ` and `>>>>>>> ` at line start, each with its trailing space). It deliberately does not match a bare row of equals signs, which is legitimate Markdown as a setext heading underline and would fire on ordinary prose.

Verified: `main` is clean under the new check, and running the same pattern against the offending branch flags exactly the two marker lines.

## Summary by Sourcery

CI:
- Introduce a workflow step that scans tracked files for Git merge-conflict markers and exits with an error if any are found.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

