### PR TITLE
Draw the duct plane-wave band with a theme-aware wash

### DIFF
--- a/.github/images/duct_mode_cut_on.svg
+++ b/.github/images/duct_mode_cut_on.svg
@@ -42,7 +42,7 @@ L 706.008438 370.06456
 L 706.008438 271.752183 
 L 53.650781 271.752183 
 z
-" clip-path="url(#p4ec35c0b19)" style="fill: #1f77b4; opacity: 0.1; stroke: #1f77b4; stroke-linejoin: miter"/>
+" clip-path="url(#p4ec35c0b19)" style="fill: #c8deed; stroke: #c8deed; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
@@ -342,7 +342,7 @@ L 77.807781 40.144623
 L 77.807781 34.313623 
 L 61.147781 34.313623 
 z
-" style="fill: #1f77b4; opacity: 0.1; stroke: #1f77b4; stroke-linejoin: miter"/>
+" style="fill: #c8deed; stroke: #c8deed; stroke-linejoin: miter"/>
     </g>
     <g id="text_16">
      <text style="font-size: 8.33px; font-family: sans-serif; text-anchor: start" x="84.471781" y="40.144623" transform="rotate(-0 84.471781 40.144623)">Plane waves only</text>

--- a/.github/images/duct_mode_cut_on_dark.svg
+++ b/.github/images/duct_mode_cut_on_dark.svg
@@ -42,7 +42,7 @@ L 706.008438 370.06456
 L 706.008438 271.752183 
 L 53.650781 271.752183 
 z
-" clip-path="url(#p4ec35c0b19)" style="fill: #1f77b4; opacity: 0.1; stroke: #1f77b4; stroke-linejoin: miter"/>
+" clip-path="url(#p4ec35c0b19)" style="fill: #081e2e; stroke: #081e2e; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
@@ -342,7 +342,7 @@ L 77.807781 40.144623
 L 77.807781 34.313623 
 L 61.147781 34.313623 
 z
-" style="fill: #1f77b4; opacity: 0.1; stroke: #1f77b4; stroke-linejoin: miter"/>
+" style="fill: #081e2e; stroke: #081e2e; stroke-linejoin: miter"/>
     </g>
     <g id="text_16">
      <text style="font-size: 8.33px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="84.471781" y="40.144623" transform="rotate(-0 84.471781 40.144623)">Plane waves only</text>

--- a/.github/images/duct_mode_cut_on_es.svg
+++ b/.github/images/duct_mode_cut_on_es.svg
@@ -42,7 +42,7 @@ L 706.008438 370.54456
 L 706.008438 272.232183 
 L 53.650781 272.232183 
 z
-" clip-path="url(#p4dcdd396a7)" style="fill: #1f77b4; opacity: 0.1; stroke: #1f77b4; stroke-linejoin: miter"/>
+" clip-path="url(#p4dcdd396a7)" style="fill: #c8deed; stroke: #c8deed; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
@@ -342,7 +342,7 @@ L 77.807781 40.624623
 L 77.807781 34.793623 
 L 61.147781 34.793623 
 z
-" style="fill: #1f77b4; opacity: 0.1; stroke: #1f77b4; stroke-linejoin: miter"/>
+" style="fill: #c8deed; stroke: #c8deed; stroke-linejoin: miter"/>
     </g>
     <g id="text_16">
      <text style="font-size: 8.33px; font-family: sans-serif; text-anchor: start" x="84.471781" y="40.624623" transform="rotate(-0 84.471781 40.624623)">Solo ondas planas</text>

--- a/.github/images/duct_mode_cut_on_es_dark.svg
+++ b/.github/images/duct_mode_cut_on_es_dark.svg
@@ -42,7 +42,7 @@ L 706.008438 370.54456
 L 706.008438 272.232183 
 L 53.650781 272.232183 
 z
-" clip-path="url(#p4dcdd396a7)" style="fill: #1f77b4; opacity: 0.1; stroke: #1f77b4; stroke-linejoin: miter"/>
+" clip-path="url(#p4dcdd396a7)" style="fill: #081e2e; stroke: #081e2e; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
@@ -342,7 +342,7 @@ L 77.807781 40.624623
 L 77.807781 34.793623 
 L 61.147781 34.793623 
 z
-" style="fill: #1f77b4; opacity: 0.1; stroke: #1f77b4; stroke-linejoin: miter"/>
+" style="fill: #081e2e; stroke: #081e2e; stroke-linejoin: miter"/>
     </g>
     <g id="text_16">
      <text style="font-size: 8.33px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="84.471781" y="40.624623" transform="rotate(-0 84.471781 40.624623)">Solo ondas planas</text>

--- a/src/phonometry/_plot/noise_control.py
+++ b/src/phonometry/_plot/noise_control.py
@@ -17,6 +17,7 @@ from .common import (
     _C_TERTIARY,
     _new_axes,
     format_frequency_axis,
+    theme_fill,
 )
 
 if TYPE_CHECKING:
@@ -251,7 +252,7 @@ def plot_duct_modes(
 
     ax = ax if ax is not None else _new_axes()
     x = np.arange(len(result.modes), dtype=np.float64)
-    ax.axhspan(0.0, result.plane_wave_limit, color=_C_PRIMARY, alpha=0.10,
+    ax.axhspan(0.0, result.plane_wave_limit, color=theme_fill(_C_PRIMARY, ax),
                label=_t("Plane waves only", language))
     ax.plot(x, np.asarray(result.cut_on_no_flow), ls="--", color=_C_MUTED,
             marker="s", ms=4, lw=1.3, label=_t("No flow", language))


### PR DESCRIPTION
The plane-wave band of `plot_duct_mode_cut_on` is shaded with the primary hue at `alpha=0.10`. Composited over the page, that lands 5.3 dE00 from white and 4.2 dE00 from black, both well under the dE00 10 threshold `scripts/check_figure_contrast.py` enforces, so the figures job currently fails on `main` for all four variants of `duct_mode_cut_on`. On the dark page the band sits within a couple of levels of the background and is effectively invisible.

`theme_fill` mixes the page colour towards the hue by the smallest amount that clears the threshold, in whichever direction the page requires, and returns an opaque wash that also survives the fiche PDF pipeline. This switches the `axhspan` to it and regenerates the four figures.

`scripts/check_figure_contrast.py` now reports all 1920 filled regions clear.

## Summary by Sourcery

Update duct mode plots to use a theme-aware wash for the plane-wave band and refresh the associated example figures.

New Features:
- Use a theme-aware fill colour for shading the duct plane-wave band in plots.

Enhancements:
- Apply theme_fill to ensure the plane-wave band wash maintains sufficient contrast across light and dark themes.
- Regenerate all duct_mode_cut_on example SVG figures to reflect the updated plane-wave band shading. 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR updates the duct mode cut-on plot to use a theme-aware wash color for the plane-wave band shading instead of a fixed semi-transparent primary hue. The change ensures the shading remains legible across both light and dark themes while passing the dE00 10 contrast threshold enforced by the figure contrast checker, fixing the CI failure on main.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Updates plot_duct_modes in noise_control.py to use theme_fill(_C_PRIMARY, ax) instead of color=_C_PRIMARY with alpha=0.10 for the axhspan plane-wave band, producing an opaque wash that adapts to light/dark backgrounds.</li>

<li>Regenerates the four duct_mode_cut_on SVG figures (light/dark variants in English and Spanish) with the new theme-aware colors: #c8deed for light themes and #081e2e for dark themes.</li>

<li>Fixes contrast threshold violation where the original semi-transparent fill landed 5.3 dE00 from white and 4.2 dE00 from black, both below the 10 dE00 limit enforced by scripts/check_figure_contrast.py.</li>

</ul>
</details>

</div>