### PR TITLE
Fan the jitted-kernel test job out across the runner's cores

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -311,6 +311,22 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    # Declared once for the whole job so the guard below runs under exactly the
+    # environment it vouches for. Split across the two steps, the guard could
+    # stay green on its own NUMBA_DISABLE_JIT while the suite lost its copy and
+    # ran interpreted from end to end.
+    env:
+      # conftest.py disables JIT by default (coverage); override it here, this
+      # is the only job exercising the numba-compiled kernel.
+      NUMBA_DISABLE_JIT: "0"
+      # Pin the numerical thread pools to one thread each so the per-core xdist
+      # workers do not oversubscribe the CPU with nested BLAS/OpenMP pools,
+      # exactly as the main test job does.
+      OMP_NUM_THREADS: "1"
+      MKL_NUM_THREADS: "1"
+      OPENBLAS_NUM_THREADS: "1"
+      NUMEXPR_NUM_THREADS: "1"
+      VECLIB_MAXIMUM_THREADS: "1"
     steps:
     - uses: actions/checkout@v7
       with:
@@ -325,12 +341,18 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements-dev.txt
         pip install -e ".[perf,plot]"
+    # Fails the job if the kernel falls back to the interpreted path, which
+    # would leave this job green while exercising nothing it exists for.
+    # Compiling here also fills numba's on-disk cache next to the module, so
+    # the test workers below load the kernel instead of each compiling a copy.
+    - name: Check the jitted kernel compiles
+      run: python scripts/check_jit_kernel.py
     - name: Run tests (jitted kernel)
-      env:
-        # conftest.py disables JIT by default (coverage); override it here —
-        # this is the only job exercising the numba-compiled kernel.
-        NUMBA_DISABLE_JIT: "0"
-      run: pytest -q
+      # Same fan-out as the main matrix. The compiled kernel is not a reason
+      # to stay serial: the step above compiles it once and the workers that
+      # reach it read the cache in a fraction of a second, against a suite
+      # that takes about twenty minutes to run one test at a time.
+      run: pytest -q -n auto
 
   sonar:
     needs: tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -983,6 +983,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   heaviest modules dispatch first. No test was removed, no signal shortened
   and no tolerance or oracle touched; coverage is line-for-line identical.
 
+- The CI job that exercises the numba-jitted kernel fans the suite out with
+  `pytest -n auto` like every other test job. It was the one job still running
+  serially, so the load groups and the heavy-first dispatch order did nothing
+  in it and it kept taking about 20 minutes while the parallel jobs halved.
+  Compilation was never the reason to keep it serial: the library jits exactly
+  one kernel, and the two signatures it is called with cost about 5 s to
+  compile from scratch and about 0.6 s to load from numba's on-disk cache
+  against a suite of 7800 tests, and the modules that reach the kernel take
+  the same time with the JIT on as with it off. A new
+  `scripts/check_jit_kernel.py` step compiles both signatures before the
+  workers start, so they read that cache instead of each building its own, and
+  fails the job when the kernel produced no machine code at all (numba missing
+  from the environment, or `NUMBA_DISABLE_JIT` left at the default the rest of
+  the suite runs under), which would otherwise leave this job green while
+  exercising the interpreted path it does not exist for. The job declares that
+  variable once for all of its steps, so the guard runs under exactly the
+  environment it vouches for and cannot stay green on a copy of its own while
+  the suite loses it. On a 12-core host the suite goes from 2312 s serial to
+  789 s on four workers and 574 s on all twelve, with the same 7800 tests
+  passing.
+
 - The eleven documentation clips still encoded as VP9 are now AV1, which is
   what the other fifteen had already moved to, so all 104 WebM files finally
   share one codec. Their 44 files come down from 20.1 MB to 15.5 MB, 23 %

