### PR TITLE
Restore the six sections a stray math delimiter had swallowed

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -69,6 +69,15 @@ jobs:
       - name: Validate HTML
         run: pnpm run html-validate
         working-directory: site
+      - name: Check every formula rendered
+        # KaTeX does not fail a build on a parse error: it emits a
+        # `katex-error` span and ships the page. A display block whose `$$`
+        # sits on a content line is worse than mis-rendered, because the
+        # parser then eats the rest of the document; that silently cost one
+        # guide six sections in both locales. HTML validation and the
+        # accessibility audit both pass on such a page.
+        run: pnpm run check:math
+        working-directory: site
       - name: Accessibility audit (pa11y, WCAG2AA)
         run: pnpm run pa11y
         working-directory: site

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -612,6 +612,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- The Spanish building-code guide had lost six of its sections, in both
+  languages, since the day a display formula was written with its `$$` on the
+  same line as the first term. Nothing complained: KaTeX does not fail a build
+  on a parse error, it emits an error span and ships the page, and here the
+  parser ran past the end of the formula and swallowed the requirements of
+  clause 2, windows and composite facades, the plots, what the guide covers,
+  the See also and the quick answers. HTML validation and the accessibility
+  audit passed on that page throughout, because both were answering a different
+  question. The delimiters now sit on their own lines, as the other 416 display
+  blocks in the documentation already did, and `site/scripts/check-math-render.mjs`
+  fails the build on any `katex-error` span left in the output or any `$$` that
+  shares a line with content.
+
 - The conformance counts quoted outside the report are generated, not typed.
   `docs/CONFORMANCE.md` has always been the authority for "N/N conformance
   checks pass across D domains and S standards", and the Astro page bodies

--- a/docs/spanish-building-code.md
+++ b/docs/spanish-building-code.md
@@ -100,9 +100,11 @@ DB-HR and ISO 717-1 reach the same place by different routes, and Annex H of
 the document itself accepts three approximations as long as the two routes
 differ by less than 1 dB:
 
-$$D_{nT,A} \approx D_{nT,w} + C \quad (H.1), \qquad
+$$
+D_{nT,A} \approx D_{nT,w} + C \quad (H.1), \qquad
 D_{2m,nT,A} \approx D_{2m,nT,w} + C \quad (H.2), \qquad
-D_{2m,nT,Atr} \approx D_{2m,nT,w} + C_{tr} \quad (H.3)$$
+D_{2m,nT,Atr} \approx D_{2m,nT,w} + C_{tr} \quad (H.3)
+$$
 
 with (H.2) covering the rail-dominant case of the previous section. On the two
 published spectra this page reproduces, the agreement is exact to the integer:

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -31721,9 +31721,11 @@ DB-HR and ISO 717-1 reach the same place by different routes, and Annex H of
 the document itself accepts three approximations as long as the two routes
 differ by less than 1 dB:
 
-$$D_{nT,A} \approx D_{nT,w} + C \quad (H.1), \qquad
+$$
+D_{nT,A} \approx D_{nT,w} + C \quad (H.1), \qquad
 D_{2m,nT,A} \approx D_{2m,nT,w} + C \quad (H.2), \qquad
-D_{2m,nT,Atr} \approx D_{2m,nT,w} + C_{tr} \quad (H.3)$$
+D_{2m,nT,Atr} \approx D_{2m,nT,w} + C_{tr} \quad (H.3)
+$$
 
 with (H.2) covering the rail-dominant case of the previous section. On the two
 published spectra this page reproduces, the agreement is exact to the integer:

--- a/site/package.json
+++ b/site/package.json
@@ -7,6 +7,7 @@
     "prebuild": "node scripts/stage-media.mjs && node scripts/copy-llms.mjs",
     "postbuild": "node scripts/add-sitemap-lastmod.mjs && node scripts/fix-redirect-doctype.mjs && node scripts/optimize-images.mjs && node scripts/emit-page-markdown.mjs",
     "check:i18n": "node scripts/check-i18n-parity.mjs",
+    "check:math": "node scripts/check-math-render.mjs",
     "dev": "astro dev",
     "build": "astro build",
     "identity:sync": "node scripts/sync-identity.mjs",

--- a/site/public/llms/llms-sound-insulation.txt
+++ b/site/public/llms/llms-sound-insulation.txt
@@ -2749,9 +2749,11 @@ DB-HR and ISO 717-1 reach the same place by different routes, and Annex H of
 the document itself accepts three approximations as long as the two routes
 differ by less than 1 dB:
 
-$$D_{nT,A} \approx D_{nT,w} + C \quad (H.1), \qquad
+$$
+D_{nT,A} \approx D_{nT,w} + C \quad (H.1), \qquad
 D_{2m,nT,A} \approx D_{2m,nT,w} + C \quad (H.2), \qquad
