### PR TITLE
Halve the wall time of the test suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -897,6 +897,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- The test suite runs in about half the wall time. The report generator
+  tests render each example fiche exactly once and assert its PDF and WebP
+  preview on the same run instead of regenerating the full set twice, the
+  conformance checks compute once per test process through a memoized
+  registry, the expensive FDTD, elastic-wave and ECMA reference fixtures are
+  computed once and shared across xdist workers via load groups, and the
+  heaviest modules dispatch first. No test was removed, no signal shortened
+  and no tolerance or oracle touched; coverage is line-for-line identical.
+
 - The eleven documentation clips still encoded as VP9 are now AV1, which is
   what the other fifteen had already moved to, so all 104 WebM files finally
   share one codec. Their 44 files come down from 20.1 MB to 15.5 MB, 23 %

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -902,7 +902,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   preview on the same run instead of regenerating the full set twice, the
   conformance checks compute once per test process through a memoized
   registry, the expensive FDTD, elastic-wave and ECMA reference fixtures are
-  computed once and shared across xdist workers via load groups, and the
+  computed once on a single worker because their tests now share load groups
+  instead of scattering and rebuilding the fixture on each one, and the
   heaviest modules dispatch first. No test was removed, no signal shortened
   and no tolerance or oracle touched; coverage is line-for-line identical.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,13 @@ relative_files = true
 
 [tool.pytest.ini_options]
 pythonpath = ["tests"]
+# Group-aware distribution for `-n auto` runs: tests marked with
+# `xdist_group` land on one worker, so an expensive module-scoped fixture
+# (FDTD steady states, ECMA-418-2 reference results, the memoized
+# conformance registry) is computed once per run instead of once per worker
+# that happens to pick one of its consumers. Unmarked tests are distributed
+# exactly as with the default `load` mode, and the flag is inert without `-n`.
+addopts = ["--dist=loadgroup"]
 filterwarnings = [
     "ignore:Low sampling rate:UserWarning",
 ]

--- a/scripts/conformance_report.py
+++ b/scripts/conformance_report.py
@@ -30,6 +30,7 @@ Design goals: deterministic, fast (< 1 min), no network, pure library calls.
 from __future__ import annotations
 
 import cmath
+import functools
 import json
 import math
 import pathlib