--- a/scripts/check_jit_kernel.py
+++ b/scripts/check_jit_kernel.py
@@ -1,0 +1,71 @@
+#  Copyright (c) 2026. Jose Manuel Requena Plens
+"""Assert that the numba-jitted impulse kernel really compiles, and warm its cache.
+
+The CI job that installs the ``perf`` extra exists to exercise the compiled
+kernel, so a silent fall back to the interpreted path (numba missing from the
+environment, ``NUMBA_DISABLE_JIT`` left at its default, a decorator that stops
+being applied) would leave the job green while testing nothing it is there for.
+Run this before the suite: it fails loudly when no machine code was produced.
+
+It has to run under the same environment as the suite it guards, which is why
+the job declares ``NUMBA_DISABLE_JIT`` once for every step. The variable is
+checked explicitly rather than inferred from whether compilation happened:
+numba's own default is JIT on, but ``tests/conftest.py`` turns it off unless
+the value is set, so a guard that only looked at the compiled signatures would
+pass with the variable absent while the suite ran entirely interpreted.
+
+Compiling here also fills numba's on-disk cache next to the module, so the
+parallel test workers started afterwards load the kernel instead of each
+compiling its own copy.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+
+import numpy as np
+
+from phonometry.metrology import parametric_filters as pf
+from phonometry.metrology.parametric_filters import time_weighting
+
+
+def main() -> int:
+    if importlib.util.find_spec("numba") is None:
+        print("FAIL: numba is not installed, the kernel is the interpreted fallback")
+        return 1
+
+    disable_jit = os.environ.get("NUMBA_DISABLE_JIT")
+    if disable_jit != "0":
+        print(
+            f"FAIL: NUMBA_DISABLE_JIT is {disable_jit!r}, not '0'; "
+            "tests/conftest.py leaves the JIT off at any other value and the "
+            "suite would run the interpreted kernel"
+        )
+        return 1
+
+    rng = np.random.default_rng(0)
+    # Both shapes the library reaches the kernel with: a single channel (scalar
+    # initial state) and a multi-channel block (array initial state). Each is a
+    # separate numba signature, so both have to be compiled to be cached.
+    time_weighting(rng.standard_normal(256), 48_000, mode="impulse")
+    time_weighting(rng.standard_normal((2, 256)), 48_000, mode="impulse")
+
+    signatures = getattr(pf._apply_impulse_kernel, "nopython_signatures", [])
+    if not signatures:
+        print(
+            "FAIL: the kernel produced no compiled signature with numba "
+            "installed and the JIT on; the decorator is no longer being "
+            "applied and the job would exercise the interpreted path"
+        )
+        return 1
+
+    print(f"OK: {len(signatures)} compiled signature(s) for the impulse kernel")
+    for sig in signatures:
+        print(f"  {sig}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_jit_kernel.py
+++ b/scripts/check_jit_kernel.py
@@ -25,11 +25,6 @@ import importlib.util
 import os
 import sys
 
-import numpy as np
-
-from phonometry.metrology import parametric_filters as pf
-from phonometry.metrology.parametric_filters import time_weighting
-
 
 def main() -> int:
     if importlib.util.find_spec("numba") is None:
@@ -44,6 +39,14 @@ def main() -> int:
             "suite would run the interpreted kernel"
         )
         return 1
+
+    # Imported here, not at module level, so the two environment failures above
+    # report themselves rather than dying in an import when the very thing they
+    # diagnose is what broke the environment.
+    import numpy as np
+
+    from phonometry.metrology import parametric_filters as pf
+    from phonometry.metrology.parametric_filters import time_weighting
 
     rng = np.random.default_rng(0)
     # Both shapes the library reaches the kernel with: a single channel (scalar

--- a/tests/test_check_jit_kernel.py
+++ b/tests/test_check_jit_kernel.py
@@ -1,0 +1,46 @@
+#  Copyright (c) 2026. Jose Manuel Requena Plens
+"""The guard that keeps the jitted-kernel CI job honest.
+
+``scripts/check_jit_kernel.py`` runs before the test suite in the job that
+installs the ``perf`` extra, and fails when the impulse kernel produced no
+machine code. Its verdict has to follow the environment in both directions:
+green only where numba is installed *and* ``NUMBA_DISABLE_JIT`` is off, red
+everywhere else, because a guard that always passes would hide exactly the
+regression it is there to catch.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import pathlib
+import sys
+
+import pytest
+
+_SCRIPTS = str(pathlib.Path(__file__).resolve().parent.parent / "scripts")
+if _SCRIPTS not in sys.path:
+    sys.path.insert(0, _SCRIPTS)
+
+import check_jit_kernel
+
+#: True only in the environment the guard is meant to pass in: numba installed
+#: (the ``perf`` extra) and the JIT left enabled.
+_JITTED = (
+    importlib.util.find_spec("numba") is not None
+    and os.environ.get("NUMBA_DISABLE_JIT") == "0"
+)
+
+
+def test_guard_verdict_follows_the_environment() -> None:
+    """The exit status must agree with whether the kernel really compiles."""
+    assert (check_jit_kernel.main() == 0) is _JITTED
+
+
+@pytest.mark.skipif(not _JITTED, reason="numba is absent or the JIT is disabled")
+def test_a_pass_is_backed_by_a_printed_signature(capsys) -> None:
+    """A pass has to name the compiled signatures, not just return zero."""
+    assert check_jit_kernel.main() == 0
+    out = capsys.readouterr().out
+    assert "compiled signature" in out
+    assert "array(float64" in out