-D_{2m,nT,Atr} \approx D_{2m,nT,w} + C_{tr} \quad (H.3)$$
+D_{2m,nT,Atr} \approx D_{2m,nT,w} + C_{tr} \quad (H.3)
+$$
 
 with (H.2) covering the rail-dominant case of the previous section. On the two
 published spectra this page reproduces, the agreement is exact to the integer:

--- a/site/scripts/check-math-render.mjs
+++ b/site/scripts/check-math-render.mjs
@@ -1,0 +1,139 @@
+// Fail the build when a formula did not render.
+//
+// KaTeX does not stop a build when it cannot parse an expression: with
+// `throwOnError` off, rehype-katex emits `<span class="katex-error">` carrying
+// the parse message as its title and the page ships. Worse, a display block
+// whose `$$` delimiters sit on a content line is not merely mis-rendered: the
+// parser consumes the rest of the document as math, so `spanish-building-code`
+// silently lost **six** `## ` sections and everything after them, in both
+// locales, for as long as it took someone to read that page to the end.
+//
+// Nothing in the pipeline noticed. `html-validate` sees well-formed markup and
+// pa11y sees an accessible page; both are right, and both are answering a
+// different question. This script asks the one that matters: did every formula
+// on the site actually render?
+//
+// It also flags the delimiter shape that caused it, in the sources rather than
+// in the output, because that failure is silent by construction: a display
+// block must open and close on its own line. Every one of the site's other
+// display blocks already does.
+//
+// Usage: node scripts/check-math-render.mjs [--dist dist] [--sources ../docs ../site]
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SITE = resolve(HERE, '..');
+const REPO = resolve(SITE, '..');
+
+/** Every file under `root` whose name ends in one of `exts`. */
+function walk(root, exts, out = []) {
+  let entries;
+  try {
+    entries = readdirSync(root, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) {
+      // `superpowers/` is gitignored working notes, not published prose.
+      if (entry.name === 'node_modules' || entry.name === '.astro') continue;
+      if (entry.name === 'superpowers') continue;
+      walk(path, exts, out);
+    } else if (exts.some((ext) => entry.name.endsWith(ext))) {
+      out.push(path);
+    }
+  }
+  return out;
+}
+
+/** Parse errors KaTeX left in the built HTML, with the message it recorded. */
+function renderFailures(distDir) {
+  const failures = [];
+  for (const file of walk(distDir, ['.html'])) {
+    const html = readFileSync(file, 'utf8');
+    if (!html.includes('katex-error')) continue;
+    // The parse message is the title attribute of the offending span.
+    const messages = [...html.matchAll(/class="katex-error"[^>]*title="([^"]*)"/g)].map(
+      (m) => m[1],
+    );
+    failures.push({
+      file: relative(REPO, file),
+      count: Math.max(messages.length, 1),
+      messages: [...new Set(messages)].slice(0, 3),
+    });
+  }
+  return failures;
+}
+
+/**
+ * Display blocks whose delimiters share a line with content.
+ *
+ * Inline `$$...$$` complete on one line is fine; what breaks the parser is a
+ * block that opens or closes on a line carrying other content.
+ */
+function delimiterProblems(sourceDirs) {
+  const problems = [];
+  for (const dir of sourceDirs) {
+    for (const file of walk(dir, ['.md', '.mdx'])) {
+      const lines = readFileSync(file, 'utf8').split('\n');
+      let inFence = false;
+      lines.forEach((line, index) => {
+        if (/^\s*(```|~~~)/.test(line)) inFence = !inFence;
+        if (inFence) return;
+        // Prose that talks *about* `$$` writes it inside a code span.
+        const trimmed = line.replace(/`[^`]*`/g, '').trim();
+        if (!trimmed.includes('$$')) return;
+        const only = trimmed === '$$';
+        const complete = /^\$\$.*\$\$$/.test(trimmed) && trimmed.length > 4;
+        if (only || complete) return;
+        problems.push({
+          file: relative(REPO, file),
+          line: index + 1,
+          text: trimmed.slice(0, 72),
+        });
+      });
+    }
+  }
+  return problems;
+}
+
+const args = process.argv.slice(2);
+const distArg = args.indexOf('--dist');
+const distDir = resolve(SITE, distArg === -1 ? 'dist' : args[distArg + 1]);
+const sourceDirs = [join(REPO, 'docs'), join(SITE, 'src', 'content')];
+
+const failures = renderFailures(distDir);
+const problems = delimiterProblems(sourceDirs);
+
+if (failures.length === 0 && problems.length === 0) {
+  console.log('Math renders: no KaTeX parse errors in the build, no stray display delimiters.');
+  process.exit(0);
+}
+
+if (failures.length > 0) {
+  console.error(
+    `\n${failures.length} built page(s) contain a formula KaTeX could not parse.\n` +
+      'The page still ships, and everything after the bad block may be swallowed:\n',
+  );
+  for (const failure of failures) {
+    console.error(`  ${failure.file}: ${failure.count} error(s)`);
+    for (const message of failure.messages) console.error(`      ${message}`);
+  }
+}
+
+if (problems.length > 0) {
+  console.error(
+    `\n${problems.length} display-math delimiter(s) share a line with content.\n` +
+      'A `$$` block must open and close on its own line, or the parser runs on\n' +
+      'past the end of the formula and eats the rest of the document:\n',
+  );
+  for (const problem of problems) {
+    console.error(`  ${problem.file}:${problem.line}: ${problem.text}`);
+  }
+}
+
+process.exit(1);

--- a/site/src/content/docs/es/guides/spanish-building-code.mdx
+++ b/site/src/content/docs/es/guides/spanish-building-code.mdx
@@ -129,9 +129,11 @@ El DB HR y la ISO 717-1 llegan al mismo sitio por caminos distintos, y el
 anejo H del propio documento admite tres aproximaciones mientras la diferencia
 entre ambas vías sea menor que 1 dB:
 
-$$D_{nT,A} \approx D_{nT,w} + C \quad (H.1), \qquad
+$$
+D_{nT,A} \approx D_{nT,w} + C \quad (H.1), \qquad
 D_{2m,nT,A} \approx D_{2m,nT,w} + C \quad (H.2), \qquad
-D_{2m,nT,Atr} \approx D_{2m,nT,w} + C_{tr} \quad (H.3)$$
+D_{2m,nT,Atr} \approx D_{2m,nT,w} + C_{tr} \quad (H.3)
+$$
 
 donde la (H.2) cubre el caso de ferrocarril dominante del apartado anterior.
 En los dos espectros publicados que reproduce esta página, la coincidencia es

--- a/site/src/content/docs/guides/spanish-building-code.mdx
+++ b/site/src/content/docs/guides/spanish-building-code.mdx
@@ -125,9 +125,11 @@ DB-HR and ISO 717-1 reach the same place by different routes, and Annex H of
 the document itself accepts three approximations as long as the two routes
 differ by less than 1 dB:
 
-$$D_{nT,A} \approx D_{nT,w} + C \quad (H.1), \qquad
+$$
+D_{nT,A} \approx D_{nT,w} + C \quad (H.1), \qquad
 D_{2m,nT,A} \approx D_{2m,nT,w} + C \quad (H.2), \qquad
-D_{2m,nT,Atr} \approx D_{2m,nT,w} + C_{tr} \quad (H.3)$$
+D_{2m,nT,Atr} \approx D_{2m,nT,w} + C_{tr} \quad (H.3)
+$$
 
 with (H.2) covering the rail-dominant case of the previous section. On the two
 published spectra this page reproduces, the agreement is exact to the integer:


### PR DESCRIPTION
Closes #452.

The display block of Annex H in the Spanish building-code guide opened with its
`$$` on the same line as the first term and closed on the last one. `remark-math`
then ran past the end of the formula and consumed the rest of the document, so
the published page ended at the rounding section **in both languages**. Six `##`
sections were missing from the site: the requirements of clause 2, windows and
composite facades, the plots, what the guide covers, the See also, and the quick
answers.

The formula itself is valid: `katex.renderToString` accepts it verbatim. Only the
delimiter placement was wrong, and every one of the other 416 display blocks in
the documentation already opens and closes on its own line.

## Nothing in the pipeline noticed, so this adds the check that would have

KaTeX does not fail a build on a parse error. With `throwOnError` off it emits a
`<span class="katex-error">` carrying the parse message and ships the page.
`html-validate` sees well-formed markup and pa11y sees an accessible page: both
pass, and both are answering a different question.

`site/scripts/check-math-render.mjs` asks the one that matters, from two sides:

- **the output**: any `katex-error` span left in `dist`, reported with the parse
  message KaTeX recorded and the page it is on;
- **the sources**: any `$$` sharing a line with content, which is the shape that
  makes the failure silent in the first place. Inline `$$...$$` completed on one
  line is fine; code spans and fenced blocks that merely talk about `$$` are not
  flagged.

Wired in as `pnpm run check:math` and run in the docs workflow right after the
HTML validation.

## Verification

Rebuilt the site: 0 `katex-error` occurrences anywhere in `dist`, and both pages
now render all ten `h2` sections, English and Spanish. Reintroducing the original
delimiter makes the check exit 1 and name the file and line.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

