### PR TITLE
Serve the KaTeX stylesheet that matches the rendered markup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -897,6 +897,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Every formula on the site was rendering under a stylesheet written for a
+  different version of KaTeX. Two copies decide how a formula looks: the one
+  `rehype-katex` renders with, and the one the site imports
+  `katex/dist/katex.min.css` from, and nothing tied the two together. The site
+  had reached `katex` 0.18.1 while `rehype-katex` still resolves 0.16.47, and
+  0.18 renamed the classes on the base box and the strut. So the markup asked
+  for `.katex .base` and `.katex .strut` and the stylesheet defined
+  `.katex-base` and `.katex-strut`: the base box lost `white-space: nowrap`,
+  `display: inline-block` and `position: relative`, and the struts that set the
+  line height stopped laying out at all. Measured on the resilient-layer guide,
+  a display block came out 142.9 px tall instead of 130.5, and inline formulas
+  broke across lines in the middle of an expression, splitting `0.886` from its
+  `m/s`. The dependency now follows the line `rehype-katex` resolves, and
+  `check-math-render.mjs` gained a third check that compares the classes the
+  built markup emits against the classes the built stylesheet defines, so the
+  two cannot drift apart again unnoticed. Neither half was invalid on its own,
+  which is why nothing complained for as long as it did.
 - Nothing in the pull-request pipeline built the documentation site, so a page
   could break the deploy while its pull request showed twenty-six green checks.
   The site build lived in a workflow triggered only by a push to `main`, which

--- a/site/package.json
+++ b/site/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@astrojs/starlight": "^0.41.4",
     "astro": "^7.1.4",
-    "katex": "^0.18.1",
+    "katex": "^0.16.47",
     "rehype-katex": "^7.0.1",
     "remark-math": "^6.0.0",
     "satori": "^0.29.0",

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^7.1.4
         version: 7.1.4(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@26.1.2)(rollup@4.62.2)(yaml@2.9.0)
       katex:
-        specifier: ^0.18.1
-        version: 0.18.1
+        specifier: ^0.16.47
+        version: 0.16.47
       rehype-katex:
         specifier: ^7.0.1
         version: 7.0.1
@@ -2048,10 +2048,6 @@ packages:
 
   katex@0.16.47:
     resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
-    hasBin: true
-
-  katex@0.18.1:
-    resolution: {integrity: sha512-Td8GCYSxDAoMhHOlKmCFMJ/hz5qlAAb71n66Dryw9nfCVfumLo7nhuotbvKom/XPADmrYC3O5QR71EPq4DarJQ==}
     hasBin: true
 
   kleur@3.0.3:
@@ -5327,10 +5323,6 @@ snapshots:
   jsonc-parser@3.3.1: {}
 
   katex@0.16.47:
-    dependencies:
-      commander: 8.3.0
-
-  katex@0.18.1:
     dependencies:
       commander: 8.3.0
 

--- a/site/scripts/check-math-render.mjs
+++ b/site/scripts/check-math-render.mjs
@@ -101,6 +101,62 @@ function delimiterProblems(sourceDirs) {
   return problems;
 }
 
+/**
+ * The shipped stylesheet must be the one that matches the renderer.
+ *
+ * Two different copies of KaTeX decide how a formula looks. `rehype-katex`
+ * writes the markup using the katex it depends on, while the site imports
+ * `katex/dist/katex.min.css` from its own katex dependency, and nothing ties
+ * the two versions together. They drifted: the site served 0.18 CSS over 0.16
+ * markup, and the class names for the base box and the strut were renamed
+ * between those lines. Every formula on the site therefore rendered with no
+ * `white-space: nowrap` on its base box and no struts setting its line height,
+ * free to wrap in the middle of an expression.
+ *
+ * Nothing caught it, because each half was valid on its own: the markup parsed,
+ * the stylesheet loaded, the pages validated. The mismatch only exists in the
+ * relationship between them, so that is what this checks. For each class KaTeX
+ * renamed, take the spelling the built markup actually uses and require the
+ * built CSS to carry a rule for that exact spelling.
+ */
+function stylesheetMismatch(distDir) {
+  // Renamed in KaTeX 0.18: `.katex .base` -> `.katex-base`, likewise the strut.
+  const RENAMED = [
+    { html: 'base', legacy: '.katex .base', current: '.katex-base' },
+    { html: 'strut', legacy: '.katex .strut', current: '.katex-strut' },
+  ];
+  const page = walk(distDir, ['.html']).find((file) =>
+    readFileSync(file, 'utf8').includes('class="katex"'),
+  );
+  // No rendered formula anywhere means there is no relationship to check.
+  if (!page) return [];
+  const html = readFileSync(page, 'utf8');
+  const css = walk(distDir, ['.css'])
+    .map((file) => readFileSync(file, 'utf8'))
+    .join('\n');
+
+  const mismatches = [];
+  for (const { html: name, legacy, current } of RENAMED) {
+    const usesLegacy = html.includes(`class="${name}"`);
+    const usesCurrent = html.includes(`class="katex-${name}"`);
+    if (!usesLegacy && !usesCurrent) continue;
+    const wanted = usesCurrent ? current : legacy;
+    // `.katex-base` is a substring of nothing in the legacy sheet and
+    // `.katex .base` of nothing in the current one, so a plain search
+    // discriminates the two spellings even after minification.
+    if (css.includes(wanted)) continue;
+    mismatches.push({
+      page: relative(REPO, page),
+      emitted: usesCurrent ? `katex-${name}` : name,
+      wanted,
+      served: css.includes(usesCurrent ? legacy : current)
+        ? `the other spelling, ${usesCurrent ? legacy : current}`
+        : 'no rule at all',
+    });
+  }
+  return mismatches;
+}
+
 const args = process.argv.slice(2);
 const distArg = args.indexOf('--dist');
 const distDir = resolve(SITE, distArg === -1 ? 'dist' : args[distArg + 1]);
