### PR TITLE
Drop the unreachable guards, and split the STI chain

### DIFF
--- a/src/phonometry/hearing/occupational_exposure.py
+++ b/src/phonometry/hearing/occupational_exposure.py
@@ -378,17 +378,17 @@ class _BudgetOptions:
     warn: bool
 
 
-def _validated_task_levels(tasks: Sequence[Task]) -> tuple[list[float], list[float]]:
-    """Per-task energy-average levels (Eq 7) and mean durations ``T_m``, validated."""
-    levels: list[float] = []
-    durations: list[float] = []
-    for task in tasks:
-        if len(task.samples) == 0:
-            raise ValueError("Each task needs at least one sample.")
-        if task.duration_hours <= 0:
-            raise ValueError("Task 'duration_hours' must be positive.")
-        levels.append(energy_mean(task.samples))  # Eq 7
-        durations.append(task.duration_hours)
+def _task_levels(tasks: Sequence[Task]) -> tuple[list[float], list[float]]:
+    """Per-task energy-average levels (Eq 7) and mean durations ``T_m``.
+
+    No validation here: :class:`Task` is a frozen dataclass that rejects an
+    empty sample set and a non-positive duration in ``__post_init__``, so an
+    invalid task cannot reach this function. The guards that used to repeat
+    those two checks were unreachable, and the test that appeared to cover them
+    was in fact exercising the constructor.
+    """
+    levels = [energy_mean(task.samples) for task in tasks]  # Eq 7
+    durations = [task.duration_hours for task in tasks]
     return levels, durations
 
 
