### PR TITLE
Hold the G weighting's reference in stateful mode, and retire two stale claims

### DIFF
--- a/docs/signals/levels/special-weightings.md
+++ b/docs/signals/levels/special-weightings.md
@@ -12,10 +12,11 @@ G curve, keeps ultrasonic components out of an audible-exposure reading.
 
 All four share the machinery of the IEC 61672-1 curves (0 dB at 1 kHz where
 applicable, multichannel and stateful block processing), and B, D and AU also
-take the `high_accuracy` oversampling. G ignores that flag, but not because
-oversampling is unnecessary: **the G design always oversamples internally**,
-toward 48 kHz, so its 0.25 Hz to 315 Hz range stays within about 0.05 dB
-whatever the input rate. That matters exactly where G is used — infrasound is
+take the `high_accuracy` oversampling, and G takes it too: **the default G
+design oversamples toward 48 kHz**, so its 0.25 Hz to 315 Hz range stays
+within about 0.05 dB whatever the input rate, while stateful block processing
+runs the plain design at the input rate, about a decibel low at 315 Hz at
+fs = 2000 and exactly on the 0 dB reference at 10 Hz. That matters exactly where G is used — infrasound is
 often recorded at 1 kHz or 2 kHz, where 315 Hz sits close to Nyquist and the
 bilinear warping grows quadratically; at audio rates the correction is
 negligible. As with A/C/Z, `high_accuracy` cannot be combined with stateful

--- a/docs/signals/levels/weighting.md
+++ b/docs/signals/levels/weighting.md
@@ -245,9 +245,11 @@ plt.show()
 </details>
 
 - `high_accuracy=False` restores the legacy plain-bilinear behavior.
-- For `'G'` the flag is silently ignored: the G design always oversamples
-  internally toward 48 kHz on its own, so its 0.25–315 Hz range stays accurate
-  whatever the input rate (see [Special Weightings](special-weightings.md)).
+- For `'G'` the flag works like the others': the default design is
+  oversampled toward 48 kHz, which is what keeps infrasound rates accurate;
+  `high_accuracy=False` runs the plain design at the input rate, costing about
+  a decibel at 315 Hz at fs = 2000 and nothing at the 10 Hz reference (see
+  [Special Weightings](special-weightings.md)).
 - **Stateful (block) processing** always uses the legacy design: the internal
   FIR resampling is incompatible with block continuity. Passing
   `high_accuracy=True` together with `stateful=True` raises a `ValueError`.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -39662,10 +39662,11 @@ G curve, keeps ultrasonic components out of an audible-exposure reading.
 
 All four share the machinery of the IEC 61672-1 curves (0 dB at 1 kHz where
 applicable, multichannel and stateful block processing), and B, D and AU also
-take the `high_accuracy` oversampling. G ignores that flag, but not because
-oversampling is unnecessary: **the G design always oversamples internally**,
-toward 48 kHz, so its 0.25 Hz to 315 Hz range stays within about 0.05 dB
-whatever the input rate. That matters exactly where G is used — infrasound is
+take the `high_accuracy` oversampling, and G takes it too: **the default G
+design oversamples toward 48 kHz**, so its 0.25 Hz to 315 Hz range stays
+within about 0.05 dB whatever the input rate, while stateful block processing
+runs the plain design at the input rate, about a decibel low at 315 Hz at
+fs = 2000 and exactly on the 0 dB reference at 10 Hz. That matters exactly where G is used — infrasound is
 often recorded at 1 kHz or 2 kHz, where 315 Hz sits close to Nyquist and the
 bilinear warping grows quadratically; at audio rates the correction is
 negligible. As with A/C/Z, `high_accuracy` cannot be combined with stateful
@@ -40503,9 +40504,11 @@ plt.show()
 </details>
 
 - `high_accuracy=False` restores the legacy plain-bilinear behavior.
