### PR TITLE
Assert filter-bank reuse by design count, and split figure generation from its checks

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -34,7 +34,8 @@ Regenerated where this change touches them:
       `site/src/generated/api-sidebar.mjs` committed
 - [ ] `make llms`, with `llms.txt`, `llms-full.txt` and the shards under
       `site/public/llms/` committed
-- [ ] `make graphs`, with `python scripts/check_figures.py` passing
+- [ ] `make figures` (generation, then `scripts/check_figure_contrast.py` and
+      `scripts/check_figures.py`), with the regenerated images committed
       (figures come from `scripts/generate_graphs.py`, never by hand)
 - [ ] `make pypi-readme` after editing `README.md`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -600,6 +600,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- The filter-bank reuse test asserts the property it is named after instead of a
+  stopwatch. It used to compare `time.time()` deltas and require the class-based
+  path to stay within 1.5x of the functional one, which on a shared runner under
+  a parallel suite measures the scheduler: it failed on a macOS leg at
+  `0.351 < 0.233 * 1.5` while passing everywhere else. The design routine is now
+  counted directly, so the assertions read as the design cache is supposed to
+  behave: ten functional calls with the cache cleared design ten times, a bank
+  plus ten `filter()` calls design exactly once, and five identical
+  `octave_filter` calls share one design while a different sample rate makes a
+  second. Both paths are also compared band for band, so the reuse cannot be a
+  shortcut past the work. Timings are still printed on every run, with a
+  ten-fold guard that no scheduling noise can trip.
+
+- `make graphs` regenerates the figures and stops there. The legibility check it
+  used to end with is now `make figure-contrast`, and `make figures` runs
+  generation, legibility and staleness in that order, one step each, the way CI
+  does. Chaining the checker inside generation meant an illegible fill aborted
+  the generation step and skipped the staleness compare after it, so a single
+  bad fill on `main` reported itself as "the figures could not be regenerated"
+  and blocked every open branch at once.
+
 - Oracle test data: the two suites that only ran on a machine holding a private
   download now run everywhere. The certified IEC 60268-16 STIPA verification
   bench from stipa.info is 133 MB of PCM that does not compress as audio, so

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,6 +117,7 @@ the affected images together with the code change:
 
 ```bash
 make graphs   # runs both: python scripts/generate_graphs.py && python scripts/generate_diagrams.py
+make figures  # the same generation, then the legibility and staleness checks CI runs
 ```
 
 When adding a feature with visual output, add a `generate_*` function to

--- a/Makefile
+++ b/Makefile
@@ -60,9 +60,21 @@ graphs:
 	find .github/images -maxdepth 1 -type f \( -name '*.svg' -o -name '*.png' -o -name '*.webp' \) -delete
 	$(FIGURE_ENV) $(PYTHON) scripts/generate_graphs.py
 	$(FIGURE_ENV) $(PYTHON) scripts/generate_diagrams.py
-	# Every shaded region has to be visible against the page it is drawn on,
-	# on both themes; the staleness check cannot see that.
+
+# Every shaded region has to be visible against the page it is drawn on, on
+# both themes; the staleness check cannot see that. Deliberately a target of
+# its own rather than the tail of `graphs`: a contrast failure inside the
+# generation step aborts it, and everything meant to run after generation
+# (the staleness compare above all) is then skipped, so one illegible fill
+# reads as "the figures could not be regenerated" instead of "this fill is
+# invisible".
+figure-contrast:
 	$(PYTHON) scripts/check_figure_contrast.py
+
+# What to run locally before committing a figure change: regenerate, then
+# verify legibility and staleness the way CI does, each as its own step.
+figures: graphs figure-contrast
+	$(PYTHON) scripts/check_figures.py
 
 # Regenerate the Tier-1 documentation animations (WebM for the site, GIF for
 # the GitHub docs). Kept out of `graphs`/CI because the ffmpeg encoding is slow
@@ -157,5 +169,6 @@ coverage:
 
 check: lint security test
 
-.PHONY: install lint format security snyk sonar graphs reports animations posters brand lighthouse \
+.PHONY: install lint format security snyk sonar graphs figure-contrast figures reports \
+	animations posters brand lighthouse \
 	llms pypi-readme api-docs site-reports conformance install-hooks test coverage check

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,12 @@ figure-contrast:
 
 # What to run locally before committing a figure change: regenerate, then
 # verify legibility and staleness the way CI does, each as its own step.
-figures: graphs figure-contrast
+# Recipe lines rather than prerequisites: prerequisites are free to run
+# concurrently under `make -j`, which would let the contrast checker parse the
+# SVGs while the generators are still deleting and rewriting them.
+figures:
+	$(MAKE) graphs
+	$(MAKE) figure-contrast
 	$(PYTHON) scripts/check_figures.py
 
 # Regenerate the Tier-1 documentation animations (WebM for the site, GIF for

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,73 +1,146 @@
 #  Copyright (c) 2026. Jose M. Requena-Plens
 """
-Performance tests to verify coefficient reuse in OctaveFilterBank.
+Tests that the filter-bank design work is reused rather than repeated.
 """
 
 import time
