### PR TITLE
Do not publish without a green CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,6 +25,14 @@ on:
       # the first entry already.)
       - ".github/brand/**"
       - "scripts/generate_llms.py"
+      # The release commit. site/src/data/citation.mjs reads all three of these
+      # from the repository root, and repo-stats.mjs reads VERSION: without
+      # them here, publishing a release rebuilt nothing, and the site kept
+      # citing the previous version until something under site/ happened to
+      # change.
+      - "VERSION"
+      - "CHANGELOG.md"
+      - "CITATION.cff"
       - ".github/workflows/docs.yml"
   pull_request:
     branches: ["main"]
@@ -37,6 +45,9 @@ on:
       - "docs/**"
       - ".github/brand/**"
       - "scripts/generate_llms.py"
+      - "VERSION"
+      - "CHANGELOG.md"
+      - "CITATION.cff"
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ on:
 
 permissions:
   contents: write
+  # Reading the conclusion of the CI run on this commit, which is what the
+  # first step of the job refuses to publish without.
+  actions: read
 
 jobs:
   release:
@@ -43,6 +46,57 @@ jobs:
           echo "skip=false" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Require a green Python CI on this commit
+        if: steps.version.outputs.skip != 'true'
+        # Publishing consulted no test result at all: a push to VERSION on a
+        # semantically broken main went to PyPI, and a version number cannot be
+        # re-uploaded once it is burned. `needs:` cannot cross workflow files,
+        # and branch protection would not cover the manual trigger below, so the
+        # job asks the API directly.
+        #
+        # Python CI runs on every push to main, which means it is in flight
+        # beside this job rather than finished before it: the loop waits for the
+        # run on this exact commit and then insists that it succeeded. A run
+        # that has not been registered yet is tolerated briefly, since the two
+        # workflows start together; one that never appears is a failure, because
+        # publishing on no evidence is the thing this step exists to stop.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          appear_deadline=$(( SECONDS + 300 ))
+          finish_deadline=$(( SECONDS + 2700 ))
+          while :; do
+            read -r status conclusion <<<"$(gh run list \
+              --repo "$GITHUB_REPOSITORY" --commit "$GITHUB_SHA" \
+              --workflow python-app.yml --limit 1 \
+              --json status,conclusion \
+              --jq '.[0] | "\(.status // "missing") \(.conclusion // "none")"')"
+            case "$status" in
+              completed)
+                if [ "$conclusion" = success ]; then
+                  echo "Python CI succeeded on $GITHUB_SHA."
+                  break
+                fi
+                echo "::error::Python CI concluded '$conclusion' on $GITHUB_SHA. Not publishing."
+                exit 1
+                ;;
+              missing)
+                if [ "$SECONDS" -ge "$appear_deadline" ]; then
+                  echo "::error::No Python CI run for $GITHUB_SHA after five minutes. Not publishing."
+                  exit 1
+                fi
+                ;;
+              *)
+                if [ "$SECONDS" -ge "$finish_deadline" ]; then
+                  echo "::error::Python CI still '$status' on $GITHUB_SHA after 45 minutes. Not publishing."
+                  exit 1
+                fi
+                ;;
+            esac
+            sleep 30
+          done
 
       - name: Set up Python
         if: steps.version.outputs.skip != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,11 +75,19 @@ jobs:
           appear_deadline=$(( SECONDS + 300 ))
           finish_deadline=$(( SECONDS + 2700 ))
           while :; do