@@ -494,7 +494,7 @@ def task_based_exposure(
         raise ValueError("'u3' must be non-negative.")
 
     # First pass: task levels and durations (Eq 7, 8).
-    levels, durations = _validated_task_levels(tasks)
+    levels, durations = _task_levels(tasks)
 
     # Daily level: energy sum of contributions (Eq 9 == Eq 10).
     energy = sum((t_m / _T0) * 10.0 ** (0.1 * lp) for lp, t_m in zip(levels, durations))
@@ -624,7 +624,7 @@ def job_based_exposure(
                     OccupationalExposureWarning,
                     stacklevel=2,
                 )
-            result = _with_advisory(result)
+            result = replace(result, sampling_advisory=True)
     return result
 
 
@@ -665,7 +665,3 @@ def full_day_exposure(
         samples, effective_duration_hours, instrument, u3, "full_day", warn, spread_advisory=spread
     )
 
-
-def _with_advisory(result: ExposureResult) -> ExposureResult:
-    """Return a copy of ``result`` with the sampling advisory flag set."""
-    return replace(result, sampling_advisory=True)

--- a/src/phonometry/speech/sti.py
+++ b/src/phonometry/speech/sti.py
@@ -229,6 +229,94 @@ def _validate_band_vector(values: Sequence[float] | np.ndarray, name: str) -> np
     return arr
 
 
+def _truncated_mtf(mtf: np.ndarray) -> np.ndarray:
+    """Validate the modulation transfer matrix and truncate it to 1,0.
+
+    Ed.4 A.5.3 NOTE 1 (= Ed.5): a value above 1,3 means the measurement is
+    invalid, and every value is truncated to 1,0 before the chain runs.
+    """
+    m = np.array(mtf, dtype=np.float64)
+    if m.ndim != 2 or m.shape[0] != _NUM_BANDS:
+        raise ValueError(
+            f"'mtf' must have shape ({_NUM_BANDS}, n_modulation_frequencies), "
+            f"got {m.shape}."
+        )
+    if np.any(m < 0.0) or not np.all(np.isfinite(m)):
+        raise ValueError("Modulation transfer values must be finite and >= 0.")
+    if np.any(m > 1.3):
+        warnings.warn(
+            "Modulation transfer values above 1.3 detected: the measurement "
+            "is likely invalid (IEC 60268-16 A.5.3). Values truncated to 1.0.",
+            STIWarning,
+            stacklevel=4,
+        )
+    return np.minimum(m, 1.0)
+
+
+def _snr_vector(
+    snr: float | Sequence[float] | np.ndarray | None,
+) -> np.ndarray | None:
+    """The per-band signal-to-noise ratios, broadcast from a scalar if given."""
+    if snr is None:
+        return None
+    snr_arr = np.asarray(snr, dtype=np.float64)
+    if snr_arr.ndim == 0:
+        return np.full(_NUM_BANDS, float(snr_arr))
+    if snr_arr.shape != (_NUM_BANDS,):
+        raise ValueError(
+            f"'snr' must be a scalar or a vector of {_NUM_BANDS} "
+            f"octave-band values, got shape {snr_arr.shape}."
+        )
+    return snr_arr
+
+
+def _corrected_mtf(
+    m: np.ndarray,
+    snr_arr: np.ndarray | None,
+    level: Sequence[float] | np.ndarray | None,
+    ambient: Sequence[float] | np.ndarray | None,
+) -> tuple[np.ndarray, np.ndarray | None]:
+    """Apply the noise and level-dependent corrections of A.5.3.
+
+    Without absolute levels only the signal-to-noise correction applies; with
+    them the auditory masking and absolute reception threshold join it. Returns
+    the corrected matrix and the validated band levels, which the result
+    carries.
+    """
+    if level is None:
+        if ambient is not None:
+            raise ValueError(
+                "'ambient' requires the speech octave-band levels 'level' to "
+                "form the intensity-domain correction; pass 'snr' instead."
+            )
+        if snr_arr is not None:
+            # I_k / (I_k + I_n,k) with I_n,k = I_k * 10^(-SNR/10).
+            m = m / (1.0 + 10.0 ** (-snr_arr[:, np.newaxis] / 10.0))
+        # No absolute level information: the auditory masking and absolute
+        # reception threshold corrections are skipped.
+        return m, None
+
+    band_levels = _validate_band_vector(level, "level")
+    i_signal = 10.0 ** (band_levels / 10.0)
+    if ambient is not None:
+        ambient_arr = _validate_band_vector(ambient, "ambient")
+    elif snr_arr is not None:
+        ambient_arr = band_levels - snr_arr
+    else:
+        ambient_arr = None
+    i_noise = (
+        10.0 ** (ambient_arr / 10.0) if ambient_arr is not None else np.zeros(_NUM_BANDS)
+    )
+    i_total = i_signal + i_noise
+    level_total = 10.0 * np.log10(i_total)
+    # Masking only acts on the next higher band; 125 Hz is unmasked.
+    i_masking = np.zeros(_NUM_BANDS)
+    i_masking[1:] = i_total[:-1] * 10.0 ** (_masking_amdb(level_total[:-1]) / 10.0)
+    i_threshold = 10.0 ** (_ART_DB / 10.0)
+    factor = i_signal / (i_signal + i_masking + i_threshold + i_noise)
+    return m * factor[:, np.newaxis], band_levels
+
+
 def _sti_from_mtf(
     mtf: np.ndarray,
     snr: float | Sequence[float] | np.ndarray | None = None,
@@ -252,70 +340,13 @@ def _sti_from_mtf(
     instead, with ``ambient`` (or ``level - snr``) defining :math:`I_{n,k}`,
     so the noise degradation is never applied twice.
     """
-    m = np.array(mtf, dtype=np.float64)
-    if m.ndim != 2 or m.shape[0] != _NUM_BANDS:
-        raise ValueError(
-            f"'mtf' must have shape ({_NUM_BANDS}, n_modulation_frequencies), "
-            f"got {m.shape}."
-        )
-    if np.any(m < 0.0) or not np.all(np.isfinite(m)):
-        raise ValueError("Modulation transfer values must be finite and >= 0.")
-    if np.any(m > 1.3):
-        # Ed.4 A.5.3 NOTE 1 (= Ed.5): m > 1,3 indicates an invalid measurement.
-        warnings.warn(
-            "Modulation transfer values above 1.3 detected: the measurement "
-            "is likely invalid (IEC 60268-16 A.5.3). Values truncated to 1.0.",
-            STIWarning,
-            stacklevel=3,
-        )
-    m = np.minimum(m, 1.0)
+    m = _truncated_mtf(mtf)
 
     if snr is not None and ambient is not None:
         raise ValueError("Provide either 'snr' or 'ambient' noise levels, not both.")
 
-    snr_arr: np.ndarray | None = None
-    if snr is not None:
-        snr_arr = np.asarray(snr, dtype=np.float64)
-        if snr_arr.ndim == 0:
-            snr_arr = np.full(_NUM_BANDS, float(snr_arr))
-        elif snr_arr.shape != (_NUM_BANDS,):
-            raise ValueError(
-                f"'snr' must be a scalar or a vector of {_NUM_BANDS} "
-                f"octave-band values, got shape {snr_arr.shape}."
-            )
-
-    band_levels: np.ndarray | None = None
-    if level is None:
-        if ambient is not None:
-            raise ValueError(
-                "'ambient' requires the speech octave-band levels 'level' to "
-                "form the intensity-domain correction; pass 'snr' instead."
-            )
-        if snr_arr is not None:
-            # I_k / (I_k + I_n,k) with I_n,k = I_k * 10^(-SNR/10).
-            m = m / (1.0 + 10.0 ** (-snr_arr[:, np.newaxis] / 10.0))
-        # No absolute level information: the auditory masking and absolute
-        # reception threshold corrections are skipped.
-    else:
-        band_levels = _validate_band_vector(level, "level")
-        i_signal = 10.0 ** (band_levels / 10.0)
-        if ambient is not None:
-            ambient_arr = _validate_band_vector(ambient, "ambient")
-        elif snr_arr is not None:
-            ambient_arr = band_levels - snr_arr
-        else:
-            ambient_arr = None
-        i_noise = (
-            10.0 ** (ambient_arr / 10.0) if ambient_arr is not None else np.zeros(_NUM_BANDS)
-        )
-        i_total = i_signal + i_noise
-        level_total = 10.0 * np.log10(i_total)
-        # Masking only acts on the next higher band; 125 Hz is unmasked.
-        i_masking = np.zeros(_NUM_BANDS)
-        i_masking[1:] = i_total[:-1] * 10.0 ** (_masking_amdb(level_total[:-1]) / 10.0)
-        i_threshold = 10.0 ** (_ART_DB / 10.0)
-        factor = i_signal / (i_signal + i_masking + i_threshold + i_noise)
-        m = m * factor[:, np.newaxis]
+    snr_arr = _snr_vector(snr)
+    m, band_levels = _corrected_mtf(m, snr_arr, level, ambient)
 
     # Effective SNR clipped to +/-15 dB (A.5.4); m = 0 and m = 1 map to the
     # clip limits through the log divergences.


### PR DESCRIPTION
Three of the four issues SonarCloud still reports on `main`, plus the dead code
the previous branch uncovered but deliberately left for a decision.

## The unreachable guards

`_validated_task_levels` re-checked what `Task.__post_init__` already rejects.
`Task` is a frozen dataclass that refuses an empty sample set and a
non-positive duration at construction, so no invalid task can reach the
function and neither guard could ever fire. Both are gone, and the function is
`_task_levels` now, since it no longer validates anything.

This is what the `pytest.raises` work found on the previous branch: the test
that appeared to cover those guards was in fact exercising the constructor, one
frame earlier. The guards had no coverage and could not have any.

## `S5886`, the return type

`_with_advisory` had a single caller and existed only to name one call to
`dataclasses.replace`. Inlining it removes the declared return type that a
static analyser cannot reconcile with `replace`'s own signature. Nothing about
the behaviour changes.

## `S3776`, the STI chain

`_sti_from_mtf` sat at cognitive complexity 23 against a limit of 15. Three
helpers come out of it, each one a step the standard itself names:

- `_truncated_mtf` — the A.5.3 NOTE 1 validity check and the truncation to 1,0
- `_snr_vector` — the per-band signal-to-noise ratios, broadcast from a scalar
- `_corrected_mtf` — the A.5.3 noise, masking and reception-threshold corrections

Validation order is unchanged, so which error fires first is unchanged. The
truncation warning gained a stack level to keep pointing at the caller rather
than at library code, which is verified rather than assumed: a controlled call
chain confirms the warning is still attributed to the caller's line.

## The fourth issue is left open on purpose

`OctaveFilterBank.filter` returns two or three values depending on `sigbands`,
which is what `S8495` objects to. That arity is the documented public contract:
four `@overload` stubs type it, 18 call sites unpack two values, 16 unpack
three, and 20 documentation pages show both forms. Making the length uniform
would break every one of them to satisfy a rule that is describing the API
correctly rather than finding a defect in it.

No suppression is added here, per the convention that exclusions get their own
branch and their own argument.

## One issue that cannot be fixed from the code

SonarCloud also lists an `S1940` on `src/phonometry/iso2631_5.py`. That file
does not exist: the taxonomy work moved it, and the API confirms it
(`Component key ... not found`). The issue has been open since 2026-07-09 with
no update since, so it is orphaned in SonarCloud rather than present in the
repository, and closing it needs the web interface.

## Checks

8041 tests, `ruff`, `mypy` over 419 files, and 533/533 conformance checks with
`docs/CONFORMANCE.md` unchanged.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal handling of occupational noise exposure calculations, preserving existing validation and sampling behavior.
  - Streamlined speech intelligibility calculations while retaining existing corrections, warnings, thresholds, and results.
  - No changes to public interfaces or expected end-user behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->