### PR DESCRIPTION
## What and why

The `tests (numba-jitted kernel)` job ran `pytest -q` serially and took about 1132 s, barely moving when the rest of the suite was halved, because the two techniques that mattered there (load groups and heavy-first dispatch) are inert without `-n`. The reason it was serial turns out to have been an assumption rather than a measurement: the PR that parallelised the suite left it out because "per-worker JIT recompilation would dominate".

Measurement says otherwise. The library jits exactly one function, `_impulse_kernel_py`, already decorated with `cache=True` and reachable only through `time_weighting(mode="impulse")`. Instrumenting the full suite records 12 calls into it in the entire run. Aggregate first-call cost is 37.5 s cold and 3.1 s warm; aggregate machine-code execution is 0.06 s. Compilation is about 0.4 percent of the job and execution 0.005 percent, and the two modules that reach the kernel take the same time with the JIT on as with it off. Serial to four workers, which is the shape of the GitHub runner, measured 1666 s to 441 s on a quiet machine.

A guard step runs before the suite. It compiles both signatures once, so the workers load that machine code rather than each building their own or racing to write the cache, and it fails the job when the kernel produced no machine code. That second part is the point: this job exists to exercise the compiled kernel, and without the guard it could quietly degrade to the pure-Python path and still report green. The environment variable is declared once at job level so the guard and the suite cannot diverge, and the guard requires it to be exactly `"0"` rather than inferring it, since numba defaults to JIT on while this repository's test default is JIT off. `tests/test_check_jit_kernel.py` asserts the guard's verdict follows the environment, so a guard that always passes cannot slip in.

Rejected with numbers: caching numba's directory between runs buys at most the cold compile, `cache=True` is already set, and narrowing the job's scope would drop coverage under the numpy version numba pins.

## Validation

No new computation. No test removed, no signal shortened, no tolerance or oracle touched. Eight rounds of twelve processes compiling simultaneously against a wiped cache produced no failure and left the cache loadable every time.

## Checklist

Ran locally, same as CI:

- [x] `ruff check .`
- [x] `mypy src scripts` (with the numpy the `quality` job installs)
- [x] `bandit -r src`
- [x] `pytest -q`: 7802 passed, 22 skipped, in both the serial and the parallel shape
- [x] `make conformance`: 533/533, no diff

Always:

- [x] CHANGELOG entry under `[Unreleased]`

## Summary by Sourcery

Parallelize the CI job that exercises the numba-jitted kernel and add a guard to ensure the kernel is actually JIT-compiled before running tests.

New Features:
- Add a scripts/check_jit_kernel.py guard script that verifies the numba impulse kernel compiles and warms its cache before the test suite.
- Introduce tests/test_check_jit_kernel.py to assert the guard script’s behavior matches the environment (numba presence and JIT settings).

Enhancements:
- Update the numba-jitted kernel CI workflow to share a single JIT-enabled environment across steps and run pytest with xdist fan-out instead of serial execution.
- Document the new jitted-kernel CI behavior and performance characteristics in the CHANGELOG.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved automated test execution time through parallel processing while maintaining full test coverage.

- **Reliability**
  - Added validation to confirm numerical acceleration is enabled and compiled successfully before performance tests run.
  - Added coverage for environment-dependent validation outcomes and compilation reporting.

- **Documentation**
  - Updated the unreleased changelog with the new test execution improvements and reported benchmark results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->