@@ -94,7 +95,10 @@ def register(domain: str, standard: str, quantity: str) -> Callable[
     """Register a check callable under a domain / standard / quantity."""
 
     def deco(fn: Callable[[], Outcome]) -> Callable[[], Outcome]:
-        CHECKS.append(Check(domain, standard, quantity, fn))
+        # Checks are deterministic and argument-free, so the outcome is
+        # cached per process: rendering the full report and re-running an
+        # individual check in the same process computes the check once.
+        CHECKS.append(Check(domain, standard, quantity, functools.cache(fn)))
         return fn
 
     return deco

--- a/scripts/generate_reports.py
+++ b/scripts/generate_reports.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import argparse
 import os
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import Any
 
 import numpy as np
@@ -3351,15 +3351,20 @@ def _write_preview(pdf_path: str) -> str:
     return preview
 
 
-def generate_reports(output_dir: str) -> list[str]:
+def generate_reports(
+    output_dir: str,
+    examples: Sequence[Callable[[], tuple[object, ReportMetadata, str]]] | None = None,
+) -> list[str]:
     """Write every example fiche (PDF + WebP preview) into ``output_dir``.
 
-    Returns the PDF paths written; each has a paired ``.webp`` preview next to
-    it (see :func:`preview_path_for`).
+    ``examples`` restricts the run to a subset of the registered factories
+    (the test suite renders one fiche per test); the default renders the
+    full registry. Returns the PDF paths written; each has a paired
+    ``.webp`` preview next to it (see :func:`preview_path_for`).
     """
     os.makedirs(output_dir, exist_ok=True)
     written: list[str] = []
-    for factory in _EXAMPLES:
+    for factory in _EXAMPLES if examples is None else examples:
         result, metadata, name = factory()
         path = os.path.join(output_dir, name)
         result.report(path, metadata=metadata)  # type: ignore[attr-defined]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,53 @@ def pytest_configure(config):
     os.environ.setdefault("NUMBA_DISABLE_JIT", "1")
 
 
+# The modules whose tests dominate the wall clock (steady-state FDTD runs,
+# the conformance registry, ECMA-418-2 chains, report generation). Collection
+# order is dispatch order under pytest-xdist, so fronting them lets the long
+# tests start while the workers still have plenty of short tests left to
+# backfill with; leaving them in alphabetical collection order used to strand
+# a 3-5 minute test on a lone worker at the end of the run.
+_FRONTLOADED_MODULES = (
+    "tests/simulation/test_fdtd_ntff.py",
+    "tests/test_conformance_report.py",
+    "tests/simulation/test_elastic_fdtd.py",
+    "tests/aircraft/test_rotorcraft_norah2.py",
+    "tests/test_generate_reports.py",
+    "tests/simulation/test_elastic_fluid_solid.py",
+    "tests/test_impact_insulation.py",
+    "tests/building/test_insulation.py",
+    "tests/psychoacoustics/test_tonality_ecma.py",
+    "tests/psychoacoustics/test_loudness_ecma.py",
+    "tests/psychoacoustics/test_fluctuation_strength_ecma.py",
+    "tests/psychoacoustics/test_loudness_moore_glasberg_time.py",
+    "tests/psychoacoustics/test_loudness_zwicker.py",
+    "tests/underwater/test_numerical_propagation.py",
+    "tests/metrology/test_iec61260_report.py",
+    "tests/room/test_room_ir.py",
+    "tests/test_golden_baseline.py",
+)
+
+
+def pytest_collection_modifyitems(config, items):
+    """Move the known-heavy modules to the front of the dispatch order.
+
+    The sort is stable, so relative order inside every module (and among all
+    remaining modules) is untouched.
+    """
+    rank = {}
+    for item in items:
+        path = item.nodeid.split("::", 1)[0]
+        if path not in rank:
+            rank[path] = len(_FRONTLOADED_MODULES)
+            for i, module in enumerate(_FRONTLOADED_MODULES):
+                # Match on the tail so the rank survives being invoked from
+                # a different rootdir (nodeids are rootdir-relative).
+                if path.endswith(module) or module.endswith(path):
+                    rank[path] = i
+                    break
+    items.sort(key=lambda item: rank[item.nodeid.split("::", 1)[0]])
+
+
 def pytest_report_header(config):
     """Report which copy of every heavy oracle set this run will read.
 

--- a/tests/psychoacoustics/test_fluctuation_strength_ecma.py
+++ b/tests/psychoacoustics/test_fluctuation_strength_ecma.py
@@ -62,6 +62,7 @@ def ref_calibration() -> EcmaFluctuationStrength:
 # --------------------------------------------------------------------------
 
 
+@pytest.mark.xdist_group("ecma-fluctuation-ref")
 def test_calibration_1khz_4hz_is_one_vacil(
     ref_calibration: EcmaFluctuationStrength,
 ) -> None:
@@ -222,6 +223,7 @@ def test_window_rejects_a_quiet_block() -> None:
 # --------------------------------------------------------------------------
 
 
+@pytest.mark.xdist_group("ecma-fluctuation-ref")
 def test_peaks_near_4hz_modulation(
     ref_calibration: EcmaFluctuationStrength,
 ) -> None:
@@ -249,6 +251,7 @@ def test_roughness_domain_modulation_scores_near_zero() -> None:
     assert f70 < 0.05
 
 
+@pytest.mark.xdist_group("ecma-fluctuation-ref")
 def test_grows_with_modulation_depth(
     ref_calibration: EcmaFluctuationStrength,
 ) -> None:
@@ -275,6 +278,7 @@ def test_silence_is_zero() -> None:
 # --------------------------------------------------------------------------
 
 
+@pytest.mark.xdist_group("ecma-fluctuation-ref")
 def test_result_structure(ref_calibration: EcmaFluctuationStrength) -> None:
     res = ref_calibration
     assert res.specific_fluctuation_strength.shape == res.bark.shape == (53,)
@@ -321,6 +325,7 @@ def test_resample_length_clamps_to_one_sample() -> None:
     assert res.fluctuation_strength == 0.0
 
 
+@pytest.mark.xdist_group("ecma-fluctuation-ref")
 def test_deterministic(ref_calibration: EcmaFluctuationStrength) -> None:
     again = fluctuation_strength_ecma(_am_tone(1000.0, 4.0, 1.0, 60.0, 5.0), FS)
     assert again.fluctuation_strength == pytest.approx(
@@ -335,6 +340,7 @@ def test_free_and_diffuse_differ() -> None:
     assert free.fluctuation_strength != diffuse.fluctuation_strength
 
 
+@pytest.mark.xdist_group("ecma-fluctuation-ref")
 def test_plot_smoke(ref_calibration: EcmaFluctuationStrength) -> None:
     import matplotlib
 
@@ -345,6 +351,7 @@ def test_plot_smoke(ref_calibration: EcmaFluctuationStrength) -> None:
     assert single is axes[0]
 
 
+@pytest.mark.xdist_group("ecma-fluctuation-ref")
 def test_plot_accepts_matplotlib_color_alias(
     ref_calibration: EcmaFluctuationStrength,
 ) -> None:

--- a/tests/psychoacoustics/test_loudness_ecma.py
+++ b/tests/psychoacoustics/test_loudness_ecma.py
@@ -35,6 +35,7 @@ def ref_1k_40() -> EcmaLoudness:
 # --------------------------------------------------------------------------
 
 
+@pytest.mark.xdist_group("ecma-loudness-ref")
 def test_calibration_1khz_40db_is_one_sone(ref_1k_40: EcmaLoudness) -> None:
     # c_N is defined so the 1 kHz / 40 dB tone gives 1 sone_HMS. With the
     # full Clause 6.2.3 band averaging this chain computes 0.9845 sone_HMS;
@@ -89,6 +90,7 @@ def test_subthreshold_tone_is_inaudible() -> None:
     assert result.loudness < 0.01
 
 
+@pytest.mark.xdist_group("ecma-loudness-ref")
 def test_specific_loudness_peaks_near_tone(ref_1k_40: EcmaLoudness) -> None:
     peak_band = int(np.argmax(ref_1k_40.specific_loudness))
     assert ref_1k_40.centre_frequencies[peak_band] == pytest.approx(1000.0, rel=0.15)
@@ -124,6 +126,7 @@ def test_resampling_matches_native_rate() -> None:
 # --------------------------------------------------------------------------
 
 
+@pytest.mark.xdist_group("ecma-loudness-ref")
 def test_result_structure(ref_1k_40: EcmaLoudness) -> None:
     assert ref_1k_40.specific_loudness.shape == (53,)
     assert ref_1k_40.bark.shape == (53,)
@@ -152,6 +155,7 @@ def test_empty_signal() -> None:
         loudness_ecma(np.array([]), FS)
 
 
+@pytest.mark.xdist_group("ecma-loudness-ref")
 def test_plot_smoke(ref_1k_40: EcmaLoudness) -> None:
     import matplotlib
 

--- a/tests/psychoacoustics/test_tonality_ecma.py
+++ b/tests/psychoacoustics/test_tonality_ecma.py
@@ -54,6 +54,7 @@ def broadband_noise() -> EcmaTonality:
 # --------------------------------------------------------------------------
 
 
+@pytest.mark.xdist_group("ecma-tonality-ref")
 def test_calibration_1khz_40db_is_one_tu(ref_1k_40: EcmaTonality) -> None:
     # c_T is defined so the 1 kHz / 40 dB tone gives 1 tu_HMS; the standard
     # allows c_T to vary within 0.25 %, and implementation differences add a
@@ -100,6 +101,7 @@ def test_decision_thresholds_are_the_standard_constants() -> None:
 # --------------------------------------------------------------------------
 
 
+@pytest.mark.xdist_group("ecma-tonality-ref")
 def test_pure_tone_far_exceeds_noise(
     ref_1k_40: EcmaTonality, broadband_noise: EcmaTonality
 ) -> None:
@@ -110,6 +112,7 @@ def test_pure_tone_far_exceeds_noise(
     assert ref_1k_40.tonality > 0.8
 
 
+@pytest.mark.xdist_group("ecma-tonality-ref")
 def test_tonal_frequency_tracks_tone(ref_1k_40: EcmaTonality) -> None:
     peak_band = int(np.argmax(ref_1k_40.specific_tonality))
     # The peaking band centres on the tone and its estimated tonal frequency
@@ -149,6 +152,7 @@ def test_silence_is_zero() -> None:
     assert np.all(result.specific_tonality == 0.0)
 
 
+@pytest.mark.xdist_group("ecma-tonality-ref")
 def test_specific_tonality_peaks_near_tone(ref_1k_40: EcmaTonality) -> None:
     peak_band = int(np.argmax(ref_1k_40.specific_tonality))
     assert ref_1k_40.centre_frequencies[peak_band] == pytest.approx(1000.0, rel=0.15)
@@ -249,6 +253,7 @@ def test_free_and_diffuse_fields_differ() -> None:
 # --------------------------------------------------------------------------
 
 
+@pytest.mark.xdist_group("ecma-tonality-ref")
 def test_result_structure(ref_1k_40: EcmaTonality) -> None:
     assert ref_1k_40.specific_tonality.shape == (53,)
     assert ref_1k_40.tonal_frequencies.shape == (53,)
@@ -279,6 +284,7 @@ def test_empty_signal() -> None:
         tonality_ecma(np.array([]), FS)
 
 
+@pytest.mark.xdist_group("ecma-tonality-ref")
 def test_plot_smoke(ref_1k_40: EcmaTonality) -> None:
     import matplotlib
 

--- a/tests/simulation/test_elastic_fdtd.py
+++ b/tests/simulation/test_elastic_fdtd.py
@@ -91,6 +91,7 @@ def _arrival(res: ElasticFDTDResult, probe: int, field: int) -> float:
     return float(res.times[1:][np.abs(res.signals[probe, field, 1:]).argmax()])
 
 
+@pytest.mark.xdist_group("elastic-body-waves")
 def test_p_wave_speed_by_time_of_flight(body_waves: ElasticFDTDResult) -> None:
     # P probes 100 and 220 cells below the source: c_P = dr / dt within 1 %
     # (measured: -0.06 %; the pulse spans ~19 cells, so grid dispersion of
@@ -100,6 +101,7 @@ def test_p_wave_speed_by_time_of_flight(body_waves: ElasticFDTDResult) -> None:
     assert c_meas == pytest.approx(CP_AL, rel=0.01)
 
 
+@pytest.mark.xdist_group("elastic-body-waves")
 def test_s_wave_speed_by_time_of_flight(body_waves: ElasticFDTDResult) -> None:
     # S probes 100 and 220 cells beside the force: c_S = dr / dt within 1 %
     # (measured: +0.02 %).

--- a/tests/simulation/test_fdtd_ntff.py
+++ b/tests/simulation/test_fdtd_ntff.py
@@ -146,6 +146,7 @@ def monopole_far_field() -> dict[str, object]:
     }
 
 
+@pytest.mark.xdist_group("fdtd-ntff-monopole")
 def test_monopole_pattern_is_omnidirectional(
         monopole_far_field: dict[str, object]) -> None:
     # A line source has no directivity: the reconstructed far-field
@@ -154,6 +155,7 @@ def test_monopole_pattern_is_omnidirectional(
     assert float(levels.max() - levels.min()) < 0.2
 
 
+@pytest.mark.xdist_group("fdtd-ntff-monopole")
 def test_monopole_level_matches_2d_green_function(
         monopole_far_field: dict[str, object]) -> None:
     # p = A H0(2)(k r) has the far-field pattern A sqrt(2/(pi k))
@@ -168,6 +170,7 @@ def test_monopole_level_matches_2d_green_function(
     assert float(np.abs(phase_error).max()) < 5.0
 
 
+@pytest.mark.xdist_group("fdtd-ntff-monopole")
 def test_monopole_finite_distance_matches_hankel(
         monopole_far_field: dict[str, object]) -> None:
     # The exact (finite-radius) evaluation must reproduce A H0(2)(k R) on
@@ -180,6 +183,7 @@ def test_monopole_finite_distance_matches_hankel(
         np.angle(reconstructed / exact))).max()) < 5.0
 
 
+@pytest.mark.xdist_group("fdtd-ntff-monopole")
 def test_contour_not_enclosing_the_source_extinguishes(
         monopole_far_field: dict[str, object]) -> None:
     # Fields whose sources lie outside the contour contribute nothing to
@@ -189,6 +193,7 @@ def test_contour_not_enclosing_the_source_extinguishes(
     assert outside < 0.02 * inside
 
 
+@pytest.mark.xdist_group("fdtd-ntff-monopole")
 def test_subtracting_a_run_from_itself_cancels(
         monopole_far_field: dict[str, object]) -> None:
     phasors = monopole_far_field["phasors"]
@@ -340,6 +345,7 @@ def metadiffuser_levels() -> np.ndarray:
                             settle=8e-3, cycles=10.0)
 
 
+@pytest.mark.xdist_group("fdtd-ntff-mesh")
 def test_meshed_qrd_far_field_matches_fraunhofer_model(
         qrd_levels: np.ndarray) -> None:
     model = predict_diffuser_polar_response(
@@ -359,6 +365,7 @@ def test_meshed_qrd_far_field_matches_fraunhofer_model(
                - model.coefficient) < 0.1
 
 
+@pytest.mark.xdist_group("fdtd-ntff-mesh")
 def test_meshed_metadiffuser_mimics_the_meshed_qrd(
         qrd_levels: np.ndarray,
         metadiffuser_levels: np.ndarray) -> None:
@@ -377,6 +384,7 @@ def test_meshed_metadiffuser_mimics_the_meshed_qrd(
                - directional_diffusion_coefficient(qrd_levels)) < 0.15
 
 
+@pytest.mark.xdist_group("fdtd-ntff-mesh")
 def test_meshed_metadiffuser_far_field_matches_tmm_model(
         metadiffuser_levels: np.ndarray) -> None:
     # End to end against the TMM + Fraunhofer chain, the library-side

--- a/tests/test_conformance_report.py
+++ b/tests/test_conformance_report.py
@@ -19,6 +19,11 @@ if _SCRIPTS not in sys.path:
 
 import conformance_report as cr
 
+# One xdist worker runs the whole module: the registry memoizes each check's
+# outcome per process, so the full-report render and the per-check tests
+# together compute every check exactly once instead of once per worker.
+pytestmark = pytest.mark.xdist_group("conformance-report")
+
 
 def test_registry_is_populated() -> None:
     # Realistic floors for the current registry size (95 checks / 22 domains

--- a/tests/test_generate_reports.py
+++ b/tests/test_generate_reports.py
@@ -5,13 +5,17 @@ The rendered PDFs (and their WebP previews) under ``.github/reports/`` are not
 byte-checked (their vector plot differs by ~1 ULP across CPUs, and the raster
 inherits it); this test only guards that ``scripts/generate_reports.py`` still
 runs and writes a valid single-page PDF plus a valid WebP preview for every
-registered example.
+registered example. One test per registered example: each fiche is rendered
+exactly once (PDF and preview asserted together on the same run) and the
+examples spread across the xdist workers instead of forming one monolithic
+test.
 """
 
 from __future__ import annotations
 
 import importlib.util
 import pathlib
+from collections.abc import Callable
 
 import pytest
 
@@ -34,29 +38,36 @@ def _load_generator():
     return module
 
 
-def test_generate_reports_writes_one_page_pdfs(tmp_path) -> None:
+_MODULE = _load_generator()
+
+
+def test_generator_registers_examples() -> None:
+    assert _MODULE._EXAMPLES, "the generator registered no examples"
+    # No factory is registered twice: a duplicate entry would render the
+    # same fiche twice and hide a forgotten registration elsewhere.
+    names = [factory.__name__ for factory in _MODULE._EXAMPLES]
+    assert len(set(names)) == len(names)
+
+
+@pytest.mark.parametrize(
+    "factory", _MODULE._EXAMPLES, ids=lambda factory: factory.__name__.strip("_")
+)
+def test_each_example_writes_a_one_page_pdf_and_preview(
+    factory: Callable[..., object], tmp_path: pathlib.Path
+) -> None:
+    from PIL import Image
     from pypdf import PdfReader
 
-    module = _load_generator()
-    written = module.generate_reports(str(tmp_path))
-    assert written, "the generator registered no examples"
-    for path in written:
-        p = pathlib.Path(path)
-        assert p.is_file() and p.stat().st_size > 0
-        with open(p, "rb") as handle:
-            assert handle.read(4) == b"%PDF"
-        assert len(PdfReader(str(p)).pages) == 1
-
-
-def test_generate_reports_writes_webp_previews(tmp_path) -> None:
-    from PIL import Image
-
-    module = _load_generator()
-    written = module.generate_reports(str(tmp_path))
-    for path in written:
-        preview = pathlib.Path(module.preview_path_for(path))
-        assert preview.suffix == ".webp"
-        assert preview.is_file() and preview.stat().st_size > 0
-        with Image.open(preview) as image:
-            assert image.format == "WEBP"
-            assert image.width == module._PREVIEW_WIDTH_PX
+    written = _MODULE.generate_reports(str(tmp_path), examples=[factory])
+    assert len(written) == 1
+    p = pathlib.Path(written[0])
+    assert p.is_file() and p.stat().st_size > 0
+    with open(p, "rb") as handle:
+        assert handle.read(4) == b"%PDF"
+    assert len(PdfReader(str(p)).pages) == 1
+    preview = pathlib.Path(_MODULE.preview_path_for(str(p)))
+    assert preview.suffix == ".webp"
+    assert preview.is_file() and preview.stat().st_size > 0
+    with Image.open(preview) as image:
+        assert image.format == "WEBP"
+        assert image.width == _MODULE._PREVIEW_WIDTH_PX


### PR DESCRIPTION
## What and why

The full suite had grown to 11:30 of wall time (690 s with 12 workers). Four changes bring it to about 5:55 (354 s) without touching what the tests assert: the report generator suite rendered all 67 example fiches twice (once for PDF assertions, once for WebP) as two single-worker monoliths of 297 s and 201 s, and now renders each fiche exactly once as its own parametrized test; the conformance registry memoizes its deterministic, argument-free checks so each computes once per process; the expensive FDTD, elastic-wave and ECMA reference fixtures are shared across xdist workers through load groups instead of recomputing per worker; and the heaviest modules dispatch first. The remaining floor is the steady-state FDTD physics behind the NTFF fixtures, which the convergence assertions are anchored to.

No test was removed, no signal shortened, no tolerance or oracle changed. Coverage is line-for-line identical to main: 251 files, 97 percent, same missing-line sets. Collected tests go from 7756 to 7822, the exact delta of splitting the two fiche monoliths into one test per fiche plus a registry guard.

## Validation

No new computation.

## Checklist

Ran locally, same as CI:

- [x] `ruff check .`, plus `ruff format --check` on the files you touched
- [x] `mypy src scripts`
- [x] `bandit -r src` (any finding fails, including Low)
- [x] `pytest -q`

Regenerated where this change touches them:

- [x] `make conformance`, with `docs/CONFORMANCE.md` byte-identical (the memoized registry produces the same report)

Always:

- [x] CHANGELOG entry under `[Unreleased]`

## Summary by Sourcery

Halve the test suite wall time by restructuring heavy tests, memoizing deterministic conformance checks, and improving xdist distribution of expensive fixtures and modules.

Enhancements:
- Parametrize report generator tests so each example fiche is rendered once, asserting PDF and WebP outputs together.
- Allow the report generator script to run on a configurable subset of registered examples.
- Memoize deterministic conformance registry checks so each outcome is computed once per process.
- Group heavy FDTD, elastic and ECMA reference tests with xdist load groups to reuse expensive module fixtures per worker.
- Front-load the heaviest test modules in pytest collection to better overlap long-running tests with the rest of the suite.

Documentation:
- Document the reduced test suite wall time and its strategies in the changelog.

Tests:
- Add a registry guard test ensuring report examples are registered uniquely and exercised individually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved test-suite execution by reusing expensive calculations and fixtures.
  * Prioritized slower tests and coordinated related tests for more efficient parallel execution.
  * Report previews now render only once per example.

* **Tests**
  * Expanded validation to ensure each report example produces a valid, one-page PDF and preview.
  * Preserved existing conformance coverage and test behavior.

* **Documentation**
  * Updated the unreleased changelog with these test-performance improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->