### PR TITLE
Hold katex at the 0.16 line rehype-katex renders with

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,6 +43,19 @@ updates:
       - "dependencies"
       - "javascript"
     open-pull-requests-limit: 5
+    # katex is not ours to choose: rehype-katex renders the markup and ships
+    # its own katex dependency, so the stylesheet we load has to come from the
+    # 0.16 line it resolves or every formula on the site loses its rules.
+    # KaTeX 0.18 prefixed nineteen internal class names (base -> katex-base and
+    # so on), which is a breaking change carried in a minor bump because the
+    # package is still 0.x, so both update types are held. rehype-katex 7, the
+    # current release, asks for katex ^0.16, and `pnpm check:math` fails the
+    # build when the two disagree. Lift this the day rehype-katex moves.
+    ignore:
+      - dependency-name: "katex"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
     groups:
       site:
         patterns:


### PR DESCRIPTION
The weekly site bump (#494) offered katex 0.18.1, and `pnpm check:math` failed the site build: the rendered markup emits `class="base"` and `class="strut"` inside `.katex`, while the 0.18 stylesheet ships the flattened `.katex-base` / `.katex-strut` spellings. Every formula on the site would have shipped without its rules.

The version is not ours to choose. `rehype-katex` renders the markup and carries its own katex; its current release (7.0.1) depends on `katex@^0.16`, so the stylesheet has to come from the same major. Dependabot now ignores major and minor katex updates, with a comment naming the condition to lift it: the day rehype-katex moves.

#494 can be rebased once this lands; it will come back with the other three bumps and without katex.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency update settings to defer incompatible KaTeX upgrades until related compatibility support is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->