@@ -108,9 +164,13 @@ const sourceDirs = [join(REPO, 'docs'), join(SITE, 'src', 'content')];
 
 const failures = renderFailures(distDir);
 const problems = delimiterProblems(sourceDirs);
+const mismatches = stylesheetMismatch(distDir);
 
-if (failures.length === 0 && problems.length === 0) {
-  console.log('Math renders: no KaTeX parse errors in the build, no stray display delimiters.');
+if (failures.length === 0 && problems.length === 0 && mismatches.length === 0) {
+  console.log(
+    'Math renders: no KaTeX parse errors in the build, no stray display\n' +
+      'delimiters, and the stylesheet matches the markup the renderer emits.',
+  );
   process.exit(0);
 }
 
@@ -133,6 +193,21 @@ if (problems.length > 0) {
   );
   for (const problem of problems) {
     console.error(`  ${problem.file}:${problem.line}: ${problem.text}`);
+  }
+}
+
+if (mismatches.length > 0) {
+  console.error(
+    '\nThe KaTeX stylesheet does not match the markup the renderer emits.\n' +
+      'Every formula on the site is missing the rules for the classes below.\n' +
+      "Align `katex` in site/package.json with the version `rehype-katex`\n" +
+      'resolves (`node -e \'require.resolve("katex", {paths: [require.resolve("rehype-katex")]})\'`):\n',
+  );
+  for (const mismatch of mismatches) {
+    console.error(
+      `  ${mismatch.page}: markup emits class="${mismatch.emitted}", ` +
+        `stylesheet has ${mismatch.served} (wanted \`${mismatch.wanted}\`)`,
+    );
   }
 }
 


### PR DESCRIPTION
Two copies of KaTeX decide how a formula looks. `rehype-katex` writes the markup with the katex it depends on, and the site imports `katex/dist/katex.min.css` from its own katex dependency. Nothing tied the two versions together, and they drifted: the site had reached 0.18.1 while `rehype-katex` still resolves 0.16.47, and 0.18 renamed the classes on the base box and on the strut.

So the markup asked for `.katex .base` and `.katex .strut` while the stylesheet defined `.katex-base` and `.katex-strut`. Every formula on the site rendered without the rules for its own layout boxes.

## Measured on `guides/resilient-layers`

| | before | after |
|---|---|---|
| `.base` `display` | `inline` | `inline-block` |
| `.base` `white-space` | `normal` | `nowrap` |
| `.base` `position` | `static` | `relative` |
| `.base` `width` | `auto` | `min-content` |
| `.strut` `display` | `inline` | `inline-block` |
| display block height | 142.9 px | 130.5 px |

The visible consequence is that inline formulas were free to break in the middle of an expression: on that page `v0 = sqrt(2gh) = 0.886` ended a line and its `m/s` began the next one.

## What changes

- `katex` in `site/package.json` follows the line `rehype-katex` resolves. This also drops a duplicate copy of katex from the lockfile, since both now resolve to the single 0.16.47 that was already there.
- `check-math-render.mjs` gains a third check, aimed at the relationship rather than at either half: it takes the classes the built markup actually emits and requires the built stylesheet to define those same classes. Neither half was invalid on its own, which is why nothing complained for as long as it did.

## Verification

Run against the previous build, the new check names both classes and exits 1:

```
markup emits class="base", stylesheet has the other spelling, .katex-base (wanted `.katex .base`)
markup emits class="strut", stylesheet has the other spelling, .katex-strut (wanted `.katex .strut`)
```

Run against this branch's build it passes. There is no `rehype-katex` release that renders 0.18 markup: 7.0.1 is the latest and pins `katex: ^0.16.0`, so aligning the stylesheet down is the only way to make the two agree.

## Summary by Sourcery

Align the KaTeX CSS used by the site with the version used by the math renderer and add a guard to prevent future mismatches between markup and stylesheet.

Bug Fixes:
- Ensure the site serves a KaTeX stylesheet whose class names match the markup emitted by rehype-katex, fixing incorrect layout and line-breaking of formulas.

Enhancements:
- Extend the math render check script to verify that KaTeX-related CSS classes defined in the built stylesheet match those referenced in the generated HTML, failing the build on mismatches.

Documentation:
- Document the KaTeX version mismatch issue, its visual impact, and the new safeguards in the changelog.