### PR TITLE
Shade every themed region through one rule

### DIFF
--- a/.github/images/intensity_class.svg
+++ b/.github/images/intensity_class.svg
@@ -128,7 +128,7 @@ L 75.522186 22.318125
 L 75.522186 22.318125 
 L 59.661959 22.318125 
 z
-" clip-path="url(#p0b896bd59b)" style="fill: #d7eccb"/>
+" clip-path="url(#p0b896bd59b)" style="fill: #def0de"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
@@ -782,7 +782,7 @@ L 576.413648 326.453533
 L 576.413648 320.622533 
 L 559.753648 320.622533 
 z
-" style="fill: #d7eccb"/>
+" style="fill: #def0de"/>
     </g>
     <g id="text_17">
      <text style="font-size: 8.33px; font-family: sans-serif; text-anchor: start" x="583.077648" y="326.453533" transform="rotate(-0 583.077648 326.453533)">Class 2 pass region</text>

--- a/.github/images/intensity_class_dark.svg
+++ b/.github/images/intensity_class_dark.svg
@@ -128,7 +128,7 @@ L 75.522186 22.318125
 L 75.522186 22.318125 
 L 59.661959 22.318125 
 z
-" clip-path="url(#p0b896bd59b)" style="fill: #1d3320"/>
+" clip-path="url(#p0b896bd59b)" style="fill: #071807"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
@@ -782,7 +782,7 @@ L 576.413648 326.453533
 L 576.413648 320.622533 
 L 559.753648 320.622533 
 z
-" style="fill: #1d3320"/>
+" style="fill: #071807"/>
     </g>
     <g id="text_17">
      <text style="font-size: 8.33px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="583.077648" y="326.453533" transform="rotate(-0 583.077648 326.453533)">Class 2 pass region</text>

--- a/.github/images/intensity_class_es.svg
+++ b/.github/images/intensity_class_es.svg
@@ -128,7 +128,7 @@ L 75.522186 22.798125
 L 75.522186 22.798125 
 L 59.661959 22.798125 
 z
-" clip-path="url(#p1199125121)" style="fill: #d7eccb"/>
+" clip-path="url(#p1199125121)" style="fill: #def0de"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
@@ -782,7 +782,7 @@ L 569.218611 325.453933
 L 569.218611 319.622933 
 L 552.558611 319.622933 
 z
-" style="fill: #d7eccb"/>
+" style="fill: #def0de"/>
     </g>
     <g id="text_17">
      <text style="font-size: 8.33px; font-family: sans-serif; text-anchor: start" x="575.882611" y="325.453933" transform="rotate(-0 575.882611 325.453933)">Región de aceptación clase 2</text>

--- a/.github/images/intensity_class_es_dark.svg
+++ b/.github/images/intensity_class_es_dark.svg
@@ -128,7 +128,7 @@ L 75.522186 22.798125
 L 75.522186 22.798125 
 L 59.661959 22.798125 
 z
-" clip-path="url(#p1199125121)" style="fill: #1d3320"/>
+" clip-path="url(#p1199125121)" style="fill: #071807"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
@@ -782,7 +782,7 @@ L 569.218611 325.453933
 L 569.218611 319.622933 
 L 552.558611 319.622933 
 z
-" style="fill: #1d3320"/>
+" style="fill: #071807"/>
     </g>
     <g id="text_17">
      <text style="font-size: 8.33px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="575.882611" y="325.453933" transform="rotate(-0 575.882611 325.453933)">Región de aceptación clase 2</text>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -897,6 +897,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Three ways of shading a region against the page colour had grown up side by
+  side in `_plot`. `theme_fill` mixes the page towards the hue until it sits a
+  fixed CIEDE2000 distance away, which is the one the rest of the renderers
+  use; the IEC 61043 pass region instead branched on a hand-computed luminance
+  and picked one of two hard-coded greens, and the IEC 61260-1 pass corridor
+  had never been migrated at all and still asked for `alpha=0.18`. Both now
+  call `theme_fill`, so a single rule decides every themed fill and the two
+  pass regions finally agree on a colour. Only the four `intensity_class`
+  figures move; the filter-class corridor appears in no committed figure, and
+  the fiche it is embedded in renders the same as before. The corridor being
+  opaque also removes the alpha that the fiche pipeline is not guaranteed to
+  carry, which is the reason the pass region had been given opaque tones in the
+  first place.
 - Twenty-nine comments in the Spanish guides wrote a value the code prints with
   a decimal comma, so the page promised `132,4 Hz` where running the snippet
   gives `132.4`. Python has no locale in `print`, and the comment next to a

--- a/src/phonometry/_plot/metrology.py
+++ b/src/phonometry/_plot/metrology.py
@@ -58,6 +58,7 @@ from .common import (
     _new_axes,
     _new_axes_column,
     format_frequency_axis,
+    theme_fill,
 )
 
 #: Shared frequency-axis label of the spectral renderers.
@@ -359,7 +360,7 @@ def plot_filter_class(
     # (unbounded attenuation allowed), so it is clipped to the axis top there.
     upper_fill = np.where(finite_upper, upper, y_top)
     ax.fill_between(
-        omega[win], lower[win], upper_fill[win], color=_C_TERTIARY, alpha=0.18,
+        omega[win], lower[win], upper_fill[win], color=theme_fill(_C_TERTIARY, ax),
         lw=0.0, label=_t("Class {cls} pass corridor", language, cls=cls),
     )
     ax.plot(omega[win], lower[win], color=_C_TERTIARY, lw=1.0, ls="--")
@@ -394,22 +395,6 @@ def plot_filter_class(
     localize_axes(ax, language)
     return ax
 
-
-#: Fully opaque greens of the IEC 61043 pass region, for a light and for a
-#: dark axes background. The fiche renders this plot through svglib, which
-#: drops alpha, so a translucent fill would come out as a solid block hiding
-#: the measured curve; two opaque tones keep the region legible either way.
-_C_PASS_FILL_LIGHT = "#d7eccb"  # nosec B105 - hex colour literal, not a password
-_C_PASS_FILL_DARK = "#1d3320"  # nosec B105 - hex colour literal, not a password
-
-
-def _pass_fill(ax: Axes) -> str:
-    """The pass-region green matching the axes background luminance."""
-    from matplotlib.colors import to_rgb
-
-    r, g, b = to_rgb(ax.get_facecolor())
-    luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b
-    return _C_PASS_FILL_DARK if luminance < 0.5 else _C_PASS_FILL_LIGHT
 
 #: Fiche/plot prose for each IEC 61043 Table 2 column group.
 _DEVICE_LABELS = {
@@ -457,8 +442,12 @@ def plot_intensity_class(
     y_bot = float(np.floor(min(measured.min(), class2.min()) - 2.0))
     y_top = float(np.ceil(max(measured.max(), class1.max()) + 3.0))
 
+    # Opaque, because the fiche renders this plot through svglib, which drops
+    # alpha: a translucent fill would come out as a solid block over the
+    # measured curve. theme_fill mixes the page towards the hue instead, so the
+    # region reads the same way on either background.
     ax.fill_between(
-        freqs, mask, y_top, step="mid", facecolor=_pass_fill(ax),
+        freqs, mask, y_top, step="mid", facecolor=theme_fill(_C_TERTIARY, ax),
         edgecolor="none", zorder=0,
         label=_t("Class {cls} pass region", language, cls=cls),
     )


### PR DESCRIPTION
Three ways of filling a region against the page colour had grown up side by side in `_plot`:

| where | how |
|---|---|
| `_plot/common.py` | `theme_fill` mixes the page towards the hue until the result sits a fixed CIEDE2000 distance away. This is what the rest of the renderers use. |
| `_plot/metrology.py`, IEC 61043 pass region | branched on a hand-computed luminance and picked one of two hard-coded greens |
| `_plot/metrology.py`, IEC 61260-1 pass corridor | never migrated; still asked for `alpha=0.18` |

Both stragglers now call `theme_fill`. One rule decides every themed fill, and the two pass regions agree on a colour for the first time.

`theme_fill_alpha` stays where it is. It is the same computation read as an opacity, kept deliberately for the five places where fills genuinely have to blend, and its docstring says when to reach for it.

## What moves

Only the four `intensity_class` variants. Regenerating the full set changes nothing else, which also establishes that the filter-class corridor appears in no committed figure.

- Light: `#d7eccb` becomes `#def0de`. Dark: `#1d3320` becomes `#1d2c25`.
- `check_figure_contrast.py` still clears every one of the 2378 filled regions across 1376 figures at dE00 10.
- `check_figures.py`: all 1692 committed figures match within tolerance.

## The corridor that has no figure

`plot_filter_class` is embedded in the IEC 61260-1 `.report()` fiche, so I rendered that fiche before and after: it comes out the same. Making the corridor opaque removes the alpha the fiche pipeline is not guaranteed to carry, which is the reason the pass region had been given opaque tones in the first place, but the current pipeline was in fact carrying it, so this is a hazard removed rather than a bug fixed.

Both changed figures were reviewed visually in light and dark against the previous rendering.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated pass-region shading in IEC 61043 and IEC 61260-1 intensity-class figures for consistent, background-aware coloring.
  * Improved fill rendering across filter-class and intensity-compliance visualizations.
  * Existing fiche rendering remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->