### PR TITLE
Make a deprecated name an error in tests and snippets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,4 +130,9 @@ pythonpath = ["tests"]
 addopts = ["--dist=loadgroup"]
 filterwarnings = [
     "ignore:Low sampling rate:UserWarning",
+    # A deprecated phonometry name used anywhere in the suite is an error, not
+    # a line in a log nobody reads: the shims exist for users on the old paths,
+    # and the tests are not users. The one file that exercises the shims on
+    # purpose catches them with pytest.warns, which passes under this filter.
+    "error:.*is deprecated since phonometry.*:DeprecationWarning",
 ]

--- a/scripts/check_doc_snippets.py
+++ b/scripts/check_doc_snippets.py
@@ -255,7 +255,16 @@ def _is_sketch(code: str) -> bool:
 def _run_page(page: pathlib.Path) -> tuple[pathlib.Path, str]:
     """Run a page's blocks as one script; return its stderr tail on failure."""
     runnable = [b for b in _blocks(page) if not _is_sketch(b)]
-    script = "import matplotlib\nmatplotlib.use('Agg')\n" + "\n".join(runnable)
+    # A deprecated phonometry name in a snippet is an error, exactly as it is
+    # in the test suite (pyproject filterwarnings): the guides teach the
+    # canonical API, and a page that teaches an alias teaches a path that the
+    # next major release removes.
+    script = (
+        "import warnings\n"
+        "warnings.filterwarnings('error', message='.*is deprecated since phonometry.*',"
+        " category=DeprecationWarning)\n"
+        "import matplotlib\nmatplotlib.use('Agg')\n" + "\n".join(runnable)
+    )
     with tempfile.TemporaryDirectory() as tmp:
         path = pathlib.Path(tmp) / "snippet.py"
         path.write_text(script, encoding="utf-8")

--- a/tests/data/cnossos/README.md
+++ b/tests/data/cnossos/README.md
@@ -16,7 +16,7 @@ workbook was computed in 2014 with the database that Commission Directive
 Delegated Directive (EU) 2021/1226 replaced Tables G-1b, G-2, G-3a, G-4 and
 G-7. The coefficients of the current text live in `tests/reference_data.py`,
 transcribed from the Official Journal, and pin the tables shipped in
-`phonometry.environmental.cnossos_rail`.
+`phonometry.environment.sources.cnossos_rail`.
 
 Only the running conditions the Directive models are transcribed. The
 catalogue carries four (constant, accelerating, decelerating, idling) where
@@ -122,7 +122,7 @@ without the reconstruction.
 The coefficients of the current text, Tables F-1 to F-4 as they stand after
 (EU) 2021/1226, are *not* here: they live in `tests/reference_data.py`, also
 machine-transcribed from the Official Journal, and pin the tables shipped in
-`phonometry.environmental.cnossos_road`.
+`phonometry.environment.sources.cnossos_road`.
 
 `tests/environment/sources/test_cnossos_road.py` feeds the shipped equations of
 Annex II 2.2 the superseded 2015 coefficient set and requires the workbook's

--- a/tests/simulation/test_fdtd_ntff.py
+++ b/tests/simulation/test_fdtd_ntff.py
@@ -32,7 +32,7 @@ three tiers, each independent of the code under test:
   (Sci. Rep. 7, 5389, 2017) is meshed at ``dx = 0.5 mm`` (slits, necks and
   cavities all resolved by at least four cells) and its 2 kHz NTFF polar
   response is compared against the library's TMM + Fraunhofer chain
-  (:func:`~phonometry.materials.metadiffuser_polar_response`), the
+  (:func:`~phonometry.materials.diffusers.metadiffuser_polar_response`), the
   end-to-end counterpart of the paper's TMM-vs-FEM comparison (their
   Fig. 3g), which the paper itself reports agreeing up to "small
   discrepancies". Grid convergence of the pattern was verified against a


### PR DESCRIPTION
The compatibility shims exist for users on the old paths, and the tests and
the guides are not users: a deprecation warning in either is a defect that a
log line nobody reads does not surface.

Two halves, one rule:

- `pytest` turns any phonometry rename warning into an error
  (`filterwarnings` in `pyproject.toml`). The one file that exercises the
  shims on purpose, `tests/test_deprecated_aliases.py`, passes unchanged:
  `pytest.warns` catches under an error filter. Proven to bite with a scratch
  test that uses a legacy path and fails naming the module; the full suite
  passes under the filter, 7991 tests in nine and a half minutes.
- The snippet runner injects the same filter into every page script, so a
  guide that teaches an alias fails the gate that runs it. All 3614 blocks
  over 505 pages pass today; a scratch page with one legacy use fails.

The sweep that preceded the filter found only three lines of prose still on
old paths, all fixed here: the CNOSSOS test-data README named the pre-4.0
module for both workbooks, and the NTFF test docstring cross-referenced the
flat materials namespace. One subtlety worth recording: a bare `import` of a
shimmed module warns nothing, because PEP 562 fires on attribute access, so
the filter catches use, which is what matters, rather than mention.

## Summary by Sourcery

Enforce deprecated phonometry names as hard errors in tests and documentation snippets and update remaining references to legacy module paths.

Bug Fixes:
- Correct legacy phonometry module paths in CNOSSOS README references.
- Fix outdated materials function reference in NTFF simulation test docstring.

Enhancements:
- Add a global pytest filter to treat phonometry deprecation warnings as errors.
- Make the doc snippet runner fail snippets that use deprecated phonometry APIs by installing a matching warnings filter.

Documentation:
- Update CNOSSOS test-data README and NTFF test documentation to reference canonical phonometry module paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CNOSSOS rail and road source references.
  * Corrected the documented location of the metadiffuser polar response function.

* **Tests**
  * Documentation snippets and automated tests now flag deprecated phonometry names as errors, while allowing intentional compatibility checks to handle expected warnings explicitly.
  * Headless plotting support remains enabled for snippet execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->