### PR TITLE
Validate the multiple-shock times with the shared checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -999,6 +999,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- The multiple-shock time guards go through `require_positive` like the rest
+  of the library. They were written as `not t > 0.0`, which rejects NaN where
+  `t <= 0.0` would accept it, and that reason lived in a comment. The shared
+  validator says the same thing in the form the whole package uses, rejects
+  infinities too, and names the parameter that failed instead of both at once.
+
 - `phonometry.vibration` has three families, by who reads them.
   `vibration.structural` is the structural acoustics that feeds building
   prediction: mobility (ISO 7626), plate junctions, radiation efficiency,

--- a/src/phonometry/vibration/human/multiple_shock.py
+++ b/src/phonometry/vibration/human/multiple_shock.py
@@ -252,10 +252,8 @@ def daily_dose(dose: float, exposure_time: float, measurement_time: float) -> fl
         was measured (same unit as ``exposure_time``).
     :return: The daily dose :math:`D_{zd} = D_z (t_d/t_m)^{1/6}`, m/s2.
     """
-    # Negated ">" rather than "<=" on purpose: it rejects NaN as well, which
-    # the opposite operator would let through.
-    if not measurement_time > 0.0 or not exposure_time > 0.0:  # NOSONAR - NaN
-        raise ValueError("exposure_time and measurement_time must be positive.")
+    exposure_time = require_positive(exposure_time, "exposure_time")
+    measurement_time = require_positive(measurement_time, "measurement_time")
     return float(dose * (exposure_time / measurement_time) ** (1.0 / DOSE_EXPONENT))
 
 
@@ -358,9 +356,7 @@ def injury_risk(
     require_choice(sex, "sex", _SEXES)
     if years <= 0:
         raise ValueError("years must be a positive integer.")
-    # Negated ">" rather than "<=" on purpose: it rejects NaN as well.
-    if not days_per_year > 0.0:  # NOSONAR - NaN
-        raise ValueError("days_per_year must be positive.")
+    days_per_year = require_positive(days_per_year, "days_per_year")
     mz = _mz_for_sex(sex) if mz is None else mz
     s_stat = static_stress(mz)
     ages = start_age + np.arange(years, dtype=np.float64)

--- a/tests/vibration/human/test_multiple_shock_vibration.py
+++ b/tests/vibration/human/test_multiple_shock_vibration.py
@@ -230,11 +230,12 @@ def test_response_peaks_rejects_2d() -> None:
     with pytest.raises(ValueError, match="1-D time series"):
         v.response_peaks(np.zeros((2, 100)))
 
-def test_the_time_guards_reject_nan() -> None:
-    """``not t > 0`` is deliberate: ``t <= 0`` would let NaN through."""
-    with pytest.raises(ValueError, match="must be positive"):
-        v.daily_dose(1.0, exposure_time=math.nan, measurement_time=1.0)
-    with pytest.raises(ValueError, match="must be positive"):
-        v.daily_dose(1.0, exposure_time=1.0, measurement_time=math.nan)
-    with pytest.raises(ValueError, match="days_per_year must be positive"):
-        v.injury_risk(0.5, start_age=20.0, years=20, days_per_year=math.nan)
+def test_the_time_guards_reject_nan_and_infinity() -> None:
+    """The guards go through require_positive, which rejects both."""
+    for bad in (math.nan, math.inf):
+        with pytest.raises(ValueError, match="'exposure_time' must be positive"):
+            v.daily_dose(1.0, exposure_time=bad, measurement_time=1.0)
+        with pytest.raises(ValueError, match="'measurement_time' must be positive"):
+            v.daily_dose(1.0, exposure_time=1.0, measurement_time=bad)
+        with pytest.raises(ValueError, match="'days_per_year' must be positive"):
+            v.injury_risk(0.5, start_age=20.0, years=20, days_per_year=bad)


### PR DESCRIPTION
## What and why

The two time guards in `vibration.human.multiple_shock` were written as `not t > 0.0`, which rejects NaN where `t <= 0.0` accepts it. That is correct and it is why they were written that way, but the reason lived in a comment and the analyzer read them as an inverted comparison.

The library already has `require_positive` for exactly this, written the same way for the same reason. Using it removes the last hand-written positivity check in the module, drops the marker that told the analyzer to look away, and gives the caller the message the rest of the library gives, naming the parameter that failed rather than both at once.

Infinity is rejected now where it was accepted before, which is what the shared checker brings for free. The test covers both NaN and infinity through all three parameters.

## Validation

No new computation. The full vibration suite passes and the conformance report is unchanged.

## Checklist

- [x] `ruff check .`
- [x] `mypy src scripts`
- [x] `pytest -q` (vibration suite; full suite in CI)
- [x] `make conformance` (no diff)
- [x] CHANGELOG entry under `[Unreleased]`

## Summary by Sourcery

Route multiple-shock time parameter validation through the shared positivity checker for more consistent error handling and robustness.

Enhancements:
- Use the shared require_positive validator for multiple-shock time parameters in daily_dose and injury_risk, ensuring consistent positivity checks and error messages across the library.

Documentation:
- Add CHANGELOG entry documenting the updated multiple-shock time guards and behavior for NaN and infinite time values.

Tests:
- Extend multiple-shock vibration tests to verify that NaN and infinite time parameters are rejected with parameter-specific error messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for multiple-shock vibration calculations.
  - Non-positive and non-finite values are now rejected for exposure time, measurement time, and days per year.
  - Error messages identify the specific invalid parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->