### PR TITLE
Write printed values with the point Python actually emits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -897,6 +897,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Twenty-nine comments in the Spanish guides wrote a value the code prints with
+  a decimal comma, so the page promised `132,4 Hz` where running the snippet
+  gives `132.4`. Python has no locale in `print`, and the comment next to a
+  `print` call is a claim about its output: the reader who types the example in
+  and compares is the person the annotation is for. The rest of the Spanish
+  guides had already settled this, using a point in 543 such comments against
+  49 stragglers. Prose inside the same comment is untouched and keeps the
+  Spanish comma, as do the symbols that only look like decimals, `L1,2m` and
+  the `(1,1)` mode index.
 - Every formula on the site was rendering under a stylesheet written for a
   different version of KaTeX. Two copies decide how a formula looks: the one
   `rehype-katex` renders with, and the one the site imports

--- a/site/src/content/docs/es/guides/absorption-measurement.mdx
+++ b/site/src/content/docs/es/guides/absorption-measurement.mdx
@@ -88,7 +88,7 @@ t_specimen = np.array([8.4, 8.2, 7.7, 7.2, 6.5, 5.7, 4.9, 4.2, 3.6, 3.15,
 m = materials.measure_sound_absorption(
     freqs, t_empty, t_specimen, volume=200.0, area=10.8, temperature=20.0
 )
-print(m.alpha_s[7])   # alpha_s a 500 Hz: 0,328...
+print(m.alpha_s[7])   # alpha_s a 500 Hz: 0.328...
 m.plot()              # alpha_s frente a la frecuencia en tercios de octava
 ```
 

--- a/site/src/content/docs/es/guides/advanced-loudness.mdx
+++ b/site/src/content/docs/es/guides/advanced-loudness.mdx
@@ -131,9 +131,9 @@ $$
 from phonometry import psychoacoustics
 
 cam = psychoacoustics.cam_from_frequency(1000.0)
-print(round(psychoacoustics.erb_bandwidth(1000.0), 1))       # 132,4 Hz
-print(round(cam, 2))                                         # 15,59 Cam
-print(round(psychoacoustics.frequency_from_cam(cam), 1))     # 1000,0 Hz
+print(round(psychoacoustics.erb_bandwidth(1000.0), 1))       # 132.4 Hz
+print(round(cam, 2))                                         # 15.59 Cam
+print(round(psychoacoustics.frequency_from_cam(cam), 1))     # 1000.0 Hz
 ```
 
 La biblioteca expresa el mismo ajuste con una cifra significativa más,

--- a/site/src/content/docs/es/guides/environmental-levels.mdx
+++ b/site/src/content/docs/es/guides/environmental-levels.mdx
@@ -155,7 +155,7 @@ from phonometry import environmental
 # ISO 1996-2:2007 Anexo C.5, Ejemplo 2 (dos tonos cerca de 400 Hz):
 res = environmental.assess_tonal_audibility(tone_level=54.1, masking_noise_level=45.2,
                               centre_frequency=430.0)
-print(res.audibility, res.adjustment)   # ΔLta ≈ 11,1 dB -> Kt = 6 dB
+print(res.audibility, res.adjustment)   # ΔLta ≈ 11.1 dB -> Kt = 6 dB
 res.plot(language="es")
 plt.show()
 ```

--- a/site/src/content/docs/es/guides/flanking-lab.mdx
+++ b/site/src/content/docs/es/guides/flanking-lab.mdx
@@ -282,7 +282,7 @@ ceiling = [17.0, 21.0, 25.0, 29.0, 32.0, 30.0, 38.0]   # placa de yeso de 9,5 mm
 res = plenum_flanking_reduction_index(
     ceiling, ceiling, ceiling_length=4.75, plenum_height=0.43, frequency=freqs
 )
-print(round(res.geometry_term, 1))    # 10,4 dB cobrados a RS + RR
+print(round(res.geometry_term, 1))    # 10.4 dB cobrados a RS + RR
 res.plot()                            # Rcl frente a los dos techos
 
 # Un plenum revestido atenúa el trayecto lateral (Ec. (9.18) en vez de (9.20)):
@@ -330,7 +330,7 @@ dnc = normalized_ceiling_attenuation(l1, l2, absorption, reference_area=12.0)
 dnc = [14.4, 18.6, 21.7, 24.1, 23.4, 30.3, 33.7, 35.2,
        41.6, 44.2, 42.1, 36.8, 35.7, 36.0, 36.9, 37.9]
 res = ceiling_attenuation_class(dnc)
-print(res.rating, res.deficiency_sum, res.max_deficiency)   # 34; 27,0; 7,0
+print(res.rating, res.deficiency_sum, res.max_deficiency)   # 34, 27.0, 7.0
 res.plot()                                                  # Dn,c frente a la curva
 
 # El número único ISO del mismo espectro, trasladado a A0 = 10 m2:

--- a/site/src/content/docs/es/guides/heavy-impact-sources.mdx
+++ b/site/src/content/docs/es/guides/heavy-impact-sources.mdx
@@ -103,8 +103,8 @@ from phonometry import (
 )
 
 spec = heavy_impact_source_specification("rubber_ball")
-print(spec.drop_height, spec.effective_mass)      # 1,0 m, 2,5 kg
-print(spec.contact_time, spec.contact_time_tolerance)   # 0,02 s +/- 0,002 s
+print(spec.drop_height, spec.effective_mass)      # 1.0 m, 2.5 kg
+print(spec.contact_time, spec.contact_time_tolerance)   # 0.02 s +/- 0.002 s
 
 freqs, lower, upper = heavy_impact_source_limits("bang_machine")
 print(list(zip(freqs, lower, upper))[0])          # (31.5, 46.0, 48.0)
@@ -195,7 +195,7 @@ li_fmax = [65.3, 64.5, 58.0, 55.8]           # promediado en energía sobre posi
 t = [1.43, 3.70, 3.10, 2.38]                 # tiempo de reverberación del receptor
 
 res = standardized_maximum_impact_level(li_fmax, 41.4, t, frequency=freqs)
-print(res.volume_term)                        # 10 lg(41,4/50) = -0,8 dB
+print(res.volume_term)                        # 10 lg(41.4/50) = -0.8 dB
 print(fast_reverberation_correction([0.5]))   # exactamente 0 dB con T = T0
 res.plot()   # espectros medido y estandarizado (requiere matplotlib)
 
@@ -229,8 +229,8 @@ from phonometry import a_weighted_maximum_impact_level
 
 # ISO 717-2:2020 Tabla D.4: una medición en obra en bandas de octava.
 res = a_weighted_maximum_impact_level([65.3, 64.5, 58.0, 55.8])
-print(list(res.corrected))   # 39,1; 48,3; 49,3; 52,6 dB
-print(res.unrounded)         # 55,350667... dB
+print(list(res.corrected))   # 39.1, 48.3, 49.3, 52.6 dB
+print(res.unrounded)         # 55.350667... dB
 print(res.rating)            # 55 dB
 res.plot()                   # niveles por banda, contribuciones y valoración
 ```

--- a/site/src/content/docs/es/guides/loudspeakers.mdx
+++ b/site/src/content/docs/es/guides/loudspeakers.mdx
@@ -442,15 +442,15 @@ from phonometry import electroacoustics as ea
 
 # Un auditorio con Zs = -6 dB, micrófono omnidireccional, uno abierto.
 res = ea.feedback_stability(-6.0, 76.0, 80.0)
-print(res.is_stable, round(res.headroom, 1))          # True 0,0 dB
-print(round(res.maximum_level_at_microphone, 1))      # 76,0 dB = L(H-L) - 4
+print(res.is_stable, round(res.headroom, 1))          # True 0.0 dB
+print(round(res.maximum_level_at_microphone, 1))      # 76.0 dB = L(H-L) - 4
 
 # Un cardioide recupera exactamente su índice de directividad relativo.
 card = ea.feedback_stability(-6.0, 78.0, 80.0, microphone_directivity=-2.0)
-print(round(card.maximum_level_at_microphone, 1))     # 78,0 dB = L(H-L) - 2
+print(round(card.maximum_level_at_microphone, 1))     # 78.0 dB = L(H-L) - 2
 
 # Cuatro micrófonos abiertos cuestan 10 lg 4 = 6 dB de ese margen.
-print(round(ea.open_microphone_correction(4), 1))     # 6,0 dB
+print(round(ea.open_microphone_correction(4), 1))     # 6.0 dB
 
 res.plot()      # la estructura de ganancias frente a la oscilación y el margen
 ```

--- a/site/src/content/docs/es/guides/marine-mammal-exposure.mdx
+++ b/site/src/content/docs/es/guides/marine-mammal-exposure.mdx
@@ -138,7 +138,7 @@ los dos puntos publicados están fijados por los tests.
 ```python
 from phonometry import underwater
 
-print(underwater.orca_audiogram(50e3).threshold[0])   # 51,20 dB re 1 uPa
+print(underwater.orca_audiogram(50e3).threshold[0])   # 51.20 dB re 1 uPa
 ```
 
 Ese valor es el umbral de audición del ejemplo de orca frente a salmón de
@@ -204,7 +204,7 @@ plt.show()
 from phonometry import underwater
 
 res = underwater.auditory_weighting(1000.0, "LF", guidance="nmfs-2018")
-print(res.weighting[0])           # -0,06 dB, el valor publicado del Apéndice D
+print(res.weighting[0])           # -0.06 dB, el valor publicado del Apéndice D
 print(res.weighted_tts_onset)     # Tw = K + C
 
 params = underwater.weighting_parameters("OW", guidance="nmfs-2024")

--- a/site/src/content/docs/es/guides/microphones.mdx
+++ b/site/src/content/docs/es/guides/microphones.mdx
@@ -174,9 +174,9 @@ result = microphone_characteristics(
     polar=(angles, cardioid), polar_frequency=1000.0,
     powering="Phantom P48 (IEC 61938)", supply_current_ma=3.1,
 )
-print(round(result.sensitivity_level_db, 1))            # -38,1 dB re 1 V/Pa
+print(round(result.sensitivity_level_db, 1))            # -38.1 dB re 1 V/Pa
 print(tuple(round(x) for x in result.effective_range))  # Hz
-print(round(result.directivity_index_db, 1))            # 4,8 dB (cardioide)
+print(round(result.directivity_index_db, 1))            # 4.8 dB (cardioide)
 print(round(result.equivalent_noise_level_db, 1))       # dB(A)
 
 result.report("microfono.pdf", metadata=ReportMetadata(measurement_standard="IEC 60268-4"),

--- a/site/src/content/docs/es/guides/open-plan-acoustics.mdx
+++ b/site/src/content/docs/es/guides/open-plan-acoustics.mdx
@@ -319,8 +319,8 @@ mutuamente coherentes; la errata queda recogida en el [registro de erratas](http
 ```python
 from phonometry import room
 
-print(round(room.absorption_per_table(1.0, -6.0), 2))   # 6,31 m2 por mesa a 1 m
-print(round(room.absorption_per_table(2.5, -9.0), 1))   # 19,8 m2 con paso de 2,5 m
+print(round(room.absorption_per_table(1.0, -6.0), 2))   # 6.31 m2 por mesa a 1 m
+print(round(room.absorption_per_table(2.5, -9.0), 1))   # 19.8 m2 con paso de 2,5 m
 
 crowd = room.crowd_noise([20.0, 95.0, 190.0], distance=1.2)
 crowd.plot()      # ruido autogenerado vs ocupación, frente al límite de -6 dB

--- a/site/src/content/docs/es/guides/panel-sound-insulation.mdx
+++ b/site/src/content/docs/es/guides/panel-sound-insulation.mdx
@@ -584,7 +584,7 @@ from phonometry import (
     wall_tie_stiffness_per_area,
 )
 
-print(wall_tie_stiffness("butterfly"))        # (0,05 m; 1,7e6 N/m)
+print(wall_tie_stiffness("butterfly"))        # (0.05 m, 1.7e6 N/m)
 
 # Hopkins Fig. 4.35: dos hojas de 140 kg/m2 con cámara vacía de 75 mm.
 print(round(mass_spring_mass_resonance(140.0, 140.0, 0.075)))          # 26 Hz

--- a/site/src/content/docs/es/guides/resilient-layers.mdx
+++ b/site/src/content/docs/es/guides/resilient-layers.mdx
@@ -99,7 +99,7 @@ from phonometry import (
     plate_contact_stiffness, tapping_force_spectrum,
 )
 
-print(round(hammer_impact_velocity(), 3))     # 0,886 m/s (0,5 kg desde 40 mm)
+print(round(hammer_impact_velocity(), 3))     # 0.886 m/s (0,5 kg desde 40 mm)
 
 # Losa de hormigón in situ de 140 mm: 2200 kg/m3, cL = 3800 m/s, nu = 0,2.
 rho, c_l, nu, h = 2200.0, 3800.0, 0.2, 0.14

--- a/site/src/content/docs/es/guides/room-image-sources.mdx
+++ b/site/src/content/docs/es/guides/room-image-sources.mdx
@@ -404,7 +404,7 @@ modes = room.room_modes(
     speed_of_sound=344.0,
     reverberation_time=0.8,     # opcional: lleva la frecuencia de Schroeder
 )
-print(modes.orders[0], round(float(modes.frequencies[0]), 1))  # [1 0 0] 24,6 Hz
+print(modes.orders[0], round(float(modes.frequencies[0]), 1))  # [1 0 0] 24.6 Hz
 print(modes.count_by_kind())   # {'axial': 7, 'tangential': 10, 'oblique': 4}
 print(round(modes.schroeder_frequency, 0))                     # 175 Hz
 modes.plot()                    # escalera de modos por familia + densidad modal

--- a/site/src/content/docs/es/guides/sound-quality.mdx
+++ b/site/src/content/docs/es/guides/sound-quality.mdx
@@ -314,7 +314,7 @@ x = (1.0 + np.cos(2 * np.pi * 4 * t)) * np.sin(2 * np.pi * 1000 * t)
 x *= 2e-5 * 10 ** (60 / 20) / np.sqrt(np.mean(x**2))   # 60 dB SPL globales
 
 res = psychoacoustics.fluctuation_strength_ecma(x, fs, field="free")
-print(f"F = {res.fluctuation_strength:.4f} vacil_HMS")   # 0,9957 vacil_HMS (referencia: 1 vacil_HMS)
+print(f"F = {res.fluctuation_strength:.4f} vacil_HMS")   # 0.9957 vacil_HMS (referencia: 1 vacil_HMS)
 
 res.plot()   # F(l50) temporal + mapa de calor de la específica
 ```

--- a/site/src/content/docs/es/guides/underwater-propagation.mdx
+++ b/site/src/content/docs/es/guides/underwater-propagation.mdx
@@ -268,7 +268,7 @@ from phonometry import underwater
 b = underwater.weston_regime_boundaries(250.0, 50.0, seabed="sand")
 print(b.cylindrical_to_mode_stripping)   # r_CS, en metros
 print(b.cutoff_frequency, b.mode_count)  # la propagación guiada exige f > f_c
-print(underwater.reflection_loss_gradient("sand"))   # 0,278 Np/rad
+print(underwater.reflection_loss_gradient("sand"))   # 0.278 Np/rad
 ```
 
 Al ser un resultado *incoherente*, el flujo describe el campo promediado en
@@ -458,7 +458,7 @@ from phonometry import underwater
 phi = np.linspace(0.0, 90.0, 361)   # ángulo rasante desde la interfase, grados
 bl = underwater.bottom_reflection_loss(phi, rho1=1000.0, c1=1500.0,   # agua
                                rho2=1900.0, c2=1650.0)          # arena
-print(bl.critical_angle)            # 24,6°
+print(bl.critical_angle)            # 24.6°
 bl.plot()   # pérdida por reflexión frente al ángulo rasante
 ```
 
@@ -496,7 +496,7 @@ from phonometry import underwater
 phi = np.linspace(0.0, 90.0, 361)   # ángulo rasante desde la interfase, grados
 sr = underwater.seabed_reflection(phi, rho1=1000.0, c1=1500.0,   # agua
                           rho2=1900.0, c2=1650.0)          # arena
-print(sr.magnitude[-1])             # 0,353 = |R| en incidencia normal
+print(sr.magnitude[-1])             # 0.353 = |R| en incidencia normal
 sr.plot()   # |R| frente al ángulo rasante (necesita matplotlib)
 ```
 


### PR DESCRIPTION
Twenty-nine comments in the Spanish guides annotated a value the code prints using a decimal comma, so the page promised `132,4 Hz` where running the snippet gives `132.4`. `print` has no locale, and a comment sitting next to a `print` call is a claim about that call's output: its reader is the person who types the example in and compares.

This was not a matter of taste. The rest of the Spanish guides had already settled it, using a point in 543 such comments against 49 stragglers, and every English counterpart of the lines changed here already read with a point.

Prose inside the same comment is left alone and keeps the Spanish comma, because it is language rather than output: `con paso de 2,5 m` and `0,5 kg desde 40 mm` stay as they are. So do the twelve remaining cases that only look like decimals, among them the symbol `L1,2m`, the `(1,1)` mode index, and the `41,0` that ISO 12354-2 itself prints.

Only comment text changed; no code, no values, no separators inside the snippets themselves.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Corrected decimal separators in Spanish guide examples to match Python’s printed output.
  - Updated numeric reference values across acoustics, environmental, marine, and underwater propagation guides.
  - Preserved Spanish prose, example logic, and non-decimal notation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->