+            # A failed call leaves the substitution empty rather than killing
+            # the step: a here-string discards the substitution's exit status,
+            # so `set -e` never sees it. Name that state, so the log shows the
+            # retries and the deadline message says what it was waiting on.
             read -r status conclusion <<<"$(gh run list \
               --repo "$GITHUB_REPOSITORY" --commit "$GITHUB_SHA" \
               --workflow python-app.yml --limit 1 \
               --json status,conclusion \
               --jq '.[0] | "\(.status // "missing") \(.conclusion // "none")"')"
+            if [ -z "$status" ]; then
+              status=unreachable
+              echo "::warning::gh run list failed; retrying."
+            fi
             case "$status" in
               completed)
                 if [ "$conclusion" = success ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,13 @@ jobs:
 
       - name: Require a green Python CI on this commit
         if: steps.version.outputs.skip != 'true'
+        # Fifty, just above the loop's own forty-five, so the message the loop
+        # writes is the one a reader gets in the ordinary case. The ceiling is
+        # not redundant with it: the loop only tests its deadline between
+        # iterations, so a `gh` call that hangs on a stalled connection never
+        # reaches the test, and without this the job would sit on a runner
+        # until the six-hour default.
+        timeout-minutes: 50
         # Publishing consulted no test result at all: a push to VERSION on a
         # semantically broken main went to PyPI, and a version number cannot be
         # re-uploaded once it is burned. `needs:` cannot cross workflow files,


### PR DESCRIPTION
The publish job consulted no test result. It triggers on a push to `VERSION` on
main and goes straight to build, `twine check` and upload, with no `needs:` and
no `workflow_run`:

```
$ grep -n 'needs:\|workflow_run' .github/workflows/release.yml
(no output)
```

The obvious mitigation is not there either. `main` has no required status
checks, no ruleset, and zero required approving reviews, so nothing stops a red
commit from reaching it and nothing stops this job from publishing it. A version
number cannot be re-uploaded once burned: recovery is a yank, a patch bump, and
everyone who installed in the window carrying a broken package. It matters more
for a major release than for a patch, because what is most likely to break is
the compatibility layer, and only the suite exercises that.

`needs:` cannot cross workflow files, and branch protection would not cover the
`workflow_dispatch` trigger, so the job asks the API for the conclusion of
Python CI on its own commit. Python CI runs on every push to main, so it is in
flight beside this job rather than finished before it: the step waits for the
run on that exact commit and then insists it succeeded.

- A run not yet registered is tolerated for five minutes, since the two
  workflows start together.
- A run that never appears is a failure. Publishing on no evidence is what the
  step exists to stop.
- It sits after the version guard and carries the same `skip` condition as every
  other step, so a push that releases nothing waits for nothing.

Exercised against a stubbed API on all five paths:

| Python CI on the commit | Result |
|---|---|
| `completed success` | proceeds |
| `completed failure` | stops, `Not publishing` |
| `completed cancelled` | stops |
| never registered | stops after five minutes |
| never finishes | stops after forty-five minutes |

The second half is the docs workflow, which was not triggered by any of the
three files a release commit touches, and which reads all three:
`site/src/data/citation.mjs` takes the version, the release date and the
citation blocks from `VERSION`, `CHANGELOG.md` and `CITATION.cff`, and
`repo-stats.mjs` takes the version too. Publishing a release therefore rebuilt
nothing, and the site went on citing the previous version until something under
`site/` happened to change. All three are in the path filters now, in both the
push and the pull request lists, which the file already says have to be kept in
step.

Required status checks on `main` are a separate matter and are not the answer
here: they gate merging a pull request, and the two ways a broken commit reaches
this job, a direct push and the manual trigger, go around them. The check that
protects the upload has to be in the upload's own job, which is where it is now.

The wider filter costs little, measured rather than guessed: of the last sixty
merges on main, fifty-one already triggered the site job through `site/`,
`docs/`, the brand artwork or the llms generator, two trigger nothing either
way, and seven newly trigger it because they touch one of the three release
files and nothing else. The three of them that matter are the ones that change
what the site says about the release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Changes to release metadata now trigger documentation builds and validation.
  * Releases require successful completion of the matching Python CI checks before packaging and publishing.
  * Release processing stops when required checks are missing, fail, are cancelled, or exceed the allowed wait time.
  * These safeguards help ensure published releases are accompanied by up-to-date documentation and verified changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->