### PR TITLE
Split the weighting-family chart between the two weighting guides

### DIFF
--- a/.github/images/special_weighting_responses.svg
+++ b/.github/images/special_weighting_responses.svg
@@ -1,0 +1,979 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="623.763281pt" height="454.599688pt" viewBox="0 0 623.763281 454.599688" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 454.599688 
+L 623.763281 454.599688 
+L 623.763281 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 49.305469 416.398125 
+L 607.305469 416.398125 
+L 607.305469 28.318125 
+L 49.305469 28.318125 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 80.925972 416.398125 
+L 80.925972 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="m3d27035b55" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m3d27035b55" x="80.925972" y="416.398125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle" x="80.925972" y="430.995781" transform="rotate(-0 80.925972 430.995781)">16</text>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 173.132398 416.398125 
+L 173.132398 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m3d27035b55" x="173.132398" y="416.398125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle" x="173.132398" y="430.995781" transform="rotate(-0 173.132398 430.995781)">63</text>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 265.862252 416.398125 
+L 265.862252 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m3d27035b55" x="265.862252" y="416.398125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle" x="265.862252" y="430.995781" transform="rotate(-0 265.862252 430.995781)">250</text>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 359.128182 416.398125 
+L 359.128182 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m3d27035b55" x="359.128182" y="416.398125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle" x="359.128182" y="430.996563" transform="rotate(-0 359.128182 430.996563)">1k</text>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 452.394112 416.398125 
+L 452.394112 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m3d27035b55" x="452.394112" y="416.398125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle" x="452.394112" y="430.996563" transform="rotate(-0 452.394112 430.996563)">4k</text>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_11">
+      <path d="M 545.660042 416.398125 
+L 545.660042 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m3d27035b55" x="545.660042" y="416.398125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle" x="545.660042" y="430.996563" transform="rotate(-0 545.660042 430.996563)">16k</text>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_13">
+      <path d="M 607.305469 416.398125 
+L 607.305469 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m3d27035b55" x="607.305469" y="416.398125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle" x="607.305469" y="430.996563" transform="rotate(-0 607.305469 430.996563)">40k</text>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_15">
+      <path d="M 95.938434 416.398125 
+L 95.938434 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_16">
+      <defs>
+       <path id="md1b22fa4b4" d="M 0 0 
+L 0 2 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="95.938434" y="416.398125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_17">
+      <path d="M 123.21697 416.398125 
+L 123.21697 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="123.21697" y="416.398125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_19">
+      <path d="M 142.571399 416.398125 
+L 142.571399 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="142.571399" y="416.398125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_21">
+      <path d="M 157.58386 416.398125 
+L 157.58386 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="157.58386" y="416.398125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_23">
+      <path d="M 169.849935 416.398125 
+L 169.849935 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="169.849935" y="416.398125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_13">
+     <g id="line2d_25">
+      <path d="M 180.220753 416.398125 
+L 180.220753 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="180.220753" y="416.398125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_27">
+      <path d="M 189.204364 416.398125 
+L 189.204364 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="189.204364" y="416.398125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_29">
+      <path d="M 197.12847 416.398125 
+L 197.12847 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="197.12847" y="416.398125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_31">
+      <path d="M 250.84979 416.398125 
+L 250.84979 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="250.84979" y="416.398125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_17">
+     <g id="line2d_33">
+      <path d="M 278.128326 416.398125 
+L 278.128326 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_34">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="278.128326" y="416.398125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_18">
+     <g id="line2d_35">
+      <path d="M 297.482755 416.398125 
+L 297.482755 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_36">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="297.482755" y="416.398125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_19">
+     <g id="line2d_37">
+      <path d="M 312.495217 416.398125 
+L 312.495217 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_38">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="312.495217" y="416.398125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_20">
+     <g id="line2d_39">
+      <path d="M 324.761291 416.398125 
+L 324.761291 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_40">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="324.761291" y="416.398125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_21">
+     <g id="line2d_41">
+      <path d="M 335.132109 416.398125 
+L 335.132109 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_42">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="335.132109" y="416.398125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_22">
+     <g id="line2d_43">
+      <path d="M 344.11572 416.398125 
+L 344.11572 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_44">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="344.11572" y="416.398125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_23">
+     <g id="line2d_45">
+      <path d="M 352.039827 416.398125 
+L 352.039827 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_46">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="352.039827" y="416.398125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_24">
+     <g id="line2d_47">
+      <path d="M 405.761147 416.398125 
+L 405.761147 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_48">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="405.761147" y="416.398125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_25">
+     <g id="line2d_49">
+      <path d="M 433.039683 416.398125 
+L 433.039683 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_50">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="433.039683" y="416.398125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_26">
+     <g id="line2d_51">
+      <path d="M 467.406574 416.398125 
+L 467.406574 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_52">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="467.406574" y="416.398125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_27">
+     <g id="line2d_53">
+      <path d="M 479.672648 416.398125 
+L 479.672648 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_54">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="479.672648" y="416.398125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_28">
+     <g id="line2d_55">
+      <path d="M 490.043466 416.398125 
+L 490.043466 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_56">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="490.043466" y="416.398125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_29">
+     <g id="line2d_57">
+      <path d="M 499.027077 416.398125 
+L 499.027077 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_58">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="499.027077" y="416.398125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_30">
+     <g id="line2d_59">
+      <path d="M 506.951184 416.398125 
+L 506.951184 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_60">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="506.951184" y="416.398125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_31">
+     <g id="line2d_61">
+      <path d="M 560.672504 416.398125 
+L 560.672504 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_62">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="560.672504" y="416.398125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_32">
+     <g id="line2d_63">
+      <path d="M 587.95104 416.398125 
+L 587.95104 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_64">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="587.95104" y="416.398125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_8">
+     <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle" x="328.305469" y="444.997344" transform="rotate(-0 328.305469 444.997344)">Frequency [Hz]</text>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_65">
+      <path d="M 49.305469 380.464792 
+L 607.305469 380.464792 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_66">
+      <defs>
+       <path id="mef640d9f3a" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mef640d9f3a" x="49.305469" y="380.464792" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="42.305469" y="384.26362" transform="rotate(-0 42.305469 384.26362)">−80</text>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_67">
+      <path d="M 49.305469 308.598125 
+L 607.305469 308.598125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_68">
+      <g>
+       <use xlink:href="#mef640d9f3a" x="49.305469" y="308.598125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="42.305469" y="312.396953" transform="rotate(-0 42.305469 312.396953)">−60</text>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_69">
+      <path d="M 49.305469 236.731458 
+L 607.305469 236.731458 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_70">
+      <g>
+       <use xlink:href="#mef640d9f3a" x="49.305469" y="236.731458" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="42.305469" y="240.530286" transform="rotate(-0 42.305469 240.530286)">−40</text>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_71">
+      <path d="M 49.305469 164.864792 
+L 607.305469 164.864792 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_72">
+      <g>
+       <use xlink:href="#mef640d9f3a" x="49.305469" y="164.864792" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="42.305469" y="168.66362" transform="rotate(-0 42.305469 168.66362)">−20</text>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_73">
+      <path d="M 49.305469 92.998125 
+L 607.305469 92.998125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_74">
+      <g>
+       <use xlink:href="#mef640d9f3a" x="49.305469" y="92.998125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="42.305469" y="96.796953" transform="rotate(-0 42.305469 96.796953)">0</text>
+     </g>
+    </g>
+    <g id="text_14">
+     <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle" x="14.798438" y="222.358125" transform="rotate(-90 14.798438 222.358125)">Level [dB]</text>
+    </g>
+   </g>
+   <g id="line2d_75">
+    <path d="M 13.342998 408.545937 
+L 59.975963 328.474177 
+L 87.254499 286.409417 
+L 106.608928 259.660148 
+L 121.621389 240.805642 
+L 133.887464 226.57592 
+L 144.258282 215.308705 
+L 153.241893 206.072893 
+L 161.165999 198.30574 
+L 168.254354 191.645287 
+L 174.666551 185.846403 
+L 180.520429 180.735816 
+L 190.891247 172.103055 
+L 199.874858 165.052403 
+L 207.798964 159.155747 
+L 214.887319 154.130921 
+L 224.290104 147.81727 
+L 232.538439 142.594457 
+L 239.885056 138.17763 
+L 248.578052 133.220805 
+L 258.069418 128.121998 
+L 266.385812 123.908157 
+L 275.173565 119.702561 
+L 284.157177 115.660847 
+L 293.140788 111.880949 
+L 301.99287 108.419368 
+L 310.629989 105.303592 
+L 319.00291 102.540526 
+L 327.085877 100.122244 
+L 334.868793 98.030278 
+L 342.855688 96.126258 
+L 350.444247 94.542275 
+L 358.46795 93.098568 
+L 366.700971 91.851769 
+L 374.976395 90.821681 
+L 383.725999 89.955625 
+L 392.914411 89.269864 
+L 402.668946 88.768479 
+L 412.803496 88.473845 
+L 423.14895 88.398474 
+L 433.301972 88.546211 
+L 443.034019 88.907383 
+L 452.22966 89.469736 
+L 460.754801 90.212115 
+L 468.630539 91.117302 
+L 476.027859 92.188822 
+L 483.00515 93.423008 
+L 489.61033 94.814846 
+L 495.986449 96.384535 
+L 502.187414 98.140521 
+L 508.252523 100.090047 
+L 514.210143 102.239449 
+L 520.044357 104.580185 
+L 525.777946 107.120386 
+L 531.36643 109.840007 
+L 536.8358 112.749855 
+L 542.28348 115.902285 
+L 547.873465 119.396934 
+L 553.911851 123.440108 
+L 560.428972 128.074334 
+L 566.569073 132.705581 
+L 571.945784 137.035828 
+L 577.341086 141.674192 
+L 584.624543 148.259935 
+L 590.894764 154.179962 
+L 595.076177 158.439915 
+L 604.099667 168.129257 
+L 606.565571 170.959681 
+L 608.092536 173.052504 
+L 609.356583 175.1652 
+L 610.512804 177.540262 
+L 611.621767 180.34161 
+L 612.721841 183.742975 
+L 613.857879 188.006019 
+L 615.098046 193.571772 
+L 616.85663 202.653429 
+L 618.135557 208.776584 
+L 618.786792 210.919508 
+L 619.233983 211.734912 
+L 619.546901 211.925637 
+L 619.56333 211.926555 
+L 619.56333 211.926555 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #9e9e9e; stroke-width: 4; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_76">
+    <path d="M 13.342998 276.239637 
+L 59.975963 217.724326 
+L 87.254499 188.188612 
+L 106.608928 170.24611 
+L 121.621389 158.141815 
+L 133.887464 149.350585 
+L 144.258282 142.610074 
+L 153.241893 137.23015 
+L 161.165999 132.805365 
+L 168.254354 129.082633 
+L 174.666551 125.895596 
+L 185.905474 120.704091 
+L 195.53289 116.64555 
+L 203.953509 113.388091 
+L 211.436453 110.724536 
+L 218.169782 108.516073 
+L 227.153394 105.84975 
+L 235.0775 103.763518 
+L 242.165855 102.104963 
+L 250.586474 100.380857 
+L 258.069418 99.061372 
+L 266.385812 97.812073 
+L 275.173565 96.716377 
+L 285.347954 95.698996 
+L 296.222723 94.861783 
+L 308.153249 94.182366 
+L 321.806531 93.641075 
+L 337.637791 93.245771 
+L 356.447463 93.008294 
+L 377.423107 92.969724 
+L 397.746642 93.150893 
+L 414.900616 93.517452 
+L 429.116889 94.035324 
+L 441.080489 94.686091 
+L 451.434648 95.465646 
+L 460.580508 96.371344 
+L 468.862396 97.410733 
+L 476.442725 98.581964 
+L 483.565536 99.906042 
+L 490.287054 101.380959 
+L 496.704352 103.015204 
+L 502.935466 104.830817 
+L 509.021413 106.835602 
+L 514.99199 109.036325 
+L 520.83291 111.424886 
+L 526.567902 114.010168 
+L 532.154015 116.772592 
+L 537.617776 119.722928 
+L 543.081802 122.927993 
+L 548.726286 126.499762 
+L 554.842513 130.638114 
+L 561.391353 135.338824 
+L 567.412403 139.926296 
+L 572.724712 144.250618 
+L 578.242712 149.039086 
+L 585.991178 156.089478 
+L 591.558091 161.403712 
+L 595.723134 165.696091 
+L 605.723343 176.514688 
+L 607.476073 178.731375 
+L 608.828765 180.802757 
+L 610.022416 183.044855 
+L 611.148734 185.64835 
+L 612.247349 188.764355 
+L 613.364347 192.624542 
+L 614.551648 197.567672 
+L 615.952758 204.428926 
+L 618.177492 215.404049 
+L 618.811714 217.417533 
+L 619.250489 218.179646 
+L 619.56333 218.350697 
+L 619.56333 218.350697 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 6.66,2.88; stroke-dashoffset: 0; stroke: #2ca02c; stroke-width: 1.8"/>
+   </g>
+   <g id="line2d_77">
+    <path d="M 13.342998 205.354826 
+L 106.608928 162.199698 
+L 144.258282 144.979518 
+L 168.254354 134.221703 
+L 185.905474 126.528587 
+L 199.874858 120.655688 
+L 211.436453 116.001808 
+L 221.299516 112.227029 
+L 232.538439 108.203554 
+L 242.165855 105.044532 
+L 250.586474 102.538625 
+L 258.069418 100.540009 
+L 264.802747 98.943349 
+L 272.369945 97.394835 
+L 279.171404 96.238431 
+L 285.347954 95.389921 
+L 292.081283 94.689754 
+L 298.201605 94.259197 
+L 304.702383 94.014598 
+L 311.435713 93.982217 
+L 319.00291 94.183013 
+L 328.963501 94.70203 
+L 338.714248 95.16648 
+L 343.852404 95.193829 
+L 348.163447 94.986718 
+L 351.776511 94.591034 
+L 355.205388 93.9875 
+L 358.46795 93.181316 
+L 361.579586 92.188893 
+L 364.916327 90.880465 
+L 368.439496 89.236914 
+L 372.113106 87.265348 
+L 376.210873 84.80661 
+L 381.218486 81.523842 
+L 388.221626 76.630808 
+L 403.285229 66.034554 
+L 409.156145 62.221354 
+L 413.860227 59.418292 
+L 418.09289 57.150874 
+L 421.92011 55.356919 
+L 425.394225 53.976017 
+L 428.557408 52.949377 
+L 431.578523 52.191741 
+L 434.598297 51.663507 
+L 437.61121 51.369886 
+L 440.612472 51.307727 
+L 443.597955 51.466075 
+L 446.778722 51.861169 
+L 450.122374 52.504983 
+L 453.792045 53.447073 
+L 457.819576 54.718305 
+L 462.388448 56.398617 
+L 467.851859 58.653243 
+L 474.767688 61.761688 
+L 484.489265 66.396709 
+L 504.634126 76.313009 
+L 534.112817 90.728943 
+L 550.766548 99.016078 
+L 575.957725 111.799273 
+L 594.661214 121.967911 
+L 607.466242 129.712744 
+L 608.674438 130.871587 
+L 609.737865 132.20252 
+L 610.728571 133.806139 
+L 611.6772 135.77454 
+L 612.603531 138.222565 
+L 613.51728 141.290369 
+L 614.40105 145.05844 
+L 615.25585 149.702052 
+L 616.065327 155.357036 
+L 616.822418 162.273558 
+L 617.503367 170.615265 
+L 618.093595 180.638363 
+L 618.595416 193.046254 
+L 619.002478 208.752286 
+L 619.341198 230.889961 
+L 619.56333 245.900406 
+L 619.56333 245.900406 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 11.52,2.88,1.8,2.88; stroke-dashoffset: 0; stroke: #9467bd; stroke-width: 1.8"/>
+   </g>
+   <g id="line2d_78">
+    <path d="M 13.342998 408.540394 
+L 59.975963 328.468764 
+L 87.254499 286.404012 
+L 106.608928 259.654746 
+L 121.621389 240.800243 
+L 133.887464 226.570523 
+L 144.258282 215.303312 
+L 153.241893 206.067504 
+L 161.165999 198.300355 
+L 168.254354 191.639907 
+L 174.666551 185.841028 
+L 180.520429 180.730446 
+L 190.891247 172.097697 
+L 199.874858 165.047058 
+L 207.798964 159.150417 
+L 214.887319 154.125608 
+L 224.290104 147.811985 
+L 232.538439 142.589202 
+L 239.885056 138.17241 
+L 248.578052 133.215635 
+L 258.069418 128.1169 
+L 266.385812 123.903139 
+L 275.173565 119.697651 
+L 284.157177 115.656078 
+L 293.140788 111.876361 
+L 301.99287 108.415006 
+L 310.629989 105.299508 
+L 319.00291 102.536779 
+L 327.085877 100.118901 
+L 334.868793 98.027412 
+L 342.855688 96.123989 
+L 350.444247 94.540696 
+L 358.46795 93.097875 
+L 366.700971 91.852182 
+L 374.976395 90.823442 
+L 383.725999 89.959101 
+L 392.914411 89.275488 
+L 402.668946 88.776752 
+L 412.803496 88.48513 
+L 423.14895 88.412684 
+L 433.301972 88.562245 
+L 443.147185 88.928128 
+L 452.426954 89.493983 
+L 461.102039 90.244278 
+L 469.170301 91.162773 
+L 476.786502 92.252883 
+L 483.936551 93.498719 
+L 490.734452 94.905798 
+L 497.161849 96.459579 
+L 502.981944 98.089432 
+L 507.821534 99.667457 
+L 511.563621 101.110588 
+L 514.523973 102.482339 
+L 516.94552 103.843154 
+L 519.027189 105.264276 
+L 520.904141 106.817651 
+L 522.626136 108.534854 
+L 524.271304 110.494777 
+L 525.8772 112.758956 
+L 527.51022 115.457782 
+L 529.199008 118.69559 
+L 530.969153 122.581063 
+L 532.932486 127.448881 
+L 535.157695 133.59144 
+L 537.784167 141.528212 
+L 541.081137 152.239713 
+L 545.59431 167.716198 
+L 552.591354 192.589523 
+L 564.198555 234.740574 
+L 574.046314 271.25649 
+L 584.333988 310.346176 
+L 593.41286 345.56091 
+L 601.421721 377.700843 
+L 607.417067 402.297664 
+L 609.499817 411.865964 
+L 611.176651 420.616058 
+L 612.658161 429.535148 
+L 614.018616 439.097325 
+L 615.25585 449.387307 
+L 615.901227 455.599688 
+L 615.901227 455.599688 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #ff7f0e; stroke-width: 1.8; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_79">
+    <path d="M 49.305469 92.998125 
+L 607.305469 92.998125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 1,1.65; stroke-dashoffset: 0; stroke: #000000; stroke-opacity: 0.3"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 49.305469 416.398125 
+L 49.305469 28.318125 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 607.305469 416.398125 
+L 607.305469 28.318125 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 49.305469 416.398125 
+L 607.305469 416.398125 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 49.305469 28.318125 
+L 607.305469 28.318125 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 332.145879 45.214285 
+Q 383.234152 48.206314 433.317915 51.139513 
+" style="fill: none; stroke: #9467bd; stroke-width: 0.9; stroke-linecap: round"/>
+    <path d="M 429.829312 49.132116 
+L 433.317915 51.139513 
+L 429.618835 52.725957 
+" style="fill: none; stroke: #9467bd; stroke-width: 0.9; stroke-linecap: round"/>
+   </g>
+   <g id="text_15">
+    <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #9467bd" x="231.495361" y="44.488125" transform="rotate(-0 231.495361 44.488125)">+11.5 dB @ 3.15 kHz</text>
+   </g>
+   <g id="patch_8">
+    <path d="M 424.403162 209.286389 
+Q 484.082433 189.191851 542.808079 169.418406 
+" style="fill: none; stroke: #ff7f0e; stroke-width: 0.9; stroke-linecap: round"/>
+    <path d="M 538.8219 168.861291 
+L 542.808079 169.418406 
+L 539.970679 172.27308 
+" style="fill: none; stroke: #ff7f0e; stroke-width: 0.9; stroke-linecap: round"/>
+   </g>
+   <g id="text_16">
+    <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ff7f0e" x="335.132109" y="218.764792" transform="rotate(-0 335.132109 218.764792)">AU is 13 dB below A at 16 kHz</text>
+   </g>
+   <g id="text_17">
+    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle" x="328.305469" y="16.318125" transform="rotate(-0 328.305469 16.318125)">Special Weighting Curves (B, D, AU)</text>
+   </g>
+   <g id="legend_1">
+    <g id="patch_9">
+     <path d="M 231.158906 411.898125 
+L 425.452031 411.898125 
+Q 427.252031 411.898125 427.252031 410.098125 
+L 427.252031 356.995313 
+Q 427.252031 355.195312 425.452031 355.195312 
+L 231.158906 355.195312 
+Q 229.358906 355.195312 229.358906 356.995313 
+L 229.358906 410.098125 
+Q 229.358906 411.898125 231.158906 411.898125 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="line2d_80">
+     <path d="M 232.958906 362.483906 
+L 241.958906 362.483906 
+L 250.958906 362.483906 
+" style="fill: none; stroke: #9e9e9e; stroke-width: 4; stroke-linecap: square"/>
+    </g>
+    <g id="text_18">
+     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start" x="258.158906" y="365.633906" transform="rotate(-0 258.158906 365.633906)">A-Weighting (reference)</text>
+    </g>
+    <g id="line2d_81">
+     <path d="M 232.958906 375.984609 
+L 241.958906 375.984609 
+L 250.958906 375.984609 
+" style="fill: none; stroke-dasharray: 6.66,2.88; stroke-dashoffset: 0; stroke: #2ca02c; stroke-width: 1.8"/>
+    </g>
+    <g id="text_19">
+     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start" x="258.158906" y="379.134609" transform="rotate(-0 258.158906 379.134609)">B-Weighting (historical)</text>
+    </g>
+    <g id="line2d_82">
+     <path d="M 232.958906 389.485313 
+L 241.958906 389.485313 
+L 250.958906 389.485313 
+" style="fill: none; stroke-dasharray: 11.52,2.88,1.8,2.88; stroke-dashoffset: 0; stroke: #9467bd; stroke-width: 1.8"/>
+    </g>
+    <g id="text_20">
+     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start" x="258.158906" y="392.635312" transform="rotate(-0 258.158906 392.635312)">D-Weighting (aircraft, withdrawn)</text>
+    </g>
+    <g id="line2d_83">
+     <path d="M 232.958906 402.986016 
+L 241.958906 402.986016 
+L 250.958906 402.986016 
+" style="fill: none; stroke: #ff7f0e; stroke-width: 1.8; stroke-linecap: square"/>
+    </g>
+    <g id="text_21">
+     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start" x="258.158906" y="406.136016" transform="rotate(-0 258.158906 406.136016)">AU-Weighting (audible + ultrasound)</text>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pa967a6db94">
+   <rect x="49.305469" y="28.318125" width="558" height="388.08"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/.github/images/special_weighting_responses_dark.svg
+++ b/.github/images/special_weighting_responses_dark.svg
@@ -1,0 +1,979 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="623.763281pt" height="454.599688pt" viewBox="0 0 623.763281 454.599688" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 454.599688 
+L 623.763281 454.599688 
+L 623.763281 0 
+L 0 0 
+z
+"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 49.305469 416.398125 
+L 607.305469 416.398125 
+L 607.305469 28.318125 
+L 49.305469 28.318125 
+z
+"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 80.925972 416.398125 
+L 80.925972 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="m8d14ee1197" d="M 0 0 
+L 0 3.5 
+" style="stroke: #ffffff; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m8d14ee1197" x="80.925972" y="416.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="80.925972" y="430.995781" transform="rotate(-0 80.925972 430.995781)">16</text>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 173.132398 416.398125 
+L 173.132398 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m8d14ee1197" x="173.132398" y="416.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="173.132398" y="430.995781" transform="rotate(-0 173.132398 430.995781)">63</text>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 265.862252 416.398125 
+L 265.862252 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m8d14ee1197" x="265.862252" y="416.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="265.862252" y="430.995781" transform="rotate(-0 265.862252 430.995781)">250</text>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 359.128182 416.398125 
+L 359.128182 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m8d14ee1197" x="359.128182" y="416.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="359.128182" y="430.996563" transform="rotate(-0 359.128182 430.996563)">1k</text>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 452.394112 416.398125 
+L 452.394112 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m8d14ee1197" x="452.394112" y="416.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="452.394112" y="430.996563" transform="rotate(-0 452.394112 430.996563)">4k</text>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_11">
+      <path d="M 545.660042 416.398125 
+L 545.660042 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m8d14ee1197" x="545.660042" y="416.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="545.660042" y="430.996563" transform="rotate(-0 545.660042 430.996563)">16k</text>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_13">
+      <path d="M 607.305469 416.398125 
+L 607.305469 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m8d14ee1197" x="607.305469" y="416.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="607.305469" y="430.996563" transform="rotate(-0 607.305469 430.996563)">40k</text>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_15">
+      <path d="M 95.938434 416.398125 
+L 95.938434 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_16">
+      <defs>
+       <path id="m1caa325441" d="M 0 0 
+L 0 2 
+" style="stroke: #ffffff; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#m1caa325441" x="95.938434" y="416.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_17">
+      <path d="M 123.21697 416.398125 
+L 123.21697 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m1caa325441" x="123.21697" y="416.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_19">
+      <path d="M 142.571399 416.398125 
+L 142.571399 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#m1caa325441" x="142.571399" y="416.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_21">
+      <path d="M 157.58386 416.398125 
+L 157.58386 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#m1caa325441" x="157.58386" y="416.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_23">
+      <path d="M 169.849935 416.398125 
+L 169.849935 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#m1caa325441" x="169.849935" y="416.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_13">
+     <g id="line2d_25">
+      <path d="M 180.220753 416.398125 
+L 180.220753 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#m1caa325441" x="180.220753" y="416.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_27">
+      <path d="M 189.204364 416.398125 
+L 189.204364 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#m1caa325441" x="189.204364" y="416.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_29">
+      <path d="M 197.12847 416.398125 
+L 197.12847 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#m1caa325441" x="197.12847" y="416.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_31">
+      <path d="M 250.84979 416.398125 
+L 250.84979 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#m1caa325441" x="250.84979" y="416.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_17">
+     <g id="line2d_33">
+      <path d="M 278.128326 416.398125 
+L 278.128326 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_34">
+      <g>
+       <use xlink:href="#m1caa325441" x="278.128326" y="416.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_18">
+     <g id="line2d_35">
+      <path d="M 297.482755 416.398125 
+L 297.482755 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_36">
+      <g>
+       <use xlink:href="#m1caa325441" x="297.482755" y="416.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_19">
+     <g id="line2d_37">
+      <path d="M 312.495217 416.398125 
+L 312.495217 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_38">
+      <g>
+       <use xlink:href="#m1caa325441" x="312.495217" y="416.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_20">
+     <g id="line2d_39">
+      <path d="M 324.761291 416.398125 
+L 324.761291 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_40">
+      <g>
+       <use xlink:href="#m1caa325441" x="324.761291" y="416.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_21">
+     <g id="line2d_41">
+      <path d="M 335.132109 416.398125 
+L 335.132109 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_42">
+      <g>
+       <use xlink:href="#m1caa325441" x="335.132109" y="416.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_22">
+     <g id="line2d_43">
+      <path d="M 344.11572 416.398125 
+L 344.11572 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_44">
+      <g>
+       <use xlink:href="#m1caa325441" x="344.11572" y="416.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_23">
+     <g id="line2d_45">
+      <path d="M 352.039827 416.398125 
+L 352.039827 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_46">
+      <g>
+       <use xlink:href="#m1caa325441" x="352.039827" y="416.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_24">
+     <g id="line2d_47">
+      <path d="M 405.761147 416.398125 
+L 405.761147 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_48">
+      <g>
+       <use xlink:href="#m1caa325441" x="405.761147" y="416.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_25">
+     <g id="line2d_49">
+      <path d="M 433.039683 416.398125 
+L 433.039683 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_50">
+      <g>
+       <use xlink:href="#m1caa325441" x="433.039683" y="416.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_26">
+     <g id="line2d_51">
+      <path d="M 467.406574 416.398125 
+L 467.406574 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_52">
+      <g>
+       <use xlink:href="#m1caa325441" x="467.406574" y="416.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_27">
+     <g id="line2d_53">
+      <path d="M 479.672648 416.398125 
+L 479.672648 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_54">
+      <g>
+       <use xlink:href="#m1caa325441" x="479.672648" y="416.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_28">
+     <g id="line2d_55">
+      <path d="M 490.043466 416.398125 
+L 490.043466 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_56">
+      <g>
+       <use xlink:href="#m1caa325441" x="490.043466" y="416.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_29">
+     <g id="line2d_57">
+      <path d="M 499.027077 416.398125 
+L 499.027077 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_58">
+      <g>
+       <use xlink:href="#m1caa325441" x="499.027077" y="416.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_30">
+     <g id="line2d_59">
+      <path d="M 506.951184 416.398125 
+L 506.951184 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_60">
+      <g>
+       <use xlink:href="#m1caa325441" x="506.951184" y="416.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_31">
+     <g id="line2d_61">
+      <path d="M 560.672504 416.398125 
+L 560.672504 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_62">
+      <g>
+       <use xlink:href="#m1caa325441" x="560.672504" y="416.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_32">
+     <g id="line2d_63">
+      <path d="M 587.95104 416.398125 
+L 587.95104 28.318125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_64">
+      <g>
+       <use xlink:href="#m1caa325441" x="587.95104" y="416.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_8">
+     <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="328.305469" y="444.997344" transform="rotate(-0 328.305469 444.997344)">Frequency [Hz]</text>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_65">
+      <path d="M 49.305469 380.464792 
+L 607.305469 380.464792 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_66">
+      <defs>
+       <path id="m5e07181663" d="M 0 0 
+L -3.5 0 
+" style="stroke: #ffffff; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m5e07181663" x="49.305469" y="380.464792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="42.305469" y="384.26362" transform="rotate(-0 42.305469 384.26362)">−80</text>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_67">
+      <path d="M 49.305469 308.598125 
+L 607.305469 308.598125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_68">
+      <g>
+       <use xlink:href="#m5e07181663" x="49.305469" y="308.598125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="42.305469" y="312.396953" transform="rotate(-0 42.305469 312.396953)">−60</text>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_69">
+      <path d="M 49.305469 236.731458 
+L 607.305469 236.731458 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_70">
+      <g>
+       <use xlink:href="#m5e07181663" x="49.305469" y="236.731458" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="42.305469" y="240.530286" transform="rotate(-0 42.305469 240.530286)">−40</text>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_71">
+      <path d="M 49.305469 164.864792 
+L 607.305469 164.864792 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_72">
+      <g>
+       <use xlink:href="#m5e07181663" x="49.305469" y="164.864792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="42.305469" y="168.66362" transform="rotate(-0 42.305469 168.66362)">−20</text>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_73">
+      <path d="M 49.305469 92.998125 
+L 607.305469 92.998125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_74">
+      <g>
+       <use xlink:href="#m5e07181663" x="49.305469" y="92.998125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="42.305469" y="96.796953" transform="rotate(-0 42.305469 96.796953)">0</text>
+     </g>
+    </g>
+    <g id="text_14">
+     <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="14.798438" y="222.358125" transform="rotate(-90 14.798438 222.358125)">Level [dB]</text>
+    </g>
+   </g>
+   <g id="line2d_75">
+    <path d="M 13.342998 408.545937 
+L 59.975963 328.474177 
+L 87.254499 286.409417 
+L 106.608928 259.660148 
+L 121.621389 240.805642 
+L 133.887464 226.57592 
+L 144.258282 215.308705 
+L 153.241893 206.072893 
+L 161.165999 198.30574 
+L 168.254354 191.645287 
+L 174.666551 185.846403 
+L 180.520429 180.735816 
+L 190.891247 172.103055 
+L 199.874858 165.052403 
+L 207.798964 159.155747 
+L 214.887319 154.130921 
+L 224.290104 147.81727 
+L 232.538439 142.594457 
+L 239.885056 138.17763 
+L 248.578052 133.220805 
+L 258.069418 128.121998 
+L 266.385812 123.908157 
+L 275.173565 119.702561 
+L 284.157177 115.660847 
+L 293.140788 111.880949 
+L 301.99287 108.419368 
+L 310.629989 105.303592 
+L 319.00291 102.540526 
+L 327.085877 100.122244 
+L 334.868793 98.030278 
+L 342.855688 96.126258 
+L 350.444247 94.542275 
+L 358.46795 93.098568 
+L 366.700971 91.851769 
+L 374.976395 90.821681 
+L 383.725999 89.955625 
+L 392.914411 89.269864 
+L 402.668946 88.768479 
+L 412.803496 88.473845 
+L 423.14895 88.398474 
+L 433.301972 88.546211 
+L 443.034019 88.907383 
+L 452.22966 89.469736 
+L 460.754801 90.212115 
+L 468.630539 91.117302 
+L 476.027859 92.188822 
+L 483.00515 93.423008 
+L 489.61033 94.814846 
+L 495.986449 96.384535 
+L 502.187414 98.140521 
+L 508.252523 100.090047 
+L 514.210143 102.239449 
+L 520.044357 104.580185 
+L 525.777946 107.120386 
+L 531.36643 109.840007 
+L 536.8358 112.749855 
+L 542.28348 115.902285 
+L 547.873465 119.396934 
+L 553.911851 123.440108 
+L 560.428972 128.074334 
+L 566.569073 132.705581 
+L 571.945784 137.035828 
+L 577.341086 141.674192 
+L 584.624543 148.259935 
+L 590.894764 154.179962 
+L 595.076177 158.439915 
+L 604.099667 168.129257 
+L 606.565571 170.959681 
+L 608.092536 173.052504 
+L 609.356583 175.1652 
+L 610.512804 177.540262 
+L 611.621767 180.34161 
+L 612.721841 183.742975 
+L 613.857879 188.006019 
+L 615.098046 193.571772 
+L 616.85663 202.653429 
+L 618.135557 208.776584 
+L 618.786792 210.919508 
+L 619.233983 211.734912 
+L 619.546901 211.925637 
+L 619.56333 211.926555 
+L 619.56333 211.926555 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #9e9e9e; stroke-width: 4; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_76">
+    <path d="M 13.342998 276.239637 
+L 59.975963 217.724326 
+L 87.254499 188.188612 
+L 106.608928 170.24611 
+L 121.621389 158.141815 
+L 133.887464 149.350585 
+L 144.258282 142.610074 
+L 153.241893 137.23015 
+L 161.165999 132.805365 
+L 168.254354 129.082633 
+L 174.666551 125.895596 
+L 185.905474 120.704091 
+L 195.53289 116.64555 
+L 203.953509 113.388091 
+L 211.436453 110.724536 
+L 218.169782 108.516073 
+L 227.153394 105.84975 
+L 235.0775 103.763518 
+L 242.165855 102.104963 
+L 250.586474 100.380857 
+L 258.069418 99.061372 
+L 266.385812 97.812073 
+L 275.173565 96.716377 
+L 285.347954 95.698996 
+L 296.222723 94.861783 
+L 308.153249 94.182366 
+L 321.806531 93.641075 
+L 337.637791 93.245771 
+L 356.447463 93.008294 
+L 377.423107 92.969724 
+L 397.746642 93.150893 
+L 414.900616 93.517452 
+L 429.116889 94.035324 
+L 441.080489 94.686091 
+L 451.434648 95.465646 
+L 460.580508 96.371344 
+L 468.862396 97.410733 
+L 476.442725 98.581964 
+L 483.565536 99.906042 
+L 490.287054 101.380959 
+L 496.704352 103.015204 
+L 502.935466 104.830817 
+L 509.021413 106.835602 
+L 514.99199 109.036325 
+L 520.83291 111.424886 
+L 526.567902 114.010168 
+L 532.154015 116.772592 
+L 537.617776 119.722928 
+L 543.081802 122.927993 
+L 548.726286 126.499762 
+L 554.842513 130.638114 
+L 561.391353 135.338824 
+L 567.412403 139.926296 
+L 572.724712 144.250618 
+L 578.242712 149.039086 
+L 585.991178 156.089478 
+L 591.558091 161.403712 
+L 595.723134 165.696091 
+L 605.723343 176.514688 
+L 607.476073 178.731375 
+L 608.828765 180.802757 
+L 610.022416 183.044855 
+L 611.148734 185.64835 
+L 612.247349 188.764355 
+L 613.364347 192.624542 
+L 614.551648 197.567672 
+L 615.952758 204.428926 
+L 618.177492 215.404049 
+L 618.811714 217.417533 
+L 619.250489 218.179646 
+L 619.56333 218.350697 
+L 619.56333 218.350697 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 6.66,2.88; stroke-dashoffset: 0; stroke: #2ca02c; stroke-width: 1.8"/>
+   </g>
+   <g id="line2d_77">
+    <path d="M 13.342998 205.354826 
+L 106.608928 162.199698 
+L 144.258282 144.979518 
+L 168.254354 134.221703 
+L 185.905474 126.528587 
+L 199.874858 120.655688 
+L 211.436453 116.001808 
+L 221.299516 112.227029 
+L 232.538439 108.203554 
+L 242.165855 105.044532 
+L 250.586474 102.538625 
+L 258.069418 100.540009 
+L 264.802747 98.943349 
+L 272.369945 97.394835 
+L 279.171404 96.238431 
+L 285.347954 95.389921 
+L 292.081283 94.689754 
+L 298.201605 94.259197 
+L 304.702383 94.014598 
+L 311.435713 93.982217 
+L 319.00291 94.183013 
+L 328.963501 94.70203 
+L 338.714248 95.16648 
+L 343.852404 95.193829 
+L 348.163447 94.986718 
+L 351.776511 94.591034 
+L 355.205388 93.9875 
+L 358.46795 93.181316 
+L 361.579586 92.188893 
+L 364.916327 90.880465 
+L 368.439496 89.236914 
+L 372.113106 87.265348 
+L 376.210873 84.80661 
+L 381.218486 81.523842 
+L 388.221626 76.630808 
+L 403.285229 66.034554 
+L 409.156145 62.221354 
+L 413.860227 59.418292 
+L 418.09289 57.150874 
+L 421.92011 55.356919 
+L 425.394225 53.976017 
+L 428.557408 52.949377 
+L 431.578523 52.191741 
+L 434.598297 51.663507 
+L 437.61121 51.369886 
+L 440.612472 51.307727 
+L 443.597955 51.466075 
+L 446.778722 51.861169 
+L 450.122374 52.504983 
+L 453.792045 53.447073 
+L 457.819576 54.718305 
+L 462.388448 56.398617 
+L 467.851859 58.653243 
+L 474.767688 61.761688 
+L 484.489265 66.396709 
+L 504.634126 76.313009 
+L 534.112817 90.728943 
+L 550.766548 99.016078 
+L 575.957725 111.799273 
+L 594.661214 121.967911 
+L 607.466242 129.712744 
+L 608.674438 130.871587 
+L 609.737865 132.20252 
+L 610.728571 133.806139 
+L 611.6772 135.77454 
+L 612.603531 138.222565 
+L 613.51728 141.290369 
+L 614.40105 145.05844 
+L 615.25585 149.702052 
+L 616.065327 155.357036 
+L 616.822418 162.273558 
+L 617.503367 170.615265 
+L 618.093595 180.638363 
+L 618.595416 193.046254 
+L 619.002478 208.752286 
+L 619.341198 230.889961 
+L 619.56333 245.900406 
+L 619.56333 245.900406 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 11.52,2.88,1.8,2.88; stroke-dashoffset: 0; stroke: #9467bd; stroke-width: 1.8"/>
+   </g>
+   <g id="line2d_78">
+    <path d="M 13.342998 408.540394 
+L 59.975963 328.468764 
+L 87.254499 286.404012 
+L 106.608928 259.654746 
+L 121.621389 240.800243 
+L 133.887464 226.570523 
+L 144.258282 215.303312 
+L 153.241893 206.067504 
+L 161.165999 198.300355 
+L 168.254354 191.639907 
+L 174.666551 185.841028 
+L 180.520429 180.730446 
+L 190.891247 172.097697 
+L 199.874858 165.047058 
+L 207.798964 159.150417 
+L 214.887319 154.125608 
+L 224.290104 147.811985 
+L 232.538439 142.589202 
+L 239.885056 138.17241 
+L 248.578052 133.215635 
+L 258.069418 128.1169 
+L 266.385812 123.903139 
+L 275.173565 119.697651 
+L 284.157177 115.656078 
+L 293.140788 111.876361 
+L 301.99287 108.415006 
+L 310.629989 105.299508 
+L 319.00291 102.536779 
+L 327.085877 100.118901 
+L 334.868793 98.027412 
+L 342.855688 96.123989 
+L 350.444247 94.540696 
+L 358.46795 93.097875 
+L 366.700971 91.852182 
+L 374.976395 90.823442 
+L 383.725999 89.959101 
+L 392.914411 89.275488 
+L 402.668946 88.776752 
+L 412.803496 88.48513 
+L 423.14895 88.412684 
+L 433.301972 88.562245 
+L 443.147185 88.928128 
+L 452.426954 89.493983 
+L 461.102039 90.244278 
+L 469.170301 91.162773 
+L 476.786502 92.252883 
+L 483.936551 93.498719 
+L 490.734452 94.905798 
+L 497.161849 96.459579 
+L 502.981944 98.089432 
+L 507.821534 99.667457 
+L 511.563621 101.110588 
+L 514.523973 102.482339 
+L 516.94552 103.843154 
+L 519.027189 105.264276 
+L 520.904141 106.817651 
+L 522.626136 108.534854 
+L 524.271304 110.494777 
+L 525.8772 112.758956 
+L 527.51022 115.457782 
+L 529.199008 118.69559 
+L 530.969153 122.581063 
+L 532.932486 127.448881 
+L 535.157695 133.59144 
+L 537.784167 141.528212 
+L 541.081137 152.239713 
+L 545.59431 167.716198 
+L 552.591354 192.589523 
+L 564.198555 234.740574 
+L 574.046314 271.25649 
+L 584.333988 310.346176 
+L 593.41286 345.56091 
+L 601.421721 377.700843 
+L 607.417067 402.297664 
+L 609.499817 411.865964 
+L 611.176651 420.616058 
+L 612.658161 429.535148 
+L 614.018616 439.097325 
+L 615.25585 449.387307 
+L 615.901227 455.599688 
+L 615.901227 455.599688 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #ff7f0e; stroke-width: 1.8; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_79">
+    <path d="M 49.305469 92.998125 
+L 607.305469 92.998125 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 1,1.65; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 49.305469 416.398125 
+L 49.305469 28.318125 
+" style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 607.305469 416.398125 
+L 607.305469 28.318125 
+" style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 49.305469 416.398125 
+L 607.305469 416.398125 
+" style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 49.305469 28.318125 
+L 607.305469 28.318125 
+" style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 332.145879 45.214285 
+Q 383.234152 48.206314 433.317915 51.139513 
+" style="fill: none; stroke: #9467bd; stroke-width: 0.9; stroke-linecap: round"/>
+    <path d="M 429.829312 49.132116 
+L 433.317915 51.139513 
+L 429.618835 52.725957 
+" style="fill: none; stroke: #9467bd; stroke-width: 0.9; stroke-linecap: round"/>
+   </g>
+   <g id="text_15">
+    <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #9467bd" x="231.495361" y="44.488125" transform="rotate(-0 231.495361 44.488125)">+11.5 dB @ 3.15 kHz</text>
+   </g>
+   <g id="patch_8">
+    <path d="M 424.403162 209.286389 
+Q 484.082433 189.191851 542.808079 169.418406 
+" style="fill: none; stroke: #ff7f0e; stroke-width: 0.9; stroke-linecap: round"/>
+    <path d="M 538.8219 168.861291 
+L 542.808079 169.418406 
+L 539.970679 172.27308 
+" style="fill: none; stroke: #ff7f0e; stroke-width: 0.9; stroke-linecap: round"/>
+   </g>
+   <g id="text_16">
+    <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ff7f0e" x="335.132109" y="218.764792" transform="rotate(-0 335.132109 218.764792)">AU is 13 dB below A at 16 kHz</text>
+   </g>
+   <g id="text_17">
+    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="328.305469" y="16.318125" transform="rotate(-0 328.305469 16.318125)">Special Weighting Curves (B, D, AU)</text>
+   </g>
+   <g id="legend_1">
+    <g id="patch_9">
+     <path d="M 231.158906 411.898125 
+L 425.452031 411.898125 
+Q 427.252031 411.898125 427.252031 410.098125 
+L 427.252031 356.995313 
+Q 427.252031 355.195312 425.452031 355.195312 
+L 231.158906 355.195312 
+Q 229.358906 355.195312 229.358906 356.995313 
+L 229.358906 410.098125 
+Q 229.358906 411.898125 231.158906 411.898125 
+z
+" style="opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="line2d_80">
+     <path d="M 232.958906 362.483906 
+L 241.958906 362.483906 
+L 250.958906 362.483906 
+" style="fill: none; stroke: #9e9e9e; stroke-width: 4; stroke-linecap: square"/>
+    </g>
+    <g id="text_18">
+     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="258.158906" y="365.633906" transform="rotate(-0 258.158906 365.633906)">A-Weighting (reference)</text>
+    </g>
+    <g id="line2d_81">
+     <path d="M 232.958906 375.984609 
+L 241.958906 375.984609 
+L 250.958906 375.984609 
+" style="fill: none; stroke-dasharray: 6.66,2.88; stroke-dashoffset: 0; stroke: #2ca02c; stroke-width: 1.8"/>
+    </g>
+    <g id="text_19">
+     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="258.158906" y="379.134609" transform="rotate(-0 258.158906 379.134609)">B-Weighting (historical)</text>
+    </g>
+    <g id="line2d_82">
+     <path d="M 232.958906 389.485313 
+L 241.958906 389.485313 
+L 250.958906 389.485313 
+" style="fill: none; stroke-dasharray: 11.52,2.88,1.8,2.88; stroke-dashoffset: 0; stroke: #9467bd; stroke-width: 1.8"/>
+    </g>
+    <g id="text_20">
+     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="258.158906" y="392.635312" transform="rotate(-0 258.158906 392.635312)">D-Weighting (aircraft, withdrawn)</text>
+    </g>
+    <g id="line2d_83">
+     <path d="M 232.958906 402.986016 
+L 241.958906 402.986016 
+L 250.958906 402.986016 
+" style="fill: none; stroke: #ff7f0e; stroke-width: 1.8; stroke-linecap: square"/>
+    </g>
+    <g id="text_21">
+     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="258.158906" y="406.136016" transform="rotate(-0 258.158906 406.136016)">AU-Weighting (audible + ultrasound)</text>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pa967a6db94">
+   <rect x="49.305469" y="28.318125" width="558" height="388.08"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/.github/images/special_weighting_responses_es.svg
+++ b/.github/images/special_weighting_responses_es.svg
@@ -1,0 +1,979 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="618.991406pt" height="455.079687pt" viewBox="0 0 618.991406 455.079687" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 455.079687 
+L 618.991406 455.079687 
+L 618.991406 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 44.533594 416.878125 
+L 602.533594 416.878125 
+L 602.533594 28.798125 
+L 44.533594 28.798125 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 76.154097 416.878125 
+L 76.154097 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="m3d27035b55" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m3d27035b55" x="76.154097" y="416.878125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle" x="76.154097" y="431.475781" transform="rotate(-0 76.154097 431.475781)">16</text>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 168.360523 416.878125 
+L 168.360523 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m3d27035b55" x="168.360523" y="416.878125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle" x="168.360523" y="431.475781" transform="rotate(-0 168.360523 431.475781)">63</text>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 261.090377 416.878125 
+L 261.090377 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m3d27035b55" x="261.090377" y="416.878125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle" x="261.090377" y="431.475781" transform="rotate(-0 261.090377 431.475781)">250</text>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 354.356307 416.878125 
+L 354.356307 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m3d27035b55" x="354.356307" y="416.878125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle" x="354.356307" y="431.476562" transform="rotate(-0 354.356307 431.476562)">1k</text>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 447.622237 416.878125 
+L 447.622237 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m3d27035b55" x="447.622237" y="416.878125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle" x="447.622237" y="431.476562" transform="rotate(-0 447.622237 431.476562)">4k</text>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_11">
+      <path d="M 540.888167 416.878125 
+L 540.888167 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m3d27035b55" x="540.888167" y="416.878125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle" x="540.888167" y="431.476562" transform="rotate(-0 540.888167 431.476562)">16k</text>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_13">
+      <path d="M 602.533594 416.878125 
+L 602.533594 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m3d27035b55" x="602.533594" y="416.878125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle" x="602.533594" y="431.476562" transform="rotate(-0 602.533594 431.476562)">40k</text>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_15">
+      <path d="M 91.166559 416.878125 
+L 91.166559 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_16">
+      <defs>
+       <path id="md1b22fa4b4" d="M 0 0 
+L 0 2 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="91.166559" y="416.878125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_17">
+      <path d="M 118.445095 416.878125 
+L 118.445095 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="118.445095" y="416.878125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_19">
+      <path d="M 137.799524 416.878125 
+L 137.799524 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="137.799524" y="416.878125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_21">
+      <path d="M 152.811985 416.878125 
+L 152.811985 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="152.811985" y="416.878125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_23">
+      <path d="M 165.07806 416.878125 
+L 165.07806 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="165.07806" y="416.878125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_13">
+     <g id="line2d_25">
+      <path d="M 175.448878 416.878125 
+L 175.448878 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="175.448878" y="416.878125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_27">
+      <path d="M 184.432489 416.878125 
+L 184.432489 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="184.432489" y="416.878125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_29">
+      <path d="M 192.356595 416.878125 
+L 192.356595 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="192.356595" y="416.878125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_31">
+      <path d="M 246.077915 416.878125 
+L 246.077915 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="246.077915" y="416.878125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_17">
+     <g id="line2d_33">
+      <path d="M 273.356451 416.878125 
+L 273.356451 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_34">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="273.356451" y="416.878125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_18">
+     <g id="line2d_35">
+      <path d="M 292.71088 416.878125 
+L 292.71088 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_36">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="292.71088" y="416.878125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_19">
+     <g id="line2d_37">
+      <path d="M 307.723342 416.878125 
+L 307.723342 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_38">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="307.723342" y="416.878125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_20">
+     <g id="line2d_39">
+      <path d="M 319.989416 416.878125 
+L 319.989416 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_40">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="319.989416" y="416.878125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_21">
+     <g id="line2d_41">
+      <path d="M 330.360234 416.878125 
+L 330.360234 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_42">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="330.360234" y="416.878125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_22">
+     <g id="line2d_43">
+      <path d="M 339.343845 416.878125 
+L 339.343845 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_44">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="339.343845" y="416.878125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_23">
+     <g id="line2d_45">
+      <path d="M 347.267952 416.878125 
+L 347.267952 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_46">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="347.267952" y="416.878125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_24">
+     <g id="line2d_47">
+      <path d="M 400.989272 416.878125 
+L 400.989272 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_48">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="400.989272" y="416.878125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_25">
+     <g id="line2d_49">
+      <path d="M 428.267808 416.878125 
+L 428.267808 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_50">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="428.267808" y="416.878125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_26">
+     <g id="line2d_51">
+      <path d="M 462.634699 416.878125 
+L 462.634699 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_52">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="462.634699" y="416.878125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_27">
+     <g id="line2d_53">
+      <path d="M 474.900773 416.878125 
+L 474.900773 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_54">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="474.900773" y="416.878125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_28">
+     <g id="line2d_55">
+      <path d="M 485.271591 416.878125 
+L 485.271591 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_56">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="485.271591" y="416.878125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_29">
+     <g id="line2d_57">
+      <path d="M 494.255202 416.878125 
+L 494.255202 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_58">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="494.255202" y="416.878125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_30">
+     <g id="line2d_59">
+      <path d="M 502.179309 416.878125 
+L 502.179309 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_60">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="502.179309" y="416.878125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_31">
+     <g id="line2d_61">
+      <path d="M 555.900629 416.878125 
+L 555.900629 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_62">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="555.900629" y="416.878125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_32">
+     <g id="line2d_63">
+      <path d="M 583.179165 416.878125 
+L 583.179165 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_64">
+      <g>
+       <use xlink:href="#md1b22fa4b4" x="583.179165" y="416.878125" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_8">
+     <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle" x="323.533594" y="445.477344" transform="rotate(-0 323.533594 445.477344)">Frecuencia [Hz]</text>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_65">
+      <path d="M 44.533594 380.944792 
+L 602.533594 380.944792 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_66">
+      <defs>
+       <path id="mef640d9f3a" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mef640d9f3a" x="44.533594" y="380.944792" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="37.533594" y="384.74362" transform="rotate(-0 37.533594 384.74362)">-80</text>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_67">
+      <path d="M 44.533594 309.078125 
+L 602.533594 309.078125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_68">
+      <g>
+       <use xlink:href="#mef640d9f3a" x="44.533594" y="309.078125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="37.533594" y="312.876953" transform="rotate(-0 37.533594 312.876953)">-60</text>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_69">
+      <path d="M 44.533594 237.211458 
+L 602.533594 237.211458 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_70">
+      <g>
+       <use xlink:href="#mef640d9f3a" x="44.533594" y="237.211458" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="37.533594" y="241.010286" transform="rotate(-0 37.533594 241.010286)">-40</text>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_71">
+      <path d="M 44.533594 165.344792 
+L 602.533594 165.344792 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_72">
+      <g>
+       <use xlink:href="#mef640d9f3a" x="44.533594" y="165.344792" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="37.533594" y="169.14362" transform="rotate(-0 37.533594 169.14362)">-20</text>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_73">
+      <path d="M 44.533594 93.478125 
+L 602.533594 93.478125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_74">
+      <g>
+       <use xlink:href="#mef640d9f3a" x="44.533594" y="93.478125" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="37.533594" y="97.276953" transform="rotate(-0 37.533594 97.276953)">0</text>
+     </g>
+    </g>
+    <g id="text_14">
+     <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle" x="14.798438" y="222.838125" transform="rotate(-90 14.798438 222.838125)">Nivel [dB]</text>
+    </g>
+   </g>
+   <g id="line2d_75">
+    <path d="M 8.571123 409.025937 
+L 55.204088 328.954177 
+L 82.482624 286.889417 
+L 101.837053 260.140148 
+L 116.849514 241.285642 
+L 129.115589 227.05592 
+L 139.486407 215.788705 
+L 148.470018 206.552893 
+L 156.394124 198.78574 
+L 163.482479 192.125287 
+L 169.894676 186.326403 
+L 175.748554 181.215816 
+L 186.119372 172.583055 
+L 195.102983 165.532403 
+L 203.027089 159.635747 
+L 210.115444 154.610921 
+L 219.518229 148.29727 
+L 227.766564 143.074457 
+L 235.113181 138.65763 
+L 243.806177 133.700805 
+L 253.297543 128.601998 
+L 261.613937 124.388157 
+L 270.40169 120.182561 
+L 279.385302 116.140847 
+L 288.368913 112.360949 
+L 297.220995 108.899368 
+L 305.858114 105.783592 
+L 314.231035 103.020526 
+L 322.314002 100.602244 
+L 330.096918 98.510278 
+L 338.083813 96.606258 
+L 345.672372 95.022275 
+L 353.696075 93.578568 
+L 361.929096 92.331769 
+L 370.20452 91.301681 
+L 378.954124 90.435625 
+L 388.142536 89.749864 
+L 397.897071 89.248479 
+L 408.031621 88.953845 
+L 418.377075 88.878474 
+L 428.530097 89.026211 
+L 438.262144 89.387383 
+L 447.457785 89.949736 
+L 455.982926 90.692115 
+L 463.858664 91.597302 
+L 471.255984 92.668822 
+L 478.233275 93.903008 
+L 484.838455 95.294846 
+L 491.214574 96.864535 
+L 497.415539 98.620521 
+L 503.480648 100.570047 
+L 509.438268 102.719449 
+L 515.272482 105.060185 
+L 521.006071 107.600386 
+L 526.594555 110.320007 
+L 532.063925 113.229855 
+L 537.511605 116.382285 
+L 543.10159 119.876934 
+L 549.139976 123.920108 
+L 555.657097 128.554334 
+L 561.797198 133.185581 
+L 567.173909 137.515828 
+L 572.569211 142.154192 
+L 579.852668 148.739935 
+L 586.122889 154.659962 
+L 590.304302 158.919915 
+L 599.327792 168.609257 
+L 601.793696 171.439681 
+L 603.320661 173.532504 
+L 604.584708 175.6452 
+L 605.740929 178.020262 
+L 606.849892 180.82161 
+L 607.949966 184.222975 
+L 609.086004 188.486019 
+L 610.326171 194.051772 
+L 612.084755 203.133429 
+L 613.363682 209.256584 
+L 614.014917 211.399508 
+L 614.462108 212.214912 
+L 614.775026 212.405637 
+L 614.791455 212.406555 
+L 614.791455 212.406555 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #9e9e9e; stroke-width: 4; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_76">
+    <path d="M 8.571123 276.719637 
+L 55.204088 218.204326 
+L 82.482624 188.668612 
+L 101.837053 170.72611 
+L 116.849514 158.621815 
+L 129.115589 149.830585 
+L 139.486407 143.090074 
+L 148.470018 137.71015 
+L 156.394124 133.285365 
+L 163.482479 129.562633 
+L 169.894676 126.375596 
+L 181.133599 121.184091 
+L 190.761015 117.12555 
+L 199.181634 113.868091 
+L 206.664578 111.204536 
+L 213.397907 108.996073 
+L 222.381519 106.32975 
+L 230.305625 104.243518 
+L 237.39398 102.584963 
+L 245.814599 100.860857 
+L 253.297543 99.541372 
+L 261.613937 98.292073 
+L 270.40169 97.196377 
+L 280.576079 96.178996 
+L 291.450848 95.341783 
+L 303.381374 94.662366 
+L 317.034656 94.121075 
+L 332.865916 93.725771 
+L 351.675588 93.488294 
+L 372.651232 93.449724 
+L 392.974767 93.630893 
+L 410.128741 93.997452 
+L 424.345014 94.515324 
+L 436.308614 95.166091 
+L 446.662773 95.945646 
+L 455.808633 96.851344 
+L 464.090521 97.890733 
+L 471.67085 99.061964 
+L 478.793661 100.386042 
+L 485.515179 101.860959 
+L 491.932477 103.495204 
+L 498.163591 105.310817 
+L 504.249538 107.315602 
+L 510.220115 109.516325 
+L 516.061035 111.904886 
+L 521.796027 114.490168 
+L 527.38214 117.252592 
+L 532.845901 120.202928 
+L 538.309927 123.407993 
+L 543.954411 126.979762 
+L 550.070638 131.118114 
+L 556.619478 135.818824 
+L 562.640528 140.406296 
+L 567.952837 144.730618 
+L 573.470837 149.519086 
+L 581.219303 156.569478 
+L 586.786216 161.883712 
+L 590.951259 166.176091 
+L 600.951468 176.994688 
+L 602.704198 179.211375 
+L 604.05689 181.282757 
+L 605.250541 183.524855 
+L 606.376859 186.12835 
+L 607.475474 189.244355 
+L 608.592472 193.104542 
+L 609.779773 198.047672 
+L 611.180883 204.908926 
+L 613.405617 215.884049 
+L 614.039839 217.897533 
+L 614.478614 218.659646 
+L 614.791455 218.830697 
+L 614.791455 218.830697 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 6.66,2.88; stroke-dashoffset: 0; stroke: #2ca02c; stroke-width: 1.8"/>
+   </g>
+   <g id="line2d_77">
+    <path d="M 8.571123 205.834826 
+L 101.837053 162.679698 
+L 139.486407 145.459518 
+L 163.482479 134.701703 
+L 181.133599 127.008587 
+L 195.102983 121.135688 
+L 206.664578 116.481808 
+L 216.527641 112.707029 
+L 227.766564 108.683554 
+L 237.39398 105.524532 
+L 245.814599 103.018625 
+L 253.297543 101.020009 
+L 260.030872 99.423349 
+L 267.59807 97.874835 
+L 274.399529 96.718431 
+L 280.576079 95.869921 
+L 287.309408 95.169754 
+L 293.42973 94.739197 
+L 299.930508 94.494598 
+L 306.663838 94.462217 
+L 314.231035 94.663013 
+L 324.191626 95.18203 
+L 333.942373 95.64648 
+L 339.080529 95.673829 
+L 343.391572 95.466718 
+L 347.004636 95.071034 
+L 350.433513 94.4675 
+L 353.696075 93.661316 
+L 356.807711 92.668893 
+L 360.144452 91.360465 
+L 363.667621 89.716914 
+L 367.341231 87.745348 
+L 371.438998 85.28661 
+L 376.446611 82.003842 
+L 383.449751 77.110808 
+L 398.513354 66.514554 
+L 404.38427 62.701354 
+L 409.088352 59.898292 
+L 413.321015 57.630874 
+L 417.148235 55.836919 
+L 420.62235 54.456017 
+L 423.785533 53.429377 
+L 426.806648 52.671741 
+L 429.826422 52.143507 
+L 432.839335 51.849886 
+L 435.840597 51.787727 
+L 438.82608 51.946075 
+L 442.006847 52.341169 
+L 445.350499 52.984983 
+L 449.02017 53.927073 
+L 453.047701 55.198305 
+L 457.616573 56.878617 
+L 463.079984 59.133243 
+L 469.995813 62.241688 
+L 479.71739 66.876709 
+L 499.862251 76.793009 
+L 529.340942 91.208943 
+L 545.994673 99.496078 
+L 571.18585 112.279273 
+L 589.889339 122.447911 
+L 602.694367 130.192744 
+L 603.902563 131.351587 
+L 604.96599 132.68252 
+L 605.956696 134.286139 
+L 606.905325 136.25454 
+L 607.831656 138.702565 
+L 608.745405 141.770369 
+L 609.629175 145.53844 
+L 610.483975 150.182052 
+L 611.293452 155.837036 
+L 612.050543 162.753558 
+L 612.731492 171.095265 
+L 613.32172 181.118363 
+L 613.823541 193.526254 
+L 614.230603 209.232286 
+L 614.569323 231.369961 
+L 614.791455 246.380406 
+L 614.791455 246.380406 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 11.52,2.88,1.8,2.88; stroke-dashoffset: 0; stroke: #9467bd; stroke-width: 1.8"/>
+   </g>
+   <g id="line2d_78">
+    <path d="M 8.571123 409.020394 
+L 55.204088 328.948764 
+L 82.482624 286.884012 
+L 101.837053 260.134746 
+L 116.849514 241.280243 
+L 129.115589 227.050523 
+L 139.486407 215.783312 
+L 148.470018 206.547504 
+L 156.394124 198.780355 
+L 163.482479 192.119907 
+L 169.894676 186.321028 
+L 175.748554 181.210446 
+L 186.119372 172.577697 
+L 195.102983 165.527058 
+L 203.027089 159.630417 
+L 210.115444 154.605608 
+L 219.518229 148.291985 
+L 227.766564 143.069202 
+L 235.113181 138.65241 
+L 243.806177 133.695635 
+L 253.297543 128.5969 
+L 261.613937 124.383139 
+L 270.40169 120.177651 
+L 279.385302 116.136078 
+L 288.368913 112.356361 
+L 297.220995 108.895006 
+L 305.858114 105.779508 
+L 314.231035 103.016779 
+L 322.314002 100.598901 
+L 330.096918 98.507412 
+L 338.083813 96.603989 
+L 345.672372 95.020696 
+L 353.696075 93.577875 
+L 361.929096 92.332182 
+L 370.20452 91.303442 
+L 378.954124 90.439101 
+L 388.142536 89.755488 
+L 397.897071 89.256752 
+L 408.031621 88.96513 
+L 418.377075 88.892684 
+L 428.530097 89.042245 
+L 438.37531 89.408128 
+L 447.655079 89.973983 
+L 456.330164 90.724278 
+L 464.398426 91.642773 
+L 472.014627 92.732883 
+L 479.164676 93.978719 
+L 485.962577 95.385798 
+L 492.389974 96.939579 
+L 498.210069 98.569432 
+L 503.049659 100.147457 
+L 506.791746 101.590588 
+L 509.752098 102.962339 
+L 512.173645 104.323154 
+L 514.255314 105.744276 
+L 516.132266 107.297651 
+L 517.854261 109.014854 
+L 519.499429 110.974777 
+L 521.105325 113.238956 
+L 522.738345 115.937782 
+L 524.427133 119.17559 
+L 526.197278 123.061063 
+L 528.160611 127.928881 
+L 530.38582 134.07144 
+L 533.012292 142.008212 
+L 536.309262 152.719713 
+L 540.822435 168.196198 
+L 547.819479 193.069523 
+L 559.42668 235.220574 
+L 569.274439 271.73649 
+L 579.562113 310.826176 
+L 588.640985 346.04091 
+L 596.649846 378.180843 
+L 602.645192 402.777664 
+L 604.727942 412.345964 
+L 606.404776 421.096058 
+L 607.886286 430.015148 
+L 609.246741 439.577325 
+L 610.483975 449.867307 
+L 611.129352 456.079687 
+L 611.129352 456.079687 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #ff7f0e; stroke-width: 1.8; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_79">
+    <path d="M 44.533594 93.478125 
+L 602.533594 93.478125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 1,1.65; stroke-dashoffset: 0; stroke: #000000; stroke-opacity: 0.3"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 44.533594 416.878125 
+L 44.533594 28.798125 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 602.533594 416.878125 
+L 602.533594 28.798125 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 44.533594 416.878125 
+L 602.533594 416.878125 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 44.533594 28.798125 
+L 602.533594 28.798125 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 327.374004 45.694285 
+Q 378.462277 48.686314 428.54604 51.619513 
+" style="fill: none; stroke: #9467bd; stroke-width: 0.9; stroke-linecap: round"/>
+    <path d="M 425.057437 49.612116 
+L 428.54604 51.619513 
+L 424.84696 53.205957 
+" style="fill: none; stroke: #9467bd; stroke-width: 0.9; stroke-linecap: round"/>
+   </g>
+   <g id="text_15">
+    <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #9467bd" x="226.723486" y="44.968125" transform="rotate(-0 226.723486 44.968125)">+11,5 dB @ 3,15 kHz</text>
+   </g>
+   <g id="patch_8">
+    <path d="M 445.054534 209.624655 
+Q 492.051561 189.67189 538.122373 170.112353 
+" style="fill: none; stroke: #ff7f0e; stroke-width: 0.9; stroke-linecap: round"/>
+    <path d="M 534.105223 169.862345 
+L 538.122373 170.112353 
+L 535.512077 173.176069 
+" style="fill: none; stroke: #ff7f0e; stroke-width: 0.9; stroke-linecap: round"/>
+   </g>
+   <g id="text_16">
+    <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ff7f0e" x="330.360234" y="219.244792" transform="rotate(-0 330.360234 219.244792)">AU queda 13 dB por debajo de A en 16 kHz</text>
+   </g>
+   <g id="text_17">
+    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle" x="323.533594" y="16.798125" transform="rotate(-0 323.533594 16.798125)">Curvas de ponderación especiales (B, D y AU)</text>
+   </g>
+   <g id="legend_1">
+    <g id="patch_9">
+     <path d="M 220.161563 412.378125 
+L 426.905625 412.378125 
+Q 428.705625 412.378125 428.705625 410.578125 
+L 428.705625 356.035312 
+Q 428.705625 354.235312 426.905625 354.235312 
+L 220.161563 354.235312 
+Q 218.361563 354.235312 218.361563 356.035312 
+L 218.361563 410.578125 
+Q 218.361563 412.378125 220.161563 412.378125 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="line2d_80">
+     <path d="M 221.961563 361.883906 
+L 230.961563 361.883906 
+L 239.961563 361.883906 
+" style="fill: none; stroke: #9e9e9e; stroke-width: 4; stroke-linecap: square"/>
+    </g>
+    <g id="text_18">
+     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start" x="247.161563" y="365.033906" transform="rotate(-0 247.161563 365.033906)">Ponderación A (referencia)</text>
+    </g>
+    <g id="line2d_81">
+     <path d="M 221.961563 375.744609 
+L 230.961563 375.744609 
+L 239.961563 375.744609 
+" style="fill: none; stroke-dasharray: 6.66,2.88; stroke-dashoffset: 0; stroke: #2ca02c; stroke-width: 1.8"/>
+    </g>
+    <g id="text_19">
+     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start" x="247.161563" y="378.894609" transform="rotate(-0 247.161563 378.894609)">Ponderación B (histórica)</text>
+    </g>
+    <g id="line2d_82">
+     <path d="M 221.961563 389.605312 
+L 230.961563 389.605312 
+L 239.961563 389.605312 
+" style="fill: none; stroke-dasharray: 11.52,2.88,1.8,2.88; stroke-dashoffset: 0; stroke: #9467bd; stroke-width: 1.8"/>
+    </g>
+    <g id="text_20">
+     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start" x="247.161563" y="392.755312" transform="rotate(-0 247.161563 392.755312)">Ponderación D (aeronaves, retirada)</text>
+    </g>
+    <g id="line2d_83">
+     <path d="M 221.961563 403.466016 
+L 230.961563 403.466016 
+L 239.961563 403.466016 
+" style="fill: none; stroke: #ff7f0e; stroke-width: 1.8; stroke-linecap: square"/>
+    </g>
+    <g id="text_21">
+     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start" x="247.161563" y="406.616016" transform="rotate(-0 247.161563 406.616016)">Ponderación AU (audible + ultrasonido)</text>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p88af68b26b">
+   <rect x="44.533594" y="28.798125" width="558" height="388.08"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/.github/images/special_weighting_responses_es_dark.svg
+++ b/.github/images/special_weighting_responses_es_dark.svg
@@ -1,0 +1,979 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="618.991406pt" height="455.079687pt" viewBox="0 0 618.991406 455.079687" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 455.079687 
+L 618.991406 455.079687 
+L 618.991406 0 
+L 0 0 
+z
+"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 44.533594 416.878125 
+L 602.533594 416.878125 
+L 602.533594 28.798125 
+L 44.533594 28.798125 
+z
+"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 76.154097 416.878125 
+L 76.154097 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="m8d14ee1197" d="M 0 0 
+L 0 3.5 
+" style="stroke: #ffffff; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m8d14ee1197" x="76.154097" y="416.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="76.154097" y="431.475781" transform="rotate(-0 76.154097 431.475781)">16</text>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 168.360523 416.878125 
+L 168.360523 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m8d14ee1197" x="168.360523" y="416.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="168.360523" y="431.475781" transform="rotate(-0 168.360523 431.475781)">63</text>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 261.090377 416.878125 
+L 261.090377 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m8d14ee1197" x="261.090377" y="416.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="261.090377" y="431.475781" transform="rotate(-0 261.090377 431.475781)">250</text>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 354.356307 416.878125 
+L 354.356307 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m8d14ee1197" x="354.356307" y="416.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="354.356307" y="431.476562" transform="rotate(-0 354.356307 431.476562)">1k</text>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 447.622237 416.878125 
+L 447.622237 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m8d14ee1197" x="447.622237" y="416.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="447.622237" y="431.476562" transform="rotate(-0 447.622237 431.476562)">4k</text>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_11">
+      <path d="M 540.888167 416.878125 
+L 540.888167 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m8d14ee1197" x="540.888167" y="416.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="540.888167" y="431.476562" transform="rotate(-0 540.888167 431.476562)">16k</text>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_13">
+      <path d="M 602.533594 416.878125 
+L 602.533594 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m8d14ee1197" x="602.533594" y="416.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="602.533594" y="431.476562" transform="rotate(-0 602.533594 431.476562)">40k</text>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_15">
+      <path d="M 91.166559 416.878125 
+L 91.166559 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_16">
+      <defs>
+       <path id="m1caa325441" d="M 0 0 
+L 0 2 
+" style="stroke: #ffffff; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#m1caa325441" x="91.166559" y="416.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_17">
+      <path d="M 118.445095 416.878125 
+L 118.445095 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m1caa325441" x="118.445095" y="416.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_19">
+      <path d="M 137.799524 416.878125 
+L 137.799524 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#m1caa325441" x="137.799524" y="416.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_21">
+      <path d="M 152.811985 416.878125 
+L 152.811985 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#m1caa325441" x="152.811985" y="416.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_23">
+      <path d="M 165.07806 416.878125 
+L 165.07806 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#m1caa325441" x="165.07806" y="416.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_13">
+     <g id="line2d_25">
+      <path d="M 175.448878 416.878125 
+L 175.448878 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#m1caa325441" x="175.448878" y="416.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_27">
+      <path d="M 184.432489 416.878125 
+L 184.432489 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#m1caa325441" x="184.432489" y="416.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_29">
+      <path d="M 192.356595 416.878125 
+L 192.356595 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#m1caa325441" x="192.356595" y="416.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_31">
+      <path d="M 246.077915 416.878125 
+L 246.077915 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#m1caa325441" x="246.077915" y="416.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_17">
+     <g id="line2d_33">
+      <path d="M 273.356451 416.878125 
+L 273.356451 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_34">
+      <g>
+       <use xlink:href="#m1caa325441" x="273.356451" y="416.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_18">
+     <g id="line2d_35">
+      <path d="M 292.71088 416.878125 
+L 292.71088 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_36">
+      <g>
+       <use xlink:href="#m1caa325441" x="292.71088" y="416.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_19">
+     <g id="line2d_37">
+      <path d="M 307.723342 416.878125 
+L 307.723342 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_38">
+      <g>
+       <use xlink:href="#m1caa325441" x="307.723342" y="416.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_20">
+     <g id="line2d_39">
+      <path d="M 319.989416 416.878125 
+L 319.989416 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_40">
+      <g>
+       <use xlink:href="#m1caa325441" x="319.989416" y="416.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_21">
+     <g id="line2d_41">
+      <path d="M 330.360234 416.878125 
+L 330.360234 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_42">
+      <g>
+       <use xlink:href="#m1caa325441" x="330.360234" y="416.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_22">
+     <g id="line2d_43">
+      <path d="M 339.343845 416.878125 
+L 339.343845 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_44">
+      <g>
+       <use xlink:href="#m1caa325441" x="339.343845" y="416.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_23">
+     <g id="line2d_45">
+      <path d="M 347.267952 416.878125 
+L 347.267952 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_46">
+      <g>
+       <use xlink:href="#m1caa325441" x="347.267952" y="416.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_24">
+     <g id="line2d_47">
+      <path d="M 400.989272 416.878125 
+L 400.989272 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_48">
+      <g>
+       <use xlink:href="#m1caa325441" x="400.989272" y="416.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_25">
+     <g id="line2d_49">
+      <path d="M 428.267808 416.878125 
+L 428.267808 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_50">
+      <g>
+       <use xlink:href="#m1caa325441" x="428.267808" y="416.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_26">
+     <g id="line2d_51">
+      <path d="M 462.634699 416.878125 
+L 462.634699 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_52">
+      <g>
+       <use xlink:href="#m1caa325441" x="462.634699" y="416.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_27">
+     <g id="line2d_53">
+      <path d="M 474.900773 416.878125 
+L 474.900773 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_54">
+      <g>
+       <use xlink:href="#m1caa325441" x="474.900773" y="416.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_28">
+     <g id="line2d_55">
+      <path d="M 485.271591 416.878125 
+L 485.271591 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_56">
+      <g>
+       <use xlink:href="#m1caa325441" x="485.271591" y="416.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_29">
+     <g id="line2d_57">
+      <path d="M 494.255202 416.878125 
+L 494.255202 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_58">
+      <g>
+       <use xlink:href="#m1caa325441" x="494.255202" y="416.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_30">
+     <g id="line2d_59">
+      <path d="M 502.179309 416.878125 
+L 502.179309 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_60">
+      <g>
+       <use xlink:href="#m1caa325441" x="502.179309" y="416.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_31">
+     <g id="line2d_61">
+      <path d="M 555.900629 416.878125 
+L 555.900629 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_62">
+      <g>
+       <use xlink:href="#m1caa325441" x="555.900629" y="416.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_32">
+     <g id="line2d_63">
+      <path d="M 583.179165 416.878125 
+L 583.179165 28.798125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 0.8,1.32; stroke-dashoffset: 0; stroke: #555555; stroke-opacity: 0.4; stroke-width: 0.8"/>
+     </g>
+     <g id="line2d_64">
+      <g>
+       <use xlink:href="#m1caa325441" x="583.179165" y="416.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_8">
+     <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="323.533594" y="445.477344" transform="rotate(-0 323.533594 445.477344)">Frecuencia [Hz]</text>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_65">
+      <path d="M 44.533594 380.944792 
+L 602.533594 380.944792 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_66">
+      <defs>
+       <path id="m5e07181663" d="M 0 0 
+L -3.5 0 
+" style="stroke: #ffffff; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m5e07181663" x="44.533594" y="380.944792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="37.533594" y="384.74362" transform="rotate(-0 37.533594 384.74362)">-80</text>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_67">
+      <path d="M 44.533594 309.078125 
+L 602.533594 309.078125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_68">
+      <g>
+       <use xlink:href="#m5e07181663" x="44.533594" y="309.078125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="37.533594" y="312.876953" transform="rotate(-0 37.533594 312.876953)">-60</text>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_69">
+      <path d="M 44.533594 237.211458 
+L 602.533594 237.211458 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_70">
+      <g>
+       <use xlink:href="#m5e07181663" x="44.533594" y="237.211458" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="37.533594" y="241.010286" transform="rotate(-0 37.533594 241.010286)">-40</text>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_71">
+      <path d="M 44.533594 165.344792 
+L 602.533594 165.344792 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_72">
+      <g>
+       <use xlink:href="#m5e07181663" x="44.533594" y="165.344792" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="37.533594" y="169.14362" transform="rotate(-0 37.533594 169.14362)">-20</text>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_73">
+      <path d="M 44.533594 93.478125 
+L 602.533594 93.478125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_74">
+      <g>
+       <use xlink:href="#m5e07181663" x="44.533594" y="93.478125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="37.533594" y="97.276953" transform="rotate(-0 37.533594 97.276953)">0</text>
+     </g>
+    </g>
+    <g id="text_14">
+     <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="14.798438" y="222.838125" transform="rotate(-90 14.798438 222.838125)">Nivel [dB]</text>
+    </g>
+   </g>
+   <g id="line2d_75">
+    <path d="M 8.571123 409.025937 
+L 55.204088 328.954177 
+L 82.482624 286.889417 
+L 101.837053 260.140148 
+L 116.849514 241.285642 
+L 129.115589 227.05592 
+L 139.486407 215.788705 
+L 148.470018 206.552893 
+L 156.394124 198.78574 
+L 163.482479 192.125287 
+L 169.894676 186.326403 
+L 175.748554 181.215816 
+L 186.119372 172.583055 
+L 195.102983 165.532403 
+L 203.027089 159.635747 
+L 210.115444 154.610921 
+L 219.518229 148.29727 
+L 227.766564 143.074457 
+L 235.113181 138.65763 
+L 243.806177 133.700805 
+L 253.297543 128.601998 
+L 261.613937 124.388157 
+L 270.40169 120.182561 
+L 279.385302 116.140847 
+L 288.368913 112.360949 
+L 297.220995 108.899368 
+L 305.858114 105.783592 
+L 314.231035 103.020526 
+L 322.314002 100.602244 
+L 330.096918 98.510278 
+L 338.083813 96.606258 
+L 345.672372 95.022275 
+L 353.696075 93.578568 
+L 361.929096 92.331769 
+L 370.20452 91.301681 
+L 378.954124 90.435625 
+L 388.142536 89.749864 
+L 397.897071 89.248479 
+L 408.031621 88.953845 
+L 418.377075 88.878474 
+L 428.530097 89.026211 
+L 438.262144 89.387383 
+L 447.457785 89.949736 
+L 455.982926 90.692115 
+L 463.858664 91.597302 
+L 471.255984 92.668822 
+L 478.233275 93.903008 
+L 484.838455 95.294846 
+L 491.214574 96.864535 
+L 497.415539 98.620521 
+L 503.480648 100.570047 
+L 509.438268 102.719449 
+L 515.272482 105.060185 
+L 521.006071 107.600386 
+L 526.594555 110.320007 
+L 532.063925 113.229855 
+L 537.511605 116.382285 
+L 543.10159 119.876934 
+L 549.139976 123.920108 
+L 555.657097 128.554334 
+L 561.797198 133.185581 
+L 567.173909 137.515828 
+L 572.569211 142.154192 
+L 579.852668 148.739935 
+L 586.122889 154.659962 
+L 590.304302 158.919915 
+L 599.327792 168.609257 
+L 601.793696 171.439681 
+L 603.320661 173.532504 
+L 604.584708 175.6452 
+L 605.740929 178.020262 
+L 606.849892 180.82161 
+L 607.949966 184.222975 
+L 609.086004 188.486019 
+L 610.326171 194.051772 
+L 612.084755 203.133429 
+L 613.363682 209.256584 
+L 614.014917 211.399508 
+L 614.462108 212.214912 
+L 614.775026 212.405637 
+L 614.791455 212.406555 
+L 614.791455 212.406555 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #9e9e9e; stroke-width: 4; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_76">
+    <path d="M 8.571123 276.719637 
+L 55.204088 218.204326 
+L 82.482624 188.668612 
+L 101.837053 170.72611 
+L 116.849514 158.621815 
+L 129.115589 149.830585 
+L 139.486407 143.090074 
+L 148.470018 137.71015 
+L 156.394124 133.285365 
+L 163.482479 129.562633 
+L 169.894676 126.375596 
+L 181.133599 121.184091 
+L 190.761015 117.12555 
+L 199.181634 113.868091 
+L 206.664578 111.204536 
+L 213.397907 108.996073 
+L 222.381519 106.32975 
+L 230.305625 104.243518 
+L 237.39398 102.584963 
+L 245.814599 100.860857 
+L 253.297543 99.541372 
+L 261.613937 98.292073 
+L 270.40169 97.196377 
+L 280.576079 96.178996 
+L 291.450848 95.341783 
+L 303.381374 94.662366 
+L 317.034656 94.121075 
+L 332.865916 93.725771 
+L 351.675588 93.488294 
+L 372.651232 93.449724 
+L 392.974767 93.630893 
+L 410.128741 93.997452 
+L 424.345014 94.515324 
+L 436.308614 95.166091 
+L 446.662773 95.945646 
+L 455.808633 96.851344 
+L 464.090521 97.890733 
+L 471.67085 99.061964 
+L 478.793661 100.386042 
+L 485.515179 101.860959 
+L 491.932477 103.495204 
+L 498.163591 105.310817 
+L 504.249538 107.315602 
+L 510.220115 109.516325 
+L 516.061035 111.904886 
+L 521.796027 114.490168 
+L 527.38214 117.252592 
+L 532.845901 120.202928 
+L 538.309927 123.407993 
+L 543.954411 126.979762 
+L 550.070638 131.118114 
+L 556.619478 135.818824 
+L 562.640528 140.406296 
+L 567.952837 144.730618 
+L 573.470837 149.519086 
+L 581.219303 156.569478 
+L 586.786216 161.883712 
+L 590.951259 166.176091 
+L 600.951468 176.994688 
+L 602.704198 179.211375 
+L 604.05689 181.282757 
+L 605.250541 183.524855 
+L 606.376859 186.12835 
+L 607.475474 189.244355 
+L 608.592472 193.104542 
+L 609.779773 198.047672 
+L 611.180883 204.908926 
+L 613.405617 215.884049 
+L 614.039839 217.897533 
+L 614.478614 218.659646 
+L 614.791455 218.830697 
+L 614.791455 218.830697 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 6.66,2.88; stroke-dashoffset: 0; stroke: #2ca02c; stroke-width: 1.8"/>
+   </g>
+   <g id="line2d_77">
+    <path d="M 8.571123 205.834826 
+L 101.837053 162.679698 
+L 139.486407 145.459518 
+L 163.482479 134.701703 
+L 181.133599 127.008587 
+L 195.102983 121.135688 
+L 206.664578 116.481808 
+L 216.527641 112.707029 
+L 227.766564 108.683554 
+L 237.39398 105.524532 
+L 245.814599 103.018625 
+L 253.297543 101.020009 
+L 260.030872 99.423349 
+L 267.59807 97.874835 
+L 274.399529 96.718431 
+L 280.576079 95.869921 
+L 287.309408 95.169754 
+L 293.42973 94.739197 
+L 299.930508 94.494598 
+L 306.663838 94.462217 
+L 314.231035 94.663013 
+L 324.191626 95.18203 
+L 333.942373 95.64648 
+L 339.080529 95.673829 
+L 343.391572 95.466718 
+L 347.004636 95.071034 
+L 350.433513 94.4675 
+L 353.696075 93.661316 
+L 356.807711 92.668893 
+L 360.144452 91.360465 
+L 363.667621 89.716914 
+L 367.341231 87.745348 
+L 371.438998 85.28661 
+L 376.446611 82.003842 
+L 383.449751 77.110808 
+L 398.513354 66.514554 
+L 404.38427 62.701354 
+L 409.088352 59.898292 
+L 413.321015 57.630874 
+L 417.148235 55.836919 
+L 420.62235 54.456017 
+L 423.785533 53.429377 
+L 426.806648 52.671741 
+L 429.826422 52.143507 
+L 432.839335 51.849886 
+L 435.840597 51.787727 
+L 438.82608 51.946075 
+L 442.006847 52.341169 
+L 445.350499 52.984983 
+L 449.02017 53.927073 
+L 453.047701 55.198305 
+L 457.616573 56.878617 
+L 463.079984 59.133243 
+L 469.995813 62.241688 
+L 479.71739 66.876709 
+L 499.862251 76.793009 
+L 529.340942 91.208943 
+L 545.994673 99.496078 
+L 571.18585 112.279273 
+L 589.889339 122.447911 
+L 602.694367 130.192744 
+L 603.902563 131.351587 
+L 604.96599 132.68252 
+L 605.956696 134.286139 
+L 606.905325 136.25454 
+L 607.831656 138.702565 
+L 608.745405 141.770369 
+L 609.629175 145.53844 
+L 610.483975 150.182052 
+L 611.293452 155.837036 
+L 612.050543 162.753558 
+L 612.731492 171.095265 
+L 613.32172 181.118363 
+L 613.823541 193.526254 
+L 614.230603 209.232286 
+L 614.569323 231.369961 
+L 614.791455 246.380406 
+L 614.791455 246.380406 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 11.52,2.88,1.8,2.88; stroke-dashoffset: 0; stroke: #9467bd; stroke-width: 1.8"/>
+   </g>
+   <g id="line2d_78">
+    <path d="M 8.571123 409.020394 
+L 55.204088 328.948764 
+L 82.482624 286.884012 
+L 101.837053 260.134746 
+L 116.849514 241.280243 
+L 129.115589 227.050523 
+L 139.486407 215.783312 
+L 148.470018 206.547504 
+L 156.394124 198.780355 
+L 163.482479 192.119907 
+L 169.894676 186.321028 
+L 175.748554 181.210446 
+L 186.119372 172.577697 
+L 195.102983 165.527058 
+L 203.027089 159.630417 
+L 210.115444 154.605608 
+L 219.518229 148.291985 
+L 227.766564 143.069202 
+L 235.113181 138.65241 
+L 243.806177 133.695635 
+L 253.297543 128.5969 
+L 261.613937 124.383139 
+L 270.40169 120.177651 
+L 279.385302 116.136078 
+L 288.368913 112.356361 
+L 297.220995 108.895006 
+L 305.858114 105.779508 
+L 314.231035 103.016779 
+L 322.314002 100.598901 
+L 330.096918 98.507412 
+L 338.083813 96.603989 
+L 345.672372 95.020696 
+L 353.696075 93.577875 
+L 361.929096 92.332182 
+L 370.20452 91.303442 
+L 378.954124 90.439101 
+L 388.142536 89.755488 
+L 397.897071 89.256752 
+L 408.031621 88.96513 
+L 418.377075 88.892684 
+L 428.530097 89.042245 
+L 438.37531 89.408128 
+L 447.655079 89.973983 
+L 456.330164 90.724278 
+L 464.398426 91.642773 
+L 472.014627 92.732883 
+L 479.164676 93.978719 
+L 485.962577 95.385798 
+L 492.389974 96.939579 
+L 498.210069 98.569432 
+L 503.049659 100.147457 
+L 506.791746 101.590588 
+L 509.752098 102.962339 
+L 512.173645 104.323154 
+L 514.255314 105.744276 
+L 516.132266 107.297651 
+L 517.854261 109.014854 
+L 519.499429 110.974777 
+L 521.105325 113.238956 
+L 522.738345 115.937782 
+L 524.427133 119.17559 
+L 526.197278 123.061063 
+L 528.160611 127.928881 
+L 530.38582 134.07144 
+L 533.012292 142.008212 
+L 536.309262 152.719713 
+L 540.822435 168.196198 
+L 547.819479 193.069523 
+L 559.42668 235.220574 
+L 569.274439 271.73649 
+L 579.562113 310.826176 
+L 588.640985 346.04091 
+L 596.649846 378.180843 
+L 602.645192 402.777664 
+L 604.727942 412.345964 
+L 606.404776 421.096058 
+L 607.886286 430.015148 
+L 609.246741 439.577325 
+L 610.483975 449.867307 
+L 611.129352 456.079687 
+L 611.129352 456.079687 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #ff7f0e; stroke-width: 1.8; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_79">
+    <path d="M 44.533594 93.478125 
+L 602.533594 93.478125 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 1,1.65; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 44.533594 416.878125 
+L 44.533594 28.798125 
+" style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 602.533594 416.878125 
+L 602.533594 28.798125 
+" style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 44.533594 416.878125 
+L 602.533594 416.878125 
+" style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 44.533594 28.798125 
+L 602.533594 28.798125 
+" style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 327.374004 45.694285 
+Q 378.462277 48.686314 428.54604 51.619513 
+" style="fill: none; stroke: #9467bd; stroke-width: 0.9; stroke-linecap: round"/>
+    <path d="M 425.057437 49.612116 
+L 428.54604 51.619513 
+L 424.84696 53.205957 
+" style="fill: none; stroke: #9467bd; stroke-width: 0.9; stroke-linecap: round"/>
+   </g>
+   <g id="text_15">
+    <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #9467bd" x="226.723486" y="44.968125" transform="rotate(-0 226.723486 44.968125)">+11,5 dB @ 3,15 kHz</text>
+   </g>
+   <g id="patch_8">
+    <path d="M 445.054534 209.624655 
+Q 492.051561 189.67189 538.122373 170.112353 
+" style="fill: none; stroke: #ff7f0e; stroke-width: 0.9; stroke-linecap: round"/>
+    <path d="M 534.105223 169.862345 
+L 538.122373 170.112353 
+L 535.512077 173.176069 
+" style="fill: none; stroke: #ff7f0e; stroke-width: 0.9; stroke-linecap: round"/>
+   </g>
+   <g id="text_16">
+    <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ff7f0e" x="330.360234" y="219.244792" transform="rotate(-0 330.360234 219.244792)">AU queda 13 dB por debajo de A en 16 kHz</text>
+   </g>
+   <g id="text_17">
+    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="323.533594" y="16.798125" transform="rotate(-0 323.533594 16.798125)">Curvas de ponderación especiales (B, D y AU)</text>
+   </g>
+   <g id="legend_1">
+    <g id="patch_9">
+     <path d="M 220.161563 412.378125 
+L 426.905625 412.378125 
+Q 428.705625 412.378125 428.705625 410.578125 
+L 428.705625 356.035312 
+Q 428.705625 354.235312 426.905625 354.235312 
+L 220.161563 354.235312 
+Q 218.361563 354.235312 218.361563 356.035312 
+L 218.361563 410.578125 
+Q 218.361563 412.378125 220.161563 412.378125 
+z
+" style="opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="line2d_80">
+     <path d="M 221.961563 361.883906 
+L 230.961563 361.883906 
+L 239.961563 361.883906 
+" style="fill: none; stroke: #9e9e9e; stroke-width: 4; stroke-linecap: square"/>
+    </g>
+    <g id="text_18">
+     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="247.161563" y="365.033906" transform="rotate(-0 247.161563 365.033906)">Ponderación A (referencia)</text>
+    </g>
+    <g id="line2d_81">
+     <path d="M 221.961563 375.744609 
+L 230.961563 375.744609 
+L 239.961563 375.744609 
+" style="fill: none; stroke-dasharray: 6.66,2.88; stroke-dashoffset: 0; stroke: #2ca02c; stroke-width: 1.8"/>
+    </g>
+    <g id="text_19">
+     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="247.161563" y="378.894609" transform="rotate(-0 247.161563 378.894609)">Ponderación B (histórica)</text>
+    </g>
+    <g id="line2d_82">
+     <path d="M 221.961563 389.605312 
+L 230.961563 389.605312 
+L 239.961563 389.605312 
+" style="fill: none; stroke-dasharray: 11.52,2.88,1.8,2.88; stroke-dashoffset: 0; stroke: #9467bd; stroke-width: 1.8"/>
+    </g>
+    <g id="text_20">
+     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="247.161563" y="392.755312" transform="rotate(-0 247.161563 392.755312)">Ponderación D (aeronaves, retirada)</text>
+    </g>
+    <g id="line2d_83">
+     <path d="M 221.961563 403.466016 
+L 230.961563 403.466016 
+L 239.961563 403.466016 
+" style="fill: none; stroke: #ff7f0e; stroke-width: 1.8; stroke-linecap: square"/>
+    </g>
+    <g id="text_21">
+     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="247.161563" y="406.616016" transform="rotate(-0 247.161563 406.616016)">Ponderación AU (audible + ultrasonido)</text>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p88af68b26b">
+   <rect x="44.533594" y="28.798125" width="558" height="388.08"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/.github/images/weighting_responses.svg
+++ b/.github/images/weighting_responses.svg
@@ -471,8 +471,8 @@ L 600.395176 28.318125
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_65">
-      <path d="M 49.305469 416.398125 
-L 607.305469 416.398125 
+      <path d="M 49.305469 407.476746 
+L 607.305469 407.476746 
 " clip-path="url(#pa967a6db94)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
@@ -482,567 +482,304 @@ L -3.5 0
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mef640d9f3a" x="49.305469" y="416.398125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mef640d9f3a" x="49.305469" y="407.476746" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
-      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="42.305469" y="420.196953" transform="rotate(-0 42.305469 420.196953)">−50</text>
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="42.305469" y="411.275574" transform="rotate(-0 42.305469 411.275574)">−70</text>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_67">
-      <path d="M 49.305469 356.69351 
-L 607.305469 356.69351 
+      <path d="M 49.305469 362.869849 
+L 607.305469 362.869849 
 " clip-path="url(#pa967a6db94)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#mef640d9f3a" x="49.305469" y="356.69351" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mef640d9f3a" x="49.305469" y="362.869849" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
-      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="42.305469" y="360.492338" transform="rotate(-0 42.305469 360.492338)">−40</text>
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="42.305469" y="366.668677" transform="rotate(-0 42.305469 366.668677)">−60</text>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_69">
-      <path d="M 49.305469 296.988894 
-L 607.305469 296.988894 
+      <path d="M 49.305469 318.262953 
+L 607.305469 318.262953 
 " clip-path="url(#pa967a6db94)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#mef640d9f3a" x="49.305469" y="296.988894" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mef640d9f3a" x="49.305469" y="318.262953" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
-      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="42.305469" y="300.787722" transform="rotate(-0 42.305469 300.787722)">−30</text>
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="42.305469" y="322.061781" transform="rotate(-0 42.305469 322.061781)">−50</text>
      </g>
     </g>
     <g id="ytick_4">
      <g id="line2d_71">
-      <path d="M 49.305469 237.284279 
-L 607.305469 237.284279 
+      <path d="M 49.305469 273.656056 
+L 607.305469 273.656056 
 " clip-path="url(#pa967a6db94)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#mef640d9f3a" x="49.305469" y="237.284279" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mef640d9f3a" x="49.305469" y="273.656056" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
-      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="42.305469" y="241.083107" transform="rotate(-0 42.305469 241.083107)">−20</text>
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="42.305469" y="277.454884" transform="rotate(-0 42.305469 277.454884)">−40</text>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_73">
-      <path d="M 49.305469 177.579663 
-L 607.305469 177.579663 
+      <path d="M 49.305469 229.049159 
+L 607.305469 229.049159 
 " clip-path="url(#pa967a6db94)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#mef640d9f3a" x="49.305469" y="177.579663" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mef640d9f3a" x="49.305469" y="229.049159" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
-      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="42.305469" y="181.378492" transform="rotate(-0 42.305469 181.378492)">−10</text>
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="42.305469" y="232.847988" transform="rotate(-0 42.305469 232.847988)">−30</text>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_75">
-      <path d="M 49.305469 117.875048 
-L 607.305469 117.875048 
+      <path d="M 49.305469 184.442263 
+L 607.305469 184.442263 
 " clip-path="url(#pa967a6db94)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_76">
       <g>
-       <use xlink:href="#mef640d9f3a" x="49.305469" y="117.875048" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mef640d9f3a" x="49.305469" y="184.442263" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
-      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="42.305469" y="121.673876" transform="rotate(-0 42.305469 121.673876)">0</text>
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="42.305469" y="188.241091" transform="rotate(-0 42.305469 188.241091)">−20</text>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_77">
-      <path d="M 49.305469 58.170433 
-L 607.305469 58.170433 
+      <path d="M 49.305469 139.835366 
+L 607.305469 139.835366 
 " clip-path="url(#pa967a6db94)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_78">
       <g>
-       <use xlink:href="#mef640d9f3a" x="49.305469" y="58.170433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mef640d9f3a" x="49.305469" y="139.835366" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
-      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="42.305469" y="61.969261" transform="rotate(-0 42.305469 61.969261)">10</text>
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="42.305469" y="143.634195" transform="rotate(-0 42.305469 143.634195)">−10</text>
      </g>
     </g>
-    <g id="text_20">
+    <g id="ytick_8">
+     <g id="line2d_79">
+      <path d="M 49.305469 95.22847 
+L 607.305469 95.22847 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_80">
+      <g>
+       <use xlink:href="#mef640d9f3a" x="49.305469" y="95.22847" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_20">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="42.305469" y="99.027298" transform="rotate(-0 42.305469 99.027298)">0</text>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_81">
+      <path d="M 49.305469 50.621573 
+L 607.305469 50.621573 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_82">
+      <g>
+       <use xlink:href="#mef640d9f3a" x="49.305469" y="50.621573" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_21">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="42.305469" y="54.420401" transform="rotate(-0 42.305469 54.420401)">10</text>
+     </g>
+    </g>
+    <g id="text_22">
      <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle" x="14.798438" y="222.358125" transform="rotate(-90 14.798438 222.358125)">Level [dB]</text>
     </g>
    </g>
-   <g id="line2d_79">
-    <path d="M 83.100925 455.599688 
-L 90.202356 439.235326 
-L 101.378772 414.851607 
-L 111.060225 394.790358 
-L 119.599871 377.916558 
-L 127.238845 363.462858 
-L 134.149137 350.892547 
-L 140.45774 339.819611 
-L 146.261092 329.959661 
-L 151.634157 321.09868 
-L 161.315609 305.753 
-L 169.855256 292.847548 
-L 177.49423 281.780917 
-L 184.404522 272.145814 
-L 190.713125 263.654337 
-L 199.252771 252.614785 
-L 206.891745 243.176247 
-L 213.802038 234.987869 
-L 220.11064 227.797918 
-L 227.749614 219.44885 
-L 234.659907 212.224184 
-L 242.463474 204.426809 
-L 249.508156 197.703155 
-L 257.14713 190.734304 
-L 265.147716 183.776384 
-L 272.352538 177.793783 
-L 279.795292 171.882695 
-L 287.345794 166.155516 
-L 294.90505 160.68714 
-L 302.400311 155.524928 
-L 309.779881 150.69672 
-L 317.008403 146.216603 
-L 324.541456 141.817715 
-L 331.797826 137.849639 
-L 338.786543 134.286011 
-L 345.518476 131.099527 
-L 352.331296 128.125788 
-L 358.856326 125.517014 
-L 365.387446 123.140385 
-L 371.876854 121.008837 
-L 378.515768 119.059998 
-L 385.219793 117.321875 
-L 392.111304 115.764949 
-L 399.260263 114.382264 
-L 406.540943 113.201544 
-L 414.133722 112.197273 
-L 422.007983 111.382755 
-L 430.118 110.768876 
-L 438.410111 110.364265 
-L 446.828431 110.176716 
-L 455.161726 110.211985 
-L 463.341858 110.466244 
-L 471.3246 110.934626 
-L 479.083159 111.61106 
-L 486.603177 112.488004 
-L 493.925119 113.565167 
-L 500.910844 114.81545 
-L 507.512051 116.220911 
-L 513.597243 117.741533 
-L 519.178467 119.362295 
-L 524.390897 121.105504 
-L 529.39512 123.013879 
-L 534.340747 125.138668 
-L 539.464348 127.58499 
-L 544.914719 130.437856 
-L 550.471809 133.596288 
-L 555.514879 136.712215 
-L 559.914999 139.687891 
-L 564.063291 142.762476 
-L 568.467019 146.311282 
-L 574.251333 151.283212 
-L 580.675352 157.073807 
-L 584.51685 160.82658 
-L 588.076953 164.626469 
-L 599.24258 177.155165 
-L 600.663733 179.171414 
-L 601.84967 181.241373 
-L 602.934526 183.58931 
-L 603.973067 186.38268 
-L 604.986974 189.766975 
-L 605.996729 193.936683 
-L 607.012005 199.107059 
-L 608.03238 205.491485 
-L 609.06687 213.413152 
-L 610.13325 223.355039 
-L 611.348724 236.922824 
-L 612.831015 253.271883 
-L 613.285862 256.03927 
-L 613.560949 256.657731 
-L 613.60522 256.674173 
-L 613.60522 256.674173 
-" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5; stroke-linecap: square"/>
-   </g>
-   <g id="line2d_80">
-    <path d="M -1 446.425714 
-L 10.549455 422.337824 
-L 39.946971 363.939885 
-L 60.80484 325.11241 
-L 76.98346 297.158594 
-L 90.202356 276.037683 
-L 101.378772 259.514222 
-L 111.060225 246.225516 
-L 119.599871 235.290005 
-L 127.238845 226.113749 
-L 134.149137 218.284051 
-L 140.45774 211.506765 
-L 146.261092 205.567558 
-L 151.634157 200.307125 
-L 156.63636 195.604909 
-L 165.711088 187.524379 
-L 173.775302 180.797425 
-L 181.031672 175.085145 
-L 187.627417 170.159587 
-L 193.67285 165.860994 
-L 201.889542 160.343187 
-L 209.269112 155.703896 
-L 215.966473 151.753288 
-L 222.097154 148.355515 
-L 229.539908 144.514291 
-L 236.289261 141.302321 
-L 242.463474 138.590964 
-L 249.508156 135.760997 
-L 255.92856 133.423149 
-L 262.950482 131.122851 
-L 269.351978 129.250576 
-L 276.169377 127.480351 
-L 283.248478 125.870722 
-L 290.464692 124.450567 
-L 298.408301 123.119987 
-L 306.79579 121.949357 
-L 315.942161 120.909666 
-L 325.958502 120.009525 
-L 336.80003 119.265001 
-L 349.004878 118.653977 
-L 362.901378 118.185094 
-L 378.741988 117.876451 
-L 396.307629 117.75974 
-L 413.855931 117.863728 
-L 429.559851 118.17261 
-L 443.021139 118.653106 
-L 454.608565 119.283948 
-L 464.803806 120.057239 
-L 474.044561 120.978097 
-L 482.617906 122.054471 
-L 490.670771 123.28846 
-L 498.222862 124.667643 
-L 505.259495 126.174875 
-L 511.709311 127.780356 
-L 517.565389 129.463849 
-L 522.952719 131.24119 
-L 528.053751 133.157192 
-L 533.061716 135.277159 
-L 538.173161 137.685557 
-L 543.578429 140.481807 
-L 549.213448 143.647744 
-L 554.441916 146.83415 
-L 558.980907 149.855561 
-L 563.163714 152.906928 
-L 567.470395 156.330539 
-L 572.820758 160.888785 
-L 579.763526 167.095455 
-L 583.839431 171.015762 
-L 587.3559 174.714131 
-L 597.859035 186.374614 
-L 599.694382 188.649655 
-L 601.022608 190.649272 
-L 602.171653 192.783707 
-L 603.241526 195.250861 
-L 604.275711 198.215306 
-L 605.29535 201.842294 
-L 606.310638 206.307509 
-L 607.331211 211.832427 
-L 608.366167 218.700641 
-L 609.424075 227.267492 
-L 610.549909 238.29803 
-L 613.134563 264.699407 
-L 613.472325 265.827733 
-L 613.60522 265.938549 
-L 613.60522 265.938549 
-" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 5.55,2.4; stroke-dashoffset: 0; stroke: #2ca02c; stroke-width: 1.5"/>
-   </g>
-   <g id="line2d_81">
-    <path d="M -1 267.767125 
-L 10.549455 251.933961 
-L 39.946971 214.518708 
-L 60.80484 190.548305 
-L 76.98346 174.08725 
-L 90.202356 162.324853 
-L 101.378772 153.681925 
-L 111.060225 147.187609 
-L 119.599871 142.213203 
-L 127.238845 138.337522 
-L 134.149137 135.271202 
-L 140.45774 132.811266 
-L 146.261092 130.812719 
-L 151.634157 129.170256 
-L 156.63636 127.806225 
-L 165.711088 125.695223 
-L 173.775302 124.162113 
-L 181.031672 123.016628 
-L 190.713125 121.77708 
-L 199.252771 120.909943 
-L 209.269112 120.109281 
-L 222.097154 119.348566 
-L 236.289261 118.761359 
-L 253.428202 118.296733 
-L 275.233839 117.950926 
-L 304.316807 117.732142 
-L 343.710322 117.66975 
-L 382.053211 117.81731 
-L 408.365019 118.126653 
-L 427.167542 118.560581 
-L 441.800992 119.11397 
-L 453.8911 119.788845 
-L 464.319758 120.58922 
-L 473.679611 121.527113 
-L 482.293748 122.610693 
-L 490.380757 123.849596 
-L 498.0052 125.240668 
-L 505.101535 126.759343 
-L 511.56481 128.366324 
-L 517.432111 130.050243 
-L 522.828994 131.827288 
-L 527.938438 133.742669 
-L 532.954104 135.862093 
-L 538.047788 138.258026 
-L 543.462071 141.054742 
-L 549.105797 144.221612 
-L 554.341759 147.408115 
-L 558.905657 150.441506 
-L 563.092685 153.491726 
-L 567.386722 156.900983 
-L 572.696369 161.420256 
-L 579.664642 167.644666 
-L 583.772676 171.589511 
-L 587.279581 175.271805 
-L 593.250143 181.962072 
-L 599.587065 189.145989 
-L 600.938327 191.151353 
-L 602.099072 193.27663 
-L 603.170009 195.710414 
-L 604.205207 198.633646 
-L 605.215895 202.171667 
-L 606.232288 206.567434 
-L 607.253957 212.007885 
-L 608.290008 218.772019 
-L 609.34902 227.208923 
-L 610.466769 237.978757 
-L 613.161286 265.124486 
-L 613.490059 266.130809 
-L 613.60522 266.214157 
-L 613.60522 266.214157 
-" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #d62728; stroke-width: 1.5; stroke-linecap: square"/>
-   </g>
-   <g id="line2d_82">
-    <path d="M -1 312.818749 
-L 101.378772 239.734074 
-L 140.45774 212.077628 
-L 165.711088 194.460436 
-L 184.404522 181.679551 
-L 199.252771 171.785537 
-L 211.570994 163.828732 
-L 222.097154 157.271407 
-L 231.287057 151.777098 
-L 239.44207 147.119595 
-L 248.152917 142.412244 
-L 255.92856 138.480042 
-L 262.950482 135.176624 
-L 269.351978 132.391446 
-L 276.169377 129.683651 
-L 282.400478 127.45887 
-L 288.138186 125.63425 
-L 294.183619 123.955282 
-L 299.763541 122.635648 
-L 305.566893 121.50417 
-L 310.939957 120.679697 
-L 316.477242 120.056252 
-L 322.116374 119.65597 
-L 327.805817 119.485863 
-L 333.503863 119.537202 
-L 339.95284 119.830997 
-L 347.630369 120.419234 
-L 360.32703 121.41707 
-L 364.842306 121.529668 
-L 368.574912 121.410054 
-L 371.876854 121.086469 
-L 374.796841 120.591187 
-L 377.603766 119.901322 
-L 380.306062 119.018367 
-L 383.124179 117.853263 
-L 385.836845 116.488048 
-L 388.648956 114.819882 
-L 391.545607 112.840545 
-L 394.694389 110.408146 
-L 398.058999 107.51991 
-L 401.933494 103.882157 
-L 406.386844 99.381946 
-L 412.308763 93.05254 
-L 432.308596 71.404528 
-L 437.411428 66.349975 
-L 441.706278 62.398425 
-L 445.491518 59.20578 
-L 448.917503 56.596875 
-L 452.106815 54.445083 
-L 455.00411 52.749579 
-L 457.790061 51.373438 
-L 460.399712 50.325579 
-L 462.918687 49.545511 
-L 465.421443 49.001456 
-L 467.906742 48.690928 
-L 470.373517 48.607056 
-L 472.882528 48.745051 
-L 475.486263 49.116005 
-L 478.171873 49.726614 
-L 481.037541 50.612509 
-L 484.11177 51.803711 
-L 487.465415 53.350163 
-L 491.199467 55.325918 
-L 495.431377 57.823442 
-L 500.448637 61.050956 
-L 506.704529 65.352659 
-L 514.886687 71.263936 
-L 525.234317 79.021619 
-L 538.722241 89.437396 
-L 551.833313 99.47483 
-L 564.500216 109.160454 
-L 579.932729 121.180976 
-L 585.632003 125.621305 
-L 596.773073 134.562989 
-L 599.177807 136.460397 
-L 600.536646 137.820999 
-L 601.651616 139.252642 
-L 602.667403 140.925039 
-L 603.628537 142.945177 
-L 604.56707 145.449785 
-L 605.493609 148.575319 
-L 606.418232 152.507461 
-L 607.331211 157.396257 
-L 608.232837 163.483006 
-L 609.104553 170.934885 
-L 609.937986 180.032771 
-L 610.715905 191.029255 
-L 611.43086 204.395043 
-L 612.066539 220.55339 
-L 612.633922 240.827609 
-L 613.214702 270.341707 
-L 613.578661 284.718158 
-L 613.60522 284.862158 
-L 613.60522 284.862158 
-" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 9.6,2.4,1.5,2.4; stroke-dashoffset: 0; stroke: #9467bd; stroke-width: 1.5"/>
-   </g>
    <g id="line2d_83">
-    <path d="M 83.09702 455.599688 
-L 90.202356 439.226354 
-L 101.378772 414.84265 
-L 111.060225 394.781408 
-L 119.599871 377.90761 
-L 127.238845 363.45391 
-L 134.149137 350.883602 
-L 140.45774 339.810667 
-L 146.261092 329.950719 
-L 151.634157 321.08974 
-L 161.315609 305.744066 
-L 169.855256 292.838621 
-L 177.49423 281.771999 
-L 184.404522 272.136905 
-L 190.713125 263.645439 
-L 199.252771 252.605904 
-L 206.891745 243.167385 
-L 213.802038 234.979026 
-L 220.11064 227.789098 
-L 227.749614 219.440062 
-L 234.659907 212.215429 
-L 242.463474 204.4181 
-L 249.508156 197.694496 
-L 257.14713 190.725708 
-L 265.147716 183.76787 
-L 272.352538 177.785357 
-L 279.795292 171.874378 
-L 287.345794 166.147332 
-L 294.90505 160.679115 
-L 302.400311 155.517092 
-L 309.779881 150.689104 
-L 317.008403 146.209241 
-L 324.541456 141.810665 
-L 331.797826 137.842941 
-L 338.786543 134.279709 
-L 345.518476 131.093664 
-L 352.331296 128.120436 
-L 358.856326 125.512226 
-L 365.387446 123.136244 
-L 371.876854 121.005435 
-L 378.515768 119.057469 
-L 385.219793 117.32037 
-L 392.111304 115.764673 
-L 399.260263 114.383491 
-L 406.540943 113.204589 
-L 414.133722 112.202575 
-L 422.007983 111.390856 
-L 430.118 110.780401 
-L 438.410111 110.379864 
-L 446.828431 110.196921 
-L 455.161726 110.236827 
-L 463.412148 110.49805 
-L 471.450473 110.97386 
-L 479.309202 111.660801 
-L 487.010214 112.556905 
-L 494.522234 113.653842 
-L 501.785139 114.93747 
-L 508.612618 116.366959 
-L 514.886687 117.904406 
-L 520.628901 119.538338 
-L 525.949521 121.282153 
-L 531.016933 123.176933 
-L 535.908445 125.243299 
-L 540.51496 127.428124 
-L 544.502638 129.55805 
-L 547.735514 131.527345 
-L 550.387183 133.3973 
-L 552.617585 135.238388 
-L 554.581903 137.147621 
-L 556.358063 139.184546 
-L 558.015571 141.424893 
-L 559.617397 143.971687 
-L 561.184596 146.892701 
-L 562.754342 150.304442 
-L 564.343226 154.303057 
-L 566.000514 159.092364 
-L 567.770823 164.913898 
-L 569.693836 172.028936 
-L 571.866858 180.957377 
-L 574.418689 192.431455 
-L 577.556301 207.620448 
-L 581.562083 228.169384 
-L 586.499075 254.69785 
-L 598.24297 319.655612 
-L 601.201382 336.811147 
-L 603.139337 349.354274 
-L 604.777326 361.418362 
-L 606.291059 374.246759 
-L 607.783425 388.850861 
-L 609.414698 407.126332 
-L 612.102695 437.609028 
-L 612.759407 442.460198 
-L 613.214702 444.4093 
-L 613.525513 444.946152 
-L 613.60522 444.973941 
-L 613.60522 444.973941 
-" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 5.55,2.4; stroke-dashoffset: 0; stroke: #ff7f0e; stroke-width: 1.5"/>
+    <path d="M 26.088799 455.599688 
+L 39.946971 427.643861 
+L 60.80484 387.54371 
+L 76.98346 358.083668 
+L 90.202356 335.32523 
+L 101.378772 317.107508 
+L 111.060225 302.119219 
+L 119.599871 289.512357 
+L 127.238845 278.713615 
+L 134.149137 269.322004 
+L 140.45774 261.04912 
+L 146.261092 253.682491 
+L 156.63636 241.065648 
+L 165.711088 230.580538 
+L 173.775302 221.670841 
+L 181.031672 213.968948 
+L 187.627417 207.22026 
+L 196.516477 198.496713 
+L 204.433774 191.08002 
+L 211.570994 184.674825 
+L 220.11064 177.354752 
+L 227.749614 171.116943 
+L 236.289261 164.479557 
+L 243.928235 158.83103 
+L 252.144926 153.04531 
+L 260.684573 147.333765 
+L 269.351978 141.833111 
+L 278.004999 136.623087 
+L 286.544645 131.744652 
+L 294.90505 127.214515 
+L 303.683587 122.716785 
+L 312.081763 118.664288 
+L 320.62141 114.800815 
+L 328.712118 111.388149 
+L 336.80003 108.226752 
+L 344.439004 105.478253 
+L 352.005438 102.989001 
+L 359.448192 100.769861 
+L 366.998694 98.751072 
+L 374.55795 96.961001 
+L 382.268674 95.366026 
+L 390.208224 93.956316 
+L 398.231831 92.757069 
+L 406.694714 91.719901 
+L 415.506929 90.868256 
+L 424.693594 90.207668 
+L 434.119938 89.752779 
+L 443.761919 89.50857 
+L 453.48942 89.484582 
+L 463.060019 89.683826 
+L 472.325522 90.098928 
+L 481.257581 90.720748 
+L 489.894809 91.544384 
+L 498.179382 92.556917 
+L 505.927008 93.724341 
+L 513.032464 95.015681 
+L 519.470884 96.408081 
+L 525.41378 97.918999 
+L 531.072216 99.586176 
+L 536.756445 101.494612 
+L 542.736447 103.740737 
+L 549.019561 106.338767 
+L 554.841163 108.978975 
+L 559.822129 111.476319 
+L 564.430485 114.035652 
+L 569.401288 117.059942 
+L 576.353022 121.576809 
+L 582.206438 125.603171 
+L 586.099181 128.552059 
+L 590.539539 132.222845 
+L 600.303073 140.612838 
+L 601.599407 142.216595 
+L 602.7497 143.99881 
+L 603.82127 146.078235 
+L 604.857263 148.586377 
+L 605.878662 151.657081 
+L 606.90529 155.474336 
+L 607.936729 160.199632 
+L 608.98201 166.076528 
+L 610.04963 173.40105 
+L 611.248209 183.280869 
+L 612.85785 196.547242 
+L 613.303641 198.503995 
+L 613.578661 198.9237 
+L 613.60522 198.928965 
+L 613.60522 198.928965 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #1f77b4; stroke-width: 1.8; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
-    <path d="M -1 117.875048 
-L 613.60522 117.875048 
-L 613.60522 117.875048 
-" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #000000; stroke-width: 1.5; stroke-linecap: square"/>
+    <path d="M -1 207.216803 
+L 10.549455 195.387428 
+L 39.946971 167.433503 
+L 60.80484 149.524581 
+L 76.98346 137.226092 
+L 90.202356 128.438094 
+L 101.378772 121.980734 
+L 111.060225 117.128659 
+L 119.599871 113.412148 
+L 127.238845 110.516525 
+L 134.149137 108.225597 
+L 140.45774 106.387713 
+L 146.261092 104.894546 
+L 151.634157 103.667418 
+L 161.315609 101.793846 
+L 169.855256 100.454939 
+L 177.49423 99.468069 
+L 187.627417 98.41484 
+L 199.252771 97.49592 
+L 211.570994 96.78104 
+L 225.913992 96.194473 
+L 242.463474 95.746492 
+L 264.057422 95.397737 
+L 293.454938 95.165644 
+L 335.98993 95.072392 
+L 381.620355 95.182917 
+L 411.59444 95.459941 
+L 432.092491 95.860298 
+L 447.7934 96.382029 
+L 460.692064 97.028434 
+L 471.826788 97.804429 
+L 481.913723 98.727209 
+L 491.24734 99.801793 
+L 499.941028 101.023916 
+L 507.893447 102.363324 
+L 514.990239 103.77969 
+L 521.359178 105.273189 
+L 527.271804 106.886644 
+L 532.981022 108.676051 
+L 538.796795 110.735168 
+L 544.983172 113.165693 
+L 551.270866 115.872957 
+L 556.785697 118.481262 
+L 561.584765 120.994176 
+L 566.239068 123.685613 
+L 571.709276 127.121351 
+L 579.352983 132.198115 
+L 583.906125 135.460351 
+L 587.736296 138.485635 
+L 598.993967 147.900706 
+L 600.568439 149.533801 
+L 601.828848 151.162115 
+L 602.955033 152.983908 
+L 604.023596 155.147106 
+L 605.056722 157.754322 
+L 606.085153 160.973812 
+L 607.118563 164.969859 
+L 608.156538 169.901925 
+L 609.217486 176.063699 
+L 610.327989 183.883846 
+L 611.785711 195.953983 
+L 612.777316 203.420306 
+L 613.25029 205.52656 
+L 613.543233 206.036399 
+L 613.60522 206.05654 
+L 613.60522 206.05654 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #d62728; stroke-width: 1.8; stroke-linecap: square"/>
    </g>
    <g id="line2d_85">
-    <path d="M 49.305469 117.875048 
-L 607.305469 117.875048 
+    <path d="M -1 95.22847 
+L 613.60522 95.22847 
+L 613.60522 95.22847 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 6.66,2.88; stroke-dashoffset: 0; stroke: #000000; stroke-width: 1.8"/>
+   </g>
+   <g id="line2d_86">
+    <path d="M 49.305469 95.22847 
+L 607.305469 95.22847 
 " clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 1,1.65; stroke-dashoffset: 0; stroke: #000000; stroke-opacity: 0.3"/>
    </g>
    <g id="patch_3">
@@ -1065,76 +802,49 @@ L 607.305469 416.398125
 L 607.305469 28.318125 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="text_21">
-    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle" x="328.305469" y="16.318125" transform="rotate(-0 328.305469 16.318125)">Frequency Weighting Curves</text>
+   <g id="text_23">
+    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle" x="328.305469" y="16.318125" transform="rotate(-0 328.305469 16.318125)">Frequency Weighting Curves (IEC 61672-1)</text>
    </g>
    <g id="legend_1">
     <g id="patch_7">
-     <path d="M 55.605469 116.522344 
-L 249.898594 116.522344 
-Q 251.698594 116.522344 251.698594 114.722344 
-L 251.698594 34.618125 
-Q 251.698594 32.818125 249.898594 32.818125 
+     <path d="M 55.605469 76.020234 
+L 165.172031 76.020234 
+Q 166.972031 76.020234 166.972031 74.220234 
+L 166.972031 34.618125 
+Q 166.972031 32.818125 165.172031 32.818125 
 L 55.605469 32.818125 
 Q 53.805469 32.818125 53.805469 34.618125 
-L 53.805469 114.722344 
-Q 53.805469 116.522344 55.605469 116.522344 
+L 53.805469 74.220234 
+Q 53.805469 76.020234 55.605469 76.020234 
 z
 " style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
     </g>
-    <g id="line2d_86">
+    <g id="line2d_87">
      <path d="M 57.405469 40.106719 
 L 66.405469 40.106719 
 L 75.405469 40.106719 
-" style="fill: none; stroke: #1f77b4; stroke-width: 1.5; stroke-linecap: square"/>
+" style="fill: none; stroke: #1f77b4; stroke-width: 1.8; stroke-linecap: square"/>
     </g>
-    <g id="text_22">
+    <g id="text_24">
      <text style="font-size: 9px; font-family: sans-serif; text-anchor: start" x="82.605469" y="43.256719" transform="rotate(-0 82.605469 43.256719)">A-Weighting</text>
     </g>
-    <g id="line2d_87">
+    <g id="line2d_88">
      <path d="M 57.405469 53.607422 
 L 66.405469 53.607422 
 L 75.405469 53.607422 
-" style="fill: none; stroke-dasharray: 5.55,2.4; stroke-dashoffset: 0; stroke: #2ca02c; stroke-width: 1.5"/>
+" style="fill: none; stroke: #d62728; stroke-width: 1.8; stroke-linecap: square"/>
     </g>
-    <g id="text_23">
-     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start" x="82.605469" y="56.757422" transform="rotate(-0 82.605469 56.757422)">B-Weighting (historical)</text>
+    <g id="text_25">
+     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start" x="82.605469" y="56.757422" transform="rotate(-0 82.605469 56.757422)">C-Weighting</text>
     </g>
-    <g id="line2d_88">
+    <g id="line2d_89">
      <path d="M 57.405469 67.108125 
 L 66.405469 67.108125 
 L 75.405469 67.108125 
-" style="fill: none; stroke: #d62728; stroke-width: 1.5; stroke-linecap: square"/>
-    </g>
-    <g id="text_24">
-     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start" x="82.605469" y="70.258125" transform="rotate(-0 82.605469 70.258125)">C-Weighting</text>
-    </g>
-    <g id="line2d_89">
-     <path d="M 57.405469 80.608828 
-L 66.405469 80.608828 
-L 75.405469 80.608828 
-" style="fill: none; stroke-dasharray: 9.6,2.4,1.5,2.4; stroke-dashoffset: 0; stroke: #9467bd; stroke-width: 1.5"/>
-    </g>
-    <g id="text_25">
-     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start" x="82.605469" y="83.758828" transform="rotate(-0 82.605469 83.758828)">D-Weighting (aircraft, withdrawn)</text>
-    </g>
-    <g id="line2d_90">
-     <path d="M 57.405469 94.109531 
-L 66.405469 94.109531 
-L 75.405469 94.109531 
-" style="fill: none; stroke-dasharray: 5.55,2.4; stroke-dashoffset: 0; stroke: #ff7f0e; stroke-width: 1.5"/>
+" style="fill: none; stroke-dasharray: 6.66,2.88; stroke-dashoffset: 0; stroke: #000000; stroke-width: 1.8"/>
     </g>
     <g id="text_26">
-     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start" x="82.605469" y="97.259531" transform="rotate(-0 82.605469 97.259531)">AU-Weighting (audible + ultrasound)</text>
-    </g>
-    <g id="line2d_91">
-     <path d="M 57.405469 107.610234 
-L 66.405469 107.610234 
-L 75.405469 107.610234 
-" style="fill: none; stroke: #000000; stroke-width: 1.5; stroke-linecap: square"/>
-    </g>
-    <g id="text_27">
-     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start" x="82.605469" y="110.760234" transform="rotate(-0 82.605469 110.760234)">Z-Weighting (Flat)</text>
+     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start" x="82.605469" y="70.258125" transform="rotate(-0 82.605469 70.258125)">Z-Weighting (Flat)</text>
     </g>
    </g>
   </g>
@@ -1149,183 +859,183 @@ z
    </g>
    <g id="matplotlib.axis_3">
     <g id="xtick_33">
-     <g id="line2d_92">
+     <g id="line2d_90">
       <path d="M 211.125469 396.398125 
 L 211.125469 264.450925 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_93">
+     <g id="line2d_91">
       <g>
        <use xlink:href="#m3d27035b55" x="211.125469" y="396.398125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_28">
+     <g id="text_27">
       <text style="font-size: 8px; font-family: sans-serif; text-anchor: middle" x="211.125469" y="409.47625" transform="rotate(-0 211.125469 409.47625)">500</text>
      </g>
     </g>
     <g id="xtick_34">
-     <g id="line2d_94">
+     <g id="line2d_92">
       <path d="M 269.715469 396.398125 
 L 269.715469 264.450925 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_95">
+     <g id="line2d_93">
       <g>
        <use xlink:href="#m3d27035b55" x="269.715469" y="396.398125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_29">
+     <g id="text_28">
       <text style="font-size: 8px; font-family: sans-serif; text-anchor: middle" x="269.715469" y="409.476875" transform="rotate(-0 269.715469 409.476875)">1k</text>
      </g>
     </g>
     <g id="xtick_35">
-     <g id="line2d_96">
+     <g id="line2d_94">
       <path d="M 347.167236 396.398125 
 L 347.167236 264.450925 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_97">
+     <g id="line2d_95">
       <g>
        <use xlink:href="#m3d27035b55" x="347.167236" y="396.398125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_30">
+     <g id="text_29">
       <text style="font-size: 8px; font-family: sans-serif; text-anchor: middle" x="347.167236" y="409.476875" transform="rotate(-0 347.167236 409.476875)">2.5k</text>
      </g>
     </g>
     <g id="xtick_36">
-     <g id="line2d_98">
+     <g id="line2d_96">
       <path d="M 405.757236 396.398125 
 L 405.757236 264.450925 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_99">
+     <g id="line2d_97">
       <g>
        <use xlink:href="#m3d27035b55" x="405.757236" y="396.398125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_31">
+     <g id="text_30">
       <text style="font-size: 8px; font-family: sans-serif; text-anchor: middle" x="405.757236" y="409.476875" transform="rotate(-0 405.757236 409.476875)">5k</text>
      </g>
     </g>
     <g id="xtick_37">
-     <g id="line2d_100">
+     <g id="line2d_98">
       <path d="M 445.485469 396.398125 
 L 445.485469 264.450925 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_101">
+     <g id="line2d_99">
       <g>
        <use xlink:href="#m3d27035b55" x="445.485469" y="396.398125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_32">
+     <g id="text_31">
       <text style="font-size: 8px; font-family: sans-serif; text-anchor: middle" x="445.485469" y="409.476875" transform="rotate(-0 445.485469 409.476875)">8k</text>
      </g>
     </g>
     <g id="xtick_38">
-     <g id="line2d_102">
+     <g id="line2d_100">
       <path d="M 226.536655 396.398125 
 L 226.536655 264.450925 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_103">
+     <g id="line2d_101">
       <g>
        <use xlink:href="#md1b22fa4b4" x="226.536655" y="396.398125" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_39">
-     <g id="line2d_104">
+     <g id="line2d_102">
       <path d="M 239.566627 396.398125 
 L 239.566627 264.450925 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_105">
+     <g id="line2d_103">
       <g>
        <use xlink:href="#md1b22fa4b4" x="239.566627" y="396.398125" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_40">
-     <g id="line2d_106">
+     <g id="line2d_104">
       <path d="M 250.853702 396.398125 
 L 250.853702 264.450925 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_107">
+     <g id="line2d_105">
       <g>
        <use xlink:href="#md1b22fa4b4" x="250.853702" y="396.398125" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_41">
-     <g id="line2d_108">
+     <g id="line2d_106">
       <path d="M 260.809608 396.398125 
 L 260.809608 264.450925 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_109">
+     <g id="line2d_107">
       <g>
        <use xlink:href="#md1b22fa4b4" x="260.809608" y="396.398125" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_42">
-     <g id="line2d_110">
+     <g id="line2d_108">
       <path d="M 328.305469 396.398125 
 L 328.305469 264.450925 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_111">
+     <g id="line2d_109">
       <g>
        <use xlink:href="#md1b22fa4b4" x="328.305469" y="396.398125" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_43">
-     <g id="line2d_112">
+     <g id="line2d_110">
       <path d="M 362.578422 396.398125 
 L 362.578422 264.450925 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_113">
+     <g id="line2d_111">
       <g>
        <use xlink:href="#md1b22fa4b4" x="362.578422" y="396.398125" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_44">
-     <g id="line2d_114">
+     <g id="line2d_112">
       <path d="M 386.895469 396.398125 
 L 386.895469 264.450925 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_115">
+     <g id="line2d_113">
       <g>
        <use xlink:href="#md1b22fa4b4" x="386.895469" y="396.398125" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_45">
-     <g id="line2d_116">
+     <g id="line2d_114">
       <path d="M 421.168422 396.398125 
 L 421.168422 264.450925 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_117">
+     <g id="line2d_115">
       <g>
        <use xlink:href="#md1b22fa4b4" x="421.168422" y="396.398125" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_46">
-     <g id="line2d_118">
+     <g id="line2d_116">
       <path d="M 434.198394 396.398125 
 L 434.198394 264.450925 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_119">
+     <g id="line2d_117">
       <g>
        <use xlink:href="#md1b22fa4b4" x="434.198394" y="396.398125" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
@@ -1333,98 +1043,98 @@ L 434.198394 264.450925
     </g>
    </g>
    <g id="matplotlib.axis_4">
-    <g id="ytick_8">
-     <g id="line2d_120">
+    <g id="ytick_10">
+     <g id="line2d_118">
       <path d="M 211.125469 396.398125 
 L 445.485469 396.398125 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_121">
+     <g id="line2d_119">
       <g>
        <use xlink:href="#mef640d9f3a" x="211.125469" y="396.398125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_33">
+     <g id="text_32">
       <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="204.125469" y="400.196953" transform="rotate(-0 204.125469 400.196953)">−3</text>
      </g>
     </g>
-    <g id="ytick_9">
-     <g id="line2d_122">
+    <g id="ytick_11">
+     <g id="line2d_120">
       <path d="M 211.125469 370.008685 
 L 445.485469 370.008685 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_123">
+     <g id="line2d_121">
       <g>
        <use xlink:href="#mef640d9f3a" x="211.125469" y="370.008685" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_34">
+     <g id="text_33">
       <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="204.125469" y="373.807513" transform="rotate(-0 204.125469 373.807513)">−2</text>
      </g>
     </g>
-    <g id="ytick_10">
-     <g id="line2d_124">
+    <g id="ytick_12">
+     <g id="line2d_122">
       <path d="M 211.125469 343.619245 
 L 445.485469 343.619245 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_125">
+     <g id="line2d_123">
       <g>
        <use xlink:href="#mef640d9f3a" x="211.125469" y="343.619245" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_35">
+     <g id="text_34">
       <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="204.125469" y="347.418073" transform="rotate(-0 204.125469 347.418073)">−1</text>
      </g>
     </g>
-    <g id="ytick_11">
-     <g id="line2d_126">
+    <g id="ytick_13">
+     <g id="line2d_124">
       <path d="M 211.125469 317.229805 
 L 445.485469 317.229805 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_127">
+     <g id="line2d_125">
       <g>
        <use xlink:href="#mef640d9f3a" x="211.125469" y="317.229805" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_36">
+     <g id="text_35">
       <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="204.125469" y="321.028633" transform="rotate(-0 204.125469 321.028633)">0</text>
      </g>
     </g>
-    <g id="ytick_12">
-     <g id="line2d_128">
+    <g id="ytick_14">
+     <g id="line2d_126">
       <path d="M 211.125469 290.840365 
 L 445.485469 290.840365 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_129">
+     <g id="line2d_127">
       <g>
        <use xlink:href="#mef640d9f3a" x="211.125469" y="290.840365" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_37">
+     <g id="text_36">
       <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="204.125469" y="294.639193" transform="rotate(-0 204.125469 294.639193)">1</text>
      </g>
     </g>
-    <g id="ytick_13">
-     <g id="line2d_130">
+    <g id="ytick_15">
+     <g id="line2d_128">
       <path d="M 211.125469 264.450925 
 L 445.485469 264.450925 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_131">
+     <g id="line2d_129">
       <g>
        <use xlink:href="#mef640d9f3a" x="211.125469" y="264.450925" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_38">
+     <g id="text_37">
       <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="204.125469" y="268.249753" transform="rotate(-0 204.125469 268.249753)">2</text>
      </g>
     </g>
    </g>
-   <g id="line2d_132">
+   <g id="line2d_130">
     <path d="M 186.925126 455.599688 
 L 193.16687 441.098422 
 L 199.080294 427.928547 
@@ -1496,9 +1206,9 @@ L 482.898057 434.167392
 L 487.049623 447.174752 
 L 489.645579 455.599688 
 L 489.645579 455.599688 
-" clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5; stroke-linecap: square"/>
+" clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke: #1f77b4; stroke-width: 1.8; stroke-linecap: square"/>
    </g>
-   <g id="line2d_133">
+   <g id="line2d_131">
     <path d="M -1 368.025376 
 L -0.248653 367.154623 
 L 5.583142 361.125609 
@@ -1566,15 +1276,15 @@ L 466.200572 440.590514
 L 470.245042 450.192613 
 L 472.413733 455.599688 
 L 472.413733 455.599688 
-" clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke: #d62728; stroke-width: 1.5; stroke-linecap: square"/>
+" clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke: #d62728; stroke-width: 1.8; stroke-linecap: square"/>
    </g>
-   <g id="line2d_134">
+   <g id="line2d_132">
     <path d="M -1 317.229805 
 L 538.338103 317.229805 
 L 538.338103 317.229805 
-" clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke: #000000; stroke-width: 1.5; stroke-linecap: square"/>
+" clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 6.66,2.88; stroke-dashoffset: 0; stroke: #000000; stroke-width: 1.8"/>
    </g>
-   <g id="line2d_135">
+   <g id="line2d_133">
     <path d="M 211.125469 317.229805 
 L 445.485469 317.229805 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 1,1.65; stroke-dashoffset: 0; stroke: #000000; stroke-opacity: 0.4"/>
@@ -1608,10 +1318,10 @@ L 350.032718 283.2823
 L 352.957796 281.222223 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
-   <g id="text_39">
+   <g id="text_38">
     <text style="font-size: 8px; font-family: sans-serif; text-anchor: start" x="391.019579" y="276.326173" transform="rotate(-0 391.019579 276.326173)">+1.27 dB</text>
    </g>
-   <g id="text_40">
+   <g id="text_39">
     <text style="font-size: 9px; font-family: sans-serif; text-anchor: middle" x="328.305469" y="258.450925" transform="rotate(-0 328.305469 258.450925)">Zoom: A-weighting is positive (max +1.27 dB @ 2.5 kHz)</text>
    </g>
   </g>

--- a/.github/images/weighting_responses_dark.svg
+++ b/.github/images/weighting_responses_dark.svg
@@ -471,8 +471,8 @@ L 600.395176 28.318125
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_65">
-      <path d="M 49.305469 416.398125 
-L 607.305469 416.398125 
+      <path d="M 49.305469 407.476746 
+L 607.305469 407.476746 
 " clip-path="url(#pa967a6db94)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
@@ -482,567 +482,304 @@ L -3.5 0
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5e07181663" x="49.305469" y="416.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m5e07181663" x="49.305469" y="407.476746" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
-      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="42.305469" y="420.196953" transform="rotate(-0 42.305469 420.196953)">−50</text>
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="42.305469" y="411.275574" transform="rotate(-0 42.305469 411.275574)">−70</text>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_67">
-      <path d="M 49.305469 356.69351 
-L 607.305469 356.69351 
+      <path d="M 49.305469 362.869849 
+L 607.305469 362.869849 
 " clip-path="url(#pa967a6db94)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m5e07181663" x="49.305469" y="356.69351" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m5e07181663" x="49.305469" y="362.869849" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
-      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="42.305469" y="360.492338" transform="rotate(-0 42.305469 360.492338)">−40</text>
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="42.305469" y="366.668677" transform="rotate(-0 42.305469 366.668677)">−60</text>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_69">
-      <path d="M 49.305469 296.988894 
-L 607.305469 296.988894 
+      <path d="M 49.305469 318.262953 
+L 607.305469 318.262953 
 " clip-path="url(#pa967a6db94)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m5e07181663" x="49.305469" y="296.988894" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m5e07181663" x="49.305469" y="318.262953" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
-      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="42.305469" y="300.787722" transform="rotate(-0 42.305469 300.787722)">−30</text>
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="42.305469" y="322.061781" transform="rotate(-0 42.305469 322.061781)">−50</text>
      </g>
     </g>
     <g id="ytick_4">
      <g id="line2d_71">
-      <path d="M 49.305469 237.284279 
-L 607.305469 237.284279 
+      <path d="M 49.305469 273.656056 
+L 607.305469 273.656056 
 " clip-path="url(#pa967a6db94)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m5e07181663" x="49.305469" y="237.284279" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m5e07181663" x="49.305469" y="273.656056" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
-      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="42.305469" y="241.083107" transform="rotate(-0 42.305469 241.083107)">−20</text>
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="42.305469" y="277.454884" transform="rotate(-0 42.305469 277.454884)">−40</text>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_73">
-      <path d="M 49.305469 177.579663 
-L 607.305469 177.579663 
+      <path d="M 49.305469 229.049159 
+L 607.305469 229.049159 
 " clip-path="url(#pa967a6db94)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m5e07181663" x="49.305469" y="177.579663" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m5e07181663" x="49.305469" y="229.049159" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
-      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="42.305469" y="181.378492" transform="rotate(-0 42.305469 181.378492)">−10</text>
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="42.305469" y="232.847988" transform="rotate(-0 42.305469 232.847988)">−30</text>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_75">
-      <path d="M 49.305469 117.875048 
-L 607.305469 117.875048 
+      <path d="M 49.305469 184.442263 
+L 607.305469 184.442263 
 " clip-path="url(#pa967a6db94)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_76">
       <g>
-       <use xlink:href="#m5e07181663" x="49.305469" y="117.875048" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m5e07181663" x="49.305469" y="184.442263" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
-      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="42.305469" y="121.673876" transform="rotate(-0 42.305469 121.673876)">0</text>
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="42.305469" y="188.241091" transform="rotate(-0 42.305469 188.241091)">−20</text>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_77">
-      <path d="M 49.305469 58.170433 
-L 607.305469 58.170433 
+      <path d="M 49.305469 139.835366 
+L 607.305469 139.835366 
 " clip-path="url(#pa967a6db94)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_78">
       <g>
-       <use xlink:href="#m5e07181663" x="49.305469" y="58.170433" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m5e07181663" x="49.305469" y="139.835366" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
-      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="42.305469" y="61.969261" transform="rotate(-0 42.305469 61.969261)">10</text>
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="42.305469" y="143.634195" transform="rotate(-0 42.305469 143.634195)">−10</text>
      </g>
     </g>
-    <g id="text_20">
+    <g id="ytick_8">
+     <g id="line2d_79">
+      <path d="M 49.305469 95.22847 
+L 607.305469 95.22847 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_80">
+      <g>
+       <use xlink:href="#m5e07181663" x="49.305469" y="95.22847" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_20">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="42.305469" y="99.027298" transform="rotate(-0 42.305469 99.027298)">0</text>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_81">
+      <path d="M 49.305469 50.621573 
+L 607.305469 50.621573 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_82">
+      <g>
+       <use xlink:href="#m5e07181663" x="49.305469" y="50.621573" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_21">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="42.305469" y="54.420401" transform="rotate(-0 42.305469 54.420401)">10</text>
+     </g>
+    </g>
+    <g id="text_22">
      <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="14.798438" y="222.358125" transform="rotate(-90 14.798438 222.358125)">Level [dB]</text>
     </g>
    </g>
-   <g id="line2d_79">
-    <path d="M 83.100925 455.599688 
-L 90.202356 439.235326 
-L 101.378772 414.851607 
-L 111.060225 394.790358 
-L 119.599871 377.916558 
-L 127.238845 363.462858 
-L 134.149137 350.892547 
-L 140.45774 339.819611 
-L 146.261092 329.959661 
-L 151.634157 321.09868 
-L 161.315609 305.753 
-L 169.855256 292.847548 
-L 177.49423 281.780917 
-L 184.404522 272.145814 
-L 190.713125 263.654337 
-L 199.252771 252.614785 
-L 206.891745 243.176247 
-L 213.802038 234.987869 
-L 220.11064 227.797918 
-L 227.749614 219.44885 
-L 234.659907 212.224184 
-L 242.463474 204.426809 
-L 249.508156 197.703155 
-L 257.14713 190.734304 
-L 265.147716 183.776384 
-L 272.352538 177.793783 
-L 279.795292 171.882695 
-L 287.345794 166.155516 
-L 294.90505 160.68714 
-L 302.400311 155.524928 
-L 309.779881 150.69672 
-L 317.008403 146.216603 
-L 324.541456 141.817715 
-L 331.797826 137.849639 
-L 338.786543 134.286011 
-L 345.518476 131.099527 
-L 352.331296 128.125788 
-L 358.856326 125.517014 
-L 365.387446 123.140385 
-L 371.876854 121.008837 
-L 378.515768 119.059998 
-L 385.219793 117.321875 
-L 392.111304 115.764949 
-L 399.260263 114.382264 
-L 406.540943 113.201544 
-L 414.133722 112.197273 
-L 422.007983 111.382755 
-L 430.118 110.768876 
-L 438.410111 110.364265 
-L 446.828431 110.176716 
-L 455.161726 110.211985 
-L 463.341858 110.466244 
-L 471.3246 110.934626 
-L 479.083159 111.61106 
-L 486.603177 112.488004 
-L 493.925119 113.565167 
-L 500.910844 114.81545 
-L 507.512051 116.220911 
-L 513.597243 117.741533 
-L 519.178467 119.362295 
-L 524.390897 121.105504 
-L 529.39512 123.013879 
-L 534.340747 125.138668 
-L 539.464348 127.58499 
-L 544.914719 130.437856 
-L 550.471809 133.596288 
-L 555.514879 136.712215 
-L 559.914999 139.687891 
-L 564.063291 142.762476 
-L 568.467019 146.311282 
-L 574.251333 151.283212 
-L 580.675352 157.073807 
-L 584.51685 160.82658 
-L 588.076953 164.626469 
-L 599.24258 177.155165 
-L 600.663733 179.171414 
-L 601.84967 181.241373 
-L 602.934526 183.58931 
-L 603.973067 186.38268 
-L 604.986974 189.766975 
-L 605.996729 193.936683 
-L 607.012005 199.107059 
-L 608.03238 205.491485 
-L 609.06687 213.413152 
-L 610.13325 223.355039 
-L 611.348724 236.922824 
-L 612.831015 253.271883 
-L 613.285862 256.03927 
-L 613.560949 256.657731 
-L 613.60522 256.674173 
-L 613.60522 256.674173 
-" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5; stroke-linecap: square"/>
-   </g>
-   <g id="line2d_80">
-    <path d="M -1 446.425714 
-L 10.549455 422.337824 
-L 39.946971 363.939885 
-L 60.80484 325.11241 
-L 76.98346 297.158594 
-L 90.202356 276.037683 
-L 101.378772 259.514222 
-L 111.060225 246.225516 
-L 119.599871 235.290005 
-L 127.238845 226.113749 
-L 134.149137 218.284051 
-L 140.45774 211.506765 
-L 146.261092 205.567558 
-L 151.634157 200.307125 
-L 156.63636 195.604909 
-L 165.711088 187.524379 
-L 173.775302 180.797425 
-L 181.031672 175.085145 
-L 187.627417 170.159587 
-L 193.67285 165.860994 
-L 201.889542 160.343187 
-L 209.269112 155.703896 
-L 215.966473 151.753288 
-L 222.097154 148.355515 
-L 229.539908 144.514291 
-L 236.289261 141.302321 
-L 242.463474 138.590964 
-L 249.508156 135.760997 
-L 255.92856 133.423149 
-L 262.950482 131.122851 
-L 269.351978 129.250576 
-L 276.169377 127.480351 
-L 283.248478 125.870722 
-L 290.464692 124.450567 
-L 298.408301 123.119987 
-L 306.79579 121.949357 
-L 315.942161 120.909666 
-L 325.958502 120.009525 
-L 336.80003 119.265001 
-L 349.004878 118.653977 
-L 362.901378 118.185094 
-L 378.741988 117.876451 
-L 396.307629 117.75974 
-L 413.855931 117.863728 
-L 429.559851 118.17261 
-L 443.021139 118.653106 
-L 454.608565 119.283948 
-L 464.803806 120.057239 
-L 474.044561 120.978097 
-L 482.617906 122.054471 
-L 490.670771 123.28846 
-L 498.222862 124.667643 
-L 505.259495 126.174875 
-L 511.709311 127.780356 
-L 517.565389 129.463849 
-L 522.952719 131.24119 
-L 528.053751 133.157192 
-L 533.061716 135.277159 
-L 538.173161 137.685557 
-L 543.578429 140.481807 
-L 549.213448 143.647744 
-L 554.441916 146.83415 
-L 558.980907 149.855561 
-L 563.163714 152.906928 
-L 567.470395 156.330539 
-L 572.820758 160.888785 
-L 579.763526 167.095455 
-L 583.839431 171.015762 
-L 587.3559 174.714131 
-L 597.859035 186.374614 
-L 599.694382 188.649655 
-L 601.022608 190.649272 
-L 602.171653 192.783707 
-L 603.241526 195.250861 
-L 604.275711 198.215306 
-L 605.29535 201.842294 
-L 606.310638 206.307509 
-L 607.331211 211.832427 
-L 608.366167 218.700641 
-L 609.424075 227.267492 
-L 610.549909 238.29803 
-L 613.134563 264.699407 
-L 613.472325 265.827733 
-L 613.60522 265.938549 
-L 613.60522 265.938549 
-" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 5.55,2.4; stroke-dashoffset: 0; stroke: #2ca02c; stroke-width: 1.5"/>
-   </g>
-   <g id="line2d_81">
-    <path d="M -1 267.767125 
-L 10.549455 251.933961 
-L 39.946971 214.518708 
-L 60.80484 190.548305 
-L 76.98346 174.08725 
-L 90.202356 162.324853 
-L 101.378772 153.681925 
-L 111.060225 147.187609 
-L 119.599871 142.213203 
-L 127.238845 138.337522 
-L 134.149137 135.271202 
-L 140.45774 132.811266 
-L 146.261092 130.812719 
-L 151.634157 129.170256 
-L 156.63636 127.806225 
-L 165.711088 125.695223 
-L 173.775302 124.162113 
-L 181.031672 123.016628 
-L 190.713125 121.77708 
-L 199.252771 120.909943 
-L 209.269112 120.109281 
-L 222.097154 119.348566 
-L 236.289261 118.761359 
-L 253.428202 118.296733 
-L 275.233839 117.950926 
-L 304.316807 117.732142 
-L 343.710322 117.66975 
-L 382.053211 117.81731 
-L 408.365019 118.126653 
-L 427.167542 118.560581 
-L 441.800992 119.11397 
-L 453.8911 119.788845 
-L 464.319758 120.58922 
-L 473.679611 121.527113 
-L 482.293748 122.610693 
-L 490.380757 123.849596 
-L 498.0052 125.240668 
-L 505.101535 126.759343 
-L 511.56481 128.366324 
-L 517.432111 130.050243 
-L 522.828994 131.827288 
-L 527.938438 133.742669 
-L 532.954104 135.862093 
-L 538.047788 138.258026 
-L 543.462071 141.054742 
-L 549.105797 144.221612 
-L 554.341759 147.408115 
-L 558.905657 150.441506 
-L 563.092685 153.491726 
-L 567.386722 156.900983 
-L 572.696369 161.420256 
-L 579.664642 167.644666 
-L 583.772676 171.589511 
-L 587.279581 175.271805 
-L 593.250143 181.962072 
-L 599.587065 189.145989 
-L 600.938327 191.151353 
-L 602.099072 193.27663 
-L 603.170009 195.710414 
-L 604.205207 198.633646 
-L 605.215895 202.171667 
-L 606.232288 206.567434 
-L 607.253957 212.007885 
-L 608.290008 218.772019 
-L 609.34902 227.208923 
-L 610.466769 237.978757 
-L 613.161286 265.124486 
-L 613.490059 266.130809 
-L 613.60522 266.214157 
-L 613.60522 266.214157 
-" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #d62728; stroke-width: 1.5; stroke-linecap: square"/>
-   </g>
-   <g id="line2d_82">
-    <path d="M -1 312.818749 
-L 101.378772 239.734074 
-L 140.45774 212.077628 
-L 165.711088 194.460436 
-L 184.404522 181.679551 
-L 199.252771 171.785537 
-L 211.570994 163.828732 
-L 222.097154 157.271407 
-L 231.287057 151.777098 
-L 239.44207 147.119595 
-L 248.152917 142.412244 
-L 255.92856 138.480042 
-L 262.950482 135.176624 
-L 269.351978 132.391446 
-L 276.169377 129.683651 
-L 282.400478 127.45887 
-L 288.138186 125.63425 
-L 294.183619 123.955282 
-L 299.763541 122.635648 
-L 305.566893 121.50417 
-L 310.939957 120.679697 
-L 316.477242 120.056252 
-L 322.116374 119.65597 
-L 327.805817 119.485863 
-L 333.503863 119.537202 
-L 339.95284 119.830997 
-L 347.630369 120.419234 
-L 360.32703 121.41707 
-L 364.842306 121.529668 
-L 368.574912 121.410054 
-L 371.876854 121.086469 
-L 374.796841 120.591187 
-L 377.603766 119.901322 
-L 380.306062 119.018367 
-L 383.124179 117.853263 
-L 385.836845 116.488048 
-L 388.648956 114.819882 
-L 391.545607 112.840545 
-L 394.694389 110.408146 
-L 398.058999 107.51991 
-L 401.933494 103.882157 
-L 406.386844 99.381946 
-L 412.308763 93.05254 
-L 432.308596 71.404528 
-L 437.411428 66.349975 
-L 441.706278 62.398425 
-L 445.491518 59.20578 
-L 448.917503 56.596875 
-L 452.106815 54.445083 
-L 455.00411 52.749579 
-L 457.790061 51.373438 
-L 460.399712 50.325579 
-L 462.918687 49.545511 
-L 465.421443 49.001456 
-L 467.906742 48.690928 
-L 470.373517 48.607056 
-L 472.882528 48.745051 
-L 475.486263 49.116005 
-L 478.171873 49.726614 
-L 481.037541 50.612509 
-L 484.11177 51.803711 
-L 487.465415 53.350163 
-L 491.199467 55.325918 
-L 495.431377 57.823442 
-L 500.448637 61.050956 
-L 506.704529 65.352659 
-L 514.886687 71.263936 
-L 525.234317 79.021619 
-L 538.722241 89.437396 
-L 551.833313 99.47483 
-L 564.500216 109.160454 
-L 579.932729 121.180976 
-L 585.632003 125.621305 
-L 596.773073 134.562989 
-L 599.177807 136.460397 
-L 600.536646 137.820999 
-L 601.651616 139.252642 
-L 602.667403 140.925039 
-L 603.628537 142.945177 
-L 604.56707 145.449785 
-L 605.493609 148.575319 
-L 606.418232 152.507461 
-L 607.331211 157.396257 
-L 608.232837 163.483006 
-L 609.104553 170.934885 
-L 609.937986 180.032771 
-L 610.715905 191.029255 
-L 611.43086 204.395043 
-L 612.066539 220.55339 
-L 612.633922 240.827609 
-L 613.214702 270.341707 
-L 613.578661 284.718158 
-L 613.60522 284.862158 
-L 613.60522 284.862158 
-" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 9.6,2.4,1.5,2.4; stroke-dashoffset: 0; stroke: #9467bd; stroke-width: 1.5"/>
-   </g>
    <g id="line2d_83">
-    <path d="M 83.09702 455.599688 
-L 90.202356 439.226354 
-L 101.378772 414.84265 
-L 111.060225 394.781408 
-L 119.599871 377.90761 
-L 127.238845 363.45391 
-L 134.149137 350.883602 
-L 140.45774 339.810667 
-L 146.261092 329.950719 
-L 151.634157 321.08974 
-L 161.315609 305.744066 
-L 169.855256 292.838621 
-L 177.49423 281.771999 
-L 184.404522 272.136905 
-L 190.713125 263.645439 
-L 199.252771 252.605904 
-L 206.891745 243.167385 
-L 213.802038 234.979026 
-L 220.11064 227.789098 
-L 227.749614 219.440062 
-L 234.659907 212.215429 
-L 242.463474 204.4181 
-L 249.508156 197.694496 
-L 257.14713 190.725708 
-L 265.147716 183.76787 
-L 272.352538 177.785357 
-L 279.795292 171.874378 
-L 287.345794 166.147332 
-L 294.90505 160.679115 
-L 302.400311 155.517092 
-L 309.779881 150.689104 
-L 317.008403 146.209241 
-L 324.541456 141.810665 
-L 331.797826 137.842941 
-L 338.786543 134.279709 
-L 345.518476 131.093664 
-L 352.331296 128.120436 
-L 358.856326 125.512226 
-L 365.387446 123.136244 
-L 371.876854 121.005435 
-L 378.515768 119.057469 
-L 385.219793 117.32037 
-L 392.111304 115.764673 
-L 399.260263 114.383491 
-L 406.540943 113.204589 
-L 414.133722 112.202575 
-L 422.007983 111.390856 
-L 430.118 110.780401 
-L 438.410111 110.379864 
-L 446.828431 110.196921 
-L 455.161726 110.236827 
-L 463.412148 110.49805 
-L 471.450473 110.97386 
-L 479.309202 111.660801 
-L 487.010214 112.556905 
-L 494.522234 113.653842 
-L 501.785139 114.93747 
-L 508.612618 116.366959 
-L 514.886687 117.904406 
-L 520.628901 119.538338 
-L 525.949521 121.282153 
-L 531.016933 123.176933 
-L 535.908445 125.243299 
-L 540.51496 127.428124 
-L 544.502638 129.55805 
-L 547.735514 131.527345 
-L 550.387183 133.3973 
-L 552.617585 135.238388 
-L 554.581903 137.147621 
-L 556.358063 139.184546 
-L 558.015571 141.424893 
-L 559.617397 143.971687 
-L 561.184596 146.892701 
-L 562.754342 150.304442 
-L 564.343226 154.303057 
-L 566.000514 159.092364 
-L 567.770823 164.913898 
-L 569.693836 172.028936 
-L 571.866858 180.957377 
-L 574.418689 192.431455 
-L 577.556301 207.620448 
-L 581.562083 228.169384 
-L 586.499075 254.69785 
-L 598.24297 319.655612 
-L 601.201382 336.811147 
-L 603.139337 349.354274 
-L 604.777326 361.418362 
-L 606.291059 374.246759 
-L 607.783425 388.850861 
-L 609.414698 407.126332 
-L 612.102695 437.609028 
-L 612.759407 442.460198 
-L 613.214702 444.4093 
-L 613.525513 444.946152 
-L 613.60522 444.973941 
-L 613.60522 444.973941 
-" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 5.55,2.4; stroke-dashoffset: 0; stroke: #ff7f0e; stroke-width: 1.5"/>
+    <path d="M 26.088799 455.599688 
+L 39.946971 427.643861 
+L 60.80484 387.54371 
+L 76.98346 358.083668 
+L 90.202356 335.32523 
+L 101.378772 317.107508 
+L 111.060225 302.119219 
+L 119.599871 289.512357 
+L 127.238845 278.713615 
+L 134.149137 269.322004 
+L 140.45774 261.04912 
+L 146.261092 253.682491 
+L 156.63636 241.065648 
+L 165.711088 230.580538 
+L 173.775302 221.670841 
+L 181.031672 213.968948 
+L 187.627417 207.22026 
+L 196.516477 198.496713 
+L 204.433774 191.08002 
+L 211.570994 184.674825 
+L 220.11064 177.354752 
+L 227.749614 171.116943 
+L 236.289261 164.479557 
+L 243.928235 158.83103 
+L 252.144926 153.04531 
+L 260.684573 147.333765 
+L 269.351978 141.833111 
+L 278.004999 136.623087 
+L 286.544645 131.744652 
+L 294.90505 127.214515 
+L 303.683587 122.716785 
+L 312.081763 118.664288 
+L 320.62141 114.800815 
+L 328.712118 111.388149 
+L 336.80003 108.226752 
+L 344.439004 105.478253 
+L 352.005438 102.989001 
+L 359.448192 100.769861 
+L 366.998694 98.751072 
+L 374.55795 96.961001 
+L 382.268674 95.366026 
+L 390.208224 93.956316 
+L 398.231831 92.757069 
+L 406.694714 91.719901 
+L 415.506929 90.868256 
+L 424.693594 90.207668 
+L 434.119938 89.752779 
+L 443.761919 89.50857 
+L 453.48942 89.484582 
+L 463.060019 89.683826 
+L 472.325522 90.098928 
+L 481.257581 90.720748 
+L 489.894809 91.544384 
+L 498.179382 92.556917 
+L 505.927008 93.724341 
+L 513.032464 95.015681 
+L 519.470884 96.408081 
+L 525.41378 97.918999 
+L 531.072216 99.586176 
+L 536.756445 101.494612 
+L 542.736447 103.740737 
+L 549.019561 106.338767 
+L 554.841163 108.978975 
+L 559.822129 111.476319 
+L 564.430485 114.035652 
+L 569.401288 117.059942 
+L 576.353022 121.576809 
+L 582.206438 125.603171 
+L 586.099181 128.552059 
+L 590.539539 132.222845 
+L 600.303073 140.612838 
+L 601.599407 142.216595 
+L 602.7497 143.99881 
+L 603.82127 146.078235 
+L 604.857263 148.586377 
+L 605.878662 151.657081 
+L 606.90529 155.474336 
+L 607.936729 160.199632 
+L 608.98201 166.076528 
+L 610.04963 173.40105 
+L 611.248209 183.280869 
+L 612.85785 196.547242 
+L 613.303641 198.503995 
+L 613.578661 198.9237 
+L 613.60522 198.928965 
+L 613.60522 198.928965 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #1f77b4; stroke-width: 1.8; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
-    <path d="M -1 117.875048 
-L 613.60522 117.875048 
-L 613.60522 117.875048 
-" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #ffffff; stroke-width: 1.5; stroke-linecap: square"/>
+    <path d="M -1 207.216803 
+L 10.549455 195.387428 
+L 39.946971 167.433503 
+L 60.80484 149.524581 
+L 76.98346 137.226092 
+L 90.202356 128.438094 
+L 101.378772 121.980734 
+L 111.060225 117.128659 
+L 119.599871 113.412148 
+L 127.238845 110.516525 
+L 134.149137 108.225597 
+L 140.45774 106.387713 
+L 146.261092 104.894546 
+L 151.634157 103.667418 
+L 161.315609 101.793846 
+L 169.855256 100.454939 
+L 177.49423 99.468069 
+L 187.627417 98.41484 
+L 199.252771 97.49592 
+L 211.570994 96.78104 
+L 225.913992 96.194473 
+L 242.463474 95.746492 
+L 264.057422 95.397737 
+L 293.454938 95.165644 
+L 335.98993 95.072392 
+L 381.620355 95.182917 
+L 411.59444 95.459941 
+L 432.092491 95.860298 
+L 447.7934 96.382029 
+L 460.692064 97.028434 
+L 471.826788 97.804429 
+L 481.913723 98.727209 
+L 491.24734 99.801793 
+L 499.941028 101.023916 
+L 507.893447 102.363324 
+L 514.990239 103.77969 
+L 521.359178 105.273189 
+L 527.271804 106.886644 
+L 532.981022 108.676051 
+L 538.796795 110.735168 
+L 544.983172 113.165693 
+L 551.270866 115.872957 
+L 556.785697 118.481262 
+L 561.584765 120.994176 
+L 566.239068 123.685613 
+L 571.709276 127.121351 
+L 579.352983 132.198115 
+L 583.906125 135.460351 
+L 587.736296 138.485635 
+L 598.993967 147.900706 
+L 600.568439 149.533801 
+L 601.828848 151.162115 
+L 602.955033 152.983908 
+L 604.023596 155.147106 
+L 605.056722 157.754322 
+L 606.085153 160.973812 
+L 607.118563 164.969859 
+L 608.156538 169.901925 
+L 609.217486 176.063699 
+L 610.327989 183.883846 
+L 611.785711 195.953983 
+L 612.777316 203.420306 
+L 613.25029 205.52656 
+L 613.543233 206.036399 
+L 613.60522 206.05654 
+L 613.60522 206.05654 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke: #d62728; stroke-width: 1.8; stroke-linecap: square"/>
    </g>
    <g id="line2d_85">
-    <path d="M 49.305469 117.875048 
-L 607.305469 117.875048 
+    <path d="M -1 95.22847 
+L 613.60522 95.22847 
+L 613.60522 95.22847 
+" clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 6.66,2.88; stroke-dashoffset: 0; stroke: #ffffff; stroke-width: 1.8"/>
+   </g>
+   <g id="line2d_86">
+    <path d="M 49.305469 95.22847 
+L 607.305469 95.22847 
 " clip-path="url(#pa967a6db94)" style="fill: none; stroke-dasharray: 1,1.65; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3"/>
    </g>
    <g id="patch_3">
@@ -1065,76 +802,49 @@ L 607.305469 416.398125
 L 607.305469 28.318125 
 " style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="text_21">
-    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="328.305469" y="16.318125" transform="rotate(-0 328.305469 16.318125)">Frequency Weighting Curves</text>
+   <g id="text_23">
+    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="328.305469" y="16.318125" transform="rotate(-0 328.305469 16.318125)">Frequency Weighting Curves (IEC 61672-1)</text>
    </g>
    <g id="legend_1">
     <g id="patch_7">
-     <path d="M 55.605469 116.522344 
-L 249.898594 116.522344 
-Q 251.698594 116.522344 251.698594 114.722344 
-L 251.698594 34.618125 
-Q 251.698594 32.818125 249.898594 32.818125 
+     <path d="M 55.605469 76.020234 
+L 165.172031 76.020234 
+Q 166.972031 76.020234 166.972031 74.220234 
+L 166.972031 34.618125 
+Q 166.972031 32.818125 165.172031 32.818125 
 L 55.605469 32.818125 
 Q 53.805469 32.818125 53.805469 34.618125 
-L 53.805469 114.722344 
-Q 53.805469 116.522344 55.605469 116.522344 
+L 53.805469 74.220234 
+Q 53.805469 76.020234 55.605469 76.020234 
 z
 " style="opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
     </g>
-    <g id="line2d_86">
+    <g id="line2d_87">
      <path d="M 57.405469 40.106719 
 L 66.405469 40.106719 
 L 75.405469 40.106719 
-" style="fill: none; stroke: #1f77b4; stroke-width: 1.5; stroke-linecap: square"/>
+" style="fill: none; stroke: #1f77b4; stroke-width: 1.8; stroke-linecap: square"/>
     </g>
-    <g id="text_22">
+    <g id="text_24">
      <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="82.605469" y="43.256719" transform="rotate(-0 82.605469 43.256719)">A-Weighting</text>
     </g>
-    <g id="line2d_87">
+    <g id="line2d_88">
      <path d="M 57.405469 53.607422 
 L 66.405469 53.607422 
 L 75.405469 53.607422 
-" style="fill: none; stroke-dasharray: 5.55,2.4; stroke-dashoffset: 0; stroke: #2ca02c; stroke-width: 1.5"/>
+" style="fill: none; stroke: #d62728; stroke-width: 1.8; stroke-linecap: square"/>
     </g>
-    <g id="text_23">
-     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="82.605469" y="56.757422" transform="rotate(-0 82.605469 56.757422)">B-Weighting (historical)</text>
+    <g id="text_25">
+     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="82.605469" y="56.757422" transform="rotate(-0 82.605469 56.757422)">C-Weighting</text>
     </g>
-    <g id="line2d_88">
+    <g id="line2d_89">
      <path d="M 57.405469 67.108125 
 L 66.405469 67.108125 
 L 75.405469 67.108125 
-" style="fill: none; stroke: #d62728; stroke-width: 1.5; stroke-linecap: square"/>
-    </g>
-    <g id="text_24">
-     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="82.605469" y="70.258125" transform="rotate(-0 82.605469 70.258125)">C-Weighting</text>
-    </g>
-    <g id="line2d_89">
-     <path d="M 57.405469 80.608828 
-L 66.405469 80.608828 
-L 75.405469 80.608828 
-" style="fill: none; stroke-dasharray: 9.6,2.4,1.5,2.4; stroke-dashoffset: 0; stroke: #9467bd; stroke-width: 1.5"/>
-    </g>
-    <g id="text_25">
-     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="82.605469" y="83.758828" transform="rotate(-0 82.605469 83.758828)">D-Weighting (aircraft, withdrawn)</text>
-    </g>
-    <g id="line2d_90">
-     <path d="M 57.405469 94.109531 
-L 66.405469 94.109531 
-L 75.405469 94.109531 
-" style="fill: none; stroke-dasharray: 5.55,2.4; stroke-dashoffset: 0; stroke: #ff7f0e; stroke-width: 1.5"/>
+" style="fill: none; stroke-dasharray: 6.66,2.88; stroke-dashoffset: 0; stroke: #ffffff; stroke-width: 1.8"/>
     </g>
     <g id="text_26">
-     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="82.605469" y="97.259531" transform="rotate(-0 82.605469 97.259531)">AU-Weighting (audible + ultrasound)</text>
-    </g>
-    <g id="line2d_91">
-     <path d="M 57.405469 107.610234 
-L 66.405469 107.610234 
-L 75.405469 107.610234 
-" style="fill: none; stroke: #ffffff; stroke-width: 1.5; stroke-linecap: square"/>
-    </g>
-    <g id="text_27">
-     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="82.605469" y="110.760234" transform="rotate(-0 82.605469 110.760234)">Z-Weighting (Flat)</text>
+     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="82.605469" y="70.258125" transform="rotate(-0 82.605469 70.258125)">Z-Weighting (Flat)</text>
     </g>
    </g>
   </g>
@@ -1149,183 +859,183 @@ z
    </g>
    <g id="matplotlib.axis_3">
     <g id="xtick_33">
-     <g id="line2d_92">
+     <g id="line2d_90">
       <path d="M 211.125469 396.398125 
 L 211.125469 264.450925 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_93">
+     <g id="line2d_91">
       <g>
        <use xlink:href="#m8d14ee1197" x="211.125469" y="396.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_28">
+     <g id="text_27">
       <text style="font-size: 8px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="211.125469" y="409.47625" transform="rotate(-0 211.125469 409.47625)">500</text>
      </g>
     </g>
     <g id="xtick_34">
-     <g id="line2d_94">
+     <g id="line2d_92">
       <path d="M 269.715469 396.398125 
 L 269.715469 264.450925 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_95">
+     <g id="line2d_93">
       <g>
        <use xlink:href="#m8d14ee1197" x="269.715469" y="396.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_29">
+     <g id="text_28">
       <text style="font-size: 8px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="269.715469" y="409.476875" transform="rotate(-0 269.715469 409.476875)">1k</text>
      </g>
     </g>
     <g id="xtick_35">
-     <g id="line2d_96">
+     <g id="line2d_94">
       <path d="M 347.167236 396.398125 
 L 347.167236 264.450925 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_97">
+     <g id="line2d_95">
       <g>
        <use xlink:href="#m8d14ee1197" x="347.167236" y="396.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_30">
+     <g id="text_29">
       <text style="font-size: 8px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="347.167236" y="409.476875" transform="rotate(-0 347.167236 409.476875)">2.5k</text>
      </g>
     </g>
     <g id="xtick_36">
-     <g id="line2d_98">
+     <g id="line2d_96">
       <path d="M 405.757236 396.398125 
 L 405.757236 264.450925 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_99">
+     <g id="line2d_97">
       <g>
        <use xlink:href="#m8d14ee1197" x="405.757236" y="396.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_31">
+     <g id="text_30">
       <text style="font-size: 8px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="405.757236" y="409.476875" transform="rotate(-0 405.757236 409.476875)">5k</text>
      </g>
     </g>
     <g id="xtick_37">
-     <g id="line2d_100">
+     <g id="line2d_98">
       <path d="M 445.485469 396.398125 
 L 445.485469 264.450925 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_101">
+     <g id="line2d_99">
       <g>
        <use xlink:href="#m8d14ee1197" x="445.485469" y="396.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_32">
+     <g id="text_31">
       <text style="font-size: 8px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="445.485469" y="409.476875" transform="rotate(-0 445.485469 409.476875)">8k</text>
      </g>
     </g>
     <g id="xtick_38">
-     <g id="line2d_102">
+     <g id="line2d_100">
       <path d="M 226.536655 396.398125 
 L 226.536655 264.450925 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_103">
+     <g id="line2d_101">
       <g>
        <use xlink:href="#m1caa325441" x="226.536655" y="396.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_39">
-     <g id="line2d_104">
+     <g id="line2d_102">
       <path d="M 239.566627 396.398125 
 L 239.566627 264.450925 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_105">
+     <g id="line2d_103">
       <g>
        <use xlink:href="#m1caa325441" x="239.566627" y="396.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_40">
-     <g id="line2d_106">
+     <g id="line2d_104">
       <path d="M 250.853702 396.398125 
 L 250.853702 264.450925 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_107">
+     <g id="line2d_105">
       <g>
        <use xlink:href="#m1caa325441" x="250.853702" y="396.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_41">
-     <g id="line2d_108">
+     <g id="line2d_106">
       <path d="M 260.809608 396.398125 
 L 260.809608 264.450925 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_109">
+     <g id="line2d_107">
       <g>
        <use xlink:href="#m1caa325441" x="260.809608" y="396.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_42">
-     <g id="line2d_110">
+     <g id="line2d_108">
       <path d="M 328.305469 396.398125 
 L 328.305469 264.450925 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_111">
+     <g id="line2d_109">
       <g>
        <use xlink:href="#m1caa325441" x="328.305469" y="396.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_43">
-     <g id="line2d_112">
+     <g id="line2d_110">
       <path d="M 362.578422 396.398125 
 L 362.578422 264.450925 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_113">
+     <g id="line2d_111">
       <g>
        <use xlink:href="#m1caa325441" x="362.578422" y="396.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_44">
-     <g id="line2d_114">
+     <g id="line2d_112">
       <path d="M 386.895469 396.398125 
 L 386.895469 264.450925 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_115">
+     <g id="line2d_113">
       <g>
        <use xlink:href="#m1caa325441" x="386.895469" y="396.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_45">
-     <g id="line2d_116">
+     <g id="line2d_114">
       <path d="M 421.168422 396.398125 
 L 421.168422 264.450925 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_117">
+     <g id="line2d_115">
       <g>
        <use xlink:href="#m1caa325441" x="421.168422" y="396.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_46">
-     <g id="line2d_118">
+     <g id="line2d_116">
       <path d="M 434.198394 396.398125 
 L 434.198394 264.450925 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_119">
+     <g id="line2d_117">
       <g>
        <use xlink:href="#m1caa325441" x="434.198394" y="396.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
       </g>
@@ -1333,98 +1043,98 @@ L 434.198394 264.450925
     </g>
    </g>
    <g id="matplotlib.axis_4">
-    <g id="ytick_8">
-     <g id="line2d_120">
+    <g id="ytick_10">
+     <g id="line2d_118">
       <path d="M 211.125469 396.398125 
 L 445.485469 396.398125 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_121">
+     <g id="line2d_119">
       <g>
        <use xlink:href="#m5e07181663" x="211.125469" y="396.398125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_33">
+     <g id="text_32">
       <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="204.125469" y="400.196953" transform="rotate(-0 204.125469 400.196953)">−3</text>
      </g>
     </g>
-    <g id="ytick_9">
-     <g id="line2d_122">
+    <g id="ytick_11">
+     <g id="line2d_120">
       <path d="M 211.125469 370.008685 
 L 445.485469 370.008685 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_123">
+     <g id="line2d_121">
       <g>
        <use xlink:href="#m5e07181663" x="211.125469" y="370.008685" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_34">
+     <g id="text_33">
       <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="204.125469" y="373.807513" transform="rotate(-0 204.125469 373.807513)">−2</text>
      </g>
     </g>
-    <g id="ytick_10">
-     <g id="line2d_124">
+    <g id="ytick_12">
+     <g id="line2d_122">
       <path d="M 211.125469 343.619245 
 L 445.485469 343.619245 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_125">
+     <g id="line2d_123">
       <g>
        <use xlink:href="#m5e07181663" x="211.125469" y="343.619245" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_35">
+     <g id="text_34">
       <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="204.125469" y="347.418073" transform="rotate(-0 204.125469 347.418073)">−1</text>
      </g>
     </g>
-    <g id="ytick_11">
-     <g id="line2d_126">
+    <g id="ytick_13">
+     <g id="line2d_124">
       <path d="M 211.125469 317.229805 
 L 445.485469 317.229805 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_127">
+     <g id="line2d_125">
       <g>
        <use xlink:href="#m5e07181663" x="211.125469" y="317.229805" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_36">
+     <g id="text_35">
       <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="204.125469" y="321.028633" transform="rotate(-0 204.125469 321.028633)">0</text>
      </g>
     </g>
-    <g id="ytick_12">
-     <g id="line2d_128">
+    <g id="ytick_14">
+     <g id="line2d_126">
       <path d="M 211.125469 290.840365 
 L 445.485469 290.840365 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_129">
+     <g id="line2d_127">
       <g>
        <use xlink:href="#m5e07181663" x="211.125469" y="290.840365" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_37">
+     <g id="text_36">
       <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="204.125469" y="294.639193" transform="rotate(-0 204.125469 294.639193)">1</text>
      </g>
     </g>
-    <g id="ytick_13">
-     <g id="line2d_130">
+    <g id="ytick_15">
+     <g id="line2d_128">
       <path d="M 211.125469 264.450925 
 L 445.485469 264.450925 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_131">
+     <g id="line2d_129">
       <g>
        <use xlink:href="#m5e07181663" x="211.125469" y="264.450925" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_38">
+     <g id="text_37">
       <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="204.125469" y="268.249753" transform="rotate(-0 204.125469 268.249753)">2</text>
      </g>
     </g>
    </g>
-   <g id="line2d_132">
+   <g id="line2d_130">
     <path d="M 186.925126 455.599688 
 L 193.16687 441.098422 
 L 199.080294 427.928547 
@@ -1496,9 +1206,9 @@ L 482.898057 434.167392
 L 487.049623 447.174752 
 L 489.645579 455.599688 
 L 489.645579 455.599688 
-" clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5; stroke-linecap: square"/>
+" clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke: #1f77b4; stroke-width: 1.8; stroke-linecap: square"/>
    </g>
-   <g id="line2d_133">
+   <g id="line2d_131">
     <path d="M -1 368.025376 
 L -0.248653 367.154623 
 L 5.583142 361.125609 
@@ -1566,15 +1276,15 @@ L 466.200572 440.590514
 L 470.245042 450.192613 
 L 472.413733 455.599688 
 L 472.413733 455.599688 
-" clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke: #d62728; stroke-width: 1.5; stroke-linecap: square"/>
+" clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke: #d62728; stroke-width: 1.8; stroke-linecap: square"/>
    </g>
-   <g id="line2d_134">
+   <g id="line2d_132">
     <path d="M -1 317.229805 
 L 538.338103 317.229805 
 L 538.338103 317.229805 
-" clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke: #ffffff; stroke-width: 1.5; stroke-linecap: square"/>
+" clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 6.66,2.88; stroke-dashoffset: 0; stroke: #ffffff; stroke-width: 1.8"/>
    </g>
-   <g id="line2d_135">
+   <g id="line2d_133">
     <path d="M 211.125469 317.229805 
 L 445.485469 317.229805 
 " clip-path="url(#pb9e1bf90ef)" style="fill: none; stroke-dasharray: 1,1.65; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.4"/>
@@ -1608,10 +1318,10 @@ L 350.032718 283.2823
 L 352.957796 281.222223 
 " style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
-   <g id="text_39">
+   <g id="text_38">
     <text style="font-size: 8px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="391.019579" y="276.326173" transform="rotate(-0 391.019579 276.326173)">+1.27 dB</text>
    </g>
-   <g id="text_40">
+   <g id="text_39">
     <text style="font-size: 9px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="328.305469" y="258.450925" transform="rotate(-0 328.305469 258.450925)">Zoom: A-weighting is positive (max +1.27 dB @ 2.5 kHz)</text>
    </g>
   </g>

--- a/.github/images/weighting_responses_es.svg
+++ b/.github/images/weighting_responses_es.svg
@@ -471,8 +471,8 @@ L 595.623301 28.798125
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_65">
-      <path d="M 44.533594 416.878125 
-L 602.533594 416.878125 
+      <path d="M 44.533594 407.956746 
+L 602.533594 407.956746 
 " clip-path="url(#p88af68b26b)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
@@ -482,567 +482,304 @@ L -3.5 0
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mef640d9f3a" x="44.533594" y="416.878125" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mef640d9f3a" x="44.533594" y="407.956746" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
-      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="37.533594" y="420.676953" transform="rotate(-0 37.533594 420.676953)">-50</text>
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="37.533594" y="411.755574" transform="rotate(-0 37.533594 411.755574)">-70</text>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_67">
-      <path d="M 44.533594 357.17351 
-L 602.533594 357.17351 
+      <path d="M 44.533594 363.349849 
+L 602.533594 363.349849 
 " clip-path="url(#p88af68b26b)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#mef640d9f3a" x="44.533594" y="357.17351" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mef640d9f3a" x="44.533594" y="363.349849" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
-      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="37.533594" y="360.972338" transform="rotate(-0 37.533594 360.972338)">-40</text>
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="37.533594" y="367.148677" transform="rotate(-0 37.533594 367.148677)">-60</text>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_69">
-      <path d="M 44.533594 297.468894 
-L 602.533594 297.468894 
+      <path d="M 44.533594 318.742953 
+L 602.533594 318.742953 
 " clip-path="url(#p88af68b26b)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#mef640d9f3a" x="44.533594" y="297.468894" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mef640d9f3a" x="44.533594" y="318.742953" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
-      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="37.533594" y="301.267722" transform="rotate(-0 37.533594 301.267722)">-30</text>
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="37.533594" y="322.541781" transform="rotate(-0 37.533594 322.541781)">-50</text>
      </g>
     </g>
     <g id="ytick_4">
      <g id="line2d_71">
-      <path d="M 44.533594 237.764279 
-L 602.533594 237.764279 
+      <path d="M 44.533594 274.136056 
+L 602.533594 274.136056 
 " clip-path="url(#p88af68b26b)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#mef640d9f3a" x="44.533594" y="237.764279" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mef640d9f3a" x="44.533594" y="274.136056" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
-      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="37.533594" y="241.563107" transform="rotate(-0 37.533594 241.563107)">-20</text>
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="37.533594" y="277.934884" transform="rotate(-0 37.533594 277.934884)">-40</text>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_73">
-      <path d="M 44.533594 178.059663 
-L 602.533594 178.059663 
+      <path d="M 44.533594 229.529159 
+L 602.533594 229.529159 
 " clip-path="url(#p88af68b26b)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#mef640d9f3a" x="44.533594" y="178.059663" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mef640d9f3a" x="44.533594" y="229.529159" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
-      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="37.533594" y="181.858492" transform="rotate(-0 37.533594 181.858492)">-10</text>
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="37.533594" y="233.327988" transform="rotate(-0 37.533594 233.327988)">-30</text>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_75">
-      <path d="M 44.533594 118.355048 
-L 602.533594 118.355048 
+      <path d="M 44.533594 184.922263 
+L 602.533594 184.922263 
 " clip-path="url(#p88af68b26b)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_76">
       <g>
-       <use xlink:href="#mef640d9f3a" x="44.533594" y="118.355048" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mef640d9f3a" x="44.533594" y="184.922263" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
-      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="37.533594" y="122.153876" transform="rotate(-0 37.533594 122.153876)">0</text>
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="37.533594" y="188.721091" transform="rotate(-0 37.533594 188.721091)">-20</text>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_77">
-      <path d="M 44.533594 58.650433 
-L 602.533594 58.650433 
+      <path d="M 44.533594 140.315366 
+L 602.533594 140.315366 
 " clip-path="url(#p88af68b26b)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_78">
       <g>
-       <use xlink:href="#mef640d9f3a" x="44.533594" y="58.650433" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mef640d9f3a" x="44.533594" y="140.315366" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
-      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="37.533594" y="62.449261" transform="rotate(-0 37.533594 62.449261)">10</text>
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="37.533594" y="144.114195" transform="rotate(-0 37.533594 144.114195)">-10</text>
      </g>
     </g>
-    <g id="text_20">
+    <g id="ytick_8">
+     <g id="line2d_79">
+      <path d="M 44.533594 95.70847 
+L 602.533594 95.70847 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_80">
+      <g>
+       <use xlink:href="#mef640d9f3a" x="44.533594" y="95.70847" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_20">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="37.533594" y="99.507298" transform="rotate(-0 37.533594 99.507298)">0</text>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_81">
+      <path d="M 44.533594 51.101573 
+L 602.533594 51.101573 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #e0e0e0; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_82">
+      <g>
+       <use xlink:href="#mef640d9f3a" x="44.533594" y="51.101573" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_21">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="37.533594" y="54.900401" transform="rotate(-0 37.533594 54.900401)">10</text>
+     </g>
+    </g>
+    <g id="text_22">
      <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle" x="14.798438" y="222.838125" transform="rotate(-90 14.798438 222.838125)">Nivel [dB]</text>
     </g>
    </g>
-   <g id="line2d_79">
-    <path d="M 78.32905 456.079687 
-L 85.430481 439.715326 
-L 96.606897 415.331607 
-L 106.28835 395.270358 
-L 114.827996 378.396558 
-L 122.46697 363.942858 
-L 129.377262 351.372547 
-L 135.685865 340.299611 
-L 141.489217 330.439661 
-L 146.862282 321.57868 
-L 156.543734 306.233 
-L 165.083381 293.327548 
-L 172.722355 282.260917 
-L 179.632647 272.625814 
-L 185.94125 264.134337 
-L 194.480896 253.094785 
-L 202.11987 243.656247 
-L 209.030163 235.467869 
-L 215.338765 228.277918 
-L 222.977739 219.92885 
-L 229.888032 212.704184 
-L 237.691599 204.906809 
-L 244.736281 198.183155 
-L 252.375255 191.214304 
-L 260.375841 184.256384 
-L 267.580663 178.273783 
-L 275.023417 172.362695 
-L 282.573919 166.635516 
-L 290.133175 161.16714 
-L 297.628436 156.004928 
-L 305.008006 151.17672 
-L 312.236528 146.696603 
-L 319.769581 142.297715 
-L 327.025951 138.329639 
-L 334.014668 134.766011 
-L 340.746601 131.579527 
-L 347.559421 128.605788 
-L 354.084451 125.997014 
-L 360.615571 123.620385 
-L 367.104979 121.488837 
-L 373.743893 119.539998 
-L 380.447918 117.801875 
-L 387.339429 116.244949 
-L 394.488388 114.862264 
-L 401.769068 113.681544 
-L 409.361847 112.677273 
-L 417.236108 111.862755 
-L 425.346125 111.248876 
-L 433.638236 110.844265 
-L 442.056556 110.656716 
-L 450.389851 110.691985 
-L 458.569983 110.946244 
-L 466.552725 111.414626 
-L 474.311284 112.09106 
-L 481.831302 112.968004 
-L 489.153244 114.045167 
-L 496.138969 115.29545 
-L 502.740176 116.700911 
-L 508.825368 118.221533 
-L 514.406592 119.842295 
-L 519.619022 121.585504 
-L 524.623245 123.493879 
-L 529.568872 125.618668 
-L 534.692473 128.06499 
-L 540.142844 130.917856 
-L 545.699934 134.076288 
-L 550.743004 137.192215 
-L 555.143124 140.167891 
-L 559.291416 143.242476 
-L 563.695144 146.791282 
-L 569.479458 151.763212 
-L 575.903477 157.553807 
-L 579.744975 161.30658 
-L 583.305078 165.106469 
-L 594.470705 177.635165 
-L 595.891858 179.651414 
-L 597.077795 181.721373 
-L 598.162651 184.06931 
-L 599.201192 186.86268 
-L 600.215099 190.246975 
-L 601.224854 194.416683 
-L 602.24013 199.587059 
-L 603.260505 205.971485 
-L 604.294995 213.893152 
-L 605.361375 223.835039 
-L 606.576849 237.402824 
-L 608.05914 253.751883 
-L 608.513987 256.51927 
-L 608.789074 257.137731 
-L 608.833345 257.154173 
-L 608.833345 257.154173 
-" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5; stroke-linecap: square"/>
-   </g>
-   <g id="line2d_80">
-    <path d="M -1 436.953349 
-L 5.77758 422.817824 
-L 35.175096 364.419885 
-L 56.032965 325.59241 
-L 72.211585 297.638594 
-L 85.430481 276.517683 
-L 96.606897 259.994222 
-L 106.28835 246.705516 
-L 114.827996 235.770005 
-L 122.46697 226.593749 
-L 129.377262 218.764051 
-L 135.685865 211.986765 
-L 141.489217 206.047558 
-L 146.862282 200.787125 
-L 151.864485 196.084909 
-L 160.939213 188.004379 
-L 169.003427 181.277425 
-L 176.259797 175.565145 
-L 182.855542 170.639587 
-L 188.900975 166.340994 
-L 197.117667 160.823187 
-L 204.497237 156.183896 
-L 211.194598 152.233288 
-L 217.325279 148.835515 
-L 224.768033 144.994291 
-L 231.517386 141.782321 
-L 237.691599 139.070964 
-L 244.736281 136.240997 
-L 251.156685 133.903149 
-L 258.178607 131.602851 
-L 264.580103 129.730576 
-L 271.397502 127.960351 
-L 278.476603 126.350722 
-L 285.692817 124.930567 
-L 293.636426 123.599987 
-L 302.023915 122.429357 
-L 311.170286 121.389666 
-L 321.186627 120.489525 
-L 332.028155 119.745001 
-L 344.233003 119.133977 
-L 358.129503 118.665094 
-L 373.970113 118.356451 
-L 391.535754 118.23974 
-L 409.084056 118.343728 
-L 424.787976 118.65261 
-L 438.249264 119.133106 
-L 449.83669 119.763948 
-L 460.031931 120.537239 
-L 469.272686 121.458097 
-L 477.846031 122.534471 
-L 485.898896 123.76846 
-L 493.450987 125.147643 
-L 500.48762 126.654875 
-L 506.937436 128.260356 
-L 512.793514 129.943849 
-L 518.180844 131.72119 
-L 523.281876 133.637192 
-L 528.289841 135.757159 
-L 533.401286 138.165557 
-L 538.806554 140.961807 
-L 544.441573 144.127744 
-L 549.670041 147.31415 
-L 554.209032 150.335561 
-L 558.391839 153.386928 
-L 562.69852 156.810539 
-L 568.048883 161.368785 
-L 574.991651 167.575455 
-L 579.067556 171.495762 
-L 582.584025 175.194131 
-L 593.08716 186.854614 
-L 594.922507 189.129655 
-L 596.250733 191.129272 
-L 597.399778 193.263707 
-L 598.469651 195.730861 
-L 599.503836 198.695306 
-L 600.523475 202.322294 
-L 601.538763 206.787509 
-L 602.559336 212.312427 
-L 603.594292 219.180641 
-L 604.6522 227.747492 
-L 605.778034 238.77803 
-L 608.362688 265.179407 
-L 608.70045 266.307733 
-L 608.833345 266.418549 
-L 608.833345 266.418549 
-" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 5.55,2.4; stroke-dashoffset: 0; stroke: #2ca02c; stroke-width: 1.5"/>
-   </g>
-   <g id="line2d_81">
-    <path d="M -1 261.705355 
-L 5.77758 252.413961 
-L 35.175096 214.998708 
-L 56.032965 191.028305 
-L 72.211585 174.56725 
-L 85.430481 162.804853 
-L 96.606897 154.161925 
-L 106.28835 147.667609 
-L 114.827996 142.693203 
-L 122.46697 138.817522 
-L 129.377262 135.751202 
-L 135.685865 133.291266 
-L 141.489217 131.292719 
-L 146.862282 129.650256 
-L 151.864485 128.286225 
-L 160.939213 126.175223 
-L 169.003427 124.642113 
-L 176.259797 123.496628 
-L 185.94125 122.25708 
-L 194.480896 121.389943 
-L 204.497237 120.589281 
-L 217.325279 119.828566 
-L 231.517386 119.241359 
-L 248.656327 118.776733 
-L 270.461964 118.430926 
-L 299.544932 118.212142 
-L 338.938447 118.14975 
-L 377.281336 118.29731 
-L 403.593144 118.606653 
-L 422.395667 119.040581 
-L 437.029117 119.59397 
-L 449.119225 120.268845 
-L 459.547883 121.06922 
-L 468.907736 122.007113 
-L 477.521873 123.090693 
-L 485.608882 124.329596 
-L 493.233325 125.720668 
-L 500.32966 127.239343 
-L 506.792935 128.846324 
-L 512.660236 130.530243 
-L 518.057119 132.307288 
-L 523.166563 134.222669 
-L 528.182229 136.342093 
-L 533.275913 138.738026 
-L 538.690196 141.534742 
-L 544.333922 144.701612 
-L 549.569884 147.888115 
-L 554.133782 150.921506 
-L 558.32081 153.971726 
-L 562.614847 157.380983 
-L 567.924494 161.900256 
-L 574.892767 168.124666 
-L 579.000801 172.069511 
-L 582.507706 175.751805 
-L 588.478268 182.442072 
-L 594.81519 189.625989 
-L 596.166452 191.631353 
-L 597.327197 193.75663 
-L 598.398134 196.190414 
-L 599.433332 199.113646 
-L 600.44402 202.651667 
-L 601.460413 207.047434 
-L 602.482082 212.487885 
-L 603.518133 219.252019 
-L 604.577145 227.688923 
-L 605.694894 238.458757 
-L 608.389411 265.604486 
-L 608.718184 266.610809 
-L 608.833345 266.694157 
-L 608.833345 266.694157 
-" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #d62728; stroke-width: 1.5; stroke-linecap: square"/>
-   </g>
-   <g id="line2d_82">
-    <path d="M -1 309.886502 
-L 96.606897 240.214074 
-L 135.685865 212.557628 
-L 160.939213 194.940436 
-L 179.632647 182.159551 
-L 194.480896 172.265537 
-L 206.799119 164.308732 
-L 217.325279 157.751407 
-L 226.515182 152.257098 
-L 234.670195 147.599595 
-L 243.381042 142.892244 
-L 251.156685 138.960042 
-L 258.178607 135.656624 
-L 264.580103 132.871446 
-L 271.397502 130.163651 
-L 277.628603 127.93887 
-L 283.366311 126.11425 
-L 289.411744 124.435282 
-L 294.991666 123.115648 
-L 300.795018 121.98417 
-L 306.168082 121.159697 
-L 311.705367 120.536252 
-L 317.344499 120.13597 
-L 323.033942 119.965863 
-L 328.731988 120.017202 
-L 335.180965 120.310997 
-L 342.858494 120.899234 
-L 355.555155 121.89707 
-L 360.070431 122.009668 
-L 363.803037 121.890054 
-L 367.104979 121.566469 
-L 370.024966 121.071187 
-L 372.831891 120.381322 
-L 375.534187 119.498367 
-L 378.352304 118.333263 
-L 381.06497 116.968048 
-L 383.877081 115.299882 
-L 386.773732 113.320545 
-L 389.922514 110.888146 
-L 393.287124 107.99991 
-L 397.161619 104.362157 
-L 401.614969 99.861946 
-L 407.536888 93.53254 
-L 427.536721 71.884528 
-L 432.639553 66.829975 
-L 436.934403 62.878425 
-L 440.719643 59.68578 
-L 444.145628 57.076875 
-L 447.33494 54.925083 
-L 450.232235 53.229579 
-L 453.018186 51.853438 
-L 455.627837 50.805579 
-L 458.146812 50.025511 
-L 460.649568 49.481456 
-L 463.134867 49.170928 
-L 465.601642 49.087056 
-L 468.110653 49.225051 
-L 470.714388 49.596005 
-L 473.399998 50.206614 
-L 476.265666 51.092509 
-L 479.339895 52.283711 
-L 482.69354 53.830163 
-L 486.427592 55.805918 
-L 490.659502 58.303442 
-L 495.676762 61.530956 
-L 501.932654 65.832659 
-L 510.114812 71.743936 
-L 520.462442 79.501619 
-L 533.950366 89.917396 
-L 547.061438 99.95483 
-L 559.728341 109.640454 
-L 575.160854 121.660976 
-L 580.860128 126.101305 
-L 592.001198 135.042989 
-L 594.405932 136.940397 
-L 595.764771 138.300999 
-L 596.879741 139.732642 
-L 597.895528 141.405039 
-L 598.856662 143.425177 
-L 599.795195 145.929785 
-L 600.721734 149.055319 
-L 601.646357 152.987461 
-L 602.559336 157.876257 
-L 603.460962 163.963006 
-L 604.332678 171.414885 
-L 605.166111 180.512771 
-L 605.94403 191.509255 
-L 606.658985 204.875043 
-L 607.294664 221.03339 
-L 607.862047 241.307609 
-L 608.442827 270.821707 
-L 608.806786 285.198158 
-L 608.833345 285.342158 
-L 608.833345 285.342158 
-" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 9.6,2.4,1.5,2.4; stroke-dashoffset: 0; stroke: #9467bd; stroke-width: 1.5"/>
-   </g>
    <g id="line2d_83">
-    <path d="M 78.325145 456.079687 
-L 85.430481 439.706354 
-L 96.606897 415.32265 
-L 106.28835 395.261408 
-L 114.827996 378.38761 
-L 122.46697 363.93391 
-L 129.377262 351.363602 
-L 135.685865 340.290667 
-L 141.489217 330.430719 
-L 146.862282 321.56974 
-L 156.543734 306.224066 
-L 165.083381 293.318621 
-L 172.722355 282.251999 
-L 179.632647 272.616905 
-L 185.94125 264.125439 
-L 194.480896 253.085904 
-L 202.11987 243.647385 
-L 209.030163 235.459026 
-L 215.338765 228.269098 
-L 222.977739 219.920062 
-L 229.888032 212.695429 
-L 237.691599 204.8981 
-L 244.736281 198.174496 
-L 252.375255 191.205708 
-L 260.375841 184.24787 
-L 267.580663 178.265357 
-L 275.023417 172.354378 
-L 282.573919 166.627332 
-L 290.133175 161.159115 
-L 297.628436 155.997092 
-L 305.008006 151.169104 
-L 312.236528 146.689241 
-L 319.769581 142.290665 
-L 327.025951 138.322941 
-L 334.014668 134.759709 
-L 340.746601 131.573664 
-L 347.559421 128.600436 
-L 354.084451 125.992226 
-L 360.615571 123.616244 
-L 367.104979 121.485435 
-L 373.743893 119.537469 
-L 380.447918 117.80037 
-L 387.339429 116.244673 
-L 394.488388 114.863491 
-L 401.769068 113.684589 
-L 409.361847 112.682575 
-L 417.236108 111.870856 
-L 425.346125 111.260401 
-L 433.638236 110.859864 
-L 442.056556 110.676921 
-L 450.389851 110.716827 
-L 458.640273 110.97805 
-L 466.678598 111.45386 
-L 474.537327 112.140801 
-L 482.238339 113.036905 
-L 489.750359 114.133842 
-L 497.013264 115.41747 
-L 503.840743 116.846959 
-L 510.114812 118.384406 
-L 515.857026 120.018338 
-L 521.177646 121.762153 
-L 526.245058 123.656933 
-L 531.13657 125.723299 
-L 535.743085 127.908124 
-L 539.730763 130.03805 
-L 542.963639 132.007345 
-L 545.615308 133.8773 
-L 547.84571 135.718388 
-L 549.810028 137.627621 
-L 551.586188 139.664546 
-L 553.243696 141.904893 
-L 554.845522 144.451687 
-L 556.412721 147.372701 
-L 557.982467 150.784442 
-L 559.571351 154.783057 
-L 561.228639 159.572364 
-L 562.998948 165.393898 
-L 564.921961 172.508936 
-L 567.094983 181.437377 
-L 569.646814 192.911455 
-L 572.784426 208.100448 
-L 576.790208 228.649384 
-L 581.7272 255.17785 
-L 593.471095 320.135612 
-L 596.429507 337.291147 
-L 598.367462 349.834274 
-L 600.005451 361.898362 
-L 601.519184 374.726759 
-L 603.01155 389.330861 
-L 604.642823 407.606332 
-L 607.33082 438.089028 
-L 607.987532 442.940198 
-L 608.442827 444.8893 
-L 608.753638 445.426152 
-L 608.833345 445.453941 
-L 608.833345 445.453941 
-" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 5.55,2.4; stroke-dashoffset: 0; stroke: #ff7f0e; stroke-width: 1.5"/>
+    <path d="M 21.316924 456.079687 
+L 35.175096 428.123861 
+L 56.032965 388.02371 
+L 72.211585 358.563668 
+L 85.430481 335.80523 
+L 96.606897 317.587508 
+L 106.28835 302.599219 
+L 114.827996 289.992357 
+L 122.46697 279.193615 
+L 129.377262 269.802004 
+L 135.685865 261.52912 
+L 141.489217 254.162491 
+L 151.864485 241.545648 
+L 160.939213 231.060538 
+L 169.003427 222.150841 
+L 176.259797 214.448948 
+L 182.855542 207.70026 
+L 191.744602 198.976713 
+L 199.661899 191.56002 
+L 206.799119 185.154825 
+L 215.338765 177.834752 
+L 222.977739 171.596943 
+L 231.517386 164.959557 
+L 239.15636 159.31103 
+L 247.373051 153.52531 
+L 255.912698 147.813765 
+L 264.580103 142.313111 
+L 273.233124 137.103087 
+L 281.77277 132.224652 
+L 290.133175 127.694515 
+L 298.911712 123.196785 
+L 307.309888 119.144288 
+L 315.849535 115.280815 
+L 323.940243 111.868149 
+L 332.028155 108.706752 
+L 339.667129 105.958253 
+L 347.233563 103.469001 
+L 354.676317 101.249861 
+L 362.226819 99.231072 
+L 369.786075 97.441001 
+L 377.496799 95.846026 
+L 385.436349 94.436316 
+L 393.459956 93.237069 
+L 401.922839 92.199901 
+L 410.735054 91.348256 
+L 419.921719 90.687668 
+L 429.348063 90.232779 
+L 438.990044 89.98857 
+L 448.717545 89.964582 
+L 458.288144 90.163826 
+L 467.553647 90.578928 
+L 476.485706 91.200748 
+L 485.122934 92.024384 
+L 493.407507 93.036917 
+L 501.155133 94.204341 
+L 508.260589 95.495681 
+L 514.699009 96.888081 
+L 520.641905 98.398999 
+L 526.300341 100.066176 
+L 531.98457 101.974612 
+L 537.964572 104.220737 
+L 544.247686 106.818767 
+L 550.069288 109.458975 
+L 555.050254 111.956319 
+L 559.65861 114.515652 
+L 564.629413 117.539942 
+L 571.581147 122.056809 
+L 577.434563 126.083171 
+L 581.327306 129.032059 
+L 585.767664 132.702845 
+L 595.531198 141.092838 
+L 596.827532 142.696595 
+L 597.977825 144.47881 
+L 599.049395 146.558235 
+L 600.085388 149.066377 
+L 601.106787 152.137081 
+L 602.133415 155.954336 
+L 603.164854 160.679632 
+L 604.210135 166.556528 
+L 605.277755 173.88105 
+L 606.476334 183.760869 
+L 608.085975 197.027242 
+L 608.531766 198.983995 
+L 608.806786 199.4037 
+L 608.833345 199.408965 
+L 608.833345 199.408965 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #1f77b4; stroke-width: 1.8; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
-    <path d="M -1 118.355048 
-L 608.833345 118.355048 
-L 608.833345 118.355048 
-" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #000000; stroke-width: 1.5; stroke-linecap: square"/>
+    <path d="M -1 202.809274 
+L 5.77758 195.867428 
+L 35.175096 167.913503 
+L 56.032965 150.004581 
+L 72.211585 137.706092 
+L 85.430481 128.918094 
+L 96.606897 122.460734 
+L 106.28835 117.608659 
+L 114.827996 113.892148 
+L 122.46697 110.996525 
+L 129.377262 108.705597 
+L 135.685865 106.867713 
+L 141.489217 105.374546 
+L 146.862282 104.147418 
+L 156.543734 102.273846 
+L 165.083381 100.934939 
+L 172.722355 99.948069 
+L 182.855542 98.89484 
+L 194.480896 97.97592 
+L 206.799119 97.26104 
+L 221.142117 96.674473 
+L 237.691599 96.226492 
+L 259.285547 95.877737 
+L 288.683063 95.645644 
+L 331.218055 95.552392 
+L 376.84848 95.662917 
+L 406.822565 95.939941 
+L 427.320616 96.340298 
+L 443.021525 96.862029 
+L 455.920189 97.508434 
+L 467.054913 98.284429 
+L 477.141848 99.207209 
+L 486.475465 100.281793 
+L 495.169153 101.503916 
+L 503.121572 102.843324 
+L 510.218364 104.25969 
+L 516.587303 105.753189 
+L 522.499929 107.366644 
+L 528.209147 109.156051 
+L 534.02492 111.215168 
+L 540.211297 113.645693 
+L 546.498991 116.352957 
+L 552.013822 118.961262 
+L 556.81289 121.474176 
+L 561.467193 124.165613 
+L 566.937401 127.601351 
+L 574.581108 132.678115 
+L 579.13425 135.940351 
+L 582.964421 138.965635 
+L 594.222092 148.380706 
+L 595.796564 150.013801 
+L 597.056973 151.642115 
+L 598.183158 153.463908 
+L 599.251721 155.627106 
+L 600.284847 158.234322 
+L 601.313278 161.453812 
+L 602.346688 165.449859 
+L 603.384663 170.381925 
+L 604.445611 176.543699 
+L 605.556114 184.363846 
+L 607.013836 196.433983 
+L 608.005441 203.900306 
+L 608.478415 206.00656 
+L 608.771358 206.516399 
+L 608.833345 206.53654 
+L 608.833345 206.53654 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #d62728; stroke-width: 1.8; stroke-linecap: square"/>
    </g>
    <g id="line2d_85">
-    <path d="M 44.533594 118.355048 
-L 602.533594 118.355048 
+    <path d="M -1 95.70847 
+L 608.833345 95.70847 
+L 608.833345 95.70847 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 6.66,2.88; stroke-dashoffset: 0; stroke: #000000; stroke-width: 1.8"/>
+   </g>
+   <g id="line2d_86">
+    <path d="M 44.533594 95.70847 
+L 602.533594 95.70847 
 " clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 1,1.65; stroke-dashoffset: 0; stroke: #000000; stroke-opacity: 0.3"/>
    </g>
    <g id="patch_3">
@@ -1065,76 +802,49 @@ L 602.533594 416.878125
 L 602.533594 28.798125 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="text_21">
-    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle" x="323.533594" y="16.798125" transform="rotate(-0 323.533594 16.798125)">Curvas de ponderación frecuencial</text>
+   <g id="text_23">
+    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle" x="323.533594" y="16.798125" transform="rotate(-0 323.533594 16.798125)">Curvas de ponderación frecuencial (IEC 61672-1)</text>
    </g>
    <g id="legend_1">
     <g id="patch_7">
-     <path d="M 50.833594 119.162344 
-L 257.577656 119.162344 
-Q 259.377656 119.162344 259.377656 117.362344 
-L 259.377656 35.098125 
-Q 259.377656 33.298125 257.577656 33.298125 
+     <path d="M 50.833594 77.580234 
+L 178.933125 77.580234 
+Q 180.733125 77.580234 180.733125 75.780234 
+L 180.733125 35.098125 
+Q 180.733125 33.298125 178.933125 33.298125 
 L 50.833594 33.298125 
 Q 49.033594 33.298125 49.033594 35.098125 
-L 49.033594 117.362344 
-Q 49.033594 119.162344 50.833594 119.162344 
+L 49.033594 75.780234 
+Q 49.033594 77.580234 50.833594 77.580234 
 z
 " style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
     </g>
-    <g id="line2d_86">
+    <g id="line2d_87">
      <path d="M 52.633594 40.946719 
 L 61.633594 40.946719 
 L 70.633594 40.946719 
-" style="fill: none; stroke: #1f77b4; stroke-width: 1.5; stroke-linecap: square"/>
+" style="fill: none; stroke: #1f77b4; stroke-width: 1.8; stroke-linecap: square"/>
     </g>
-    <g id="text_22">
+    <g id="text_24">
      <text style="font-size: 9px; font-family: sans-serif; text-anchor: start" x="77.833594" y="44.096719" transform="rotate(-0 77.833594 44.096719)">Ponderación A</text>
     </g>
-    <g id="line2d_87">
+    <g id="line2d_88">
      <path d="M 52.633594 54.807422 
 L 61.633594 54.807422 
 L 70.633594 54.807422 
-" style="fill: none; stroke-dasharray: 5.55,2.4; stroke-dashoffset: 0; stroke: #2ca02c; stroke-width: 1.5"/>
+" style="fill: none; stroke: #d62728; stroke-width: 1.8; stroke-linecap: square"/>
     </g>
-    <g id="text_23">
-     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start" x="77.833594" y="57.957422" transform="rotate(-0 77.833594 57.957422)">Ponderación B (histórica)</text>
+    <g id="text_25">
+     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start" x="77.833594" y="57.957422" transform="rotate(-0 77.833594 57.957422)">Ponderación C</text>
     </g>
-    <g id="line2d_88">
+    <g id="line2d_89">
      <path d="M 52.633594 68.668125 
 L 61.633594 68.668125 
 L 70.633594 68.668125 
-" style="fill: none; stroke: #d62728; stroke-width: 1.5; stroke-linecap: square"/>
-    </g>
-    <g id="text_24">
-     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start" x="77.833594" y="71.818125" transform="rotate(-0 77.833594 71.818125)">Ponderación C</text>
-    </g>
-    <g id="line2d_89">
-     <path d="M 52.633594 82.528828 
-L 61.633594 82.528828 
-L 70.633594 82.528828 
-" style="fill: none; stroke-dasharray: 9.6,2.4,1.5,2.4; stroke-dashoffset: 0; stroke: #9467bd; stroke-width: 1.5"/>
-    </g>
-    <g id="text_25">
-     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start" x="77.833594" y="85.678828" transform="rotate(-0 77.833594 85.678828)">Ponderación D (aeronaves, retirada)</text>
-    </g>
-    <g id="line2d_90">
-     <path d="M 52.633594 96.389531 
-L 61.633594 96.389531 
-L 70.633594 96.389531 
-" style="fill: none; stroke-dasharray: 5.55,2.4; stroke-dashoffset: 0; stroke: #ff7f0e; stroke-width: 1.5"/>
+" style="fill: none; stroke-dasharray: 6.66,2.88; stroke-dashoffset: 0; stroke: #000000; stroke-width: 1.8"/>
     </g>
     <g id="text_26">
-     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start" x="77.833594" y="99.539531" transform="rotate(-0 77.833594 99.539531)">Ponderación AU (audible + ultrasonido)</text>
-    </g>
-    <g id="line2d_91">
-     <path d="M 52.633594 110.250234 
-L 61.633594 110.250234 
-L 70.633594 110.250234 
-" style="fill: none; stroke: #000000; stroke-width: 1.5; stroke-linecap: square"/>
-    </g>
-    <g id="text_27">
-     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start" x="77.833594" y="113.400234" transform="rotate(-0 77.833594 113.400234)">Ponderación Z (plana)</text>
+     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start" x="77.833594" y="71.818125" transform="rotate(-0 77.833594 71.818125)">Ponderación Z (plana)</text>
     </g>
    </g>
   </g>
@@ -1149,183 +859,183 @@ z
    </g>
    <g id="matplotlib.axis_3">
     <g id="xtick_33">
-     <g id="line2d_92">
+     <g id="line2d_90">
       <path d="M 206.353594 396.878125 
 L 206.353594 264.930925 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_93">
+     <g id="line2d_91">
       <g>
        <use xlink:href="#m3d27035b55" x="206.353594" y="396.878125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_28">
+     <g id="text_27">
       <text style="font-size: 8px; font-family: sans-serif; text-anchor: middle" x="206.353594" y="409.95625" transform="rotate(-0 206.353594 409.95625)">500</text>
      </g>
     </g>
     <g id="xtick_34">
-     <g id="line2d_94">
+     <g id="line2d_92">
       <path d="M 264.943594 396.878125 
 L 264.943594 264.930925 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_95">
+     <g id="line2d_93">
       <g>
        <use xlink:href="#m3d27035b55" x="264.943594" y="396.878125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_29">
+     <g id="text_28">
       <text style="font-size: 8px; font-family: sans-serif; text-anchor: middle" x="264.943594" y="409.956875" transform="rotate(-0 264.943594 409.956875)">1k</text>
      </g>
     </g>
     <g id="xtick_35">
-     <g id="line2d_96">
+     <g id="line2d_94">
       <path d="M 342.395361 396.878125 
 L 342.395361 264.930925 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_97">
+     <g id="line2d_95">
       <g>
        <use xlink:href="#m3d27035b55" x="342.395361" y="396.878125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_30">
+     <g id="text_29">
       <text style="font-size: 8px; font-family: sans-serif; text-anchor: middle" x="342.395361" y="409.956875" transform="rotate(-0 342.395361 409.956875)">2,5k</text>
      </g>
     </g>
     <g id="xtick_36">
-     <g id="line2d_98">
+     <g id="line2d_96">
       <path d="M 400.985361 396.878125 
 L 400.985361 264.930925 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_99">
+     <g id="line2d_97">
       <g>
        <use xlink:href="#m3d27035b55" x="400.985361" y="396.878125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_31">
+     <g id="text_30">
       <text style="font-size: 8px; font-family: sans-serif; text-anchor: middle" x="400.985361" y="409.956875" transform="rotate(-0 400.985361 409.956875)">5k</text>
      </g>
     </g>
     <g id="xtick_37">
-     <g id="line2d_100">
+     <g id="line2d_98">
       <path d="M 440.713594 396.878125 
 L 440.713594 264.930925 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_101">
+     <g id="line2d_99">
       <g>
        <use xlink:href="#m3d27035b55" x="440.713594" y="396.878125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_32">
+     <g id="text_31">
       <text style="font-size: 8px; font-family: sans-serif; text-anchor: middle" x="440.713594" y="409.956875" transform="rotate(-0 440.713594 409.956875)">8k</text>
      </g>
     </g>
     <g id="xtick_38">
-     <g id="line2d_102">
+     <g id="line2d_100">
       <path d="M 221.76478 396.878125 
 L 221.76478 264.930925 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_103">
+     <g id="line2d_101">
       <g>
        <use xlink:href="#md1b22fa4b4" x="221.76478" y="396.878125" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_39">
-     <g id="line2d_104">
+     <g id="line2d_102">
       <path d="M 234.794752 396.878125 
 L 234.794752 264.930925 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_105">
+     <g id="line2d_103">
       <g>
        <use xlink:href="#md1b22fa4b4" x="234.794752" y="396.878125" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_40">
-     <g id="line2d_106">
+     <g id="line2d_104">
       <path d="M 246.081827 396.878125 
 L 246.081827 264.930925 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_107">
+     <g id="line2d_105">
       <g>
        <use xlink:href="#md1b22fa4b4" x="246.081827" y="396.878125" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_41">
-     <g id="line2d_108">
+     <g id="line2d_106">
       <path d="M 256.037733 396.878125 
 L 256.037733 264.930925 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_109">
+     <g id="line2d_107">
       <g>
        <use xlink:href="#md1b22fa4b4" x="256.037733" y="396.878125" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_42">
-     <g id="line2d_110">
+     <g id="line2d_108">
       <path d="M 323.533594 396.878125 
 L 323.533594 264.930925 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_111">
+     <g id="line2d_109">
       <g>
        <use xlink:href="#md1b22fa4b4" x="323.533594" y="396.878125" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_43">
-     <g id="line2d_112">
+     <g id="line2d_110">
       <path d="M 357.806547 396.878125 
 L 357.806547 264.930925 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_113">
+     <g id="line2d_111">
       <g>
        <use xlink:href="#md1b22fa4b4" x="357.806547" y="396.878125" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_44">
-     <g id="line2d_114">
+     <g id="line2d_112">
       <path d="M 382.123594 396.878125 
 L 382.123594 264.930925 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_115">
+     <g id="line2d_113">
       <g>
        <use xlink:href="#md1b22fa4b4" x="382.123594" y="396.878125" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_45">
-     <g id="line2d_116">
+     <g id="line2d_114">
       <path d="M 416.396547 396.878125 
 L 416.396547 264.930925 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_117">
+     <g id="line2d_115">
       <g>
        <use xlink:href="#md1b22fa4b4" x="416.396547" y="396.878125" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_46">
-     <g id="line2d_118">
+     <g id="line2d_116">
       <path d="M 429.426519 396.878125 
 L 429.426519 264.930925 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_119">
+     <g id="line2d_117">
       <g>
        <use xlink:href="#md1b22fa4b4" x="429.426519" y="396.878125" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
@@ -1333,98 +1043,98 @@ L 429.426519 264.930925
     </g>
    </g>
    <g id="matplotlib.axis_4">
-    <g id="ytick_8">
-     <g id="line2d_120">
+    <g id="ytick_10">
+     <g id="line2d_118">
       <path d="M 206.353594 396.878125 
 L 440.713594 396.878125 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_121">
+     <g id="line2d_119">
       <g>
        <use xlink:href="#mef640d9f3a" x="206.353594" y="396.878125" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_33">
+     <g id="text_32">
       <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="199.353594" y="400.676953" transform="rotate(-0 199.353594 400.676953)">-3</text>
      </g>
     </g>
-    <g id="ytick_9">
-     <g id="line2d_122">
+    <g id="ytick_11">
+     <g id="line2d_120">
       <path d="M 206.353594 370.488685 
 L 440.713594 370.488685 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_123">
+     <g id="line2d_121">
       <g>
        <use xlink:href="#mef640d9f3a" x="206.353594" y="370.488685" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_34">
+     <g id="text_33">
       <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="199.353594" y="374.287513" transform="rotate(-0 199.353594 374.287513)">-2</text>
      </g>
     </g>
-    <g id="ytick_10">
-     <g id="line2d_124">
+    <g id="ytick_12">
+     <g id="line2d_122">
       <path d="M 206.353594 344.099245 
 L 440.713594 344.099245 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_125">
+     <g id="line2d_123">
       <g>
        <use xlink:href="#mef640d9f3a" x="206.353594" y="344.099245" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_35">
+     <g id="text_34">
       <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="199.353594" y="347.898073" transform="rotate(-0 199.353594 347.898073)">-1</text>
      </g>
     </g>
-    <g id="ytick_11">
-     <g id="line2d_126">
+    <g id="ytick_13">
+     <g id="line2d_124">
       <path d="M 206.353594 317.709805 
 L 440.713594 317.709805 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_127">
+     <g id="line2d_125">
       <g>
        <use xlink:href="#mef640d9f3a" x="206.353594" y="317.709805" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_36">
+     <g id="text_35">
       <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="199.353594" y="321.508633" transform="rotate(-0 199.353594 321.508633)">0</text>
      </g>
     </g>
-    <g id="ytick_12">
-     <g id="line2d_128">
+    <g id="ytick_14">
+     <g id="line2d_126">
       <path d="M 206.353594 291.320365 
 L 440.713594 291.320365 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_129">
+     <g id="line2d_127">
       <g>
        <use xlink:href="#mef640d9f3a" x="206.353594" y="291.320365" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_37">
+     <g id="text_36">
       <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="199.353594" y="295.119193" transform="rotate(-0 199.353594 295.119193)">1</text>
      </g>
     </g>
-    <g id="ytick_13">
-     <g id="line2d_130">
+    <g id="ytick_15">
+     <g id="line2d_128">
       <path d="M 206.353594 264.930925 
 L 440.713594 264.930925 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_131">
+     <g id="line2d_129">
       <g>
        <use xlink:href="#mef640d9f3a" x="206.353594" y="264.930925" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_38">
+     <g id="text_37">
       <text style="font-size: 10px; font-family: sans-serif; text-anchor: end" x="199.353594" y="268.729753" transform="rotate(-0 199.353594 268.729753)">2</text>
      </g>
     </g>
    </g>
-   <g id="line2d_132">
+   <g id="line2d_130">
     <path d="M 182.153251 456.079687 
 L 188.394995 441.578422 
 L 194.308419 428.408547 
@@ -1496,9 +1206,9 @@ L 478.126182 434.647392
 L 482.277748 447.654752 
 L 484.873704 456.079687 
 L 484.873704 456.079687 
-" clip-path="url(#p0d2a40e86a)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5; stroke-linecap: square"/>
+" clip-path="url(#p0d2a40e86a)" style="fill: none; stroke: #1f77b4; stroke-width: 1.8; stroke-linecap: square"/>
    </g>
-   <g id="line2d_133">
+   <g id="line2d_131">
     <path d="M -1 363.478129 
 L 0.811267 361.605609 
 L 6.266547 356.550569 
@@ -1565,15 +1275,15 @@ L 461.428697 441.070514
 L 465.473167 450.672613 
 L 467.641858 456.079687 
 L 467.641858 456.079687 
-" clip-path="url(#p0d2a40e86a)" style="fill: none; stroke: #d62728; stroke-width: 1.5; stroke-linecap: square"/>
+" clip-path="url(#p0d2a40e86a)" style="fill: none; stroke: #d62728; stroke-width: 1.8; stroke-linecap: square"/>
    </g>
-   <g id="line2d_134">
+   <g id="line2d_132">
     <path d="M -1 317.709805 
 L 533.566228 317.709805 
 L 533.566228 317.709805 
-" clip-path="url(#p0d2a40e86a)" style="fill: none; stroke: #000000; stroke-width: 1.5; stroke-linecap: square"/>
+" clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 6.66,2.88; stroke-dashoffset: 0; stroke: #000000; stroke-width: 1.8"/>
    </g>
-   <g id="line2d_135">
+   <g id="line2d_133">
     <path d="M 206.353594 317.709805 
 L 440.713594 317.709805 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 1,1.65; stroke-dashoffset: 0; stroke: #000000; stroke-opacity: 0.4"/>
@@ -1607,10 +1317,10 @@ L 345.260843 283.7623
 L 348.185921 281.702223 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
-   <g id="text_39">
+   <g id="text_38">
     <text style="font-size: 8px; font-family: sans-serif; text-anchor: start" x="386.247704" y="276.806173" transform="rotate(-0 386.247704 276.806173)">+1,27 dB</text>
    </g>
-   <g id="text_40">
+   <g id="text_39">
     <text style="font-size: 9px; font-family: sans-serif; text-anchor: middle" x="323.533594" y="258.930925" transform="rotate(-0 323.533594 258.930925)">Zoom: la ponderación A es positiva (máx +1,27 dB @ 2,5 kHz)</text>
    </g>
   </g>

--- a/.github/images/weighting_responses_es_dark.svg
+++ b/.github/images/weighting_responses_es_dark.svg
@@ -471,8 +471,8 @@ L 595.623301 28.798125
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_65">
-      <path d="M 44.533594 416.878125 
-L 602.533594 416.878125 
+      <path d="M 44.533594 407.956746 
+L 602.533594 407.956746 
 " clip-path="url(#p88af68b26b)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
@@ -482,567 +482,304 @@ L -3.5 0
 " style="stroke: #ffffff; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m5e07181663" x="44.533594" y="416.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m5e07181663" x="44.533594" y="407.956746" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
-      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="37.533594" y="420.676953" transform="rotate(-0 37.533594 420.676953)">-50</text>
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="37.533594" y="411.755574" transform="rotate(-0 37.533594 411.755574)">-70</text>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_67">
-      <path d="M 44.533594 357.17351 
-L 602.533594 357.17351 
+      <path d="M 44.533594 363.349849 
+L 602.533594 363.349849 
 " clip-path="url(#p88af68b26b)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m5e07181663" x="44.533594" y="357.17351" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m5e07181663" x="44.533594" y="363.349849" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
-      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="37.533594" y="360.972338" transform="rotate(-0 37.533594 360.972338)">-40</text>
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="37.533594" y="367.148677" transform="rotate(-0 37.533594 367.148677)">-60</text>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_69">
-      <path d="M 44.533594 297.468894 
-L 602.533594 297.468894 
+      <path d="M 44.533594 318.742953 
+L 602.533594 318.742953 
 " clip-path="url(#p88af68b26b)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m5e07181663" x="44.533594" y="297.468894" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m5e07181663" x="44.533594" y="318.742953" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
-      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="37.533594" y="301.267722" transform="rotate(-0 37.533594 301.267722)">-30</text>
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="37.533594" y="322.541781" transform="rotate(-0 37.533594 322.541781)">-50</text>
      </g>
     </g>
     <g id="ytick_4">
      <g id="line2d_71">
-      <path d="M 44.533594 237.764279 
-L 602.533594 237.764279 
+      <path d="M 44.533594 274.136056 
+L 602.533594 274.136056 
 " clip-path="url(#p88af68b26b)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m5e07181663" x="44.533594" y="237.764279" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m5e07181663" x="44.533594" y="274.136056" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
-      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="37.533594" y="241.563107" transform="rotate(-0 37.533594 241.563107)">-20</text>
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="37.533594" y="277.934884" transform="rotate(-0 37.533594 277.934884)">-40</text>
      </g>
     </g>
     <g id="ytick_5">
      <g id="line2d_73">
-      <path d="M 44.533594 178.059663 
-L 602.533594 178.059663 
+      <path d="M 44.533594 229.529159 
+L 602.533594 229.529159 
 " clip-path="url(#p88af68b26b)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m5e07181663" x="44.533594" y="178.059663" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m5e07181663" x="44.533594" y="229.529159" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
-      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="37.533594" y="181.858492" transform="rotate(-0 37.533594 181.858492)">-10</text>
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="37.533594" y="233.327988" transform="rotate(-0 37.533594 233.327988)">-30</text>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_75">
-      <path d="M 44.533594 118.355048 
-L 602.533594 118.355048 
+      <path d="M 44.533594 184.922263 
+L 602.533594 184.922263 
 " clip-path="url(#p88af68b26b)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_76">
       <g>
-       <use xlink:href="#m5e07181663" x="44.533594" y="118.355048" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m5e07181663" x="44.533594" y="184.922263" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
-      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="37.533594" y="122.153876" transform="rotate(-0 37.533594 122.153876)">0</text>
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="37.533594" y="188.721091" transform="rotate(-0 37.533594 188.721091)">-20</text>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_77">
-      <path d="M 44.533594 58.650433 
-L 602.533594 58.650433 
+      <path d="M 44.533594 140.315366 
+L 602.533594 140.315366 
 " clip-path="url(#p88af68b26b)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_78">
       <g>
-       <use xlink:href="#m5e07181663" x="44.533594" y="58.650433" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+       <use xlink:href="#m5e07181663" x="44.533594" y="140.315366" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
-      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="37.533594" y="62.449261" transform="rotate(-0 37.533594 62.449261)">10</text>
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="37.533594" y="144.114195" transform="rotate(-0 37.533594 144.114195)">-10</text>
      </g>
     </g>
-    <g id="text_20">
+    <g id="ytick_8">
+     <g id="line2d_79">
+      <path d="M 44.533594 95.70847 
+L 602.533594 95.70847 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_80">
+      <g>
+       <use xlink:href="#m5e07181663" x="44.533594" y="95.70847" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_20">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="37.533594" y="99.507298" transform="rotate(-0 37.533594 99.507298)">0</text>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_81">
+      <path d="M 44.533594 51.101573 
+L 602.533594 51.101573 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #555555; stroke-opacity: 0.5; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_82">
+      <g>
+       <use xlink:href="#m5e07181663" x="44.533594" y="51.101573" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_21">
+      <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="37.533594" y="54.900401" transform="rotate(-0 37.533594 54.900401)">10</text>
+     </g>
+    </g>
+    <g id="text_22">
      <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="14.798438" y="222.838125" transform="rotate(-90 14.798438 222.838125)">Nivel [dB]</text>
     </g>
    </g>
-   <g id="line2d_79">
-    <path d="M 78.32905 456.079687 
-L 85.430481 439.715326 
-L 96.606897 415.331607 
-L 106.28835 395.270358 
-L 114.827996 378.396558 
-L 122.46697 363.942858 
-L 129.377262 351.372547 
-L 135.685865 340.299611 
-L 141.489217 330.439661 
-L 146.862282 321.57868 
-L 156.543734 306.233 
-L 165.083381 293.327548 
-L 172.722355 282.260917 
-L 179.632647 272.625814 
-L 185.94125 264.134337 
-L 194.480896 253.094785 
-L 202.11987 243.656247 
-L 209.030163 235.467869 
-L 215.338765 228.277918 
-L 222.977739 219.92885 
-L 229.888032 212.704184 
-L 237.691599 204.906809 
-L 244.736281 198.183155 
-L 252.375255 191.214304 
-L 260.375841 184.256384 
-L 267.580663 178.273783 
-L 275.023417 172.362695 
-L 282.573919 166.635516 
-L 290.133175 161.16714 
-L 297.628436 156.004928 
-L 305.008006 151.17672 
-L 312.236528 146.696603 
-L 319.769581 142.297715 
-L 327.025951 138.329639 
-L 334.014668 134.766011 
-L 340.746601 131.579527 
-L 347.559421 128.605788 
-L 354.084451 125.997014 
-L 360.615571 123.620385 
-L 367.104979 121.488837 
-L 373.743893 119.539998 
-L 380.447918 117.801875 
-L 387.339429 116.244949 
-L 394.488388 114.862264 
-L 401.769068 113.681544 
-L 409.361847 112.677273 
-L 417.236108 111.862755 
-L 425.346125 111.248876 
-L 433.638236 110.844265 
-L 442.056556 110.656716 
-L 450.389851 110.691985 
-L 458.569983 110.946244 
-L 466.552725 111.414626 
-L 474.311284 112.09106 
-L 481.831302 112.968004 
-L 489.153244 114.045167 
-L 496.138969 115.29545 
-L 502.740176 116.700911 
-L 508.825368 118.221533 
-L 514.406592 119.842295 
-L 519.619022 121.585504 
-L 524.623245 123.493879 
-L 529.568872 125.618668 
-L 534.692473 128.06499 
-L 540.142844 130.917856 
-L 545.699934 134.076288 
-L 550.743004 137.192215 
-L 555.143124 140.167891 
-L 559.291416 143.242476 
-L 563.695144 146.791282 
-L 569.479458 151.763212 
-L 575.903477 157.553807 
-L 579.744975 161.30658 
-L 583.305078 165.106469 
-L 594.470705 177.635165 
-L 595.891858 179.651414 
-L 597.077795 181.721373 
-L 598.162651 184.06931 
-L 599.201192 186.86268 
-L 600.215099 190.246975 
-L 601.224854 194.416683 
-L 602.24013 199.587059 
-L 603.260505 205.971485 
-L 604.294995 213.893152 
-L 605.361375 223.835039 
-L 606.576849 237.402824 
-L 608.05914 253.751883 
-L 608.513987 256.51927 
-L 608.789074 257.137731 
-L 608.833345 257.154173 
-L 608.833345 257.154173 
-" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5; stroke-linecap: square"/>
-   </g>
-   <g id="line2d_80">
-    <path d="M -1 436.953349 
-L 5.77758 422.817824 
-L 35.175096 364.419885 
-L 56.032965 325.59241 
-L 72.211585 297.638594 
-L 85.430481 276.517683 
-L 96.606897 259.994222 
-L 106.28835 246.705516 
-L 114.827996 235.770005 
-L 122.46697 226.593749 
-L 129.377262 218.764051 
-L 135.685865 211.986765 
-L 141.489217 206.047558 
-L 146.862282 200.787125 
-L 151.864485 196.084909 
-L 160.939213 188.004379 
-L 169.003427 181.277425 
-L 176.259797 175.565145 
-L 182.855542 170.639587 
-L 188.900975 166.340994 
-L 197.117667 160.823187 
-L 204.497237 156.183896 
-L 211.194598 152.233288 
-L 217.325279 148.835515 
-L 224.768033 144.994291 
-L 231.517386 141.782321 
-L 237.691599 139.070964 
-L 244.736281 136.240997 
-L 251.156685 133.903149 
-L 258.178607 131.602851 
-L 264.580103 129.730576 
-L 271.397502 127.960351 
-L 278.476603 126.350722 
-L 285.692817 124.930567 
-L 293.636426 123.599987 
-L 302.023915 122.429357 
-L 311.170286 121.389666 
-L 321.186627 120.489525 
-L 332.028155 119.745001 
-L 344.233003 119.133977 
-L 358.129503 118.665094 
-L 373.970113 118.356451 
-L 391.535754 118.23974 
-L 409.084056 118.343728 
-L 424.787976 118.65261 
-L 438.249264 119.133106 
-L 449.83669 119.763948 
-L 460.031931 120.537239 
-L 469.272686 121.458097 
-L 477.846031 122.534471 
-L 485.898896 123.76846 
-L 493.450987 125.147643 
-L 500.48762 126.654875 
-L 506.937436 128.260356 
-L 512.793514 129.943849 
-L 518.180844 131.72119 
-L 523.281876 133.637192 
-L 528.289841 135.757159 
-L 533.401286 138.165557 
-L 538.806554 140.961807 
-L 544.441573 144.127744 
-L 549.670041 147.31415 
-L 554.209032 150.335561 
-L 558.391839 153.386928 
-L 562.69852 156.810539 
-L 568.048883 161.368785 
-L 574.991651 167.575455 
-L 579.067556 171.495762 
-L 582.584025 175.194131 
-L 593.08716 186.854614 
-L 594.922507 189.129655 
-L 596.250733 191.129272 
-L 597.399778 193.263707 
-L 598.469651 195.730861 
-L 599.503836 198.695306 
-L 600.523475 202.322294 
-L 601.538763 206.787509 
-L 602.559336 212.312427 
-L 603.594292 219.180641 
-L 604.6522 227.747492 
-L 605.778034 238.77803 
-L 608.362688 265.179407 
-L 608.70045 266.307733 
-L 608.833345 266.418549 
-L 608.833345 266.418549 
-" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 5.55,2.4; stroke-dashoffset: 0; stroke: #2ca02c; stroke-width: 1.5"/>
-   </g>
-   <g id="line2d_81">
-    <path d="M -1 261.705355 
-L 5.77758 252.413961 
-L 35.175096 214.998708 
-L 56.032965 191.028305 
-L 72.211585 174.56725 
-L 85.430481 162.804853 
-L 96.606897 154.161925 
-L 106.28835 147.667609 
-L 114.827996 142.693203 
-L 122.46697 138.817522 
-L 129.377262 135.751202 
-L 135.685865 133.291266 
-L 141.489217 131.292719 
-L 146.862282 129.650256 
-L 151.864485 128.286225 
-L 160.939213 126.175223 
-L 169.003427 124.642113 
-L 176.259797 123.496628 
-L 185.94125 122.25708 
-L 194.480896 121.389943 
-L 204.497237 120.589281 
-L 217.325279 119.828566 
-L 231.517386 119.241359 
-L 248.656327 118.776733 
-L 270.461964 118.430926 
-L 299.544932 118.212142 
-L 338.938447 118.14975 
-L 377.281336 118.29731 
-L 403.593144 118.606653 
-L 422.395667 119.040581 
-L 437.029117 119.59397 
-L 449.119225 120.268845 
-L 459.547883 121.06922 
-L 468.907736 122.007113 
-L 477.521873 123.090693 
-L 485.608882 124.329596 
-L 493.233325 125.720668 
-L 500.32966 127.239343 
-L 506.792935 128.846324 
-L 512.660236 130.530243 
-L 518.057119 132.307288 
-L 523.166563 134.222669 
-L 528.182229 136.342093 
-L 533.275913 138.738026 
-L 538.690196 141.534742 
-L 544.333922 144.701612 
-L 549.569884 147.888115 
-L 554.133782 150.921506 
-L 558.32081 153.971726 
-L 562.614847 157.380983 
-L 567.924494 161.900256 
-L 574.892767 168.124666 
-L 579.000801 172.069511 
-L 582.507706 175.751805 
-L 588.478268 182.442072 
-L 594.81519 189.625989 
-L 596.166452 191.631353 
-L 597.327197 193.75663 
-L 598.398134 196.190414 
-L 599.433332 199.113646 
-L 600.44402 202.651667 
-L 601.460413 207.047434 
-L 602.482082 212.487885 
-L 603.518133 219.252019 
-L 604.577145 227.688923 
-L 605.694894 238.458757 
-L 608.389411 265.604486 
-L 608.718184 266.610809 
-L 608.833345 266.694157 
-L 608.833345 266.694157 
-" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #d62728; stroke-width: 1.5; stroke-linecap: square"/>
-   </g>
-   <g id="line2d_82">
-    <path d="M -1 309.886502 
-L 96.606897 240.214074 
-L 135.685865 212.557628 
-L 160.939213 194.940436 
-L 179.632647 182.159551 
-L 194.480896 172.265537 
-L 206.799119 164.308732 
-L 217.325279 157.751407 
-L 226.515182 152.257098 
-L 234.670195 147.599595 
-L 243.381042 142.892244 
-L 251.156685 138.960042 
-L 258.178607 135.656624 
-L 264.580103 132.871446 
-L 271.397502 130.163651 
-L 277.628603 127.93887 
-L 283.366311 126.11425 
-L 289.411744 124.435282 
-L 294.991666 123.115648 
-L 300.795018 121.98417 
-L 306.168082 121.159697 
-L 311.705367 120.536252 
-L 317.344499 120.13597 
-L 323.033942 119.965863 
-L 328.731988 120.017202 
-L 335.180965 120.310997 
-L 342.858494 120.899234 
-L 355.555155 121.89707 
-L 360.070431 122.009668 
-L 363.803037 121.890054 
-L 367.104979 121.566469 
-L 370.024966 121.071187 
-L 372.831891 120.381322 
-L 375.534187 119.498367 
-L 378.352304 118.333263 
-L 381.06497 116.968048 
-L 383.877081 115.299882 
-L 386.773732 113.320545 
-L 389.922514 110.888146 
-L 393.287124 107.99991 
-L 397.161619 104.362157 
-L 401.614969 99.861946 
-L 407.536888 93.53254 
-L 427.536721 71.884528 
-L 432.639553 66.829975 
-L 436.934403 62.878425 
-L 440.719643 59.68578 
-L 444.145628 57.076875 
-L 447.33494 54.925083 
-L 450.232235 53.229579 
-L 453.018186 51.853438 
-L 455.627837 50.805579 
-L 458.146812 50.025511 
-L 460.649568 49.481456 
-L 463.134867 49.170928 
-L 465.601642 49.087056 
-L 468.110653 49.225051 
-L 470.714388 49.596005 
-L 473.399998 50.206614 
-L 476.265666 51.092509 
-L 479.339895 52.283711 
-L 482.69354 53.830163 
-L 486.427592 55.805918 
-L 490.659502 58.303442 
-L 495.676762 61.530956 
-L 501.932654 65.832659 
-L 510.114812 71.743936 
-L 520.462442 79.501619 
-L 533.950366 89.917396 
-L 547.061438 99.95483 
-L 559.728341 109.640454 
-L 575.160854 121.660976 
-L 580.860128 126.101305 
-L 592.001198 135.042989 
-L 594.405932 136.940397 
-L 595.764771 138.300999 
-L 596.879741 139.732642 
-L 597.895528 141.405039 
-L 598.856662 143.425177 
-L 599.795195 145.929785 
-L 600.721734 149.055319 
-L 601.646357 152.987461 
-L 602.559336 157.876257 
-L 603.460962 163.963006 
-L 604.332678 171.414885 
-L 605.166111 180.512771 
-L 605.94403 191.509255 
-L 606.658985 204.875043 
-L 607.294664 221.03339 
-L 607.862047 241.307609 
-L 608.442827 270.821707 
-L 608.806786 285.198158 
-L 608.833345 285.342158 
-L 608.833345 285.342158 
-" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 9.6,2.4,1.5,2.4; stroke-dashoffset: 0; stroke: #9467bd; stroke-width: 1.5"/>
-   </g>
    <g id="line2d_83">
-    <path d="M 78.325145 456.079687 
-L 85.430481 439.706354 
-L 96.606897 415.32265 
-L 106.28835 395.261408 
-L 114.827996 378.38761 
-L 122.46697 363.93391 
-L 129.377262 351.363602 
-L 135.685865 340.290667 
-L 141.489217 330.430719 
-L 146.862282 321.56974 
-L 156.543734 306.224066 
-L 165.083381 293.318621 
-L 172.722355 282.251999 
-L 179.632647 272.616905 
-L 185.94125 264.125439 
-L 194.480896 253.085904 
-L 202.11987 243.647385 
-L 209.030163 235.459026 
-L 215.338765 228.269098 
-L 222.977739 219.920062 
-L 229.888032 212.695429 
-L 237.691599 204.8981 
-L 244.736281 198.174496 
-L 252.375255 191.205708 
-L 260.375841 184.24787 
-L 267.580663 178.265357 
-L 275.023417 172.354378 
-L 282.573919 166.627332 
-L 290.133175 161.159115 
-L 297.628436 155.997092 
-L 305.008006 151.169104 
-L 312.236528 146.689241 
-L 319.769581 142.290665 
-L 327.025951 138.322941 
-L 334.014668 134.759709 
-L 340.746601 131.573664 
-L 347.559421 128.600436 
-L 354.084451 125.992226 
-L 360.615571 123.616244 
-L 367.104979 121.485435 
-L 373.743893 119.537469 
-L 380.447918 117.80037 
-L 387.339429 116.244673 
-L 394.488388 114.863491 
-L 401.769068 113.684589 
-L 409.361847 112.682575 
-L 417.236108 111.870856 
-L 425.346125 111.260401 
-L 433.638236 110.859864 
-L 442.056556 110.676921 
-L 450.389851 110.716827 
-L 458.640273 110.97805 
-L 466.678598 111.45386 
-L 474.537327 112.140801 
-L 482.238339 113.036905 
-L 489.750359 114.133842 
-L 497.013264 115.41747 
-L 503.840743 116.846959 
-L 510.114812 118.384406 
-L 515.857026 120.018338 
-L 521.177646 121.762153 
-L 526.245058 123.656933 
-L 531.13657 125.723299 
-L 535.743085 127.908124 
-L 539.730763 130.03805 
-L 542.963639 132.007345 
-L 545.615308 133.8773 
-L 547.84571 135.718388 
-L 549.810028 137.627621 
-L 551.586188 139.664546 
-L 553.243696 141.904893 
-L 554.845522 144.451687 
-L 556.412721 147.372701 
-L 557.982467 150.784442 
-L 559.571351 154.783057 
-L 561.228639 159.572364 
-L 562.998948 165.393898 
-L 564.921961 172.508936 
-L 567.094983 181.437377 
-L 569.646814 192.911455 
-L 572.784426 208.100448 
-L 576.790208 228.649384 
-L 581.7272 255.17785 
-L 593.471095 320.135612 
-L 596.429507 337.291147 
-L 598.367462 349.834274 
-L 600.005451 361.898362 
-L 601.519184 374.726759 
-L 603.01155 389.330861 
-L 604.642823 407.606332 
-L 607.33082 438.089028 
-L 607.987532 442.940198 
-L 608.442827 444.8893 
-L 608.753638 445.426152 
-L 608.833345 445.453941 
-L 608.833345 445.453941 
-" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 5.55,2.4; stroke-dashoffset: 0; stroke: #ff7f0e; stroke-width: 1.5"/>
+    <path d="M 21.316924 456.079687 
+L 35.175096 428.123861 
+L 56.032965 388.02371 
+L 72.211585 358.563668 
+L 85.430481 335.80523 
+L 96.606897 317.587508 
+L 106.28835 302.599219 
+L 114.827996 289.992357 
+L 122.46697 279.193615 
+L 129.377262 269.802004 
+L 135.685865 261.52912 
+L 141.489217 254.162491 
+L 151.864485 241.545648 
+L 160.939213 231.060538 
+L 169.003427 222.150841 
+L 176.259797 214.448948 
+L 182.855542 207.70026 
+L 191.744602 198.976713 
+L 199.661899 191.56002 
+L 206.799119 185.154825 
+L 215.338765 177.834752 
+L 222.977739 171.596943 
+L 231.517386 164.959557 
+L 239.15636 159.31103 
+L 247.373051 153.52531 
+L 255.912698 147.813765 
+L 264.580103 142.313111 
+L 273.233124 137.103087 
+L 281.77277 132.224652 
+L 290.133175 127.694515 
+L 298.911712 123.196785 
+L 307.309888 119.144288 
+L 315.849535 115.280815 
+L 323.940243 111.868149 
+L 332.028155 108.706752 
+L 339.667129 105.958253 
+L 347.233563 103.469001 
+L 354.676317 101.249861 
+L 362.226819 99.231072 
+L 369.786075 97.441001 
+L 377.496799 95.846026 
+L 385.436349 94.436316 
+L 393.459956 93.237069 
+L 401.922839 92.199901 
+L 410.735054 91.348256 
+L 419.921719 90.687668 
+L 429.348063 90.232779 
+L 438.990044 89.98857 
+L 448.717545 89.964582 
+L 458.288144 90.163826 
+L 467.553647 90.578928 
+L 476.485706 91.200748 
+L 485.122934 92.024384 
+L 493.407507 93.036917 
+L 501.155133 94.204341 
+L 508.260589 95.495681 
+L 514.699009 96.888081 
+L 520.641905 98.398999 
+L 526.300341 100.066176 
+L 531.98457 101.974612 
+L 537.964572 104.220737 
+L 544.247686 106.818767 
+L 550.069288 109.458975 
+L 555.050254 111.956319 
+L 559.65861 114.515652 
+L 564.629413 117.539942 
+L 571.581147 122.056809 
+L 577.434563 126.083171 
+L 581.327306 129.032059 
+L 585.767664 132.702845 
+L 595.531198 141.092838 
+L 596.827532 142.696595 
+L 597.977825 144.47881 
+L 599.049395 146.558235 
+L 600.085388 149.066377 
+L 601.106787 152.137081 
+L 602.133415 155.954336 
+L 603.164854 160.679632 
+L 604.210135 166.556528 
+L 605.277755 173.88105 
+L 606.476334 183.760869 
+L 608.085975 197.027242 
+L 608.531766 198.983995 
+L 608.806786 199.4037 
+L 608.833345 199.408965 
+L 608.833345 199.408965 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #1f77b4; stroke-width: 1.8; stroke-linecap: square"/>
    </g>
    <g id="line2d_84">
-    <path d="M -1 118.355048 
-L 608.833345 118.355048 
-L 608.833345 118.355048 
-" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #ffffff; stroke-width: 1.5; stroke-linecap: square"/>
+    <path d="M -1 202.809274 
+L 5.77758 195.867428 
+L 35.175096 167.913503 
+L 56.032965 150.004581 
+L 72.211585 137.706092 
+L 85.430481 128.918094 
+L 96.606897 122.460734 
+L 106.28835 117.608659 
+L 114.827996 113.892148 
+L 122.46697 110.996525 
+L 129.377262 108.705597 
+L 135.685865 106.867713 
+L 141.489217 105.374546 
+L 146.862282 104.147418 
+L 156.543734 102.273846 
+L 165.083381 100.934939 
+L 172.722355 99.948069 
+L 182.855542 98.89484 
+L 194.480896 97.97592 
+L 206.799119 97.26104 
+L 221.142117 96.674473 
+L 237.691599 96.226492 
+L 259.285547 95.877737 
+L 288.683063 95.645644 
+L 331.218055 95.552392 
+L 376.84848 95.662917 
+L 406.822565 95.939941 
+L 427.320616 96.340298 
+L 443.021525 96.862029 
+L 455.920189 97.508434 
+L 467.054913 98.284429 
+L 477.141848 99.207209 
+L 486.475465 100.281793 
+L 495.169153 101.503916 
+L 503.121572 102.843324 
+L 510.218364 104.25969 
+L 516.587303 105.753189 
+L 522.499929 107.366644 
+L 528.209147 109.156051 
+L 534.02492 111.215168 
+L 540.211297 113.645693 
+L 546.498991 116.352957 
+L 552.013822 118.961262 
+L 556.81289 121.474176 
+L 561.467193 124.165613 
+L 566.937401 127.601351 
+L 574.581108 132.678115 
+L 579.13425 135.940351 
+L 582.964421 138.965635 
+L 594.222092 148.380706 
+L 595.796564 150.013801 
+L 597.056973 151.642115 
+L 598.183158 153.463908 
+L 599.251721 155.627106 
+L 600.284847 158.234322 
+L 601.313278 161.453812 
+L 602.346688 165.449859 
+L 603.384663 170.381925 
+L 604.445611 176.543699 
+L 605.556114 184.363846 
+L 607.013836 196.433983 
+L 608.005441 203.900306 
+L 608.478415 206.00656 
+L 608.771358 206.516399 
+L 608.833345 206.53654 
+L 608.833345 206.53654 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke: #d62728; stroke-width: 1.8; stroke-linecap: square"/>
    </g>
    <g id="line2d_85">
-    <path d="M 44.533594 118.355048 
-L 602.533594 118.355048 
+    <path d="M -1 95.70847 
+L 608.833345 95.70847 
+L 608.833345 95.70847 
+" clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 6.66,2.88; stroke-dashoffset: 0; stroke: #ffffff; stroke-width: 1.8"/>
+   </g>
+   <g id="line2d_86">
+    <path d="M 44.533594 95.70847 
+L 602.533594 95.70847 
 " clip-path="url(#p88af68b26b)" style="fill: none; stroke-dasharray: 1,1.65; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3"/>
    </g>
    <g id="patch_3">
@@ -1065,76 +802,49 @@ L 602.533594 416.878125
 L 602.533594 28.798125 
 " style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="text_21">
-    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="323.533594" y="16.798125" transform="rotate(-0 323.533594 16.798125)">Curvas de ponderación frecuencial</text>
+   <g id="text_23">
+    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="323.533594" y="16.798125" transform="rotate(-0 323.533594 16.798125)">Curvas de ponderación frecuencial (IEC 61672-1)</text>
    </g>
    <g id="legend_1">
     <g id="patch_7">
-     <path d="M 50.833594 119.162344 
-L 257.577656 119.162344 
-Q 259.377656 119.162344 259.377656 117.362344 
-L 259.377656 35.098125 
-Q 259.377656 33.298125 257.577656 33.298125 
+     <path d="M 50.833594 77.580234 
+L 178.933125 77.580234 
+Q 180.733125 77.580234 180.733125 75.780234 
+L 180.733125 35.098125 
+Q 180.733125 33.298125 178.933125 33.298125 
 L 50.833594 33.298125 
 Q 49.033594 33.298125 49.033594 35.098125 
-L 49.033594 117.362344 
-Q 49.033594 119.162344 50.833594 119.162344 
+L 49.033594 75.780234 
+Q 49.033594 77.580234 50.833594 77.580234 
 z
 " style="opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
     </g>
-    <g id="line2d_86">
+    <g id="line2d_87">
      <path d="M 52.633594 40.946719 
 L 61.633594 40.946719 
 L 70.633594 40.946719 
-" style="fill: none; stroke: #1f77b4; stroke-width: 1.5; stroke-linecap: square"/>
+" style="fill: none; stroke: #1f77b4; stroke-width: 1.8; stroke-linecap: square"/>
     </g>
-    <g id="text_22">
+    <g id="text_24">
      <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="77.833594" y="44.096719" transform="rotate(-0 77.833594 44.096719)">Ponderación A</text>
     </g>
-    <g id="line2d_87">
+    <g id="line2d_88">
      <path d="M 52.633594 54.807422 
 L 61.633594 54.807422 
 L 70.633594 54.807422 
-" style="fill: none; stroke-dasharray: 5.55,2.4; stroke-dashoffset: 0; stroke: #2ca02c; stroke-width: 1.5"/>
+" style="fill: none; stroke: #d62728; stroke-width: 1.8; stroke-linecap: square"/>
     </g>
-    <g id="text_23">
-     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="77.833594" y="57.957422" transform="rotate(-0 77.833594 57.957422)">Ponderación B (histórica)</text>
+    <g id="text_25">
+     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="77.833594" y="57.957422" transform="rotate(-0 77.833594 57.957422)">Ponderación C</text>
     </g>
-    <g id="line2d_88">
+    <g id="line2d_89">
      <path d="M 52.633594 68.668125 
 L 61.633594 68.668125 
 L 70.633594 68.668125 
-" style="fill: none; stroke: #d62728; stroke-width: 1.5; stroke-linecap: square"/>
-    </g>
-    <g id="text_24">
-     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="77.833594" y="71.818125" transform="rotate(-0 77.833594 71.818125)">Ponderación C</text>
-    </g>
-    <g id="line2d_89">
-     <path d="M 52.633594 82.528828 
-L 61.633594 82.528828 
-L 70.633594 82.528828 
-" style="fill: none; stroke-dasharray: 9.6,2.4,1.5,2.4; stroke-dashoffset: 0; stroke: #9467bd; stroke-width: 1.5"/>
-    </g>
-    <g id="text_25">
-     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="77.833594" y="85.678828" transform="rotate(-0 77.833594 85.678828)">Ponderación D (aeronaves, retirada)</text>
-    </g>
-    <g id="line2d_90">
-     <path d="M 52.633594 96.389531 
-L 61.633594 96.389531 
-L 70.633594 96.389531 
-" style="fill: none; stroke-dasharray: 5.55,2.4; stroke-dashoffset: 0; stroke: #ff7f0e; stroke-width: 1.5"/>
+" style="fill: none; stroke-dasharray: 6.66,2.88; stroke-dashoffset: 0; stroke: #ffffff; stroke-width: 1.8"/>
     </g>
     <g id="text_26">
-     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="77.833594" y="99.539531" transform="rotate(-0 77.833594 99.539531)">Ponderación AU (audible + ultrasonido)</text>
-    </g>
-    <g id="line2d_91">
-     <path d="M 52.633594 110.250234 
-L 61.633594 110.250234 
-L 70.633594 110.250234 
-" style="fill: none; stroke: #ffffff; stroke-width: 1.5; stroke-linecap: square"/>
-    </g>
-    <g id="text_27">
-     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="77.833594" y="113.400234" transform="rotate(-0 77.833594 113.400234)">Ponderación Z (plana)</text>
+     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="77.833594" y="71.818125" transform="rotate(-0 77.833594 71.818125)">Ponderación Z (plana)</text>
     </g>
    </g>
   </g>
@@ -1149,183 +859,183 @@ z
    </g>
    <g id="matplotlib.axis_3">
     <g id="xtick_33">
-     <g id="line2d_92">
+     <g id="line2d_90">
       <path d="M 206.353594 396.878125 
 L 206.353594 264.930925 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_93">
+     <g id="line2d_91">
       <g>
        <use xlink:href="#m8d14ee1197" x="206.353594" y="396.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_28">
+     <g id="text_27">
       <text style="font-size: 8px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="206.353594" y="409.95625" transform="rotate(-0 206.353594 409.95625)">500</text>
      </g>
     </g>
     <g id="xtick_34">
-     <g id="line2d_94">
+     <g id="line2d_92">
       <path d="M 264.943594 396.878125 
 L 264.943594 264.930925 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_95">
+     <g id="line2d_93">
       <g>
        <use xlink:href="#m8d14ee1197" x="264.943594" y="396.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_29">
+     <g id="text_28">
       <text style="font-size: 8px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="264.943594" y="409.956875" transform="rotate(-0 264.943594 409.956875)">1k</text>
      </g>
     </g>
     <g id="xtick_35">
-     <g id="line2d_96">
+     <g id="line2d_94">
       <path d="M 342.395361 396.878125 
 L 342.395361 264.930925 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_97">
+     <g id="line2d_95">
       <g>
        <use xlink:href="#m8d14ee1197" x="342.395361" y="396.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_30">
+     <g id="text_29">
       <text style="font-size: 8px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="342.395361" y="409.956875" transform="rotate(-0 342.395361 409.956875)">2,5k</text>
      </g>
     </g>
     <g id="xtick_36">
-     <g id="line2d_98">
+     <g id="line2d_96">
       <path d="M 400.985361 396.878125 
 L 400.985361 264.930925 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_99">
+     <g id="line2d_97">
       <g>
        <use xlink:href="#m8d14ee1197" x="400.985361" y="396.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_31">
+     <g id="text_30">
       <text style="font-size: 8px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="400.985361" y="409.956875" transform="rotate(-0 400.985361 409.956875)">5k</text>
      </g>
     </g>
     <g id="xtick_37">
-     <g id="line2d_100">
+     <g id="line2d_98">
       <path d="M 440.713594 396.878125 
 L 440.713594 264.930925 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_101">
+     <g id="line2d_99">
       <g>
        <use xlink:href="#m8d14ee1197" x="440.713594" y="396.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_32">
+     <g id="text_31">
       <text style="font-size: 8px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="440.713594" y="409.956875" transform="rotate(-0 440.713594 409.956875)">8k</text>
      </g>
     </g>
     <g id="xtick_38">
-     <g id="line2d_102">
+     <g id="line2d_100">
       <path d="M 221.76478 396.878125 
 L 221.76478 264.930925 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_103">
+     <g id="line2d_101">
       <g>
        <use xlink:href="#m1caa325441" x="221.76478" y="396.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_39">
-     <g id="line2d_104">
+     <g id="line2d_102">
       <path d="M 234.794752 396.878125 
 L 234.794752 264.930925 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_105">
+     <g id="line2d_103">
       <g>
        <use xlink:href="#m1caa325441" x="234.794752" y="396.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_40">
-     <g id="line2d_106">
+     <g id="line2d_104">
       <path d="M 246.081827 396.878125 
 L 246.081827 264.930925 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_107">
+     <g id="line2d_105">
       <g>
        <use xlink:href="#m1caa325441" x="246.081827" y="396.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_41">
-     <g id="line2d_108">
+     <g id="line2d_106">
       <path d="M 256.037733 396.878125 
 L 256.037733 264.930925 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_109">
+     <g id="line2d_107">
       <g>
        <use xlink:href="#m1caa325441" x="256.037733" y="396.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_42">
-     <g id="line2d_110">
+     <g id="line2d_108">
       <path d="M 323.533594 396.878125 
 L 323.533594 264.930925 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_111">
+     <g id="line2d_109">
       <g>
        <use xlink:href="#m1caa325441" x="323.533594" y="396.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_43">
-     <g id="line2d_112">
+     <g id="line2d_110">
       <path d="M 357.806547 396.878125 
 L 357.806547 264.930925 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_113">
+     <g id="line2d_111">
       <g>
        <use xlink:href="#m1caa325441" x="357.806547" y="396.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_44">
-     <g id="line2d_114">
+     <g id="line2d_112">
       <path d="M 382.123594 396.878125 
 L 382.123594 264.930925 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_115">
+     <g id="line2d_113">
       <g>
        <use xlink:href="#m1caa325441" x="382.123594" y="396.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_45">
-     <g id="line2d_116">
+     <g id="line2d_114">
       <path d="M 416.396547 396.878125 
 L 416.396547 264.930925 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_117">
+     <g id="line2d_115">
       <g>
        <use xlink:href="#m1caa325441" x="416.396547" y="396.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="xtick_46">
-     <g id="line2d_118">
+     <g id="line2d_116">
       <path d="M 429.426519 396.878125 
 L 429.426519 264.930925 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_119">
+     <g id="line2d_117">
       <g>
        <use xlink:href="#m1caa325441" x="429.426519" y="396.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.6"/>
       </g>
@@ -1333,98 +1043,98 @@ L 429.426519 264.930925
     </g>
    </g>
    <g id="matplotlib.axis_4">
-    <g id="ytick_8">
-     <g id="line2d_120">
+    <g id="ytick_10">
+     <g id="line2d_118">
       <path d="M 206.353594 396.878125 
 L 440.713594 396.878125 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_121">
+     <g id="line2d_119">
       <g>
        <use xlink:href="#m5e07181663" x="206.353594" y="396.878125" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_33">
+     <g id="text_32">
       <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="199.353594" y="400.676953" transform="rotate(-0 199.353594 400.676953)">-3</text>
      </g>
     </g>
-    <g id="ytick_9">
-     <g id="line2d_122">
+    <g id="ytick_11">
+     <g id="line2d_120">
       <path d="M 206.353594 370.488685 
 L 440.713594 370.488685 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_123">
+     <g id="line2d_121">
       <g>
        <use xlink:href="#m5e07181663" x="206.353594" y="370.488685" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_34">
+     <g id="text_33">
       <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="199.353594" y="374.287513" transform="rotate(-0 199.353594 374.287513)">-2</text>
      </g>
     </g>
-    <g id="ytick_10">
-     <g id="line2d_124">
+    <g id="ytick_12">
+     <g id="line2d_122">
       <path d="M 206.353594 344.099245 
 L 440.713594 344.099245 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_125">
+     <g id="line2d_123">
       <g>
        <use xlink:href="#m5e07181663" x="206.353594" y="344.099245" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_35">
+     <g id="text_34">
       <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="199.353594" y="347.898073" transform="rotate(-0 199.353594 347.898073)">-1</text>
      </g>
     </g>
-    <g id="ytick_11">
-     <g id="line2d_126">
+    <g id="ytick_13">
+     <g id="line2d_124">
       <path d="M 206.353594 317.709805 
 L 440.713594 317.709805 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_127">
+     <g id="line2d_125">
       <g>
        <use xlink:href="#m5e07181663" x="206.353594" y="317.709805" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_36">
+     <g id="text_35">
       <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="199.353594" y="321.508633" transform="rotate(-0 199.353594 321.508633)">0</text>
      </g>
     </g>
-    <g id="ytick_12">
-     <g id="line2d_128">
+    <g id="ytick_14">
+     <g id="line2d_126">
       <path d="M 206.353594 291.320365 
 L 440.713594 291.320365 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_129">
+     <g id="line2d_127">
       <g>
        <use xlink:href="#m5e07181663" x="206.353594" y="291.320365" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_37">
+     <g id="text_36">
       <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="199.353594" y="295.119193" transform="rotate(-0 199.353594 295.119193)">1</text>
      </g>
     </g>
-    <g id="ytick_13">
-     <g id="line2d_130">
+    <g id="ytick_15">
+     <g id="line2d_128">
       <path d="M 206.353594 264.930925 
 L 440.713594 264.930925 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.3; stroke-width: 0.8"/>
      </g>
-     <g id="line2d_131">
+     <g id="line2d_129">
       <g>
        <use xlink:href="#m5e07181663" x="206.353594" y="264.930925" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_38">
+     <g id="text_37">
       <text style="font-size: 10px; font-family: sans-serif; text-anchor: end; fill: #ffffff" x="199.353594" y="268.729753" transform="rotate(-0 199.353594 268.729753)">2</text>
      </g>
     </g>
    </g>
-   <g id="line2d_132">
+   <g id="line2d_130">
     <path d="M 182.153251 456.079687 
 L 188.394995 441.578422 
 L 194.308419 428.408547 
@@ -1496,9 +1206,9 @@ L 478.126182 434.647392
 L 482.277748 447.654752 
 L 484.873704 456.079687 
 L 484.873704 456.079687 
-" clip-path="url(#p0d2a40e86a)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5; stroke-linecap: square"/>
+" clip-path="url(#p0d2a40e86a)" style="fill: none; stroke: #1f77b4; stroke-width: 1.8; stroke-linecap: square"/>
    </g>
-   <g id="line2d_133">
+   <g id="line2d_131">
     <path d="M -1 363.478129 
 L 0.811267 361.605609 
 L 6.266547 356.550569 
@@ -1565,15 +1275,15 @@ L 461.428697 441.070514
 L 465.473167 450.672613 
 L 467.641858 456.079687 
 L 467.641858 456.079687 
-" clip-path="url(#p0d2a40e86a)" style="fill: none; stroke: #d62728; stroke-width: 1.5; stroke-linecap: square"/>
+" clip-path="url(#p0d2a40e86a)" style="fill: none; stroke: #d62728; stroke-width: 1.8; stroke-linecap: square"/>
    </g>
-   <g id="line2d_134">
+   <g id="line2d_132">
     <path d="M -1 317.709805 
 L 533.566228 317.709805 
 L 533.566228 317.709805 
-" clip-path="url(#p0d2a40e86a)" style="fill: none; stroke: #ffffff; stroke-width: 1.5; stroke-linecap: square"/>
+" clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 6.66,2.88; stroke-dashoffset: 0; stroke: #ffffff; stroke-width: 1.8"/>
    </g>
-   <g id="line2d_135">
+   <g id="line2d_133">
     <path d="M 206.353594 317.709805 
 L 440.713594 317.709805 
 " clip-path="url(#p0d2a40e86a)" style="fill: none; stroke-dasharray: 1,1.65; stroke-dashoffset: 0; stroke: #ffffff; stroke-opacity: 0.4"/>
@@ -1607,10 +1317,10 @@ L 345.260843 283.7623
 L 348.185921 281.702223 
 " style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linecap: round"/>
    </g>
-   <g id="text_39">
+   <g id="text_38">
     <text style="font-size: 8px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="386.247704" y="276.806173" transform="rotate(-0 386.247704 276.806173)">+1,27 dB</text>
    </g>
-   <g id="text_40">
+   <g id="text_39">
     <text style="font-size: 9px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="323.533594" y="258.930925" transform="rotate(-0 323.533594 258.930925)">Zoom: la ponderación A es positiva (máx +1,27 dB @ 2,5 kHz)</text>
    </g>
   </g>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -293,6 +293,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Frequency-weighting guides: the single chart that drew A, B, C, D, AU and Z
+  together is split so each guide shows only the curves it documents.
+  `weighting_responses` now holds the three curves of IEC 61672-1, and with
+  B/D/AU gone its floor drops from -50 to -72 dB so the A curve no longer
+  runs off the bottom-left corner at 10 Hz. The new
+  `special_weighting_responses` figure gives the special-weightings guide the
+  chart it was missing: B, D and AU against a wide A reference, measured at
+  96 kHz so the axis reaches the 40 kHz where IEC 61012 specifies the U
+  low-pass of AU, with the +11.5 dB D hump at 3.15 kHz and the 13 dB AU
+  cutoff at 16 kHz annotated. Both guides were revised around the split in
+  English and Spanish: the A/C/Z page no longer hedges about curves it does
+  not show, and the special-weightings page describes the three it now draws.
+
 - Documentation animations: a field that sits tens of dB under the one
   setting the colour scale is now drawn with an explicit display gain
   instead of collapsing into the page background. The gain is measured off

--- a/docs/special-weightings.md
+++ b/docs/special-weightings.md
@@ -77,7 +77,51 @@ L<sub>pG</sub> (or L<sub>Geq</sub> for the equivalent level over time).
 
 ## 2. Historical and special-purpose curves: B, D and AU
 
-Three more curves complete the family.
+Three more curves complete the family. All three work in the audible range,
+so they share one chart, drawn against the A curve because that is what each
+of them is defined or described against: B as the curve between A and C, D as
+the one with a hump A does not have, AU as A itself with a low-pass added.
+
+<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/special_weighting_responses_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/special_weighting_responses.svg" alt="B, D and AU weighting curves measured at 96 kHz against a wide grey A-weighting reference, with the +11.5 dB D hump at 3.15 kHz and the AU cutoff 13 dB below A at 16 kHz annotated" width="80%"></picture>
+
+*The three curves against the A reference (wide grey), measured at 96 kHz so
+the axis reaches the 40 kHz where IEC 61012 still specifies the U low-pass.
+B (green, dashed) discards less bass than A; D (purple) carries the +11.5 dB
+hump at 3.15 kHz where jet turbomachinery whine annoys most; AU (orange) runs
+inside the A reference up to 10 kHz and then falls away with U, reaching 13 dB
+below A at 16 kHz. The infrasound G curve keeps its own chart in section 1,
+and A, C and Z are in [Frequency Weighting](weighting.md).*
+
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import metrology
+
+# Measure each curve's response: weight a centered unit impulse and take its
+# spectrum. 96 kHz, not 48 kHz: it reaches the 40 kHz top row of the
+# IEC 61012 U-weighting table, which is the whole point of AU.
+fs = 96000
+impulse = np.zeros(fs)
+impulse[fs // 2] = 1.0
+freqs = np.fft.rfftfreq(fs, 1 / fs)
+
+fig, ax = plt.subplots(figsize=(9, 5))
+# A goes first and wide, as the reference the other three are read against.
+for curve, width in (("A", 4.0), ("B", 1.8), ("D", 1.8), ("AU", 1.8)):
+    spectrum = np.fft.rfft(metrology.weighting_filter(impulse, fs, curve=curve))
+    ax.semilogx(freqs[1:], 20 * np.log10(np.abs(spectrum[1:]) + np.finfo(float).eps),
+                label=curve, linewidth=width)
+ax.set(xlim=(10, 40000), ylim=(-90, 18),
+       xlabel="Frequency [Hz]", ylabel="Response [dB]")
+ax.grid(True, which="both", alpha=0.3)
+ax.legend()
+plt.show()
+```
+
+</details>
 
 ### B (ANSI S1.4-1983, historical)
 

--- a/docs/weighting.md
+++ b/docs/weighting.md
@@ -9,12 +9,14 @@ Table 3 class verification. The rest of the family, the infrasound G curve,
 the historical B and D and the AU curve, is
 [Special Weightings](special-weightings.md).
 
-<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/weighting_responses_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/weighting_responses.svg" alt="A, B, C, D, AU and Z frequency weighting curves with a zoom showing the positive region of the A curve (+1.27 dB at 2.5 kHz)" width="80%"></picture>
+<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/weighting_responses_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/weighting_responses.svg" alt="A, C and Z frequency weighting curves of IEC 61672-1 with a zoom showing the positive region of the A curve (+1.27 dB at 2.5 kHz)" width="80%"></picture>
 
-*The audible-range weighting family measured on one chart. This guide covers
-the A, C and Z responses; the B, D and AU curves drawn alongside them, and
-the infrasound G curve, are the subject of
-[Special Weightings](special-weightings.md).*
+*The three curves of IEC 61672-1, measured through the library's own filters
+at 48 kHz: A, which discards the bass; C, which keeps it; and Z, which
+weights nothing at all. The inset magnifies the small positive region of A
+around 2.5 kHz. The special B, D and AU curves have their own chart in
+[Special Weightings](special-weightings.md), together with the infrasound
+G curve.*
 
 <details>
 <summary>Show the code for this figure</summary>
@@ -32,11 +34,11 @@ impulse[fs // 2] = 1.0
 freqs = np.fft.rfftfreq(fs, 1 / fs)
 
 fig, ax = plt.subplots(figsize=(9, 5))
-for curve in ("A", "B", "C", "D", "AU", "Z"):
+for curve in ("A", "C", "Z"):
     spectrum = np.fft.rfft(metrology.weighting_filter(impulse, fs, curve=curve))
     ax.semilogx(freqs[1:], 20 * np.log10(np.abs(spectrum[1:]) + np.finfo(float).eps),
                 label=curve)
-ax.set(xlim=(10, 20000), ylim=(-80, 15),
+ax.set(xlim=(10, 22000), ylim=(-72, 15),
        xlabel="Frequency [Hz]", ylabel="Response [dB]")
 ax.grid(True, which="both", alpha=0.3)
 ax.legend()
@@ -48,10 +50,12 @@ plt.show()
 * **A-Weighting (`A`):** Standard for environmental noise (IEC 61672-1).
 * **C-Weighting (`C`):** Used for peak sound pressure and high-level noise.
 * **Z-Weighting (`Z`):** Zero weighting, completely flat response.
-* **G-Weighting (`G`):** Infrasound weighting per ISO 7196 ([Special Weightings](special-weightings.md)).
-* **B-Weighting (`B`):** Historical middle curve of ANSI S1.4-1983 ([Special Weightings](special-weightings.md)).
-* **D-Weighting (`D`):** Aircraft-noise weighting of the withdrawn IEC 537 ([Special Weightings](special-weightings.md)).
-* **AU-Weighting (`AU`):** A-weighting with the IEC 61012 ultrasound cutoff ([Special Weightings](special-weightings.md)).
+
+The `curve` argument also accepts the four special weightings, charted and
+documented in [Special Weightings](special-weightings.md): `'G'` for
+infrasound (ISO 7196), the historical `'B'` (ANSI S1.4-1983) and `'D'`
+(IEC 537), and `'AU'` for audible sound in the presence of ultrasound
+(IEC 61012).
 
 ## 1. Where the curves come from
 
@@ -143,10 +147,8 @@ weighted_signal = metrology.weighting_filter(recording, fs, curve='A')
 c_weighted_signal = metrology.weighting_filter(recording, fs, curve='C')
 ```
 
-The rest of the family has its own guide:
-[Special Weightings](special-weightings.md): the infrasound G curve of
-ISO 7196, the historical B and D, and AU for audible sound in the
-presence of ultrasound.
+The special weightings take the same `curve` argument; each is documented,
+with its own response chart, in [Special Weightings](special-weightings.md).
 
 ## 3. `weighting_filter()` / `WeightingFilter` parameters
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -30308,7 +30308,51 @@ L<sub>pG</sub> (or L<sub>Geq</sub> for the equivalent level over time).
 
 ## 2. Historical and special-purpose curves: B, D and AU
 
-Three more curves complete the family.
+Three more curves complete the family. All three work in the audible range,
+so they share one chart, drawn against the A curve because that is what each
+of them is defined or described against: B as the curve between A and C, D as
+the one with a hump A does not have, AU as A itself with a low-pass added.
+
+<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/special_weighting_responses_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/special_weighting_responses.svg" alt="B, D and AU weighting curves measured at 96 kHz against a wide grey A-weighting reference, with the +11.5 dB D hump at 3.15 kHz and the AU cutoff 13 dB below A at 16 kHz annotated" width="80%"></picture>
+
+*The three curves against the A reference (wide grey), measured at 96 kHz so
+the axis reaches the 40 kHz where IEC 61012 still specifies the U low-pass.
+B (green, dashed) discards less bass than A; D (purple) carries the +11.5 dB
+hump at 3.15 kHz where jet turbomachinery whine annoys most; AU (orange) runs
+inside the A reference up to 10 kHz and then falls away with U, reaching 13 dB
+below A at 16 kHz. The infrasound G curve keeps its own chart in section 1,
+and A, C and Z are in [Frequency Weighting](https://jmrplens.github.io/phonometry/guides/weighting/).*
+
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import metrology
+
+# Measure each curve's response: weight a centered unit impulse and take its
+# spectrum. 96 kHz, not 48 kHz: it reaches the 40 kHz top row of the
+# IEC 61012 U-weighting table, which is the whole point of AU.
+fs = 96000
+impulse = np.zeros(fs)
+impulse[fs // 2] = 1.0
+freqs = np.fft.rfftfreq(fs, 1 / fs)
+
+fig, ax = plt.subplots(figsize=(9, 5))
+# A goes first and wide, as the reference the other three are read against.
+for curve, width in (("A", 4.0), ("B", 1.8), ("D", 1.8), ("AU", 1.8)):
+    spectrum = np.fft.rfft(metrology.weighting_filter(impulse, fs, curve=curve))
+    ax.semilogx(freqs[1:], 20 * np.log10(np.abs(spectrum[1:]) + np.finfo(float).eps),
+                label=curve, linewidth=width)
+ax.set(xlim=(10, 40000), ylim=(-90, 18),
+       xlabel="Frequency [Hz]", ylabel="Response [dB]")
+ax.grid(True, which="both", alpha=0.3)
+ax.legend()
+plt.show()
+```
+
+</details>
 
 ### B (ANSI S1.4-1983, historical)
 
@@ -37903,12 +37947,14 @@ Table 3 class verification. The rest of the family, the infrasound G curve,
 the historical B and D and the AU curve, is
 [Special Weightings](https://jmrplens.github.io/phonometry/guides/special-weightings/).
 
-<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/weighting_responses_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/weighting_responses.svg" alt="A, B, C, D, AU and Z frequency weighting curves with a zoom showing the positive region of the A curve (+1.27 dB at 2.5 kHz)" width="80%"></picture>
+<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/weighting_responses_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/weighting_responses.svg" alt="A, C and Z frequency weighting curves of IEC 61672-1 with a zoom showing the positive region of the A curve (+1.27 dB at 2.5 kHz)" width="80%"></picture>
 
-*The audible-range weighting family measured on one chart. This guide covers
-the A, C and Z responses; the B, D and AU curves drawn alongside them, and
-the infrasound G curve, are the subject of
-[Special Weightings](https://jmrplens.github.io/phonometry/guides/special-weightings/).*
+*The three curves of IEC 61672-1, measured through the library's own filters
+at 48 kHz: A, which discards the bass; C, which keeps it; and Z, which
+weights nothing at all. The inset magnifies the small positive region of A
+around 2.5 kHz. The special B, D and AU curves have their own chart in
+[Special Weightings](https://jmrplens.github.io/phonometry/guides/special-weightings/), together with the infrasound
+G curve.*
 
 <details>
 <summary>Show the code for this figure</summary>
@@ -37926,11 +37972,11 @@ impulse[fs // 2] = 1.0
 freqs = np.fft.rfftfreq(fs, 1 / fs)
 
 fig, ax = plt.subplots(figsize=(9, 5))
-for curve in ("A", "B", "C", "D", "AU", "Z"):
+for curve in ("A", "C", "Z"):
     spectrum = np.fft.rfft(metrology.weighting_filter(impulse, fs, curve=curve))
     ax.semilogx(freqs[1:], 20 * np.log10(np.abs(spectrum[1:]) + np.finfo(float).eps),
                 label=curve)
-ax.set(xlim=(10, 20000), ylim=(-80, 15),
+ax.set(xlim=(10, 22000), ylim=(-72, 15),
        xlabel="Frequency [Hz]", ylabel="Response [dB]")
 ax.grid(True, which="both", alpha=0.3)
 ax.legend()
@@ -37942,10 +37988,12 @@ plt.show()
 * **A-Weighting (`A`):** Standard for environmental noise (IEC 61672-1).
 * **C-Weighting (`C`):** Used for peak sound pressure and high-level noise.
 * **Z-Weighting (`Z`):** Zero weighting, completely flat response.
-* **G-Weighting (`G`):** Infrasound weighting per ISO 7196 ([Special Weightings](https://jmrplens.github.io/phonometry/guides/special-weightings/)).
-* **B-Weighting (`B`):** Historical middle curve of ANSI S1.4-1983 ([Special Weightings](https://jmrplens.github.io/phonometry/guides/special-weightings/)).
-* **D-Weighting (`D`):** Aircraft-noise weighting of the withdrawn IEC 537 ([Special Weightings](https://jmrplens.github.io/phonometry/guides/special-weightings/)).
-* **AU-Weighting (`AU`):** A-weighting with the IEC 61012 ultrasound cutoff ([Special Weightings](https://jmrplens.github.io/phonometry/guides/special-weightings/)).
+
+The `curve` argument also accepts the four special weightings, charted and
+documented in [Special Weightings](https://jmrplens.github.io/phonometry/guides/special-weightings/): `'G'` for
+infrasound (ISO 7196), the historical `'B'` (ANSI S1.4-1983) and `'D'`
+(IEC 537), and `'AU'` for audible sound in the presence of ultrasound
+(IEC 61012).
 
 ## 1. Where the curves come from
 
@@ -38037,10 +38085,8 @@ weighted_signal = metrology.weighting_filter(recording, fs, curve='A')
 c_weighted_signal = metrology.weighting_filter(recording, fs, curve='C')
 ```
 
-The rest of the family has its own guide:
-[Special Weightings](https://jmrplens.github.io/phonometry/guides/special-weightings/): the infrasound G curve of
-ISO 7196, the historical B and D, and AU for audible sound in the
-presence of ultrasound.
+The special weightings take the same `curve` argument; each is documented,
+with its own response chart, in [Special Weightings](https://jmrplens.github.io/phonometry/guides/special-weightings/).
 
 ## 3. `weighting_filter()` / `WeightingFilter` parameters
 

--- a/scripts/generate_graphs.py
+++ b/scripts/generate_graphs.py
@@ -235,6 +235,7 @@ _ES_EXACT = {
     "4 kHz Toneburst Response vs IEC 61672-1 Table 4 (FAST)":
         "Respuesta a r\u00e1fagas de 4 kHz vs Tabla 4 de IEC 61672-1 (FAST)",
     "A-Weighting": "Ponderaci\u00f3n A",
+    "A-Weighting (reference)": "Ponderaci\u00f3n A (referencia)",
     "B-Weighting (historical)": "Ponderaci\u00f3n B (hist\u00f3rica)",
     "C-Weighting": "Ponderaci\u00f3n C",
     "D-Weighting (aircraft, withdrawn)":
@@ -276,7 +277,13 @@ _ES_EXACT = {
     "A weighting deviation (48 kHz)": "Desviaci\u00f3n de ponderaci\u00f3n A (48 kHz)",
     "C weighting deviation (48 kHz)": "Desviaci\u00f3n de ponderaci\u00f3n C (48 kHz)",
     "Deviation from design goal [dB]": "Desviaci\u00f3n del objetivo de dise\u00f1o [dB]",
-    "Frequency Weighting Curves": "Curvas de ponderaci\u00f3n frecuencial",
+    "Frequency Weighting Curves (IEC 61672-1)":
+        "Curvas de ponderaci\u00f3n frecuencial (IEC 61672-1)",
+    # special_weighting_responses figure (B, D and AU against the A reference)
+    "Special Weighting Curves (B, D, AU)":
+        "Curvas de ponderaci\u00f3n especiales (B, D y AU)",
+    "AU is 13 dB below A at 16 kHz":
+        "AU queda 13 dB por debajo de A en 16 kHz",
     "Group Delay Comparison (1 kHz Octave Band, Order 6)":
         "Comparativa de retardo de grupo (banda de 1 kHz, orden 6)",
     "Hearing threshold $T_f$ (Table 1)": "Umbral de audici\u00f3n $T_f$ (Tabla 1)",
@@ -2467,39 +2474,57 @@ def measure_weighting_response(
     return w, mag_db
 
 
+def _draw_weighting_curves(
+    ax: Any,
+    fs: int,
+    curves: tuple[tuple[str, str, str, str, float], ...],
+    inset: Any = None,
+) -> None:
+    """Draw ``(code, label, colour, linestyle, linewidth)`` curves measured at *fs*.
+
+    Shared by the two weighting-family figures (the IEC 61672-1 A/C/Z chart and
+    the special B/D/AU chart), which differ only in the curves they hold and in
+    the axis they hold them on. Curves are drawn in the order given, so a wide
+    reference line listed first sits behind the curves that follow it.
+    """
+    for code, label, color, style, width in curves:
+        # measure_weighting_response is covered by tests/test_graph_measurements.py
+        w, mag_db = measure_weighting_response(fs, code)
+        ax.semilogx(w, mag_db, label=label, color=color, linestyle=style, linewidth=width)
+        if inset is not None:
+            inset.plot(w, mag_db, color=color, linestyle=style, linewidth=width)
+    ax.axhline(0, color=COLOR_FG, linestyle=":", alpha=0.3, linewidth=1)
+
+
 def generate_weighting_responses(output_dir: str) -> None:
-    """Plot the A/B/C/D/AU/Z weighting frequency responses."""
+    """Plot the IEC 61672-1 A/C/Z weighting frequency responses."""
     print("Generating weighting_responses.png...")
     fs = 48000
 
     _, ax = plt.subplots(figsize=(10, 7))
 
     # Zoom inset: the A curve is POSITIVE (+1.27 dB max at ~2.5 kHz per
-    # IEC 61672-1 Table 2), invisible at the full -50..15 dB scale. Only the
-    # IEC 61672-1 curves are drawn in it: D peaks at +11.5 dB (out of the
-    # inset range) and B/AU hug C/A there.
+    # IEC 61672-1 Table 2), invisible at the full -72..15 dB scale, so all
+    # three curves of this figure are redrawn in it.
     from mpl_toolkits.axes_grid1.inset_locator import inset_axes
     axins = inset_axes(ax, width="42%", height="34%", loc="lower center", borderpad=2)
     axins.set_xscale("log")
 
-    curves = [
-        ("A", "A-Weighting", COLOR_PRIMARY, "-"),
-        ("B", "B-Weighting (historical)", COLOR_TERTIARY, "--"),
-        ("C", "C-Weighting", COLOR_SECONDARY, "-"),
-        ("D", "D-Weighting (aircraft, withdrawn)", "#9467bd", "-."),
-        ("AU", "AU-Weighting (audible + ultrasound)", "#ff7f0e", "--"),
-        ("Z", "Z-Weighting (Flat)", COLOR_FG, "-"),
-    ]
+    # The special B, D and AU curves have their own figure
+    # (generate_special_weighting_responses); the infrasound G curve has
+    # generate_g_weighting_response.
+    curves = (
+        ("A", "A-Weighting", COLOR_PRIMARY, "-", 1.8),
+        ("C", "C-Weighting", COLOR_SECONDARY, "-", 1.8),
+        ("Z", "Z-Weighting (Flat)", COLOR_FG, "--", 1.8),
+    )
+    _draw_weighting_curves(ax, fs, curves, inset=axins)
 
-    for code, label, color, style in curves:
-        # measure_weighting_response is covered by tests/test_graph_measurements.py
-        w, mag_db = measure_weighting_response(fs, code)
-        ax.semilogx(w, mag_db, label=label, color=color, linestyle=style)
-        if code in ("A", "C", "Z"):
-            axins.plot(w, mag_db, color=color)
-
-    ax.axhline(0, color=COLOR_FG, linestyle=":", alpha=0.3, linewidth=1)
-    apply_axis_styling(ax, "Frequency Weighting Curves", xlim=(10, 22000), ylim=(-50, 15))
+    # -72 dB, not the -50 the six-curve version used: with only A, C and Z left
+    # nothing forces the floor up, and A reaches -70.4 dB at 10 Hz, so the whole
+    # curve now fits on the axis instead of running off the bottom-left corner.
+    apply_axis_styling(ax, "Frequency Weighting Curves (IEC 61672-1)",
+                       xlim=(10, 22000), ylim=(-72, 15))
 
     axins.axhline(0, color=COLOR_FG, linestyle=":", alpha=0.4, linewidth=1)
     axins.set_xlim(500, 8000)
@@ -2518,6 +2543,52 @@ def generate_weighting_responses(output_dir: str) -> None:
 
     ax.legend(loc="upper left", fontsize=9)
     save_figure(output_dir, "weighting_responses.png")
+    plt.close()
+
+
+def generate_special_weighting_responses(output_dir: str) -> None:
+    """Plot the special B/D/AU weighting curves against the A reference."""
+    print("Generating special_weighting_responses.png...")
+    # 96 kHz, not the 48 kHz of the IEC 61672-1 figure: the point of AU is the
+    # IEC 61012 U low-pass, specified up to 40 kHz, and a 48 kHz axis would cut
+    # it off mid-slope (the guide says the same about measuring it).
+    fs = 96000
+
+    _, ax = plt.subplots(figsize=(10, 7))
+
+    # A is drawn first, as a wide pale line, so it reads as the reference the
+    # other three are described against: AU runs inside it up to 10 kHz and
+    # then leaves, B stays above it, D crosses it at its 3.15 kHz hump.
+    curves = (
+        ("A", "A-Weighting (reference)", COLOR_MUTED, "-", 4.0),
+        ("B", "B-Weighting (historical)", COLOR_TERTIARY, "--", 1.8),
+        ("D", "D-Weighting (aircraft, withdrawn)", "#9467bd", "-.", 1.8),
+        ("AU", "AU-Weighting (audible + ultrasound)", "#ff7f0e", "-", 1.8),
+    )
+    _draw_weighting_curves(ax, fs, curves)
+
+    apply_axis_styling(ax, "Special Weighting Curves (B, D, AU)",
+                       xlim=(10, 40000), ylim=(-90, 18))
+    # apply_axis_styling stops labelling at 16 kHz; this axis runs into the
+    # ultrasonic decade AU exists for, so it needs the 40 kHz end labelled.
+    ax.set_xticks([16, 63, 250, 1000, 4000, 16000, 40000])
+    ax.set_xticklabels(["16", "63", "250", "1k", "4k", "16k", "40k"])
+
+    # The two numbers the guide quotes from the standards: the D hump of
+    # IEC 537 (+11.5 dB at 3.15 kHz, NASA CR-3406 Table SLD-I) and the U
+    # low-pass of IEC 61012 (-13 dB at 16 kHz, Table 1).
+    ax.annotate(
+        "+11.5 dB @ 3.15 kHz", xy=(3150, 11.6), xytext=(150, 13.5), fontsize=9,
+        color="#9467bd", arrowprops={"arrowstyle": "->", "lw": 0.9, "color": "#9467bd"},
+    )
+    ax.annotate(
+        "AU is 13 dB below A at 16 kHz", xy=(16000, -21.0), xytext=(700, -35.0),
+        fontsize=9, color="#ff7f0e",
+        arrowprops={"arrowstyle": "->", "lw": 0.9, "color": "#ff7f0e"},
+    )
+
+    ax.legend(loc="lower center", fontsize=9)
+    save_figure(output_dir, "special_weighting_responses.png")
     plt.close()
 
 
@@ -12569,6 +12640,7 @@ _FIGURE_FUNCS: tuple[Callable[[str], None], ...] = (
     generate_multichannel_response,
     generate_decomposition_plot,
     generate_weighting_responses,
+    generate_special_weighting_responses,
     generate_g_weighting_response,
     generate_equal_loudness_contours,
     generate_time_weighting_plot,
@@ -18958,7 +19030,8 @@ _FIGURE_WEIGHTS: dict[str, float] = {
     "moore_glasberg_time_loudness": 2.6,
     "numerical_propagation": 2.5,
     "fluctuation_strength": 2.2,
-    "weighting_responses": 1.7,
+    "weighting_responses": 1.1,
+    "special_weighting_responses": 2.6,
     "sti_curve": 1.7,
     "schroeder_decay": 1.3,
     "excitation_signals": 1.2,

--- a/site/public/llms/llms-levels-weighting.txt
+++ b/site/public/llms/llms-levels-weighting.txt
@@ -16,12 +16,14 @@ Table 3 class verification. The rest of the family, the infrasound G curve,
 the historical B and D and the AU curve, is
 [Special Weightings](https://jmrplens.github.io/phonometry/guides/special-weightings/).
 
-<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/weighting_responses_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/weighting_responses.svg" alt="A, B, C, D, AU and Z frequency weighting curves with a zoom showing the positive region of the A curve (+1.27 dB at 2.5 kHz)" width="80%"></picture>
+<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/weighting_responses_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/weighting_responses.svg" alt="A, C and Z frequency weighting curves of IEC 61672-1 with a zoom showing the positive region of the A curve (+1.27 dB at 2.5 kHz)" width="80%"></picture>
 
-*The audible-range weighting family measured on one chart. This guide covers
-the A, C and Z responses; the B, D and AU curves drawn alongside them, and
-the infrasound G curve, are the subject of
-[Special Weightings](https://jmrplens.github.io/phonometry/guides/special-weightings/).*
+*The three curves of IEC 61672-1, measured through the library's own filters
+at 48 kHz: A, which discards the bass; C, which keeps it; and Z, which
+weights nothing at all. The inset magnifies the small positive region of A
+around 2.5 kHz. The special B, D and AU curves have their own chart in
+[Special Weightings](https://jmrplens.github.io/phonometry/guides/special-weightings/), together with the infrasound
+G curve.*
 
 <details>
 <summary>Show the code for this figure</summary>
@@ -39,11 +41,11 @@ impulse[fs // 2] = 1.0
 freqs = np.fft.rfftfreq(fs, 1 / fs)
 
 fig, ax = plt.subplots(figsize=(9, 5))
-for curve in ("A", "B", "C", "D", "AU", "Z"):
+for curve in ("A", "C", "Z"):
     spectrum = np.fft.rfft(metrology.weighting_filter(impulse, fs, curve=curve))
     ax.semilogx(freqs[1:], 20 * np.log10(np.abs(spectrum[1:]) + np.finfo(float).eps),
                 label=curve)
-ax.set(xlim=(10, 20000), ylim=(-80, 15),
+ax.set(xlim=(10, 22000), ylim=(-72, 15),
        xlabel="Frequency [Hz]", ylabel="Response [dB]")
 ax.grid(True, which="both", alpha=0.3)
 ax.legend()
@@ -55,10 +57,12 @@ plt.show()
 * **A-Weighting (`A`):** Standard for environmental noise (IEC 61672-1).
 * **C-Weighting (`C`):** Used for peak sound pressure and high-level noise.
 * **Z-Weighting (`Z`):** Zero weighting, completely flat response.
-* **G-Weighting (`G`):** Infrasound weighting per ISO 7196 ([Special Weightings](https://jmrplens.github.io/phonometry/guides/special-weightings/)).
-* **B-Weighting (`B`):** Historical middle curve of ANSI S1.4-1983 ([Special Weightings](https://jmrplens.github.io/phonometry/guides/special-weightings/)).
-* **D-Weighting (`D`):** Aircraft-noise weighting of the withdrawn IEC 537 ([Special Weightings](https://jmrplens.github.io/phonometry/guides/special-weightings/)).
-* **AU-Weighting (`AU`):** A-weighting with the IEC 61012 ultrasound cutoff ([Special Weightings](https://jmrplens.github.io/phonometry/guides/special-weightings/)).
+
+The `curve` argument also accepts the four special weightings, charted and
+documented in [Special Weightings](https://jmrplens.github.io/phonometry/guides/special-weightings/): `'G'` for
+infrasound (ISO 7196), the historical `'B'` (ANSI S1.4-1983) and `'D'`
+(IEC 537), and `'AU'` for audible sound in the presence of ultrasound
+(IEC 61012).
 
 ## 1. Where the curves come from
 
@@ -150,10 +154,8 @@ weighted_signal = metrology.weighting_filter(recording, fs, curve='A')
 c_weighted_signal = metrology.weighting_filter(recording, fs, curve='C')
 ```
 
-The rest of the family has its own guide:
-[Special Weightings](https://jmrplens.github.io/phonometry/guides/special-weightings/): the infrasound G curve of
-ISO 7196, the historical B and D, and AU for audible sound in the
-presence of ultrasound.
+The special weightings take the same `curve` argument; each is documented,
+with its own response chart, in [Special Weightings](https://jmrplens.github.io/phonometry/guides/special-weightings/).
 
 ## 3. `weighting_filter()` / `WeightingFilter` parameters
 
@@ -464,7 +466,51 @@ L<sub>pG</sub> (or L<sub>Geq</sub> for the equivalent level over time).
 
 ## 2. Historical and special-purpose curves: B, D and AU
 
-Three more curves complete the family.
+Three more curves complete the family. All three work in the audible range,
+so they share one chart, drawn against the A curve because that is what each
+of them is defined or described against: B as the curve between A and C, D as
+the one with a hump A does not have, AU as A itself with a low-pass added.
+
+<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/special_weighting_responses_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/special_weighting_responses.svg" alt="B, D and AU weighting curves measured at 96 kHz against a wide grey A-weighting reference, with the +11.5 dB D hump at 3.15 kHz and the AU cutoff 13 dB below A at 16 kHz annotated" width="80%"></picture>
+
+*The three curves against the A reference (wide grey), measured at 96 kHz so
+the axis reaches the 40 kHz where IEC 61012 still specifies the U low-pass.
+B (green, dashed) discards less bass than A; D (purple) carries the +11.5 dB
+hump at 3.15 kHz where jet turbomachinery whine annoys most; AU (orange) runs
+inside the A reference up to 10 kHz and then falls away with U, reaching 13 dB
+below A at 16 kHz. The infrasound G curve keeps its own chart in section 1,
+and A, C and Z are in [Frequency Weighting](https://jmrplens.github.io/phonometry/guides/weighting/).*
+
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import metrology
+
+# Measure each curve's response: weight a centered unit impulse and take its
+# spectrum. 96 kHz, not 48 kHz: it reaches the 40 kHz top row of the
+# IEC 61012 U-weighting table, which is the whole point of AU.
+fs = 96000
+impulse = np.zeros(fs)
+impulse[fs // 2] = 1.0
+freqs = np.fft.rfftfreq(fs, 1 / fs)
+
+fig, ax = plt.subplots(figsize=(9, 5))
+# A goes first and wide, as the reference the other three are read against.
+for curve, width in (("A", 4.0), ("B", 1.8), ("D", 1.8), ("AU", 1.8)):
+    spectrum = np.fft.rfft(metrology.weighting_filter(impulse, fs, curve=curve))
+    ax.semilogx(freqs[1:], 20 * np.log10(np.abs(spectrum[1:]) + np.finfo(float).eps),
+                label=curve, linewidth=width)
+ax.set(xlim=(10, 40000), ylim=(-90, 18),
+       xlabel="Frequency [Hz]", ylabel="Response [dB]")
+ax.grid(True, which="both", alpha=0.3)
+ax.legend()
+plt.show()
+```
+
+</details>
 
 ### B (ANSI S1.4-1983, historical)
 

--- a/site/src/content/docs/es/guides/special-weightings.mdx
+++ b/site/src/content/docs/es/guides/special-weightings.mdx
@@ -120,7 +120,53 @@ expresan como L<sub>pG</sub> (o L<sub>Geq</sub> para el nivel equivalente).
 
 ## 2. Curvas históricas y de propósito especial: B, D y AU
 
-Tres curvas más completan la familia.
+Tres curvas más completan la familia. Las tres trabajan en el rango audible,
+así que comparten una gráfica, dibujada frente a la curva A porque es la
+referencia con la que se define o se describe cada una: B como la curva
+intermedia entre A y C, D como la que tiene una joroba que A no tiene, y AU
+como la propia A con un paso bajo añadido.
+
+<ThemeImage src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/special_weighting_responses_es.svg" alt="Curvas de ponderación B, D y AU medidas a 96 kHz frente a una referencia gris ancha de ponderación A, con la joroba de +11,5 dB de D en 3,15 kHz y el corte de AU 13 dB por debajo de A en 16 kHz anotados" width="80%" />
+
+*Las tres curvas frente a la referencia A (gris ancha), medidas a 96 kHz para
+que el eje llegue a los 40 kHz donde IEC 61012 aún especifica el paso bajo U.
+B (verde, discontinua) descarta menos graves que A; D (morada) lleva la joroba
+de +11,5 dB en 3,15 kHz, donde más molesta el silbido de la turbomaquinaria;
+AU (naranja) recorre el interior de la referencia A hasta 10 kHz y luego se
+desprende con U, hasta quedar 13 dB por debajo de A en 16 kHz. La curva G de
+infrasonido conserva su propia gráfica en la sección 1, y A, C y Z están en
+[Ponderación frecuencial](/phonometry/es/guides/weighting/).*
+
+<details>
+<summary>Mostrar el código de esta figura</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import metrology
+
+# Medimos la respuesta de cada curva: ponderamos un impulso unitario centrado
+# y tomamos su espectro. 96 kHz, no 48 kHz: así se alcanza la fila de 40 kHz
+# de la tabla de la ponderación U de IEC 61012, que es la razón de ser de AU.
+fs = 96000
+impulse = np.zeros(fs)
+impulse[fs // 2] = 1.0
+freqs = np.fft.rfftfreq(fs, 1 / fs)
+
+fig, ax = plt.subplots(figsize=(9, 5))
+# A va primero y ancha, como referencia con la que se leen las otras tres.
+for curve, width in (("A", 4.0), ("B", 1.8), ("D", 1.8), ("AU", 1.8)):
+    spectrum = np.fft.rfft(metrology.weighting_filter(impulse, fs, curve=curve))
+    ax.semilogx(freqs[1:], 20 * np.log10(np.abs(spectrum[1:]) + np.finfo(float).eps),
+                label=curve, linewidth=width)
+ax.set(xlim=(10, 40000), ylim=(-90, 18),
+       xlabel="Frecuencia [Hz]", ylabel="Respuesta [dB]")
+ax.grid(True, which="both", alpha=0.3)
+ax.legend()
+plt.show()
+```
+
+</details>
 
 ### B (ANSI S1.4-1983, histórica)
 

--- a/site/src/content/docs/es/guides/weighting.mdx
+++ b/site/src/content/docs/es/guides/weighting.mdx
@@ -37,12 +37,14 @@ Esta guía cubre **A**, **C** y **Z**, las curvas especificadas en
 la familia, la curva G de infrasonido, las históricas B y D y la curva AU, es
 [Ponderaciones especiales](/phonometry/es/guides/special-weightings/).
 
-<ThemeImage src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/weighting_responses_es.svg" alt="Curvas de ponderación A, B, C, D, AU y Z con zoom de la región positiva de la curva A (+1,27 dB en 2,5 kHz)" width="80%" loading="eager" />
+<ThemeImage src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/weighting_responses_es.svg" alt="Curvas de ponderación A, C y Z de IEC 61672-1 con zoom de la región positiva de la curva A (+1,27 dB en 2,5 kHz)" width="80%" loading="eager" />
 
-*La familia de ponderaciones del rango audible medida en una sola gráfica.
-Esta guía cubre las respuestas A, C y Z; las curvas B, D y AU dibujadas junto
-a ellas, y la curva G de infrasonido, son el tema de
-[Ponderaciones especiales](/phonometry/es/guides/special-weightings/).*
+*Las tres curvas de IEC 61672-1, medidas con los filtros de la propia
+biblioteca a 48 kHz: A, que descarta los graves; C, que los conserva; y Z,
+que no pondera nada. El recuadro amplía la pequeña región positiva de A en
+torno a 2,5 kHz. Las curvas especiales B, D y AU tienen su propia gráfica en
+[Ponderaciones especiales](/phonometry/es/guides/special-weightings/), junto
+con la curva G de infrasonido.*
 
 <details>
 <summary>Mostrar el código de esta figura</summary>
@@ -60,11 +62,11 @@ impulse[fs // 2] = 1.0
 freqs = np.fft.rfftfreq(fs, 1 / fs)
 
 fig, ax = plt.subplots(figsize=(9, 5))
-for curve in ("A", "B", "C", "D", "AU", "Z"):
+for curve in ("A", "C", "Z"):
     spectrum = np.fft.rfft(metrology.weighting_filter(impulse, fs, curve=curve))
     ax.semilogx(freqs[1:], 20 * np.log10(np.abs(spectrum[1:]) + np.finfo(float).eps),
                 label=curve)
-ax.set(xlim=(10, 20000), ylim=(-80, 15),
+ax.set(xlim=(10, 22000), ylim=(-72, 15),
        xlabel="Frecuencia [Hz]", ylabel="Respuesta [dB]")
 ax.grid(True, which="both", alpha=0.3)
 ax.legend()
@@ -76,10 +78,13 @@ plt.show()
 * **Ponderación A (`A`):** estándar para ruido ambiental (IEC 61672-1).
 * **Ponderación C (`C`):** para presión acústica de pico y ruido de alto nivel.
 * **Ponderación Z (`Z`):** ponderación cero, respuesta completamente plana.
-* **Ponderación G (`G`):** ponderación de infrasonido según ISO 7196 ([Ponderaciones especiales](/phonometry/es/guides/special-weightings/)).
-* **Ponderación B (`B`):** curva intermedia histórica de ANSI S1.4-1983 ([Ponderaciones especiales](/phonometry/es/guides/special-weightings/)).
-* **Ponderación D (`D`):** ponderación de ruido de aeronaves de la retirada IEC 537 ([Ponderaciones especiales](/phonometry/es/guides/special-weightings/)).
-* **Ponderación AU (`AU`):** ponderación A con el corte de ultrasonidos de IEC 61012 ([Ponderaciones especiales](/phonometry/es/guides/special-weightings/)).
+
+El argumento `curve` acepta además las cuatro ponderaciones especiales, con
+gráfica y documentación en
+[Ponderaciones especiales](/phonometry/es/guides/special-weightings/): `'G'`
+para infrasonido (ISO 7196), las históricas `'B'` (ANSI S1.4-1983) y `'D'`
+(IEC 537), y `'AU'` para sonido audible en presencia de ultrasonidos
+(IEC 61012).
 
 ## ¿Cómo aplico la ponderación A a una señal con Python?
 
@@ -182,10 +187,9 @@ weighted_signal = metrology.weighting_filter(recording, fs, curve='A')
 c_weighted_signal = metrology.weighting_filter(recording, fs, curve='C')
 ```
 
-El resto de la familia tiene su propia guía:
-[Ponderaciones especiales](/phonometry/es/guides/special-weightings/): la
-curva G de infrasonido de ISO 7196, las históricas B y D, y la AU para
-sonido audible en presencia de ultrasonidos.
+Las ponderaciones especiales usan el mismo argumento `curve`; cada una está
+documentada, con su propia gráfica de respuesta, en
+[Ponderaciones especiales](/phonometry/es/guides/special-weightings/).
 
 ## 3. Parámetros de `weighting_filter()` / `WeightingFilter`
 

--- a/site/src/content/docs/es/reference/theory/signal-analysis.md
+++ b/site/src/content/docs/es/reference/theory/signal-analysis.md
@@ -277,9 +277,9 @@ modo `high_accuracy` por defecto diseña y ejecuta el filtro a una frecuencia
 interna sobremuestreada (≥ 144 kHz); consulta
 [Ponderación frecuencial](/phonometry/es/guides/weighting/).
 
-<img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/weighting_responses_es.svg" alt="Curvas de ponderación A, B, C, D, AU y Z con zoom de la región positiva de la curva A (+1,27 dB en 2,5 kHz)" style="width:80%" loading="lazy"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/weighting_responses_es_dark.svg" alt="Curvas de ponderación A, B, C, D, AU y Z con zoom de la región positiva de la curva A (+1,27 dB en 2,5 kHz)" style="width:80%" loading="lazy">
+<img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/weighting_responses_es.svg" alt="Curvas de ponderación A, C y Z de IEC 61672-1 con zoom de la región positiva de la curva A (+1,27 dB en 2,5 kHz)" style="width:80%" loading="lazy"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/weighting_responses_es_dark.svg" alt="Curvas de ponderación A, C y Z de IEC 61672-1 con zoom de la región positiva de la curva A (+1,27 dB en 2,5 kHz)" style="width:80%" loading="lazy">
 
-*Las curvas de ponderación que aplica la biblioteca, con la pequeña región positiva de la curva A ampliada.*
+*Las tres curvas de ponderación de IEC 61672-1 que aplica la biblioteca, con la pequeña región positiva de la curva A ampliada. Las curvas especiales B, D y AU están en [Ponderaciones especiales](/phonometry/es/guides/special-weightings/).*
 
 ## Integración temporal
 

--- a/site/src/content/docs/guides/special-weightings.mdx
+++ b/site/src/content/docs/guides/special-weightings.mdx
@@ -116,7 +116,52 @@ L<sub>pG</sub> (or L<sub>Geq</sub> for the equivalent level over time).
 
 ## 2. Historical and special-purpose curves: B, D and AU
 
-Three more curves complete the family.
+Three more curves complete the family. All three work in the audible range,
+so they share one chart, drawn against the A curve because that is what each
+of them is defined or described against: B as the curve between A and C, D as
+the one with a hump A does not have, AU as A itself with a low-pass added.
+
+<ThemeImage src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/special_weighting_responses.svg" alt="B, D and AU weighting curves measured at 96 kHz against a wide grey A-weighting reference, with the +11.5 dB D hump at 3.15 kHz and the AU cutoff 13 dB below A at 16 kHz annotated" width="80%" />
+
+*The three curves against the A reference (wide grey), measured at 96 kHz so
+the axis reaches the 40 kHz where IEC 61012 still specifies the U low-pass.
+B (green, dashed) discards less bass than A; D (purple) carries the +11.5 dB
+hump at 3.15 kHz where jet turbomachinery whine annoys most; AU (orange) runs
+inside the A reference up to 10 kHz and then falls away with U, reaching 13 dB
+below A at 16 kHz. The infrasound G curve keeps its own chart in section 1,
+and A, C and Z are in
+[Frequency Weighting](/phonometry/guides/weighting/).*
+
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from phonometry import metrology
+
+# Measure each curve's response: weight a centered unit impulse and take its
+# spectrum. 96 kHz, not 48 kHz: it reaches the 40 kHz top row of the
+# IEC 61012 U-weighting table, which is the whole point of AU.
+fs = 96000
+impulse = np.zeros(fs)
+impulse[fs // 2] = 1.0
+freqs = np.fft.rfftfreq(fs, 1 / fs)
+
+fig, ax = plt.subplots(figsize=(9, 5))
+# A goes first and wide, as the reference the other three are read against.
+for curve, width in (("A", 4.0), ("B", 1.8), ("D", 1.8), ("AU", 1.8)):
+    spectrum = np.fft.rfft(metrology.weighting_filter(impulse, fs, curve=curve))
+    ax.semilogx(freqs[1:], 20 * np.log10(np.abs(spectrum[1:]) + np.finfo(float).eps),
+                label=curve, linewidth=width)
+ax.set(xlim=(10, 40000), ylim=(-90, 18),
+       xlabel="Frequency [Hz]", ylabel="Response [dB]")
+ax.grid(True, which="both", alpha=0.3)
+ax.legend()
+plt.show()
+```
+
+</details>
 
 ### B (ANSI S1.4-1983, historical)
 

--- a/site/src/content/docs/guides/weighting.mdx
+++ b/site/src/content/docs/guides/weighting.mdx
@@ -37,12 +37,14 @@ Table 3 class verification. The rest of the family, the infrasound G curve,
 the historical B and D and the AU curve, is
 [Special Weightings](/phonometry/guides/special-weightings/).
 
-<ThemeImage src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/weighting_responses.svg" alt="A, B, C, D, AU and Z frequency weighting curves with a zoom showing the positive region of the A curve (+1.27 dB at 2.5 kHz)" width="80%" loading="eager" />
+<ThemeImage src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/weighting_responses.svg" alt="A, C and Z frequency weighting curves of IEC 61672-1 with a zoom showing the positive region of the A curve (+1.27 dB at 2.5 kHz)" width="80%" loading="eager" />
 
-*The audible-range weighting family measured on one chart. This guide covers
-the A, C and Z responses; the B, D and AU curves drawn alongside them, and
-the infrasound G curve, are the subject of
-[Special Weightings](/phonometry/guides/special-weightings/).*
+*The three curves of IEC 61672-1, measured through the library's own filters
+at 48 kHz: A, which discards the bass; C, which keeps it; and Z, which
+weights nothing at all. The inset magnifies the small positive region of A
+around 2.5 kHz. The special B, D and AU curves have their own chart in
+[Special Weightings](/phonometry/guides/special-weightings/), together with
+the infrasound G curve.*
 
 <details>
 <summary>Show the code for this figure</summary>
@@ -60,11 +62,11 @@ impulse[fs // 2] = 1.0
 freqs = np.fft.rfftfreq(fs, 1 / fs)
 
 fig, ax = plt.subplots(figsize=(9, 5))
-for curve in ("A", "B", "C", "D", "AU", "Z"):
+for curve in ("A", "C", "Z"):
     spectrum = np.fft.rfft(metrology.weighting_filter(impulse, fs, curve=curve))
     ax.semilogx(freqs[1:], 20 * np.log10(np.abs(spectrum[1:]) + np.finfo(float).eps),
                 label=curve)
-ax.set(xlim=(10, 20000), ylim=(-80, 15),
+ax.set(xlim=(10, 22000), ylim=(-72, 15),
        xlabel="Frequency [Hz]", ylabel="Response [dB]")
 ax.grid(True, which="both", alpha=0.3)
 ax.legend()
@@ -76,10 +78,12 @@ plt.show()
 * **A-Weighting (`A`):** Standard for environmental noise (IEC 61672-1).
 * **C-Weighting (`C`):** Used for peak sound pressure and high-level noise.
 * **Z-Weighting (`Z`):** Zero weighting, completely flat response.
-* **G-Weighting (`G`):** Infrasound weighting per ISO 7196 ([Special Weightings](/phonometry/guides/special-weightings/)).
-* **B-Weighting (`B`):** Historical middle curve of ANSI S1.4-1983 ([Special Weightings](/phonometry/guides/special-weightings/)).
-* **D-Weighting (`D`):** Aircraft-noise weighting of the withdrawn IEC 537 ([Special Weightings](/phonometry/guides/special-weightings/)).
-* **AU-Weighting (`AU`):** A-weighting with the IEC 61012 ultrasound cutoff ([Special Weightings](/phonometry/guides/special-weightings/)).
+
+The `curve` argument also accepts the four special weightings, charted and
+documented in [Special Weightings](/phonometry/guides/special-weightings/):
+`'G'` for infrasound (ISO 7196), the historical `'B'` (ANSI S1.4-1983) and
+`'D'` (IEC 537), and `'AU'` for audible sound in the presence of ultrasound
+(IEC 61012).
 
 ## How do I apply A-weighting to a signal in Python?
 
@@ -179,10 +183,9 @@ weighted_signal = metrology.weighting_filter(recording, fs, curve='A')
 c_weighted_signal = metrology.weighting_filter(recording, fs, curve='C')
 ```
 
-The rest of the family has its own guide:
-[Special Weightings](/phonometry/guides/special-weightings/): the
-infrasound G curve of ISO 7196, the historical B and D, and AU for
-audible sound in the presence of ultrasound.
+The special weightings take the same `curve` argument; each is documented,
+with its own response chart, in
+[Special Weightings](/phonometry/guides/special-weightings/).
 
 ## 3. `weighting_filter()` / `WeightingFilter` parameters
 

--- a/site/src/content/docs/reference/theory/signal-analysis.md
+++ b/site/src/content/docs/reference/theory/signal-analysis.md
@@ -273,9 +273,9 @@ transform. Because the bilinear transform compresses frequencies near Nyquist,
 the default `high_accuracy` mode designs and runs the filter at an internally
 oversampled rate (≥ 144 kHz); see [Frequency Weighting](/phonometry/guides/weighting/).
 
-<img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/weighting_responses.svg" alt="A, B, C, D, AU and Z frequency weighting curves with a zoom showing the positive region of the A curve (+1.27 dB at 2.5 kHz)" style="width:80%" loading="lazy"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/weighting_responses_dark.svg" alt="A, B, C, D, AU and Z frequency weighting curves with a zoom showing the positive region of the A curve (+1.27 dB at 2.5 kHz)" style="width:80%" loading="lazy">
+<img class="light-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/weighting_responses.svg" alt="A, C and Z frequency weighting curves of IEC 61672-1 with a zoom showing the positive region of the A curve (+1.27 dB at 2.5 kHz)" style="width:80%" loading="lazy"><img class="dark-only" src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/weighting_responses_dark.svg" alt="A, C and Z frequency weighting curves of IEC 61672-1 with a zoom showing the positive region of the A curve (+1.27 dB at 2.5 kHz)" style="width:80%" loading="lazy">
 
-*The weighting curves realized by the library, with the small positive region of the A curve magnified.*
+*The three IEC 61672-1 weighting curves realized by the library, with the small positive region of the A curve magnified. The special B, D and AU curves are charted in [Special Weightings](/phonometry/guides/special-weightings/).*
 
 ## Time Integration
 

--- a/tests/test_graph_measurements.py
+++ b/tests/test_graph_measurements.py
@@ -9,16 +9,32 @@ These tests call the ACTUAL graph measurement helper, so CI breaks if the
 figures would ship distorted curves again.
 """
 
+import math
 import pathlib
 import sys
 
 import numpy as np
 import pytest
+from reference_data import (
+    ANSIS14_TABLE4_B,
+    ANSIS14_TABLE5,
+    IEC537_NASA_TABLE_SLD1,
+    IEC61012_TABLE1,
+)
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "scripts"))
 import generate_graphs
 
 FS = 48000
+#: Sample rate of the special-curves figure (B, D, AU). It runs at 96 kHz, not
+#: the 48 kHz of the IEC 61672-1 figure, because the IEC 61012 U low-pass that
+#: makes AU what it is is specified up to 40 kHz.
+SPECIAL_FS = 96000
+
+
+def _exact(freq: float) -> float:
+    """Exact base-10 frequency behind a nominal one-third-octave label."""
+    return float(10.0 ** (round(10.0 * math.log10(freq)) / 10.0))
 
 
 def _analytic_a_db(f: np.ndarray) -> np.ndarray:
@@ -73,3 +89,63 @@ def test_graph_curves_anchor_at_1khz() -> None:
     for curve in ("A", "C"):
         _, mag = generate_graphs.measure_weighting_response(FS, curve, np.array([1000.0]))
         assert mag[0] == pytest.approx(0.0, abs=0.1), f"{curve} at 1 kHz: {mag[0]:+.2f} dB"
+
+
+def test_graph_b_curve_matches_published_table() -> None:
+    """
+    The B trace of the special-curves figure, against its published table.
+
+    Oracle: ANSI S1.4-1983 Table IV design goals (B column) with the Table V
+    Type 0 tolerance, evaluated at the exact base-10 frequency behind each
+    nominal label (the standard's rows are labels for 1000*10**(n/10) Hz).
+    """
+    freqs = np.array([_exact(row[0]) for row in ANSIS14_TABLE4_B])
+    _, mag = generate_graphs.measure_weighting_response(SPECIAL_FS, "B", freqs)
+    for (freq, goal), limits, got in zip(
+        ANSIS14_TABLE4_B, ANSIS14_TABLE5, mag, strict=True
+    ):
+        upper0, lower0 = limits[1], limits[2]
+        assert lower0 <= got - goal <= upper0, (
+            f"B at {freq:.0f} Hz deviates {got - goal:+.2f} dB from the "
+            f"Table IV goal, outside the Type 0 mask"
+        )
+
+
+def test_graph_d_curve_matches_published_table() -> None:
+    """
+    The D trace of the special-curves figure, including the annotated hump.
+
+    Oracle: the IEC 537:1976 one-third-octave table republished in NASA
+    CR-3406 Table SLD-I, whose maximum is the +11.5 dB at 3.15 kHz the
+    figure annotates. The 1600 Hz and 2500 Hz cells round a different source
+    curve (see ``reference_data``), hence the wider bound there.
+    """
+    freqs = np.array([f for f, _ in IEC537_NASA_TABLE_SLD1])
+    _, mag = generate_graphs.measure_weighting_response(SPECIAL_FS, "D", freqs)
+    for (freq, value), got in zip(IEC537_NASA_TABLE_SLD1, mag, strict=True):
+        bound = 0.45 if freq in (1600, 2500) else 0.25
+        assert got == pytest.approx(value, abs=bound), f"D at {freq:.0f} Hz"
+    peak = max(value for _, value in IEC537_NASA_TABLE_SLD1)
+    assert peak == 11.5, "the annotated +11.5 dB hump left the table"
+
+
+def test_graph_au_trace_is_a_plus_the_u_lowpass() -> None:
+    """
+    AU must sit on the A reference through the audible range, then cut.
+
+    Oracle: IEC 61012:1990 Table 1, the nominal relative response of the U
+    weighting as a separate unit with its per-row tolerance. AU is A
+    cascaded with U (subclause 2.2), so the difference between the figure's
+    own AU and A traces is the U response. The extra 0,2 dB of slack covers
+    the 1 kHz row, whose published tolerance is exactly zero.
+    """
+    rows = [row for row in IEC61012_TABLE1
+            if row[0] in (1000.0, 8000.0, 16000.0, 20000.0, 40000.0)]
+    freqs = np.array([row[0] for row in rows])
+    _, mag_au = generate_graphs.measure_weighting_response(SPECIAL_FS, "AU", freqs)
+    _, mag_a = generate_graphs.measure_weighting_response(SPECIAL_FS, "A", freqs)
+    for (freq, nominal, upper, lower), u_db in zip(rows, mag_au - mag_a, strict=True):
+        assert nominal + lower - 0.2 <= u_db <= nominal + upper + 0.2, (
+            f"U response at {freq:.0f} Hz is {u_db:+.2f} dB, outside the "
+            f"IEC 61012 Table 1 band {nominal + lower:+.1f}/{nominal + upper:+.1f} dB"
+        )


### PR DESCRIPTION
The frequency-weighting guide and the special-weightings guide shared one
chart drawing A, B, C, D, AU and Z together. Each page therefore showed four
curves it does not document, and the prose on both had to keep apologising
for the ones the reader was looking at but would not find explained there.

## Figures

`weighting_responses` now holds only the three curves of **IEC 61672-1**. With
B, D and AU gone nothing forces the floor up any more, so it drops from -50 to
-72 dB and the A curve fits on the axis instead of running off the bottom-left
corner at 10 Hz. Z is dashed so it reads as a curve rather than as the zero
line it sits on, and all three curves now appear in the positive-region inset
(it previously had to exclude the ones that did not fit).

`special_weighting_responses` is new and gives the special-weightings guide the
chart it never had: B, D and AU against a wide A reference, because A is what
each of the three is defined or described against (B as the curve between A and
C, D as the one with a hump A does not have, AU as A itself with a low-pass
added). It is measured at 96 kHz, not 48 kHz, so the axis reaches the 40 kHz
where **IEC 61012** still specifies the U low-pass that makes AU what it is;
a 48 kHz axis cut it off mid-slope. The +11.5 dB D hump at 3.15 kHz
(NASA CR-3406 Table SLD-I) and the 13 dB AU cutoff at 16 kHz (IEC 61012
Table 1) are annotated.

Both share a small `_draw_weighting_curves` helper, so the split adds one
figure without duplicating the drawing loop.

## Prose

Both guides are revised around the split, in English and Spanish:

- **Frequency Weighting**: the four bullet items that each ended in the same
  cross-link are gone, replaced by one sentence naming the special curves and
  where they live; the caption describes the three curves actually on the chart
  and says where the others are; the figure snippet, its axis limits and the
  alt text follow.
- **Special Weightings**: section 2 gains the description its curves now need,
  plus the chart, its caption and its reproducible snippet.
- The theory page keeps the same figure name (no churn in its embed) and gets
  the caption and alt text the split leaves true, with a pointer to the
  special-weightings chart.

## Tests

Three new graph-measurement guards run the figure's own measurement path at
96 kHz against published tables, in the spirit of the existing ones (that file
exists because a weighting figure once shipped curves 2.4 dB low): B against
the ANSI S1.4-1983 Table IV goals within the Table V Type 0 mask, D against the
IEC 537 curve republished in NASA CR-3406, and AU minus A against the IEC 61012
Table 1 nominal U response.

## Checks

`ruff check .`, `mypy src scripts`, `bandit -r src`, full `pytest` (6287
passed), `check_figures.py`, `check_figure_contrast.py`, conformance report and
claims, api-docs and llms regeneration, `check:i18n`, `pnpm build` and
`html-validate`. All four variants of both figures were rendered and inspected
in light and dark, English and Spanish.

## Summary by Sourcery

Split the audible-range weighting-family figure into separate charts for IEC 61672-1 A/C/Z and the special B/D/AU curves, and update documentation and tests accordingly.

New Features:
- Add a dedicated special-weighting chart plotting B, D and AU against an A-weighting reference at 96 kHz, including annotations for key standard-specified points.

Enhancements:
- Restrict the main frequency-weighting figure to the IEC 61672-1 A, C and Z curves with adjusted axis limits and dashed Z curve for clearer visualization.
- Introduce a shared helper for drawing weighting curves to avoid duplication between the two figures.
- Update English and Spanish guides and theory pages so each weighting guide shows and describes only the curves it documents, with revised captions, alt text and example code snippets.

Documentation:
- Document the new special-weightings chart and its interpretation in both English and Spanish guides and reference docs, and clarify how the standard A/C/Z curves and special curves are split between guides.

Tests:
- Extend graph-measurement tests to validate the B, D and AU traces of the new special-weightings figure against published ANSI, IEC and NASA tables, including checks for the AU–A difference matching the IEC 61012 U response.

Chores:
- Adjust graph-generation wiring and animation timings to include the new special-weighting figure and reflect its rendering cost.