### PR TITLE
Give the duct cut-on plane-wave band a background-aware wash

### DIFF
--- a/.github/images/duct_mode_cut_on.svg
+++ b/.github/images/duct_mode_cut_on.svg
@@ -42,7 +42,7 @@ L 706.008438 370.06456
 L 706.008438 271.752183 
 L 53.650781 271.752183 
 z
-" clip-path="url(#p4ec35c0b19)" style="fill: #1f77b4; opacity: 0.1; stroke: #1f77b4; stroke-linejoin: miter"/>
+" clip-path="url(#p4ec35c0b19)" style="fill: #c8deed; stroke: #c8deed; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
@@ -342,7 +342,7 @@ L 77.807781 40.144623
 L 77.807781 34.313623 
 L 61.147781 34.313623 
 z
-" style="fill: #1f77b4; opacity: 0.1; stroke: #1f77b4; stroke-linejoin: miter"/>
+" style="fill: #c8deed; stroke: #c8deed; stroke-linejoin: miter"/>
     </g>
     <g id="text_16">
      <text style="font-size: 8.33px; font-family: sans-serif; text-anchor: start" x="84.471781" y="40.144623" transform="rotate(-0 84.471781 40.144623)">Plane waves only</text>

--- a/.github/images/duct_mode_cut_on_dark.svg
+++ b/.github/images/duct_mode_cut_on_dark.svg
@@ -42,7 +42,7 @@ L 706.008438 370.06456
 L 706.008438 271.752183 
 L 53.650781 271.752183 
 z
-" clip-path="url(#p4ec35c0b19)" style="fill: #1f77b4; opacity: 0.1; stroke: #1f77b4; stroke-linejoin: miter"/>
+" clip-path="url(#p4ec35c0b19)" style="fill: #081e2e; stroke: #081e2e; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
@@ -342,7 +342,7 @@ L 77.807781 40.144623
 L 77.807781 34.313623 
 L 61.147781 34.313623 
 z
-" style="fill: #1f77b4; opacity: 0.1; stroke: #1f77b4; stroke-linejoin: miter"/>
+" style="fill: #081e2e; stroke: #081e2e; stroke-linejoin: miter"/>
     </g>
     <g id="text_16">
      <text style="font-size: 8.33px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="84.471781" y="40.144623" transform="rotate(-0 84.471781 40.144623)">Plane waves only</text>

--- a/.github/images/duct_mode_cut_on_es.svg
+++ b/.github/images/duct_mode_cut_on_es.svg
@@ -42,7 +42,7 @@ L 706.008438 370.54456
 L 706.008438 272.232183 
 L 53.650781 272.232183 
 z
-" clip-path="url(#p4dcdd396a7)" style="fill: #1f77b4; opacity: 0.1; stroke: #1f77b4; stroke-linejoin: miter"/>
+" clip-path="url(#p4dcdd396a7)" style="fill: #c8deed; stroke: #c8deed; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
@@ -342,7 +342,7 @@ L 77.807781 40.624623
 L 77.807781 34.793623 
 L 61.147781 34.793623 
 z
-" style="fill: #1f77b4; opacity: 0.1; stroke: #1f77b4; stroke-linejoin: miter"/>
+" style="fill: #c8deed; stroke: #c8deed; stroke-linejoin: miter"/>
     </g>
     <g id="text_16">
      <text style="font-size: 8.33px; font-family: sans-serif; text-anchor: start" x="84.471781" y="40.624623" transform="rotate(-0 84.471781 40.624623)">Solo ondas planas</text>

--- a/.github/images/duct_mode_cut_on_es_dark.svg
+++ b/.github/images/duct_mode_cut_on_es_dark.svg
@@ -42,7 +42,7 @@ L 706.008438 370.54456
 L 706.008438 272.232183 
 L 53.650781 272.232183 
 z
-" clip-path="url(#p4dcdd396a7)" style="fill: #1f77b4; opacity: 0.1; stroke: #1f77b4; stroke-linejoin: miter"/>
+" clip-path="url(#p4dcdd396a7)" style="fill: #081e2e; stroke: #081e2e; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
@@ -342,7 +342,7 @@ L 77.807781 40.624623
 L 77.807781 34.793623 
 L 61.147781 34.793623 
 z
-" style="fill: #1f77b4; opacity: 0.1; stroke: #1f77b4; stroke-linejoin: miter"/>
+" style="fill: #081e2e; stroke: #081e2e; stroke-linejoin: miter"/>
     </g>
     <g id="text_16">
      <text style="font-size: 8.33px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="84.471781" y="40.624623" transform="rotate(-0 84.471781 40.624623)">Solo ondas planas</text>

--- a/src/phonometry/_plot/noise_control.py
+++ b/src/phonometry/_plot/noise_control.py
@@ -17,6 +17,7 @@ from .common import (
     _C_TERTIARY,
     _new_axes,
     format_frequency_axis,
+    theme_fill,
 )
 
 if TYPE_CHECKING:
@@ -251,7 +252,8 @@ def plot_duct_modes(
 
     ax = ax if ax is not None else _new_axes()
     x = np.arange(len(result.modes), dtype=np.float64)
-    ax.axhspan(0.0, result.plane_wave_limit, color=_C_PRIMARY, alpha=0.10,
+    ax.axhspan(0.0, result.plane_wave_limit,
+               color=theme_fill(_C_PRIMARY, ax), edgecolor="none", zorder=0,
                label=_t("Plane waves only", language))
     ax.plot(x, np.asarray(result.cut_on_no_flow), ls="--", color=_C_MUTED,
             marker="s", ms=4, lw=1.3, label=_t("No flow", language))


### PR DESCRIPTION
The plane-wave-only band of the duct higher-order-mode cut-on plot (`DuctModeResult.plot()`) was shaded with a fixed `alpha=0.10`, which reads at dE00 5.27 against the light page and 4.23 against the dark one, below the dE00 10 legibility threshold the figures job now enforces. The two changes landed in parallel and first met on rebased branches, so `main` currently fails its own figures job on this figure.

The fix derives the wash from the page colour with `theme_fill`, exactly as the other shaded regions do since the background-aware fills change, and regenerates the four variants of `duct_mode_cut_on.svg`. After it, `scripts/check_figure_contrast.py` reports all 1920 filled regions in 1276 figures clear of the threshold.

Gates run locally: ruff, mypy, the contrast and fill-contrast test suites (74 passed) and the duct-related tests (114 passed).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>Fixes low-contrast shading in the duct higher-order-mode cut-on plot where the plane-wave-only band used a fixed alpha overlay that fell below the dE00 10 legibility threshold on both light and dark backgrounds. The fix replaces the alpha-based approach with the existing theme_fill() utility to generate opaque, theme-aware fills, and regenerates the affected figure assets.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Replaced fixed alpha=0.10 shading in plot_duct_modes (noise_control.py) with theme_fill(_C_PRIMARY, ax) to derive background-aware opaque wash for the plane-wave-only band, maintaining required dE00 ≥ 10 contrast.</li>

<li>Regenerated four duct mode cut-on SVG figures to reflect the updated fill colors: light variant uses #c8deed and dark variant uses #081e2e (previously both used #1f77b4 at 10% opacity).</li>

<li>Exported theme_fill from common.py module to enable use in noise_control.py.</li>

</ul>
</details>

</div>