### PR TITLE
Give the tenth topic its section on the map

### DIFF
--- a/site/scripts/check-guides-index.mjs
+++ b/site/scripts/check-guides-index.mjs
@@ -128,6 +128,24 @@ for (const { lang, root, word } of LOCALES) {
 		ok(`${lang}: every count it states in figures says ${routes.length}`);
 	}
 
+	// The structured data has to agree with itself and with the page: the list
+	// declared ten items over nine entries once, while the description said
+	// nine and the frontmatter said ten, all in one file.
+	const ld = index.match(/\{\s*\n\s*"@context": "https:\/\/schema\.org"[\s\S]*?\n {6}\}/);
+	if (ld) {
+		const data = JSON.parse(ld[0]);
+		const declared = data.numberOfItems;
+		const listed = (data.itemListElement ?? []).length;
+		const headings = (index.match(/^## \[/gm) ?? []).length;
+		if (declared === listed && listed === headings) {
+			ok(`${lang}: the JSON-LD declares ${declared} areas, lists ${listed}, and the page has ${headings} sections`);
+		} else {
+			fail(`${lang}: numberOfItems ${declared}, itemListElement ${listed}, ## headings ${headings}`);
+		}
+	} else {
+		fail(`${lang}: no ItemList JSON-LD found in the index`);
+	}
+
 	// And the same number in words, which is the half nobody updates.
 	// `spell` returns a pattern rather than one spelling, since a number has more
 	// than one correct wording and the check is about the arithmetic.

--- a/site/src/content/docs/buildings/insulation/index.md
+++ b/site/src/content/docs/buildings/insulation/index.md
@@ -71,6 +71,9 @@ related EN 12354-5, lives in
 - [Laboratory Flanking Transmission (ISO 10848)](/phonometry/buildings/insulation/flanking-lab/):
   the measured vibration reduction index Kij and the flanking descriptors
   Dn,f and Ln,f.
+- [Heavy and Soft Impact Sources (ISO 16283-2)](/phonometry/buildings/insulation/heavy-impact-sources/):
+  the rubber ball and the bang machine, the impact force exposure level that
+  specifies them, and the A-weighted single number of ISO 717-2 Annex D.
 - [Insulation Ratings (ISO 717)](/phonometry/buildings/insulation/insulation-ratings/):
   the ISO 717-1/-2 reference-curve engines, C, Ctr and CI, the enlarged-range
   terms and the ISO 717 fiche.

--- a/site/src/content/docs/devices/emission/index.md
+++ b/site/src/content/docs/devices/emission/index.md
@@ -46,3 +46,6 @@ against.
   the direct and comparison methods of ISO 3741.
 - [Sound Power by Intensity Scanning](/phonometry/devices/emission/sound-power-intensity/):
   the on-site scanning of ISO 9614-2 and the ISO 9614-3 precision grade.
+- [Sound Power from Surface Vibration (ISO/TS 7849)](/phonometry/devices/emission/vibration-sound-power/):
+  the airborne power estimated from the velocity of the machine's own surface,
+  with the radiation factor deciding how honest the estimate is.

--- a/site/src/content/docs/environment/propagation/index.md
+++ b/site/src/content/docs/environment/propagation/index.md
@@ -77,6 +77,9 @@ sections.
   the Weyl-Van der Pol spherical-wave ground reflection and wave-theoretic
   barrier diffraction (Kurze-Anderson, exact rigid half-plane, thick barriers
   and the coherent four-path barrier on the ground).
+- [Atmospheric refraction: rays and the GFPE](/phonometry/environment/propagation/atmospheric-refraction/):
+  the refracting atmosphere itself: effective sound-speed profiles, curved rays
+  with their shadow zones, and the Green's function parabolic equation.
 - [Impulsive-sound prominence (NT ACOU 112)](/phonometry/environment/assessment/impulsive-sound/):
   the predicted prominence of impulsive sounds and the graduated LAeq
   adjustment KI.

--- a/site/src/content/docs/es/buildings/insulation/index.md
+++ b/site/src/content/docs/es/buildings/insulation/index.md
@@ -74,6 +74,10 @@ emparentada EN 12354-5, vive en
 - [Transmisión por flancos en laboratorio (ISO 10848)](/phonometry/es/buildings/insulation/flanking-lab/):
   el índice de reducción de vibraciones Kij medido y los descriptores de
   flanco Dn,f y Ln,f.
+- [Fuentes de impacto pesadas y blandas (ISO 16283-2)](/phonometry/es/buildings/insulation/heavy-impact-sources/):
+  la pelota de caucho y la máquina de neumático, el nivel de exposición a la
+  fuerza de impacto que las especifica y el número único ponderado A del
+  anexo D de ISO 717-2.
 - [Índices globales de aislamiento (ISO 717)](/phonometry/es/buildings/insulation/insulation-ratings/):
   los motores de curva de referencia de ISO 717-1/-2, C, Ctr y CI, los
   términos de rango ampliado y la ficha de ISO 717.

--- a/site/src/content/docs/es/devices/emission/index.md
+++ b/site/src/content/docs/es/devices/emission/index.md
@@ -49,3 +49,6 @@ referencia contra la que se juzgan las medidas correctoras de las páginas de
   los métodos directo y de comparación de ISO 3741.
 - [Potencia acústica por barrido de intensidad](/phonometry/es/devices/emission/sound-power-intensity/):
   el barrido in situ de ISO 9614-2 y el grado de precisión ISO 9614-3.
+- [Potencia acústica desde la vibración superficial (ISO/TS 7849)](/phonometry/es/devices/emission/vibration-sound-power/):
+  la potencia aérea estimada desde la velocidad de la propia superficie de la
+  máquina, con el factor de radiación decidiendo cuánto vale la estimación.

--- a/site/src/content/docs/es/environment/propagation/index.md
+++ b/site/src/content/docs/es/environment/propagation/index.md
@@ -81,6 +81,10 @@ y las fuentes que alimentan un cálculo de propagación en las secciones de
   la reflexión de onda esférica de Weyl-Van der Pol en el suelo y la difracción
   de barreras por teoría ondulatoria (Kurze-Anderson, semiplano rígido exacto,
   barreras gruesas y la barrera coherente de cuatro caminos sobre el suelo).
+- [Refracción atmosférica: rayos y GFPE](/phonometry/es/environment/propagation/atmospheric-refraction/):
+  la propia atmósfera refractante: perfiles efectivos de velocidad del sonido,
+  rayos curvados con sus zonas de sombra, y la ecuación parabólica de función
+  de Green.
 - [Prominencia de sonidos impulsivos (NT ACOU 112)](/phonometry/es/environment/assessment/impulsive-sound/):
   la prominencia predicha de los sonidos impulsivos y el ajuste graduado KI
   del LAeq.

--- a/site/src/content/docs/es/reference/index.md
+++ b/site/src/content/docs/es/reference/index.md
@@ -52,6 +52,13 @@ evidencia, la lectura que implementa la librería y el test que la fija. Léelo
 cuando un valor esperado impreso y la librería no coincidan, antes de dar por
 hecho que el error es de la librería.
 
+## [Glosario de magnitudes](/phonometry/es/reference/glossary/)
+
+Cada magnitud acústica que calculan las guías, con su símbolo, una definición
+de una frase, su unidad, la norma y cláusula que la define y la guía que la
+implementa. Para cuando un símbolo de una fórmula necesita nombre, o un nombre
+necesita la cláusula de la que viene.
+
 ## [Bibliografía](/phonometry/es/reference/bibliography/)
 
 Todos los libros y artículos que citan las guías, en una sola lista agrupada

--- a/site/src/content/docs/es/reference/index.md
+++ b/site/src/content/docs/es/reference/index.md
@@ -56,8 +56,8 @@ hecho que el error es de la librería.
 
 Cada magnitud acústica que calculan las guías, con su símbolo, una definición
 de una frase, su unidad, la norma y cláusula que la define y la guía que la
-implementa. Para cuando un símbolo de una fórmula necesita nombre, o un nombre
-necesita la cláusula de la que viene.
+implementa. Léelo cuando un símbolo de una fórmula necesite nombre, o un
+nombre necesite la cláusula de la que viene.
 
 ## [Bibliografía](/phonometry/es/reference/bibliography/)
 

--- a/site/src/content/docs/es/start/guides.md
+++ b/site/src/content/docs/es/start/guides.md
@@ -11,7 +11,7 @@ head:
         "@type": "ItemList",
         "@id": "https://jmrplens.github.io/phonometry/es/start/guides/#areas",
         "name": "Áreas de la documentación de phonometry",
-        "description": "Los diez temas documentados de las guías de phonometry, cada una con las normas que implementa.",
+        "description": "Las diez áreas documentadas de las guías de phonometry, cada una con las normas que implementa.",
         "inLanguage": "es",
         "numberOfItems": 10,
         "itemListOrder": "https://schema.org/ItemListUnordered",
@@ -61,20 +61,27 @@ head:
           {
             "@type": "ListItem",
             "position": 7,
+            "name": "Ruido de aeronaves",
+            "description": "Niveles de certificación, contornos de aeropuerto y el método del hemisferio.",
+            "url": "https://jmrplens.github.io/phonometry/es/aircraft/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 8,
             "name": "Acústica submarina",
             "description": "Niveles re 1 microPa, ruido radiado por buques, hincado de pilotes, ruido ambiente, pérdidas por transmisión.",
             "url": "https://jmrplens.github.io/phonometry/es/underwater/"
           },
           {
             "@type": "ListItem",
-            "position": 8,
+            "position": 9,
             "name": "Fuentes y dispositivos",
             "description": "Potencia acústica, intensidad, declaraciones de emisión, electroacústica, sonoridad de programa.",
             "url": "https://jmrplens.github.io/phonometry/es/devices/"
           },
           {
             "@type": "ListItem",
-            "position": 9,
+            "position": 10,
             "name": "Simulación de ondas",
             "description": "Un solver FDTD 2D determinista, validado frente a oráculos analíticos y no frente a una norma.",
             "url": "https://jmrplens.github.io/phonometry/es/simulation/"
@@ -437,12 +444,12 @@ EN 12354-5, ISO 2631-1/-2/-4/-5, ISO 5349-1/-2 e ISO 8041-1.
 
 ## [Medio ambiente y transporte](/phonometry/es/environment/)
 
-Propagación en exteriores, barreras, refracción, aeronaves, helicópteros y
-aerogeneradores. Todo lo de aquí trata de sonido que tiene que recorrer una
-distancia larga antes de valorarse, así que la atmósfera, el suelo y el propio
-movimiento de la fuente entran en la respuesta. Implementa ISO 9613-1/-2,
-ISO 1996-1/-2, ISO/PAS 1996-3, NT ACOU 112, CNOSSOS-EU (Directiva 2002/49/CE,
-anexo II), Anexo 16 OACI, IEC 61265, SAE ARP 5534, ECAC Doc 29/32 e
+Propagación en exteriores, barreras, refracción, fuentes viarias,
+ferroviarias y de aerogenerador, y la valoración construida sobre ellas. Todo
+lo de aquí trata de sonido que tiene que recorrer una distancia larga antes de
+valorarse, así que la atmósfera, el suelo y el propio movimiento de la fuente
+entran en la respuesta. Implementa ISO 9613-1/-2, ISO 1996-1/-2,
+ISO/PAS 1996-3, NT ACOU 112, CNOSSOS-EU (Directiva 2002/49/CE, anexo II) e
 IEC 61400-11.
 
 **[Sonido en exteriores](/phonometry/es/environment/propagation/)**
@@ -458,6 +465,9 @@ IEC 61400-11.
   la fuente ferroviaria del anexo II 2.3: rugosidad y filtro de contacto, ruido
   de impacto, chirrido en curva, tracción y ruido aerodinámico, y las dos líneas
   de fuente equivalentes.
+- [Ruido de aerogeneradores: potencia y audibilidad tonal](/phonometry/es/environment/sources/wind-turbine-noise/):
+  el nivel de potencia acústica aparente referido al centro del rotor y la cadena
+  de audibilidad tonal que decide si un tono se oye.
 - [Efecto suelo esférico y barreras avanzadas](/phonometry/es/environment/propagation/ground-barriers/):
   el coeficiente de reflexión de Weyl-Van der Pol sobre suelo de impedancia
   finita y la difracción en barreras desde la teoría ondulatoria.
@@ -468,7 +478,13 @@ IEC 61400-11.
   la prominencia prevista de cada impulso a partir de su tasa de ataque y su
   diferencia de nivel, y el ajuste que se suma al $L_{Aeq}$.
 
-**[Aeronaves y energía eólica](/phonometry/es/aircraft/)**
+## [Ruido de aeronaves](/phonometry/es/aircraft/)
+
+Niveles de certificación, contornos de aeropuerto y el método del
+hemisferio para helicópteros: el ruido del vuelo medido como lo prescriben
+los documentos de certificación y de planificación aeroportuaria.
+Implementa el Anexo 16 de la OACI, IEC 61265, SAE ARP 866B/5534 y
+ECAC Doc 29/32.
 
 - [Ruido de aeronaves: nivel efectivo de ruido percibido](/phonometry/es/aircraft/aircraft-noise/):
   la ruidosidad percibida y el PNL, la corrección por tonos, la corrección por
@@ -479,9 +495,6 @@ IEC 61400-11.
 - [Ruido de rotorcraft: el método del hemisferio](/phonometry/es/aircraft/rotorcraft-noise/):
   el modelo de fuente en hemisferio con sus ajustes de propagación, la
   interpolación de condiciones de vuelo y los contornos de suceso único.
-- [Ruido de aerogeneradores: potencia y audibilidad tonal](/phonometry/es/environment/sources/wind-turbine-noise/):
-  el nivel de potencia acústica aparente referido al centro del rotor y la cadena
-  de audibilidad tonal que decide si un tono se oye.
 
 ## [Acústica submarina](/phonometry/es/underwater/)
 

--- a/site/src/content/docs/reference/index.md
+++ b/site/src/content/docs/reference/index.md
@@ -50,6 +50,13 @@ recorded with the printed edition, the evidence, the reading the library
 implements and the test that pins it. Read it when a printed expected value
 and the library disagree, before assuming the library is at fault.
 
+## [Glossary of quantities](/phonometry/reference/glossary/)
+
+Every acoustic quantity the guides compute, with its symbol, a one-sentence
+definition, its unit, the standard and clause that defines it, and the guide
+that implements it. Read it when a symbol in a formula needs a name, or a name
+needs the clause it came from.
+
 ## [Bibliography](/phonometry/reference/bibliography/)
 
 Every book and paper cited by the guides, in one list grouped by domain, each

--- a/site/src/content/docs/start/guides.md
+++ b/site/src/content/docs/start/guides.md
@@ -11,7 +11,7 @@ head:
         "@type": "ItemList",
         "@id": "https://jmrplens.github.io/phonometry/start/guides/#areas",
         "name": "phonometry documentation areas",
-        "description": "The nine documented areas of the phonometry guides, each with the standards it implements.",
+        "description": "The ten documented areas of the phonometry guides, each with the standards it implements.",
         "inLanguage": "en",
         "numberOfItems": 10,
         "itemListOrder": "https://schema.org/ItemListUnordered",
@@ -61,20 +61,27 @@ head:
           {
             "@type": "ListItem",
             "position": 7,
+            "name": "Aircraft noise",
+            "description": "Certification levels, airport contours and the rotorcraft hemisphere method.",
+            "url": "https://jmrplens.github.io/phonometry/aircraft/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 8,
             "name": "Underwater acoustics",
             "description": "Levels re 1 microPa, ship radiated noise, pile driving, ambient noise, transmission loss.",
             "url": "https://jmrplens.github.io/phonometry/underwater/"
           },
           {
             "@type": "ListItem",
-            "position": 8,
+            "position": 9,
             "name": "Sources and devices",
             "description": "Sound power, intensity, emission declarations, electroacoustics, programme loudness.",
             "url": "https://jmrplens.github.io/phonometry/devices/"
           },
           {
             "@type": "ListItem",
-            "position": 9,
+            "position": 10,
             "name": "Wave simulation",
             "description": "A deterministic 2D FDTD solver, validated against analytic oracles rather than a standard.",
             "url": "https://jmrplens.github.io/phonometry/simulation/"
@@ -416,12 +423,12 @@ ISO 2631-1/-2/-4/-5, ISO 5349-1/-2 and ISO 8041-1.
 
 ## [Environment and transport](/phonometry/environment/)
 
-Outdoor propagation, barriers, refraction, aircraft, rotorcraft and wind
-turbines. Everything here concerns sound that has to travel a long way before
-it is assessed, so the atmosphere, the ground and the source's own motion all
-enter the answer. Implements ISO 9613-1/-2, ISO 1996-1/-2, ISO/PAS 1996-3,
-NT ACOU 112, CNOSSOS-EU (2002/49/EC Annex II), ICAO Annex 16, IEC 61265,
-SAE ARP 5534, ECAC Doc 29/32 and IEC 61400-11.
+Outdoor propagation, barriers, refraction, road, rail and wind-turbine
+sources, and the assessment built on them. Everything here concerns sound that
+has to travel a long way before it is assessed, so the atmosphere, the ground
+and the source's own motion all enter the answer. Implements ISO 9613-1/-2,
+ISO 1996-1/-2, ISO/PAS 1996-3, NT ACOU 112, CNOSSOS-EU (2002/49/EC Annex II)
+and IEC 61400-11.
 
 **[Outdoor sound](/phonometry/environment/propagation/)**
 
@@ -435,6 +442,9 @@ SAE ARP 5534, ECAC Doc 29/32 and IEC 61400-11.
   the rail source of Annex II 2.3: roughness and the contact filter, impact
   noise, curve squeal, traction and aerodynamic noise, and the two equivalent
   source lines.
+- [Wind-turbine noise: sound power and tonal audibility](/phonometry/environment/sources/wind-turbine-noise/):
+  the apparent sound power level referred to the rotor centre, and the tonal
+  audibility chain that decides whether a tone is audible.
 - [Spherical ground effect and advanced barriers](/phonometry/environment/propagation/ground-barriers/):
   the Weyl-Van der Pol reflection coefficient over finite-impedance ground, and
   wave-theoretic barrier diffraction.
@@ -445,7 +455,12 @@ SAE ARP 5534, ECAC Doc 29/32 and IEC 61400-11.
   the predicted prominence of each impulse from its onset rate and level
   difference, and the adjustment added to $L_{Aeq}$.
 
-**[Aircraft and wind energy](/phonometry/aircraft/)**
+## [Aircraft noise](/phonometry/aircraft/)
+
+Certification levels, airport contours and the rotorcraft hemisphere
+method: the noise of flight measured the way the certification and
+airport-planning documents prescribe. Implements ICAO Annex 16, IEC 61265,
+SAE ARP 866B/5534 and ECAC Doc 29/32.
 
 - [Aircraft noise: Effective Perceived Noise Level](/phonometry/aircraft/aircraft-noise/):
   perceived noisiness and PNL, the tone correction, the duration correction and
@@ -456,9 +471,6 @@ SAE ARP 5534, ECAC Doc 29/32 and IEC 61400-11.
 - [Rotorcraft noise: the hemisphere method](/phonometry/aircraft/rotorcraft-noise/):
   the hemisphere source model with its propagation adjustments, flight-condition
   interpolation, and the single-event contours.
-- [Wind-turbine noise: sound power and tonal audibility](/phonometry/environment/sources/wind-turbine-noise/):
-  the apparent sound power level referred to the rotor centre, and the tonal
-  audibility chain that decides whether a tone is audible.
 
 ## [Underwater acoustics](/phonometry/underwater/)
 


### PR DESCRIPTION
Aircraft noise has been its own topic since the reorganisation, and the guides
page still filed it as a bold block inside Environment and transport. Three
incoherences hung off that one fact:

- the Environment lead claimed ICAO Annex 16, IEC 61265, SAE ARP 5534 and
  ECAC Doc 29/32 as its own standards, which the landing page assigns to
  Aircraft noise;
- the page's structured data declared `numberOfItems: 10` over nine
  `itemListElement` entries;
- its JSON-LD description said "the nine documented areas" while the
  frontmatter description said ten.

The topic has its own `##` section now, in both languages, with the lead and
the standards that are actually its. Environment keeps the wind turbine, whose
routes live under it, and stops claiming the certification chain. The
structured data lists ten areas with renumbered positions, and
`check-guides-index.mjs` now asserts that `numberOfItems`, the item count and
the `##` headings agree, which is the coherence this page managed to lose
three ways at once.

Separately, four guides could not be reached from the prose of their own
folder overview, one of them from no prose anywhere:

- the heavy and soft impact sources join the insulation overview after the
  flanking row, matching the sidebar order;
- the sound power from surface vibration joins the emission overview;
- atmospheric refraction joins the propagation overview;
- the glossary, which neither reference overview linked in either language,
  gets its section beside the bibliography.

Each summary is taken from the page it links, not invented. Verified: build,
HTML validation, math, i18n parity, the guides index check with its new
JSON-LD assertion, and the accessibility audit, all green in both locales.

This intentionally carries no regenerated llms artifacts: the overview edits
feed them, and #495 changes how they are generated, so the regeneration
belongs to whichever lands second.

## Summary by Sourcery

Separate aircraft noise into its own documented area and ensure the guides index, structured data, and topic descriptions are consistent across languages, while adding missing cross-links to several existing guides and glossary pages.

New Features:
- Introduce a dedicated Aircraft noise section in the guides map in both languages, with its own description and standards list.
- Add glossary-of-quantities sections to the reference overviews in both languages so the glossary is reachable from prose.

Bug Fixes:
- Align JSON-LD ItemList metadata with the actual number and structure of documented areas in both locales, including positions and descriptions.
- Correct the Environment and transport topic description and standards list so it only claims the standards and sources that actually belong to it.
- Make previously orphaned or hard-to-discover guides reachable from their corresponding overview pages in both languages.

Enhancements:
- Strengthen the guides index check script to validate consistency between JSON-LD numberOfItems, listed entries, and the count of section headings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new reference pages covering Heavy and Soft Impact Sources, Sound Power from Surface Vibration, and Atmospheric Refraction.
  * Added Glossary of quantities section describing acoustic quantities, symbols, definitions, units, and standards.
  * Reorganized guides to separate Aircraft noise as a standalone topic; moved Wind turbine guide to Environment and Transport section.
  * Updated Spanish content with corresponding additions and reorganizations.

* **Chores**
  * Added validation for documentation index consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->