### PR TITLE
Derive the plane-wave band of the duct cut-on plot from the background

### DIFF
--- a/.github/images/duct_mode_cut_on.svg
+++ b/.github/images/duct_mode_cut_on.svg
@@ -42,7 +42,7 @@ L 706.008438 370.06456
 L 706.008438 271.752183 
 L 53.650781 271.752183 
 z
-" clip-path="url(#p4ec35c0b19)" style="fill: #1f77b4; opacity: 0.1; stroke: #1f77b4; stroke-linejoin: miter"/>
+" clip-path="url(#p4ec35c0b19)" style="fill: #c8deed; stroke: #c8deed; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
@@ -342,7 +342,7 @@ L 77.807781 40.144623
 L 77.807781 34.313623 
 L 61.147781 34.313623 
 z
-" style="fill: #1f77b4; opacity: 0.1; stroke: #1f77b4; stroke-linejoin: miter"/>
+" style="fill: #c8deed; stroke: #c8deed; stroke-linejoin: miter"/>
     </g>
     <g id="text_16">
      <text style="font-size: 8.33px; font-family: sans-serif; text-anchor: start" x="84.471781" y="40.144623" transform="rotate(-0 84.471781 40.144623)">Plane waves only</text>

--- a/.github/images/duct_mode_cut_on_dark.svg
+++ b/.github/images/duct_mode_cut_on_dark.svg
@@ -42,7 +42,7 @@ L 706.008438 370.06456
 L 706.008438 271.752183 
 L 53.650781 271.752183 
 z
-" clip-path="url(#p4ec35c0b19)" style="fill: #1f77b4; opacity: 0.1; stroke: #1f77b4; stroke-linejoin: miter"/>
+" clip-path="url(#p4ec35c0b19)" style="fill: #081e2e; stroke: #081e2e; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
@@ -342,7 +342,7 @@ L 77.807781 40.144623
 L 77.807781 34.313623 
 L 61.147781 34.313623 
 z
-" style="fill: #1f77b4; opacity: 0.1; stroke: #1f77b4; stroke-linejoin: miter"/>
+" style="fill: #081e2e; stroke: #081e2e; stroke-linejoin: miter"/>
     </g>
     <g id="text_16">
      <text style="font-size: 8.33px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="84.471781" y="40.144623" transform="rotate(-0 84.471781 40.144623)">Plane waves only</text>

--- a/.github/images/duct_mode_cut_on_es.svg
+++ b/.github/images/duct_mode_cut_on_es.svg
@@ -42,7 +42,7 @@ L 706.008438 370.54456
 L 706.008438 272.232183 
 L 53.650781 272.232183 
 z
-" clip-path="url(#p4dcdd396a7)" style="fill: #1f77b4; opacity: 0.1; stroke: #1f77b4; stroke-linejoin: miter"/>
+" clip-path="url(#p4dcdd396a7)" style="fill: #c8deed; stroke: #c8deed; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
@@ -342,7 +342,7 @@ L 77.807781 40.624623
 L 77.807781 34.793623 
 L 61.147781 34.793623 
 z
-" style="fill: #1f77b4; opacity: 0.1; stroke: #1f77b4; stroke-linejoin: miter"/>
+" style="fill: #c8deed; stroke: #c8deed; stroke-linejoin: miter"/>
     </g>
     <g id="text_16">
      <text style="font-size: 8.33px; font-family: sans-serif; text-anchor: start" x="84.471781" y="40.624623" transform="rotate(-0 84.471781 40.624623)">Solo ondas planas</text>

--- a/.github/images/duct_mode_cut_on_es_dark.svg
+++ b/.github/images/duct_mode_cut_on_es_dark.svg
@@ -42,7 +42,7 @@ L 706.008438 370.54456
 L 706.008438 272.232183 
 L 53.650781 272.232183 
 z
-" clip-path="url(#p4dcdd396a7)" style="fill: #1f77b4; opacity: 0.1; stroke: #1f77b4; stroke-linejoin: miter"/>
+" clip-path="url(#p4dcdd396a7)" style="fill: #081e2e; stroke: #081e2e; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
@@ -342,7 +342,7 @@ L 77.807781 40.624623
 L 77.807781 34.793623 
 L 61.147781 34.793623 
 z
-" style="fill: #1f77b4; opacity: 0.1; stroke: #1f77b4; stroke-linejoin: miter"/>
+" style="fill: #081e2e; stroke: #081e2e; stroke-linejoin: miter"/>
     </g>
     <g id="text_16">
      <text style="font-size: 8.33px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="84.471781" y="40.624623" transform="rotate(-0 84.471781 40.624623)">Solo ondas planas</text>

--- a/src/phonometry/_plot/noise_control.py
+++ b/src/phonometry/_plot/noise_control.py
@@ -17,6 +17,7 @@ from .common import (
     _C_TERTIARY,
     _new_axes,
     format_frequency_axis,
+    theme_fill,
 )
 
 if TYPE_CHECKING:
@@ -251,8 +252,8 @@ def plot_duct_modes(
 
     ax = ax if ax is not None else _new_axes()
     x = np.arange(len(result.modes), dtype=np.float64)
-    ax.axhspan(0.0, result.plane_wave_limit, color=_C_PRIMARY, alpha=0.10,
-               label=_t("Plane waves only", language))
+    ax.axhspan(0.0, result.plane_wave_limit, color=theme_fill(_C_PRIMARY, ax),
+               zorder=0, label=_t("Plane waves only", language))
     ax.plot(x, np.asarray(result.cut_on_no_flow), ls="--", color=_C_MUTED,
             marker="s", ms=4, lw=1.3, label=_t("No flow", language))
     kwargs.setdefault("color", _C_PRIMARY)


### PR DESCRIPTION
`main` is currently red on the figures job, and it blocks every open pull request.

`plot_duct_modes` draws its plane-wave band with a fixed `alpha=0.10`. On the dark theme that composites to within a couple of levels of the page, so the region is invisible; the four `duct_mode_cut_on` variants come out at dE00 5.27 on white and 4.23 on black, under the threshold of 10.

The figure predates the legibility threshold, so it entered `main` without ever being measured against it. The ordering was the problem: the gate merged before the branch that carried the figure.

**Why this blocks everyone**: `make graphs` now ends with `check_figure_contrast.py`, so its non-zero exit fails step 5 of the figures job and steps 6 and 7 are skipped. The staleness check never runs, and no pull request can go green on figures until this is fixed.

The fix uses the background-derived opaque wash the other 36 figures already use. It is applied in `_plot/noise_control.py` rather than in the figure script, so `.plot()` gains the same legibility rather than only the committed documentation image.

Verified: all 1920 filled regions across 1276 figures clear dE00 10; ruff and mypy clean; both variants rendered to PNG and read back, with the band now clearly legible on the dark page.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR fixes the legibility of the plane-wave band fill in the duct mode cut-on figure by replacing the fixed alpha=0.10 transparency with a background-derived opaque wash, and regenerates the corresponding documentation SVGs to pass the CI contrast gate.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Modified plot_duct_modes in _plot/noise_control.py to use theme_fill(_C_PRIMARY, ax) instead of color=_C_PRIMARY with alpha=0.10, making the plane-wave band region legible on both light and dark themes.</li>

<li>Added zorder=0 to the axhspan call to ensure the fill renders beneath the data lines rather than obscuring them.</li>

<li>Regenerated four duct_mode_cut_on documentation SVGs (light, dark, Spanish, Spanish dark) with opaque fills that achieve dE00 > 10 against their respective backgrounds, clearing the CI contrast gate.</li>

<li>Verified all 1920 filled regions across 1276 figures pass the contrast threshold; ruff and mypy static checks are clean.</li>

</ul>
</details>

</div>