-- For `'G'` the flag is silently ignored: the G design always oversamples
-  internally toward 48 kHz on its own, so its 0.25–315 Hz range stays accurate
-  whatever the input rate (see [Special Weightings](https://jmrplens.github.io/phonometry/signals/levels/special-weightings/)).
+- For `'G'` the flag works like the others': the default design is
+  oversampled toward 48 kHz, which is what keeps infrasound rates accurate;
+  `high_accuracy=False` runs the plain design at the input rate, costing about
+  a decibel at 315 Hz at fs = 2000 and nothing at the 10 Hz reference (see
+  [Special Weightings](https://jmrplens.github.io/phonometry/signals/levels/special-weightings/)).
 - **Stateful (block) processing** always uses the legacy design: the internal
   FIR resampling is incompatible with block continuity. Passing
   `high_accuracy=True` together with `stateful=True` raises a `ValueError`.

--- a/site/public/llms/llms-signals-levels.txt
+++ b/site/public/llms/llms-signals-levels.txt
@@ -349,9 +349,11 @@ plt.show()
 </details>
 
 - `high_accuracy=False` restores the legacy plain-bilinear behavior.
-- For `'G'` the flag is silently ignored: the G design always oversamples
-  internally toward 48 kHz on its own, so its 0.25–315 Hz range stays accurate
-  whatever the input rate (see [Special Weightings](https://jmrplens.github.io/phonometry/signals/levels/special-weightings/)).
+- For `'G'` the flag works like the others': the default design is
+  oversampled toward 48 kHz, which is what keeps infrasound rates accurate;
+  `high_accuracy=False` runs the plain design at the input rate, costing about
+  a decibel at 315 Hz at fs = 2000 and nothing at the 10 Hz reference (see
+  [Special Weightings](https://jmrplens.github.io/phonometry/signals/levels/special-weightings/)).
 - **Stateful (block) processing** always uses the legacy design: the internal
   FIR resampling is incompatible with block continuity. Passing
   `high_accuracy=True` together with `stateful=True` raises a `ValueError`.
@@ -514,10 +516,11 @@ G curve, keeps ultrasonic components out of an audible-exposure reading.
 
 All four share the machinery of the IEC 61672-1 curves (0 dB at 1 kHz where
 applicable, multichannel and stateful block processing), and B, D and AU also
-take the `high_accuracy` oversampling. G ignores that flag, but not because
-oversampling is unnecessary: **the G design always oversamples internally**,
-toward 48 kHz, so its 0.25 Hz to 315 Hz range stays within about 0.05 dB
-whatever the input rate. That matters exactly where G is used — infrasound is
+take the `high_accuracy` oversampling, and G takes it too: **the default G
+design oversamples toward 48 kHz**, so its 0.25 Hz to 315 Hz range stays
+within about 0.05 dB whatever the input rate, while stateful block processing
+runs the plain design at the input rate, about a decibel low at 315 Hz at
+fs = 2000 and exactly on the 0 dB reference at 10 Hz. That matters exactly where G is used — infrasound is
 often recorded at 1 kHz or 2 kHz, where 315 Hz sits close to Nyquist and the
 bilinear warping grows quadratically; at audio rates the correction is
 negligible. As with A/C/Z, `high_accuracy` cannot be combined with stateful

--- a/site/src/content/docs/devices/electroacoustics/electroacoustics.mdx
+++ b/site/src/content/docs/devices/electroacoustics/electroacoustics.mdx
@@ -635,8 +635,10 @@ and ordinary coherence.
 functions: they take a captured array and compute the ratio the clause defines,
 so the bench, the operating point and the three acceptance checks are the
 reader's to keep. Other parts of the IEC 60268 series sit outside this page:
-Part 16 (objective speech intelligibility, the speech transmission index) is
-not implemented, and the Part 4 microphone and Part 5 loudspeaker
+Part 16 (objective speech intelligibility) is implemented as the speech
+transmission index in
+[Speech Transmission](/phonometry/perception/speech/speech-transmission/),
+and the Part 4 microphone and Part 5 loudspeaker
 rated-characteristics reports have moved to
 [Microphone Characterisation](/phonometry/devices/electroacoustics/microphones/) and
 [Loudspeaker Characterisation](/phonometry/devices/electroacoustics/loudspeakers/). The

--- a/site/src/content/docs/es/devices/electroacoustics/electroacoustics.mdx
+++ b/site/src/content/docs/es/devices/electroacoustics/electroacoustics.mdx
@@ -667,8 +667,10 @@ coherencia ordinaria.
 funciones: toman un array capturado y calculan la razón que define el apartado,
 así que el banco, el punto de funcionamiento y las tres comprobaciones de
 aceptación quedan a cargo de quien lee. Otras partes de la serie IEC 60268
-quedan fuera de esta página: la Parte 16 (inteligibilidad objetiva del habla, el
-índice de transmisión del habla) no está implementada, y los informes de
+quedan fuera de esta página: la Parte 16 (inteligibilidad objetiva del habla)
+está implementada como el índice de transmisión del habla en
+[Transmisión del habla](/phonometry/es/perception/speech/speech-transmission/),
+y los informes de
 características nominales de micrófono (Parte 4) y de altavoz (Parte 5) se
 han trasladado a
 [Caracterización de micrófonos](/phonometry/es/devices/electroacoustics/microphones/) y

--- a/site/src/content/docs/es/perception/psychoacoustics/psychoacoustic-annoyance.mdx
+++ b/site/src/content/docs/es/perception/psychoacoustics/psychoacoustic-annoyance.mdx
@@ -431,7 +431,7 @@ exactitud para tonos FM. Aquí solo se validan estímulos AM. El front-end
 también se aparta del planteamiento exacto del artículo (tramas de 2 s,
 solape del 90 %, umbral absoluto de audición). Como resultado, un tono
 estacionario de 1 kHz marca unos 0,09 vacil en vez de 0, y el ruido de banda
-ancha estacionario marca unos 0,4 vacil. Para el ruido de banda ancha AM,
+ancha estacionario marca unos 0,15-0,19 vacil. Para el ruido de banda ancha AM,
 cita `fluctuation_strength_am_noise` (§3.1) en vez de `fluctuation_strength`,
 que sobreestima ese estímulo. La intensidad de fluctuación normativa del
 modelo de Sottek del apartado 9 de ECMA-418-2 no está implementada en esta

--- a/site/src/content/docs/es/signals/levels/special-weightings.mdx
+++ b/site/src/content/docs/es/signals/levels/special-weightings.mdx
@@ -52,10 +52,12 @@ lectura de exposición audible.
 
 Las cuatro comparten la maquinaria de las curvas de IEC 61672-1 (0 dB a
 1 kHz donde aplica, procesado multicanal y por bloques con estado), y B, D y
-AU toman además el sobremuestreo `high_accuracy`. La G ignora ese indicador,
-pero no porque sobremuestrear sea innecesario: **el diseño de G sobremuestrea
-siempre internamente**, hacia 48 kHz, de modo que su rango de 0,25 Hz a 315 Hz
-se mantiene dentro de unos 0,05 dB sea cual sea la frecuencia de entrada. Y eso
+AU toman además el sobremuestreo `high_accuracy`, y la G también: **el diseño
+por defecto de G se sobremuestrea hacia 48 kHz**, de modo que su rango de
+0,25 Hz a 315 Hz se mantiene dentro de unos 0,05 dB sea cual sea la frecuencia
+de entrada, mientras que el procesado por bloques con estado ejecuta el diseño
+simple a la tasa de entrada, en torno a un decibelio por debajo en 315 Hz a
+fs = 2000 y exactamente en la referencia de 0 dB a 10 Hz. Y eso
 importa justo donde se usa la G: el infrasonido se graba a menudo a 1 kHz o
 2 kHz, donde 315 Hz queda cerca de Nyquist y la deformación bilineal crece de
 forma cuadrática; a frecuencias de audio la corrección es despreciable. Como con

--- a/site/src/content/docs/es/signals/levels/weighting.mdx
+++ b/site/src/content/docs/es/signals/levels/weighting.mdx
@@ -373,8 +373,11 @@ plt.show()
 </details>
 
 - `high_accuracy=False` restaura el comportamiento bilineal clásico.
-- Con `'G'` el indicador se ignora en silencio: su rango de 0,25–315 Hz ya es
-  exacto con el diseño simple.
+- Con `'G'` el indicador funciona como en las demás: el diseño por defecto se
+  sobremuestrea hacia 48 kHz, que es lo que mantiene exactas las tasas de
+  infrasonido; `high_accuracy=False` ejecuta el diseño simple a la tasa de
+  entrada, que cuesta en torno a un decibelio en 315 Hz a fs = 2000 y nada en
+  la referencia de 10 Hz.
 - El **procesado por bloques (stateful)** usa siempre el diseño clásico: el
   remuestreo FIR interno es incompatible con la continuidad entre bloques. Pasar
   `high_accuracy=True` junto con `stateful=True` lanza un `ValueError`.

--- a/site/src/content/docs/perception/psychoacoustics/psychoacoustic-annoyance.mdx
+++ b/site/src/content/docs/perception/psychoacoustics/psychoacoustic-annoyance.mdx
@@ -410,7 +410,7 @@ with the exact model.
 not pursued. Only AM stimuli are validated here. The front-end also departs
 from the paper's exact framing (2 s frames, 90 % overlap, absolute-threshold
 gating). As a result, a steady 1 kHz tone reads about 0.09 vacil instead of
-0, and steady broadband noise reads about 0.4 vacil. For AM broadband noise,
+0, and steady broadband noise reads about 0.15-0.19 vacil. For AM broadband noise,
 quote `fluctuation_strength_am_noise` (§3.1) instead of
 `fluctuation_strength`, which overshoots that stimulus. The normative
 Sottek-model fluctuation strength of ECMA-418-2 Clause 9 is not implemented

--- a/site/src/content/docs/reference/api/psychoacoustics/fluctuation-strength.md
+++ b/site/src/content/docs/reference/api/psychoacoustics/fluctuation-strength.md
@@ -42,7 +42,7 @@ excitation level > max - 60 dB), with $k = 1$ at the filter-bank
 edges.
 Measured consequences: a steady 1 kHz tone returns ~0.09 vacil instead of ~0
 (analysis-window envelope leakage through the 2 Hz high-pass) and steady
-broadband noise returns ~0.4 vacil (partly physical level fluctuation of the
+broadband noise returns ~0.15-0.19 vacil (partly physical level fluctuation of the
 noise itself).
 
 ECMA-418-2:2025 (4th ed.) introduced a normative hearing-model fluctuation

--- a/site/src/content/docs/signals/levels/special-weightings.mdx
+++ b/site/src/content/docs/signals/levels/special-weightings.mdx
@@ -50,10 +50,11 @@ G curve, keeps ultrasonic components out of an audible-exposure reading.
 
 All four share the machinery of the IEC 61672-1 curves (0 dB at 1 kHz where
 applicable, multichannel and stateful block processing), and B, D and AU also
-take the `high_accuracy` oversampling. G ignores that flag, but not because
-oversampling is unnecessary: **the G design always oversamples internally**,
-toward 48 kHz, so its 0.25 Hz to 315 Hz range stays within about 0.05 dB
-whatever the input rate. That matters exactly where G is used — infrasound is
+take the `high_accuracy` oversampling, and G takes it too: **the default G
+design oversamples toward 48 kHz**, so its 0.25 Hz to 315 Hz range stays
+within about 0.05 dB whatever the input rate, while stateful block processing
+runs the plain design at the input rate, about a decibel low at 315 Hz at
+fs = 2000 and exactly on the 0 dB reference at 10 Hz. That matters exactly where G is used — infrasound is
 often recorded at 1 kHz or 2 kHz, where 315 Hz sits close to Nyquist and the
 bilinear warping grows quadratically; at audio rates the correction is
 negligible. As with A/C/Z, `high_accuracy` cannot be combined with stateful

--- a/site/src/content/docs/signals/levels/weighting.mdx
+++ b/site/src/content/docs/signals/levels/weighting.mdx
@@ -362,8 +362,10 @@ plt.show()
 </details>
 
 - `high_accuracy=False` restores the legacy plain-bilinear behavior.
-- For `'G'` the flag is silently ignored: its 0.25–315 Hz range is already
-  exact with the plain design.
+- For `'G'` the flag works like the others': the default design is
+  oversampled toward 48 kHz, which is what keeps infrasound rates accurate;
+  `high_accuracy=False` runs the plain design at the input rate, costing about
+  a decibel at 315 Hz at fs = 2000 and nothing at the 10 Hz reference.
 - **Stateful (block) processing** always uses the legacy design: the internal
   FIR resampling is incompatible with block continuity. Passing
   `high_accuracy=True` together with `stateful=True` raises a `ValueError`.

--- a/src/phonometry/filters/weighting.py
+++ b/src/phonometry/filters/weighting.py
@@ -181,7 +181,15 @@ class WeightingFilter:
             # infrasound recordings, however, 315 Hz approaches Nyquist and
             # the warping grows quadratically; oversample the design toward
             # 48 kHz so the response stays within ~0.05 dB regardless of fs.
-            self._oversample = min(8, max(1, math.ceil(48000 / self.fs)))
+            # Guarded like AU's target doubling below: only the high-accuracy
+            # path resamples around the filter, so only it may design above
+            # the input rate. Stateful mode filters block by block at self.fs,
+            # and an SOS designed for a higher rate applied at the input rate
+            # read -36 dB at G's own 10 Hz reference at fs = 2000. Stateful
+            # therefore runs the plain design at the input rate, which is
+            # what its documentation always said it did.
+            if self.high_accuracy:
+                self._oversample = min(8, max(1, math.ceil(48000 / self.fs)))
         elif self.curve in ("A", "AU"):
             f2 = 107.65265
             f3 = 737.86223

--- a/src/phonometry/psychoacoustics/quality/fluctuation_strength.py
+++ b/src/phonometry/psychoacoustics/quality/fluctuation_strength.py
@@ -37,7 +37,7 @@ excitation level > max - 60 dB), with :math:`k = 1` at the filter-bank
 edges.
 Measured consequences: a steady 1 kHz tone returns ~0.09 vacil instead of ~0
 (analysis-window envelope leakage through the 2 Hz high-pass) and steady
-broadband noise returns ~0.4 vacil (partly physical level fluctuation of the
+broadband noise returns ~0.15-0.19 vacil (partly physical level fluctuation of the
 noise itself).
 
 ECMA-418-2:2025 (4th ed.) introduced a normative hearing-model fluctuation

--- a/tests/filters/test_g_weighting.py
+++ b/tests/filters/test_g_weighting.py
@@ -85,6 +85,28 @@ def test_g_multichannel_and_stateful() -> None:
     np.testing.assert_allclose(y_blocks, y_ref, atol=1e-12)
 
 
+def test_g_stateful_holds_its_reference_at_low_fs() -> None:
+    """Stateful G at infrasound rates must keep 0 dB at 10 Hz (ISO 7196
+    clause 4). The design once oversampled toward 48 kHz unconditionally
+    while stateful filtering ran at the input rate, so an SOS built for
+    fs * 24 was applied at fs = 2000 and the reference read -36 dB. The
+    existing stateful test could not see it: at 48 kHz the oversample
+    factor is one and both paths coincide."""
+    fs = 2000
+    t = np.arange(fs * 8) / fs
+    x = np.sin(2 * np.pi * 10.0 * t)
+    wf = WeightingFilter(fs, "G", stateful=True)
+    blocks = [wf.filter(x[i : i + 500]) for i in range(0, fs * 8, 500)]
+    y = np.concatenate(blocks)
+    s = slice(fs * 2, fs * 7)
+    gain = 20 * np.log10(np.std(y[s]) / np.std(x[s]))
+    assert gain == pytest.approx(0.0, abs=0.1)
+
+    # And block processing still matches the one-shot plain design exactly.
+    y_ref = WeightingFilter(fs, "G", high_accuracy=False).filter(x)
+    np.testing.assert_allclose(y, y_ref, atol=1e-12)
+
+
 def test_invalid_curve_message_mentions_g() -> None:
     with pytest.raises(ValueError, match="G"):
         WeightingFilter(FS, "Q")


### PR DESCRIPTION
Reading both editions of sixty pages with the duty to recompute every number surfaced three defects that reach beyond documentation. This change closes them.

## A stateful G filter read -36.25 dB at its own reference

`WeightingFilter(fs, "G", stateful=True)` at infrasound rates applied an SOS designed for one sample rate at another. The G design oversampled toward 48 kHz unconditionally, while stateful filtering runs block by block at the input rate; at fs = 2000 the 10 Hz reference, which ISO 7196 defines as 0 dB, read -36.25 dB.

The oversampling is now guarded behind the high-accuracy path, the way AU's target doubling always was. The default design still oversamples and keeps every rate within 0.05 dB. Stateful mode now genuinely runs the plain design at the input rate, which is what its documentation always said it did; the cost is about a decibel at 315 Hz at fs = 2000 and nothing at the reference.

The regression test fails at -36.25 dB on the unfixed code. It could not have been written at 48 kHz, where the oversample factor is one and both paths coincide, which is why the existing stateful test never saw the bug.

The pages that taught the old behaviour are corrected in both editions and in the mirror: G does not ignore the `high_accuracy` flag, and its design does not always oversample.

## Two claims that recomputation retired

The fluctuation-strength docstring said steady broadband noise reads about 0.4 vacil. Six recomputed variants across duration, level and seed give 0.15 to 0.19. The docstring, both editions of the annoyance page and the generated reference now agree with the measurement.

The electroacoustics page said IEC 60268-16 is not implemented. The conformance report verifies the speech transmission index against IEC 60268-16:2020 at ten of ten checks. Both editions now point at the guide that implements it.

## Checked

316 filter tests green, the regression proven in both directions, conformance intact, and the full local run of every CI gate clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * G-weighting now supports `high_accuracy` oversampling by default, improving accuracy at low sample rates.
  * Disabling `high_accuracy` uses the input-rate design, with documented accuracy tradeoffs.
  * Stateful G-weighting processing retains consistent input-rate behavior.

* **Documentation**
  * Clarified G-weighting accuracy and processing behavior across English and Spanish guides.
  * Updated speech intelligibility coverage to reflect STI availability.
  * Corrected the reported broadband-noise fluctuation-strength range to approximately 0.15–0.19 vacil.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->