### PR TITLE
Assert what the chips guarantee, and run their check in CI

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -10,7 +10,7 @@
     "check:icons": "node scripts/icon-sheet.mjs --check",
     "check:math": "node scripts/check-math-render.mjs",
     "check:sidebar": "node scripts/with-preview.mjs -- node scripts/check-sidebar.mjs",
-    "check:visual": "node scripts/with-preview.mjs -- sh -c 'node scripts/check-contrast.mjs && node scripts/check-home-headings.mjs && node scripts/check-lang-suggest.mjs'",
+    "check:visual": "node scripts/with-preview.mjs -- sh -c 'node scripts/check-contrast.mjs && node scripts/check-home-headings.mjs && node scripts/check-lang-suggest.mjs && node scripts/check-page-chips.mjs'",
     "dev": "astro dev",
     "html-validate": "html-validate 'dist/**/*.html'",
     "icons:sheet": "node scripts/icon-sheet.mjs",

--- a/site/scripts/check-page-chips.mjs
+++ b/site/scripts/check-page-chips.mjs
@@ -151,7 +151,17 @@ async function landing({ path, viewport, theme, banner }) {
 		const [entry, moreTop] = tops;
 		return {
 			banner: wantBanner ? barShown : !barShown,
-			sameLanding: entry.top === moreTop.top,
+			// Not equality, and not a fixed band either. The two chips target
+			// different element kinds (a bibliography <li> and the References
+			// <h2>), which the engine lands a stable 12 px apart even with
+			// identical scroll-margin and scroll-padding; and on a tall
+			// viewport the references heading sits so close to the end of the
+			// document that the scroll clamps before the alignment position,
+			// which is correct behaviour, not a defect. What a reader needs is
+			// the target on screen below the sticky chrome, which `clears`
+			// asserts, and inside the viewport, asserted here.
+			entryOnScreen: tops[0].top < innerHeight,
+			moreOnScreen: tops[1].top < innerHeight,
 			entryClears: entry.clears,
 			moreClears: moreTop.clears,
 		};
@@ -188,7 +198,8 @@ for (const c of LANDINGS) {
 	const label = `landing: ${c.path} ${c.viewport.width}x${c.viewport.height} ${c.theme}${c.banner ? ' with the language bar' : ''}`;
 	expect(label, await landing(c), {
 		banner: true,
-		sameLanding: true,
+		entryOnScreen: true,
+		moreOnScreen: true,
 		entryClears: true,
 		moreClears: true,
 	});

--- a/site/scripts/check-page-chips.mjs
+++ b/site/scripts/check-page-chips.mjs
@@ -146,7 +146,9 @@ async function landing({ path, viewport, theme, banner }) {
 			const target = document.getElementById(decodeURIComponent(href.slice(1)));
 			if (!target) return { error: `the chip pointing at ${href} has no target on the page` };
 			const r = target.getBoundingClientRect();
-			tops.push({ top: Math.round(r.top), clears: r.top >= chrome - 1, hidden: r.bottom < chrome });
+			// Unrounded: a target at innerHeight - 0.4 is on screen, and rounding
+			// it to innerHeight would fail an audit the reader's eye passes.
+			tops.push({ top: r.top, clears: r.top >= chrome - 1, hidden: r.bottom < chrome });
 		}
 		const [entry, moreTop] = tops;
 		return {


### PR DESCRIPTION
`check-page-chips` existed, was wired into nothing, and was red: four of its
sixteen cases failed on `sameLanding`, which demanded that a bibliography
`<li>` and the References `<h2>` land at the same pixel after a chip click.

Two diagnoses of that failure were wrong before one was right, and the record
is worth keeping. It was not the scroll margins: one rule in `References.astro`
gives both elements the same `scroll-margin-top`, so the earlier claim that the
`<li>`'s top margin made the expectation unreachable does not hold, since
anchor scrolling aligns the scroll-margin box, not the margin box. And it is
not only the engine, though fragment alignment really does land the two element
kinds a stable 12 px apart with identical margins and padding, measured over
three seconds with no layout shift. On a tall viewport the cause is the end of
the document: the references heading sits so close to the bottom that the
scroll clamps before the alignment position. That is correct behaviour, not a
defect, and it is why the failure set changed with viewport height.

The assertion now states what a reader is actually owed: each chip's target
lands on screen and clear of the sticky chrome. Verified in both directions:

- all sixteen cases pass on a clean build;
- a negative scroll margin on the heading, which lands it under the header,
  fails four cases;
- removing the margin entirely does not fail, because the global scroll
  padding still protects the landing, which is exactly why the old equality
  asserted more than the page ever promised.

`check:visual` runs all four audits now (contrast, home headings, language
bar, page chips), closing the last of the site checks that ran for nobody.

## Summary by Sourcery

Update the page chip landing assertions to reflect real user-visible guarantees and wire their audit into the visual checks run in CI.

Tests:
- Relax page-chip landing expectations to assert that chip targets are visible on screen and clear of sticky chrome rather than pixel-aligned.
- Ensure the page-chip audit is included in the `check:visual` script so it runs with the other site visual checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page validation for entry and “+N more” links by ensuring both remain visible in the viewport and clear sticky interface elements.
  * Updated visual checks to reflect the more flexible landing-position requirements.

* **Tests**
  * Added page-chip validation to the visual preview check sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->