+from typing import Any
 
 import numpy as np
+import pytest
 
 import phonometry
 from phonometry import OctaveFilterBank, octave_filter
+from phonometry.metrology import core
 
 
-def test_filterbank_reuse_performance() -> None:
+class _DesignCounter:
+    """Wraps ``_design_sos_filter`` and counts how often it is invoked."""
+
+    def __init__(self, inner: Any) -> None:
+        self._inner = inner
+        self.calls = 0
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        self.calls += 1
+        return self._inner(*args, **kwargs)
+
+
+@pytest.fixture
+def design_counter(monkeypatch: pytest.MonkeyPatch) -> _DesignCounter:
+    """Count filter designs, and start from a cold design cache."""
+    counter = _DesignCounter(core._design_sos_filter)
+    monkeypatch.setattr(core, "_design_sos_filter", counter)
+    core._cached_filter_bank.cache_clear()
+    return counter
+
+
+def test_filterbank_reuse_skips_redesign(design_counter: _DesignCounter) -> None:
     """
-    Verify that reusing OctaveFilterBank is faster than calling octave_filter multiple times.
-    
+    Verify that reusing OctaveFilterBank designs its coefficients exactly once.
+
     **Purpose:**
-    The refactored class-based approach allows pre-calculating SOS coefficients.
-    Subsequent filtering should be faster as it skips the design phase.
+    The class-based API exists so that the SOS design runs at construction and
+    every subsequent ``filter()`` call skips it. That is a property of the code
+    path, so it is asserted as one: the number of times the design routine runs.
+    An earlier version of this test compared ``time.time()`` deltas instead and
+    asserted the class path stayed within 1.5x of the functional one. Under a
+    parallel suite on a shared runner that measures the scheduler, not the
+    filter bank, and it failed on CI legs while passing locally.
 
     **Verification:**
-    - Perform 10 iterations of filtering using the functional API (which re-designs every time).
-    - Perform 10 iterations of filtering using a pre-initialized `OctaveFilterBank`.
-    - Measure and compare the total execution time.
-
-    **Expectation:**
-    - Class-based filtering (after initialization) must be significantly faster.
-    - Total time (init + 10 filters) should also be less than 10 functional calls.
+    - Ten functional calls with the design cache cleared each time re-design the
+      bank on every call.
+    - One ``OctaveFilterBank`` plus ten ``filter()`` calls design exactly once.
+    - Both paths return the same band levels, so the reuse is not a shortcut
+      around the work.
     """
     fs = 48000
-    duration = 0.5
     rng = np.random.default_rng(42)
-    x = rng.standard_normal(int(fs * duration))
+    x = rng.standard_normal(int(fs * 0.5))
     num_iterations = 10
-    
-    # 1. Using functional API with a cold design cache on every call.
-    # octave_filter() now caches bank designs, so clear it each iteration to
-    # measure the redesign cost this test is about.
+
+    # 1. Functional API with a cold design cache on every call: octave_filter()
+    #    caches bank designs, so clearing it isolates the redesign cost.
+    for _ in range(num_iterations):
+        core._cached_filter_bank.cache_clear()
+        spl_func, freq_func = octave_filter(x, fs)
+    assert design_counter.calls == num_iterations
+
+    # 2. The class designs once at construction and never again.
+    design_counter.calls = 0
+    bank = OctaveFilterBank(fs)
+    assert design_counter.calls == 1
+    for _ in range(num_iterations):
+        spl_class, freq_class = bank.filter(x)
+    assert design_counter.calls == 1, "filter() must not re-design the bank"
+
+    # 3. Reuse is not a shortcut: the two paths agree band for band.
+    assert freq_class == freq_func
+    np.testing.assert_allclose(spl_class, spl_func)
+
+
+def test_octave_filter_cache_reuses_the_bank(design_counter: _DesignCounter) -> None:
+    """
+    Verify that repeated ``octave_filter`` calls share one design.
+
+    **Purpose:**
+    ``_cached_filter_bank`` is what makes the functional API affordable in a
+    loop. Without it every call would pay a full design, which is the cost the
+    class-based API was introduced to avoid.
+
+    **Verification:**
+    Five identical calls, cache left warm, must design the bank once; a call
+    with a different sample rate is a different bank and designs again.
+    """
+    fs = 48000
+    rng = np.random.default_rng(7)
+    x = rng.standard_normal(fs // 4)
+
+    for _ in range(5):
+        octave_filter(x, fs)
+    assert design_counter.calls == 1
+
+    octave_filter(x[: fs // 8], 24000)
+    assert design_counter.calls == 2
+
+
+def test_filterbank_reuse_is_not_slower() -> None:
+    """
+    Report the wall-clock cost of both paths, without gating on it.
+
+    **Purpose:**
+    The timings are what a reader of this file wants to see, and they are worth
+    printing on every run; they are not worth failing a build over, because a
+    shared runner under a parallel suite can stretch either path arbitrarily.
+    The gate is the design count in the tests above. This one only fails if the
+    class path is more than an order of magnitude slower than the functional
+    one, which no scheduling noise explains and which would mean the reuse has
+    stopped being a saving at all.
+    """
+    fs = 48000
+    rng = np.random.default_rng(42)
+    x = rng.standard_normal(int(fs * 0.5))
+    num_iterations = 10
+
     start_func = time.time()
     for _ in range(num_iterations):
         phonometry.metrology.core._cached_filter_bank.cache_clear()
         octave_filter(x, fs)
     time_func = time.time() - start_func
-    
-    # 2. Using FilterBank class (designs once)
+
     start_class_init = time.time()
     bank = OctaveFilterBank(fs)
     time_class_init = time.time() - start_class_init
-    
+
     start_class_filter = time.time()
     for _ in range(num_iterations):
         bank.filter(x)
     time_class_filter = time.time() - start_class_filter
-    
-    time_class_total = time_class_init + time_class_filter
-    
+
     print(f"\nFunctional API Time: {time_func:.4f}s")
     print(f"Class Init Time: {time_class_init:.4f}s")
     print(f"Class Filter Only Time: {time_class_filter:.4f}s")
-    print(f"Class Total Time: {time_class_total:.4f}s")
-    
-    # The class-based filtering (after init) should not be slower than the
-    # functional API calls which include a full redesign every time. Wall-clock
-    # timing on shared CI runners jitters, and the two paths can land within
-    # fractions of a millisecond of each other, so a zero-margin comparison
-    # flakes; a 1.5x allowance still fails if the design cache regresses (a
-    # redesign per call costs ~10x the filtering itself).
-    assert time_class_filter < time_func * 1.5
+    print(f"Class Total Time: {time_class_init + time_class_filter:.4f}s")
 
-    # Even including init, it should be comparable or better for multiple
-    # iterations (same 1.5x jitter allowance as above).
-    assert time_class_total < time_func * 1.5
+    assert time_class_filter < time_func * 10.0


### PR DESCRIPTION
Two testing gates that answered a narrower question than the one they were asked.

## The filter-bank reuse test was a stopwatch

`test_filterbank_reuse_performance` asserted `time_class_filter < time_func * 1.5` on
`time.time()` deltas over ten iterations. Under a parallel suite on a shared runner that
measures the scheduler, not the filter bank: it failed on a macOS 3.13 leg at
`0.351 < 0.233 * 1.5` while passing locally and on every other leg.

The property the test is named after is now asserted directly, by counting calls into
`_design_sos_filter`:

- ten functional calls with the design cache cleared design the bank ten times;
- one `OctaveFilterBank` plus ten `filter()` calls design it exactly once;
- five identical `octave_filter` calls share one design, and a different sample rate makes
  a second.

Both paths are also compared band for band, so the reuse cannot be a shortcut past the
work rather than a saving on it. The timings still print on every run, since they are what
a reader of this file wants to see, now with a ten-fold guard that no scheduling noise can
trip.

I checked that the new assertions can fail, rather than assuming it. Setting
`lru_cache(maxsize=0)` on `_cached_filter_bank` fails `test_octave_filter_cache_reuses_the_bank`
with `assert 5 == 1`; injecting a redesign into `filter()` fails both design-count tests
with `assert 20 == 10` and `assert 6 == 1`.

## `make graphs` ended by verifying, so a verification failure looked like a generation failure

The contrast checker ran as the last line of the `graphs` target. A failure there aborts
the generation step, and everything meant to run after generation, the staleness compare
above all, is then skipped. That is how one illegible fill on `main` reported itself as
"the figures could not be regenerated" and blocked every open branch at once.

Generation and verification are separate targets now: `graphs` regenerates,
`figure-contrast` checks legibility, and `figures` runs generation, legibility and
staleness in that order, one step each, the way the workflow does. The figures job already
ran the contrast check as its own step, so it needed no change; the pull-request template
and CONTRIBUTING now point at `make figures`.

## Verification

`ruff check .`, `mypy src scripts`, `bandit -r src`, `make figure-contrast` (2258 filled
regions in 1324 figures clear dE00 10) and the full suite, 7002 passed and 15 skipped.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Tests**
  - Strengthened filter-bank reuse validation using design-call counting and functional equivalence, replacing the prior timing-sensitive assertion.
  - Added more granular performance reporting with a less strict slowdown threshold.

- **Chores**
  - Reorganized figure generation and verification into clearer steps: `make graphs`, `make figure-contrast`, and `make figures`.
  - Updated contributor guidance and the changelog to reflect the new figure/legibility/staleness workflow.

- **Documentation**
  - Adjusted the pull request checklist to use “make figures” instead of “make graphs”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->