### PR TITLE
Sweep the Spanish tree's recorded divergences, and stop mangling clause numbers

### DIFF
--- a/.github/images/age_threshold_sex_and_spread_es.svg
+++ b/.github/images/age_threshold_sex_and_spread_es.svg
@@ -1168,7 +1168,7 @@ L 740.069191 111.32338
    <g id="text_37">
     <text style="font-size: 10px; font-family: sans-serif; fill: #d62728" transform="translate(764.791184 88.237085)">por encima de 70 años:</text>
     <text style="font-size: 10px; font-family: sans-serif; fill: #d62728" transform="translate(783.599778 100.239819)">solo informativo</text>
-    <text style="font-size: 10px; font-family: sans-serif; fill: #d62728" transform="translate(764.196653 112.642553)">(capítulo 4,1, f ≥ 3 kHz)</text>
+    <text style="font-size: 10px; font-family: sans-serif; fill: #d62728" transform="translate(764.196653 112.642553)">(capítulo 4.1, f ≥ 3 kHz)</text>
    </g>
    <g id="patch_17">
     <path d="M 807.058274 288.217476 

--- a/.github/images/age_threshold_sex_and_spread_es_dark.svg
+++ b/.github/images/age_threshold_sex_and_spread_es_dark.svg
@@ -1168,7 +1168,7 @@ L 740.069191 111.32338
    <g id="text_37">
     <text style="font-size: 10px; font-family: sans-serif; fill: #d62728" transform="translate(764.791184 88.237085)">por encima de 70 años:</text>
     <text style="font-size: 10px; font-family: sans-serif; fill: #d62728" transform="translate(783.599778 100.239819)">solo informativo</text>
-    <text style="font-size: 10px; font-family: sans-serif; fill: #d62728" transform="translate(764.196653 112.642553)">(capítulo 4,1, f ≥ 3 kHz)</text>
+    <text style="font-size: 10px; font-family: sans-serif; fill: #d62728" transform="translate(764.196653 112.642553)">(capítulo 4.1, f ≥ 3 kHz)</text>
    </g>
    <g id="patch_17">
     <path d="M 807.058274 288.217476 

--- a/.github/images/atmospheric_sound_speed_profiles_es.svg
+++ b/.github/images/atmospheric_sound_speed_profiles_es.svg
@@ -416,7 +416,7 @@ L 61.327493 28.318125
 " clip-path="url(#pa26f814d75)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="text_17">
-    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle" x="265.344609" y="16.318125" transform="rotate(-0 265.344609 16.318125)">Perfiles de velocidad efectiva del sonido (Salomons ec. 4,5)</text>
+    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle" x="265.344609" y="16.318125" transform="rotate(-0 265.344609 16.318125)">Perfiles de velocidad efectiva del sonido (Salomons ec. 4.5)</text>
    </g>
    <g id="legend_1">
     <g id="patch_7">

--- a/.github/images/atmospheric_sound_speed_profiles_es_dark.svg
+++ b/.github/images/atmospheric_sound_speed_profiles_es_dark.svg
@@ -416,7 +416,7 @@ L 61.327493 28.318125
 " clip-path="url(#pa26f814d75)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
    </g>
    <g id="text_17">
-    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="265.344609" y="16.318125" transform="rotate(-0 265.344609 16.318125)">Perfiles de velocidad efectiva del sonido (Salomons ec. 4,5)</text>
+    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="265.344609" y="16.318125" transform="rotate(-0 265.344609 16.318125)">Perfiles de velocidad efectiva del sonido (Salomons ec. 4.5)</text>
    </g>
    <g id="legend_1">
     <g id="patch_7">

--- a/.github/images/diffusion_measurement_chain_es.svg
+++ b/.github/images/diffusion_measurement_chain_es.svg
@@ -787,7 +787,7 @@ L 702.134976 84.337891
     <text style="font-size: 8px; font-family: sans-serif; text-anchor: middle" x="520.838529" y="65.85365" transform="rotate(-0 520.838529 65.85365)">muestra</text>
    </g>
    <g id="text_5">
-    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle" x="445.699375" y="16.318125" transform="rotate(-0 445.699375 16.318125)">De tres respuestas al impulso a un nivel (ISO 17497-2, apartado 7,4)</text>
+    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle" x="445.699375" y="16.318125" transform="rotate(-0 445.699375 16.318125)">De tres respuestas al impulso a un nivel (ISO 17497-2, apartado 7.4)</text>
    </g>
   </g>
   <g id="axes_2">

--- a/.github/images/diffusion_measurement_chain_es_dark.svg
+++ b/.github/images/diffusion_measurement_chain_es_dark.svg
@@ -787,7 +787,7 @@ L 702.134976 84.337891
     <text style="font-size: 8px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="520.838529" y="65.85365" transform="rotate(-0 520.838529 65.85365)">muestra</text>
    </g>
    <g id="text_5">
-    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="445.699375" y="16.318125" transform="rotate(-0 445.699375 16.318125)">De tres respuestas al impulso a un nivel (ISO 17497-2, apartado 7,4)</text>
+    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="445.699375" y="16.318125" transform="rotate(-0 445.699375 16.318125)">De tres respuestas al impulso a un nivel (ISO 17497-2, apartado 7.4)</text>
    </g>
   </g>
   <g id="axes_2">

--- a/.github/images/duct_regenerated_noise_es.svg
+++ b/.github/images/duct_regenerated_noise_es.svg
@@ -693,7 +693,7 @@ L 168.887203 123.224855
     <text style="font-size: 8.33px; font-family: sans-serif" transform="translate(199.257499 237.913083)">duplicación, en cada banda</text>
    </g>
    <g id="text_20">
-    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle" x="242.636167" y="16.798125" transform="rotate(-0 242.636167 16.798125)">Ruido propio del silenciador (Long Ec. 14,31)</text>
+    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle" x="242.636167" y="16.798125" transform="rotate(-0 242.636167 16.798125)">Ruido propio del silenciador (Long Ec. 14.31)</text>
    </g>
    <g id="legend_1">
     <g id="patch_8">
@@ -1293,7 +1293,7 @@ L 612.146761 45.936915
     <text style="font-size: 8.33px; font-family: sans-serif" transform="translate(629.220838 160.325186)">ASHRAE limita el cuello de una salida de impulsión RC 30 a 2,2 m/s</text>
    </g>
    <g id="text_42">
-    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle" x="684.973813" y="16.798125" transform="rotate(-0 684.973813 16.798125)">Potencia acústica del difusor (Long Ecs. 13,27-13,33)</text>
+    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle" x="684.973813" y="16.798125" transform="rotate(-0 684.973813 16.798125)">Potencia acústica del difusor (Long Ecs. 13.27-13.33)</text>
    </g>
    <g id="legend_2">
     <g id="patch_15">

--- a/.github/images/duct_regenerated_noise_es_dark.svg
+++ b/.github/images/duct_regenerated_noise_es_dark.svg
@@ -693,7 +693,7 @@ L 168.887203 123.224855
     <text style="font-size: 8.33px; font-family: sans-serif; fill: #ffffff" transform="translate(199.257499 237.913083)">duplicación, en cada banda</text>
    </g>
    <g id="text_20">
-    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="242.636167" y="16.798125" transform="rotate(-0 242.636167 16.798125)">Ruido propio del silenciador (Long Ec. 14,31)</text>
+    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="242.636167" y="16.798125" transform="rotate(-0 242.636167 16.798125)">Ruido propio del silenciador (Long Ec. 14.31)</text>
    </g>
    <g id="legend_1">
     <g id="patch_8">
@@ -1293,7 +1293,7 @@ L 612.146761 45.936915
     <text style="font-size: 8.33px; font-family: sans-serif; fill: #ffffff" transform="translate(629.220838 160.325186)">ASHRAE limita el cuello de una salida de impulsión RC 30 a 2,2 m/s</text>
    </g>
    <g id="text_42">
-    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="684.973813" y="16.798125" transform="rotate(-0 684.973813 16.798125)">Potencia acústica del difusor (Long Ecs. 13,27-13,33)</text>
+    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="684.973813" y="16.798125" transform="rotate(-0 684.973813 16.798125)">Potencia acústica del difusor (Long Ecs. 13.27-13.33)</text>
    </g>
    <g id="legend_2">
     <g id="patch_15">

--- a/.github/images/duct_sheet_verification_es.svg
+++ b/.github/images/duct_sheet_verification_es.svg
@@ -589,7 +589,7 @@ L 312.234167 21.798437
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_19">
-    <text style="font-weight: 700; font-size: 10px; font-family: sans-serif; text-anchor: middle" x="179.761224" y="14.798437" transform="rotate(-0 179.761224 14.798437)">Ventilador, Ec. 13,1  (peor Δ 13 dB)</text>
+    <text style="font-weight: 700; font-size: 10px; font-family: sans-serif; text-anchor: middle" x="179.761224" y="14.798437" transform="rotate(-0 179.761224 14.798437)">Ventilador, Ec. 13.1  (peor Δ 13 dB)</text>
    </g>
    <g id="legend_1">
     <g id="patch_7">

--- a/.github/images/duct_sheet_verification_es_dark.svg
+++ b/.github/images/duct_sheet_verification_es_dark.svg
@@ -589,7 +589,7 @@ L 312.234167 21.798437
 " style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_19">
-    <text style="font-weight: 700; font-size: 10px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="179.761224" y="14.798437" transform="rotate(-0 179.761224 14.798437)">Ventilador, Ec. 13,1  (peor Δ 13 dB)</text>
+    <text style="font-weight: 700; font-size: 10px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="179.761224" y="14.798437" transform="rotate(-0 179.761224 14.798437)">Ventilador, Ec. 13.1  (peor Δ 13 dB)</text>
    </g>
    <g id="legend_1">
     <g id="patch_7">

--- a/.github/images/dynamic_stiffness_es.svg
+++ b/.github/images/dynamic_stiffness_es.svg
@@ -605,7 +605,7 @@ z
 " style="fill: #f0f2f5; stroke: #e0e0e0; stroke-linejoin: miter"/>
     </g>
     <text style="font-size: 10px; font-family: sans-serif" transform="translate(519.846035 347.518455)">f0 = (1/2pi) sqrt(s'/m')  (Fórmula 2)</text>
-    <text style="font-size: 10px; font-family: sans-serif" transform="translate(550.964785 359.521189)">s'  = s't + s'a  (apartado 8,2)</text>
+    <text style="font-size: 10px; font-family: sans-serif" transform="translate(550.964785 359.521189)">s'  = s't + s'a  (apartado 8.2)</text>
     <text style="font-size: 10px; font-family: sans-serif" transform="translate(526.71166 371.923923)">s't = 4 pi^2 m't fr^2  (Fórmula 4)</text>
     <text style="font-size: 10px; font-family: sans-serif" transform="translate(483.702285 383.926658)">s'a = p0/(d eps) ~ 111/d MN/m^3  (NOTA)</text>
    </g>

--- a/.github/images/dynamic_stiffness_es_dark.svg
+++ b/.github/images/dynamic_stiffness_es_dark.svg
@@ -605,7 +605,7 @@ z
 " style="fill: #1c2128; stroke: #555555; stroke-linejoin: miter"/>
     </g>
     <text style="font-size: 10px; font-family: sans-serif; fill: #ffffff" transform="translate(519.846035 347.518455)">f0 = (1/2pi) sqrt(s'/m')  (Fórmula 2)</text>
-    <text style="font-size: 10px; font-family: sans-serif; fill: #ffffff" transform="translate(550.964785 359.521189)">s'  = s't + s'a  (apartado 8,2)</text>
+    <text style="font-size: 10px; font-family: sans-serif; fill: #ffffff" transform="translate(550.964785 359.521189)">s'  = s't + s'a  (apartado 8.2)</text>
     <text style="font-size: 10px; font-family: sans-serif; fill: #ffffff" transform="translate(526.71166 371.923923)">s't = 4 pi^2 m't fr^2  (Fórmula 4)</text>
     <text style="font-size: 10px; font-family: sans-serif; fill: #ffffff" transform="translate(483.702285 383.926658)">s'a = p0/(d eps) ~ 111/d MN/m^3  (NOTA)</text>
    </g>

--- a/.github/images/effective_kappa_es.svg
+++ b/.github/images/effective_kappa_es.svg
@@ -148,7 +148,7 @@ L 678.403281 28.798125
      </g>
     </g>
     <g id="text_8">
-     <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle" x="364.685625" y="430.394219" transform="rotate(-0 364.685625 430.394219)">Frecuencia del pistón f [Hz]  (ISO 9053-2, apartado 6,2: de 1 a 4 Hz)</text>
+     <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle" x="364.685625" y="430.394219" transform="rotate(-0 364.685625 430.394219)">Frecuencia del pistón f [Hz]  (ISO 9053-2, apartado 6.2: de 1 a 4 Hz)</text>
     </g>
    </g>
    <g id="matplotlib.axis_2">

--- a/.github/images/effective_kappa_es_dark.svg
+++ b/.github/images/effective_kappa_es_dark.svg
@@ -148,7 +148,7 @@ L 678.403281 28.798125
      </g>
     </g>
     <g id="text_8">
-     <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="364.685625" y="430.394219" transform="rotate(-0 364.685625 430.394219)">Frecuencia del pistón f [Hz]  (ISO 9053-2, apartado 6,2: de 1 a 4 Hz)</text>
+     <text style="font-size: 10px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="364.685625" y="430.394219" transform="rotate(-0 364.685625 430.394219)">Frecuencia del pistón f [Hz]  (ISO 9053-2, apartado 6.2: de 1 a 4 Hz)</text>
     </g>
    </g>
    <g id="matplotlib.axis_2">

--- a/.github/images/enclosed_gas_stiffness_es.svg
+++ b/.github/images/enclosed_gas_stiffness_es.svg
@@ -437,7 +437,7 @@ Q 46.294911 400.945898 50.794911 400.945898
 z
 " style="fill: #f0f2f5; stroke: #e0e0e0; stroke-linejoin: miter"/>
     </g>
-    <text style="font-size: 9px; font-family: sans-serif" transform="translate(50.794911 371.730879)">apartado 8,2:  r &gt;= 100 kPa.s/m2 -&gt; s' = s't</text>
+    <text style="font-size: 9px; font-family: sans-serif" transform="translate(50.794911 371.730879)">apartado 8.2:  r &gt;= 100 kPa.s/m2 -&gt; s' = s't</text>
     <text style="font-size: 9px; font-family: sans-serif" transform="translate(50.794911 382.532637)">               10 &lt;= r &lt; 100     -&gt; s' = s't + s'a</text>
     <text style="font-size: 9px; font-family: sans-serif" transform="translate(50.794911 393.38291)">               r &lt; 10            -&gt; s' = s't solo si s'a es despreciable</text>
    </g>
@@ -513,7 +513,7 @@ L 469.185625 68.308125
 " style="fill: none; stroke: #d62728; stroke-width: 2.4; stroke-linecap: square"/>
     </g>
     <g id="text_19">
-     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start" x="476.385625" y="71.458125" transform="rotate(-0 476.385625 71.458125)">s' instalada = s't + s'a (apartado 8,2)</text>
+     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start" x="476.385625" y="71.458125" transform="rotate(-0 476.385625 71.458125)">s' instalada = s't + s'a (apartado 8.2)</text>
     </g>
    </g>
    <g id="PathCollection_1">

--- a/.github/images/enclosed_gas_stiffness_es_dark.svg
+++ b/.github/images/enclosed_gas_stiffness_es_dark.svg
@@ -437,7 +437,7 @@ Q 46.294911 400.945898 50.794911 400.945898
 z
 " style="fill: #1c2128; stroke: #555555; stroke-linejoin: miter"/>
     </g>
-    <text style="font-size: 9px; font-family: sans-serif; fill: #ffffff" transform="translate(50.794911 371.730879)">apartado 8,2:  r &gt;= 100 kPa.s/m2 -&gt; s' = s't</text>
+    <text style="font-size: 9px; font-family: sans-serif; fill: #ffffff" transform="translate(50.794911 371.730879)">apartado 8.2:  r &gt;= 100 kPa.s/m2 -&gt; s' = s't</text>
     <text style="font-size: 9px; font-family: sans-serif; fill: #ffffff" transform="translate(50.794911 382.532637)">               10 &lt;= r &lt; 100     -&gt; s' = s't + s'a</text>
     <text style="font-size: 9px; font-family: sans-serif; fill: #ffffff" transform="translate(50.794911 393.38291)">               r &lt; 10            -&gt; s' = s't solo si s'a es despreciable</text>
    </g>
@@ -513,7 +513,7 @@ L 469.185625 68.308125
 " style="fill: none; stroke: #d62728; stroke-width: 2.4; stroke-linecap: square"/>
     </g>
     <g id="text_19">
-     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="476.385625" y="71.458125" transform="rotate(-0 476.385625 71.458125)">s' instalada = s't + s'a (apartado 8,2)</text>
+     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="476.385625" y="71.458125" transform="rotate(-0 476.385625 71.458125)">s' instalada = s't + s'a (apartado 8.2)</text>
     </g>
    </g>
    <g id="PathCollection_1">

--- a/.github/images/fan_sound_power_es.svg
+++ b/.github/images/fan_sound_power_es.svg
@@ -657,7 +657,7 @@ L 501.248962 151.556894
     <text style="font-size: 8.33px; font-family: sans-serif" transform="translate(231.456426 260.147312)">× 24 álabes, 2 kHz si el ventilador se elige más rápido</text>
    </g>
    <g id="text_18">
-    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle" x="376.587109" y="16.798125" transform="rotate(-0 376.587109 16.798125)">La fila del ventilador: 5000 cfm a 2 in c.a., álabes curvados hacia delante (Long Ec. 13,1)</text>
+    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle" x="376.587109" y="16.798125" transform="rotate(-0 376.587109 16.798125)">La fila del ventilador: 5000 cfm a 2 in c.a., álabes curvados hacia delante (Long Ec. 13.1)</text>
    </g>
    <g id="axes_2">
     <g id="patch_8">
@@ -967,7 +967,7 @@ L 475.521089 89.357727
      </g>
     </g>
     <g id="text_36">
-     <text style="font-size: 8.33px; font-family: sans-serif; text-anchor: start" x="482.185089" y="92.273227" transform="rotate(-0 482.185089 92.273227)">Atenuación de la carcasa (Tabla 13,8)</text>
+     <text style="font-size: 8.33px; font-family: sans-serif; text-anchor: start" x="482.185089" y="92.273227" transform="rotate(-0 482.185089 92.273227)">Atenuación de la carcasa (Tabla 13.8)</text>
     </g>
    </g>
   </g>

--- a/.github/images/fan_sound_power_es_dark.svg
+++ b/.github/images/fan_sound_power_es_dark.svg
@@ -657,7 +657,7 @@ L 501.248962 151.556894
     <text style="font-size: 8.33px; font-family: sans-serif; fill: #ffffff" transform="translate(231.456426 260.147312)">× 24 álabes, 2 kHz si el ventilador se elige más rápido</text>
    </g>
    <g id="text_18">
-    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="376.587109" y="16.798125" transform="rotate(-0 376.587109 16.798125)">La fila del ventilador: 5000 cfm a 2 in c.a., álabes curvados hacia delante (Long Ec. 13,1)</text>
+    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="376.587109" y="16.798125" transform="rotate(-0 376.587109 16.798125)">La fila del ventilador: 5000 cfm a 2 in c.a., álabes curvados hacia delante (Long Ec. 13.1)</text>
    </g>
    <g id="axes_2">
     <g id="patch_8">
@@ -967,7 +967,7 @@ L 475.521089 89.357727
      </g>
     </g>
     <g id="text_36">
-     <text style="font-size: 8.33px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="482.185089" y="92.273227" transform="rotate(-0 482.185089 92.273227)">Atenuación de la carcasa (Tabla 13,8)</text>
+     <text style="font-size: 8.33px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="482.185089" y="92.273227" transform="rotate(-0 482.185089 92.273227)">Atenuación de la carcasa (Tabla 13.8)</text>
     </g>
    </g>
   </g>

--- a/.github/images/fluctuation_strength_es.svg
+++ b/.github/images/fluctuation_strength_es.svg
@@ -580,7 +580,7 @@ L 259.120567 64.007406
 " style="fill: none; stroke: #1f77b4; stroke-width: 2.4; stroke-linecap: square"/>
     </g>
     <g id="text_20">
-     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start" x="266.320567" y="67.157406" transform="rotate(-0 266.320567 67.157406)">forma cerrada, Ec. 10,2: máximo 3,7 vacil</text>
+     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start" x="266.320567" y="67.157406" transform="rotate(-0 266.320567 67.157406)">forma cerrada, Ec. 10.2: máximo 3,7 vacil</text>
     </g>
     <g id="line2d_55">
      <path d="M 241.120567 77.868109 

--- a/.github/images/fluctuation_strength_es_dark.svg
+++ b/.github/images/fluctuation_strength_es_dark.svg
@@ -580,7 +580,7 @@ L 259.120567 64.007406
 " style="fill: none; stroke: #1f77b4; stroke-width: 2.4; stroke-linecap: square"/>
     </g>
     <g id="text_20">
-     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="266.320567" y="67.157406" transform="rotate(-0 266.320567 67.157406)">forma cerrada, Ec. 10,2: máximo 3,7 vacil</text>
+     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="266.320567" y="67.157406" transform="rotate(-0 266.320567 67.157406)">forma cerrada, Ec. 10.2: máximo 3,7 vacil</text>
     </g>
     <g id="line2d_55">
      <path d="M 241.120567 77.868109 

--- a/.github/images/hvac_elbow_flow_noise_es.svg
+++ b/.github/images/hvac_elbow_flow_noise_es.svg
@@ -629,7 +629,7 @@ L 440.843437 26.798125
     <text style="font-size: 8.33px; font-family: sans-serif" transform="translate(299.947435 310.787171)">(W = 0,30 m, 1143 Hz)</text>
    </g>
    <g id="text_18">
-    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle" x="241.084609" y="16.798125" transform="rotate(-0 241.084609 16.798125)">Pérdida por inserción del codo (ASHRAE Tabla 8,11)</text>
+    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle" x="241.084609" y="16.798125" transform="rotate(-0 241.084609 16.798125)">Pérdida por inserción del codo (ASHRAE Tabla 8.11)</text>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -1303,7 +1303,7 @@ L 569.090254 61.039155
     <text style="font-size: 8.33px; font-family: sans-serif" transform="translate(633.819243 165.931677)">por debajo de 500 Hz</text>
    </g>
    <g id="text_42">
-    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle" x="693.604609" y="16.798125" transform="rotate(-0 693.604609 16.798125)">Potencia acústica del flujo (VDI 2081, Bies Ec. 8,252)</text>
+    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle" x="693.604609" y="16.798125" transform="rotate(-0 693.604609 16.798125)">Potencia acústica del flujo (VDI 2081, Bies Ec. 8.252)</text>
    </g>
    <g id="legend_2">
     <g id="patch_14">

--- a/.github/images/hvac_elbow_flow_noise_es_dark.svg
+++ b/.github/images/hvac_elbow_flow_noise_es_dark.svg
@@ -629,7 +629,7 @@ L 440.843437 26.798125
     <text style="font-size: 8.33px; font-family: sans-serif; fill: #ffffff" transform="translate(299.947435 310.787171)">(W = 0,30 m, 1143 Hz)</text>
    </g>
    <g id="text_18">
-    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="241.084609" y="16.798125" transform="rotate(-0 241.084609 16.798125)">Pérdida por inserción del codo (ASHRAE Tabla 8,11)</text>
+    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="241.084609" y="16.798125" transform="rotate(-0 241.084609 16.798125)">Pérdida por inserción del codo (ASHRAE Tabla 8.11)</text>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -1303,7 +1303,7 @@ L 569.090254 61.039155
     <text style="font-size: 8.33px; font-family: sans-serif; fill: #ffffff" transform="translate(633.819243 165.931677)">por debajo de 500 Hz</text>
    </g>
    <g id="text_42">
-    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="693.604609" y="16.798125" transform="rotate(-0 693.604609 16.798125)">Potencia acústica del flujo (VDI 2081, Bies Ec. 8,252)</text>
+    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="693.604609" y="16.798125" transform="rotate(-0 693.604609 16.798125)">Potencia acústica del flujo (VDI 2081, Bies Ec. 8.252)</text>
    </g>
    <g id="legend_2">
     <g id="patch_14">

--- a/.github/images/hvac_end_reflection_es.svg
+++ b/.github/images/hvac_end_reflection_es.svg
@@ -526,7 +526,7 @@ L 706.104063 26.798125
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_17">
-    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle" x="378.485234" y="16.798125" transform="rotate(-0 378.485234 16.798125)">Pérdida por reflexión del extremo del conducto (ASHRAE Tabla 8,14)</text>
+    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle" x="378.485234" y="16.798125" transform="rotate(-0 378.485234 16.798125)">Pérdida por reflexión del extremo del conducto (ASHRAE Tabla 8.14)</text>
    </g>
    <g id="legend_1">
     <g id="patch_7">

--- a/.github/images/hvac_end_reflection_es_dark.svg
+++ b/.github/images/hvac_end_reflection_es_dark.svg
@@ -526,7 +526,7 @@ L 706.104063 26.798125
 " style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_17">
-    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="378.485234" y="16.798125" transform="rotate(-0 378.485234 16.798125)">Pérdida por reflexión del extremo del conducto (ASHRAE Tabla 8,14)</text>
+    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="378.485234" y="16.798125" transform="rotate(-0 378.485234 16.798125)">Pérdida por reflexión del extremo del conducto (ASHRAE Tabla 8.14)</text>
    </g>
    <g id="legend_1">
     <g id="patch_7">

--- a/.github/images/infinite_mobilities_es.svg
+++ b/.github/images/infinite_mobilities_es.svg
@@ -1469,7 +1469,7 @@ z
     <text style="font-size: 10px; font-family: sans-serif" transform="translate(547.531473 87.448309)">placa |Y| = 2,55e-06 m/(N·s)</text>
    </g>
    <g id="text_9">
-    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle" x="375.701172" y="16.318125" transform="rotate(-0 375.701172 16.318125)">Movilidades puntuales de estructuras infinitas (Cremer, tabla 5,1)</text>
+    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle" x="375.701172" y="16.318125" transform="rotate(-0 375.701172 16.318125)">Movilidades puntuales de estructuras infinitas (Cremer, tabla 5.1)</text>
    </g>
    <g id="legend_1">
     <g id="patch_8">

--- a/.github/images/infinite_mobilities_es_dark.svg
+++ b/.github/images/infinite_mobilities_es_dark.svg
@@ -1469,7 +1469,7 @@ z
     <text style="font-size: 10px; font-family: sans-serif; fill: #ffffff" transform="translate(547.531473 87.448309)">placa |Y| = 2,55e-06 m/(N·s)</text>
    </g>
    <g id="text_9">
-    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="375.701172" y="16.318125" transform="rotate(-0 375.701172 16.318125)">Movilidades puntuales de estructuras infinitas (Cremer, tabla 5,1)</text>
+    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="375.701172" y="16.318125" transform="rotate(-0 375.701172 16.318125)">Movilidades puntuales de estructuras infinitas (Cremer, tabla 5.1)</text>
    </g>
    <g id="legend_1">
     <g id="patch_8">

--- a/.github/images/insitu_method_windows_es.svg
+++ b/.github/images/insitu_method_windows_es.svg
@@ -544,7 +544,7 @@ L 548.269375 247.827187
 " style="fill: none; stroke: #d62728; stroke-width: 2.2; stroke-linecap: square"/>
     </g>
     <g id="text_25">
-     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start" x="555.469375" y="250.977187" transform="rotate(-0 555.469375 250.977187)">f_u = 0,58 c0 / d (apartado 5,4)</text>
+     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start" x="555.469375" y="250.977187" transform="rotate(-0 555.469375 250.977187)">f_u = 0,58 c0 / d (apartado 5.4)</text>
     </g>
    </g>
    <g id="PathCollection_1">

--- a/.github/images/insitu_method_windows_es_dark.svg
+++ b/.github/images/insitu_method_windows_es_dark.svg
@@ -544,7 +544,7 @@ L 548.269375 247.827187
 " style="fill: none; stroke: #d62728; stroke-width: 2.2; stroke-linecap: square"/>
     </g>
     <g id="text_25">
-     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="555.469375" y="250.977187" transform="rotate(-0 555.469375 250.977187)">f_u = 0,58 c0 / d (apartado 5,4)</text>
+     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="555.469375" y="250.977187" transform="rotate(-0 555.469375 250.977187)">f_u = 0,58 c0 / d (apartado 5.4)</text>
     </g>
    </g>
    <g id="PathCollection_1">

--- a/.github/images/marine_mammal_audiograms_es.svg
+++ b/.github/images/marine_mammal_audiograms_es.svg
@@ -1825,7 +1825,7 @@ z
     <text style="font-size: 8.5px; font-family: sans-serif" transform="translate(553.688141 278.597762)">leer el segundo a 50 kHz pierde 0,7 dB</text>
    </g>
    <g id="text_50">
-    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle" x="742.887109" y="16.318125" transform="rotate(-0 742.887109 16.318125)">Orca (Ainslie 2010, ec. 11,159)</text>
+    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle" x="742.887109" y="16.318125" transform="rotate(-0 742.887109 16.318125)">Orca (Ainslie 2010, ec. 11.159)</text>
    </g>
    <g id="line2d_167">
     <defs>

--- a/.github/images/marine_mammal_audiograms_es_dark.svg
+++ b/.github/images/marine_mammal_audiograms_es_dark.svg
@@ -1825,7 +1825,7 @@ z
     <text style="font-size: 8.5px; font-family: sans-serif; fill: #ffffff" transform="translate(553.688141 278.597762)">leer el segundo a 50 kHz pierde 0,7 dB</text>
    </g>
    <g id="text_50">
-    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="742.887109" y="16.318125" transform="rotate(-0 742.887109 16.318125)">Orca (Ainslie 2010, ec. 11,159)</text>
+    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="742.887109" y="16.318125" transform="rotate(-0 742.887109 16.318125)">Orca (Ainslie 2010, ec. 11.159)</text>
    </g>
    <g id="line2d_167">
     <defs>

--- a/.github/images/plateau_transmission_loss_es.svg
+++ b/.github/images/plateau_transmission_loss_es.svg
@@ -775,7 +775,7 @@ L 68.727344 68.308125
      </g>
     </g>
     <g id="text_36">
-     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start" x="75.927344" y="71.458125" transform="rotate(-0 75.927344 71.458125)">estimación por meseta (Norton, tabla 3,1)</text>
+     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start" x="75.927344" y="71.458125" transform="rotate(-0 75.927344 71.458125)">estimación por meseta (Norton, tabla 3.1)</text>
     </g>
     <g id="line2d_64">
      <path d="M 50.727344 82.168828 

--- a/.github/images/plateau_transmission_loss_es_dark.svg
+++ b/.github/images/plateau_transmission_loss_es_dark.svg
@@ -775,7 +775,7 @@ L 68.727344 68.308125
      </g>
     </g>
     <g id="text_36">
-     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="75.927344" y="71.458125" transform="rotate(-0 75.927344 71.458125)">estimación por meseta (Norton, tabla 3,1)</text>
+     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="75.927344" y="71.458125" transform="rotate(-0 75.927344 71.458125)">estimación por meseta (Norton, tabla 3.1)</text>
     </g>
     <g id="line2d_64">
      <path d="M 50.727344 82.168828 

--- a/.github/images/rice_peak_distribution_es.svg
+++ b/.github/images/rice_peak_distribution_es.svg
@@ -2945,7 +2945,7 @@ L 77.800781 359.722969
 " style="fill: none; stroke: #d62728; stroke-width: 1.7; stroke-linecap: square"/>
     </g>
     <g id="text_20">
-     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start" x="85.000781" y="362.872969" transform="rotate(-0 85.000781 362.872969)">Mezcla de Rice con r = 0,746 (Ec. 5,223)</text>
+     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start" x="85.000781" y="362.872969" transform="rotate(-0 85.000781 362.872969)">Mezcla de Rice con r = 0,746 (Ec. 5.223)</text>
     </g>
     <g id="line2d_74">
      <path d="M 59.800781 373.583672 

--- a/.github/images/rice_peak_distribution_es_dark.svg
+++ b/.github/images/rice_peak_distribution_es_dark.svg
@@ -2945,7 +2945,7 @@ L 77.800781 359.722969
 " style="fill: none; stroke: #d62728; stroke-width: 1.7; stroke-linecap: square"/>
     </g>
     <g id="text_20">
-     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="85.000781" y="362.872969" transform="rotate(-0 85.000781 362.872969)">Mezcla de Rice con r = 0,746 (Ec. 5,223)</text>
+     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="85.000781" y="362.872969" transform="rotate(-0 85.000781 362.872969)">Mezcla de Rice con r = 0,746 (Ec. 5.223)</text>
     </g>
     <g id="line2d_74">
      <path d="M 59.800781 373.583672 

--- a/.github/images/silencer_expansion_chamber_es.svg
+++ b/.github/images/silencer_expansion_chamber_es.svg
@@ -1212,7 +1212,7 @@ L 628.104063 26.798125
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_19">
-    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle" x="339.485234" y="16.798125" transform="rotate(-0 339.485234 16.798125)">Pérdida de transmisión de cámara de expansión (Bies Ec. 8,111)</text>
+    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle" x="339.485234" y="16.798125" transform="rotate(-0 339.485234 16.798125)">Pérdida de transmisión de cámara de expansión (Bies Ec. 8.111)</text>
    </g>
    <g id="legend_1">
     <g id="patch_7">

--- a/.github/images/silencer_expansion_chamber_es_dark.svg
+++ b/.github/images/silencer_expansion_chamber_es_dark.svg
@@ -1212,7 +1212,7 @@ L 628.104063 26.798125
 " style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_19">
-    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="339.485234" y="16.798125" transform="rotate(-0 339.485234 16.798125)">Pérdida de transmisión de cámara de expansión (Bies Ec. 8,111)</text>
+    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="339.485234" y="16.798125" transform="rotate(-0 339.485234 16.798125)">Pérdida de transmisión de cámara de expansión (Bies Ec. 8.111)</text>
    </g>
    <g id="legend_1">
     <g id="patch_7">

--- a/.github/images/silencer_side_branch_es.svg
+++ b/.github/images/silencer_side_branch_es.svg
@@ -530,7 +530,7 @@ L 706.163437 26.798125
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_14">
-    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle" x="373.744609" y="16.798125" transform="rotate(-0 373.744609 16.798125)">Resonadores en derivación: pérdida de transmisión (Bies Ecs. 8,44, 8,46)</text>
+    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle" x="373.744609" y="16.798125" transform="rotate(-0 373.744609 16.798125)">Resonadores en derivación: pérdida de transmisión (Bies Ecs. 8.44, 8.46)</text>
    </g>
    <g id="legend_1">
     <g id="patch_7">

--- a/.github/images/silencer_side_branch_es_dark.svg
+++ b/.github/images/silencer_side_branch_es_dark.svg
@@ -530,7 +530,7 @@ L 706.163437 26.798125
 " style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="text_14">
-    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="373.744609" y="16.798125" transform="rotate(-0 373.744609 16.798125)">Resonadores en derivación: pérdida de transmisión (Bies Ecs. 8,44, 8,46)</text>
+    <text style="font-weight: 700; font-size: 12px; font-family: sans-serif; text-anchor: middle; fill: #ffffff" x="373.744609" y="16.798125" transform="rotate(-0 373.744609 16.798125)">Resonadores en derivación: pérdida de transmisión (Bies Ecs. 8.44, 8.46)</text>
    </g>
    <g id="legend_1">
     <g id="patch_7">

--- a/.github/images/tnr_pr_comparison_es.svg
+++ b/.github/images/tnr_pr_comparison_es.svg
@@ -517,7 +517,7 @@ L 277.186875 63.647406
 " style="fill: none; stroke: #1f77b4; stroke-width: 2.2; stroke-linecap: square"/>
     </g>
     <g id="text_18">
-     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start" x="284.386875" y="66.797406" transform="rotate(-0 284.386875 66.797406)">criterio TNR (apartado 11,5)</text>
+     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start" x="284.386875" y="66.797406" transform="rotate(-0 284.386875 66.797406)">criterio TNR (apartado 11.5)</text>
     </g>
     <g id="line2d_60">
      <path d="M 259.186875 77.148109 
@@ -526,7 +526,7 @@ L 277.186875 77.148109
 " style="fill: none; stroke-dasharray: 8.14,3.52; stroke-dashoffset: 0; stroke: #d62728; stroke-width: 2.2"/>
     </g>
     <g id="text_19">
-     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start" x="284.386875" y="80.298109" transform="rotate(-0 284.386875 80.298109)">criterio PR (apartado 12,5)</text>
+     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start" x="284.386875" y="80.298109" transform="rotate(-0 284.386875 80.298109)">criterio PR (apartado 12.5)</text>
     </g>
    </g>
    <g id="line2d_61">

--- a/.github/images/tnr_pr_comparison_es_dark.svg
+++ b/.github/images/tnr_pr_comparison_es_dark.svg
@@ -517,7 +517,7 @@ L 277.186875 63.647406
 " style="fill: none; stroke: #1f77b4; stroke-width: 2.2; stroke-linecap: square"/>
     </g>
     <g id="text_18">
-     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="284.386875" y="66.797406" transform="rotate(-0 284.386875 66.797406)">criterio TNR (apartado 11,5)</text>
+     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="284.386875" y="66.797406" transform="rotate(-0 284.386875 66.797406)">criterio TNR (apartado 11.5)</text>
     </g>
     <g id="line2d_60">
      <path d="M 259.186875 77.148109 
@@ -526,7 +526,7 @@ L 277.186875 77.148109
 " style="fill: none; stroke-dasharray: 8.14,3.52; stroke-dashoffset: 0; stroke: #d62728; stroke-width: 2.2"/>
     </g>
     <g id="text_19">
-     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="284.386875" y="80.298109" transform="rotate(-0 284.386875 80.298109)">criterio PR (apartado 12,5)</text>
+     <text style="font-size: 9px; font-family: sans-serif; text-anchor: start; fill: #ffffff" x="284.386875" y="80.298109" transform="rotate(-0 284.386875 80.298109)">criterio PR (apartado 12.5)</text>
     </g>
    </g>
    <g id="line2d_61">

--- a/docs/perception/psychoacoustics/psychoacoustic-annoyance.md
+++ b/docs/perception/psychoacoustics/psychoacoustic-annoyance.md
@@ -267,7 +267,7 @@ accumulates more of it than the single closed form allows.
 > overlap and absolute-threshold screening become 50 % overlap, a Hann window
 > and relative floors here), so perfectly steady signals do not read exactly
 > zero: a steady 1 kHz tone comes out near 0.09 vacil and steady broadband
-> noise a few tenths of a vacil, partly the physical level fluctuation of the
+> noise about 0.15-0.19 vacil, partly the physical level fluctuation of the
 > noise itself. For **AM broadband noise** the signal model overshoots
 > the absolute level (it spreads the modulated energy across bands); quote the
 > closed form `fluctuation_strength_am_noise` (§3.1) for that stimulus.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -29476,7 +29476,7 @@ accumulates more of it than the single closed form allows.
 > overlap and absolute-threshold screening become 50 % overlap, a Hann window
 > and relative floors here), so perfectly steady signals do not read exactly
 > zero: a steady 1 kHz tone comes out near 0.09 vacil and steady broadband
-> noise a few tenths of a vacil, partly the physical level fluctuation of the
+> noise about 0.15-0.19 vacil, partly the physical level fluctuation of the
 > noise itself. For **AM broadband noise** the signal model overshoots
 > the absolute level (it spreads the modulated energy across bands); quote the
 > closed form `fluctuation_strength_am_noise` (§3.1) for that stimulus.

--- a/scripts/figures/i18n.py
+++ b/scripts/figures/i18n.py
@@ -12,6 +12,7 @@ translation fix never means touching a figure.
 """
 
 import os
+import re
 import sys
 from typing import Any
 
@@ -5154,6 +5155,46 @@ _ES_PATTERNS = [
       "sobre f2 a 20b = \\2 dB/década")),
 ]
 
+# The Spanish decimal comma, with the numbers that are NOT decimals carved
+# out. A number introduced by a clause/equation/table/annex token ("apartado
+# 7.4", "Ec. 8.252", "Tabla 13.8") is a reference into a standard or a book,
+# and the Spanish pages keep its dot; a plural token ("Ecs. 8.44, 8.46",
+# "apartados 6.2 y 6.3") extends that reading over its whole list, and a
+# dash-joined range ("Ecs. 13.27-13.33", "apartado 4.1-4.3") is
+# reference-to-reference after either. The carve-out is deliberately no wider:
+# after a singular token only the first number binds, so a genuine decimal in
+# the same breath ("Ec. 10.2: máximo 3.7 vacil", "Fórmula 7, eps = 0.9",
+# "Tabla 2 -0.5 dB") still takes its comma, and the dash of a range must sit
+# digit-to-digit so a spaced negative value is never read as a range.
+_REF_NUM = r"\d+(?:\.\d+)*(?:[-–−]\d+(?:\.\d+)*)*"
+_CLAUSE_REF_RE = re.compile(
+    r"\b(?:apartados|cap[ií]tulos|cl[aá]usulas|anexos|tablas|f[oó]rmulas"
+    r"|ecs\.)\s*" + _REF_NUM + r"(?:(?:\s*,\s*|\s+y\s+)" + _REF_NUM + r")*"
+    r"|(?:\b(?:apartado|cap[ií]tulo|cl[aá]usula|anexo|tabla|f[oó]rmula"
+    r"|f[oó]rm\.|ec\.)|§)\s*" + _REF_NUM,
+    re.IGNORECASE,
+)
+# A letter immediately before the number marks a standard designation
+# (e.g. "S3.5"), not a decimal; a further digit or dot on either side marks
+# a three-part clause/version number ("7.4.3"). Both keep their dots.
+_DECIMAL_RE = re.compile(r"(?<![\d.A-Za-z])(\d+)\.(\d+)(?![.\d])")
+
+
+def _decimal_comma(s: str) -> str:
+    """Rewrite the decimal dots of *s* into Spanish commas.
+
+    Reference numbers matched by :data:`_CLAUSE_REF_RE` are passed through
+    untouched; everything between them gets :data:`_DECIMAL_RE` applied.
+    """
+    out: list[str] = []
+    last = 0
+    for m in _CLAUSE_REF_RE.finditer(s):
+        out.append(_DECIMAL_RE.sub(r"\1,\2", s[last:m.start()]))
+        out.append(m.group(0))
+        last = m.end()
+    out.append(_DECIMAL_RE.sub(r"\1,\2", s[last:]))
+    return "".join(out)
+
 
 def set_lang(lang: str) -> None:
     """Switch the output language ('en' or 'es')."""
@@ -5239,18 +5280,12 @@ def _translate_figure(fig: Any) -> None:
     if _LANG == "en":
         _audit_english(fig)
         return
-    import re as _re2
-
     from matplotlib.category import StrCategoryFormatter as _SCF
     from matplotlib.ticker import FixedFormatter as _FxF
     from matplotlib.ticker import FuncFormatter as _FF
     from matplotlib.ticker import ScalarFormatter as _SF
 
-    def _comma(s: str) -> str:
-        # A letter immediately before the number marks a standard designation
-        # (e.g. "S3.5"), not a decimal - leave those untouched.
-        return _re2.sub(r"(?<![\d.A-Za-z])(\d+)\.(\d+)(?![.\d])", r"\1,\2", s)
-
+    _comma = _decimal_comma  # the guarded decimal-comma pass, defined above
     _tr_words = lookup  # the exact / pattern lookups, no decimal comma
 
     for ax in fig.get_axes():
@@ -5296,8 +5331,6 @@ def _translate_figure(fig: Any) -> None:
         # decimals in the same label (e.g. ``8.0 sone_HMS``) still get commas.
         s = artist.get_text()
         if s and "$" not in s and _re.search(r"\d\.\d", s):
-            # Clause/version numbers like 5.3.3 and standard designations like
-            # "S3.5" (a letter immediately before the number) keep their dots.
-            artist.set_text(
-                _re.sub(r"(?<![\d.A-Za-z])(\d+)\.(\d+)(?![.\d])", r"\1,\2", s)
-            )
+            # Clause/version numbers like 5.3.3, standard designations like
+            # "S3.5" and guarded references ("apartado 7.4") keep their dots.
+            artist.set_text(_decimal_comma(s))

--- a/site/public/llms/llms-perception-psychoacoustics.txt
+++ b/site/public/llms/llms-perception-psychoacoustics.txt
@@ -2132,7 +2132,7 @@ accumulates more of it than the single closed form allows.
 > overlap and absolute-threshold screening become 50 % overlap, a Hann window
 > and relative floors here), so perfectly steady signals do not read exactly
 > zero: a steady 1 kHz tone comes out near 0.09 vacil and steady broadband
-> noise a few tenths of a vacil, partly the physical level fluctuation of the
+> noise about 0.15-0.19 vacil, partly the physical level fluctuation of the
 > noise itself. For **AM broadband noise** the signal model overshoots
 > the absolute level (it spreads the modulated energy across bands); quote the
 > closed form `fluctuation_strength_am_noise` (§3.1) for that stimulus.

--- a/site/src/content/docs/devices/noise-control/silencers.mdx
+++ b/site/src/content/docs/devices/noise-control/silencers.mdx
@@ -774,7 +774,7 @@ reflecting surface is more than twice as far away as the microphone.
 The procedure is then two series with nothing else changed. $L_{pI}$ is
 determined with the test object installed, $L_{pII}$ with the substitution duct
 in its place, at identical points or paths and with an unchanged source
-spectrum, and the insertion loss is $D_i = L_{pI} - L_{pII}$ third octave by
+spectrum, and the insertion loss is $D_i = L_{pII} - L_{pI}$ third octave by
 third octave (6.2.1). In a test duct the spatial average takes **at least three
 equally spaced positions** on a line inclined to the duct axis at about half its
 length, spanning at least a quarter wavelength of the lowest band, going to five

--- a/site/src/content/docs/es/devices/index.md
+++ b/site/src/content/docs/es/devices/index.md
@@ -94,7 +94,7 @@ Control de ruido industrial en el camino, entre la máquina y quien la oye.
   transmisión que necesita una partición o un cerramiento para cumplir un
   criterio de ruido de fondo.
 - [Control de ruido industrial: HVAC y cerramientos](/phonometry/es/devices/noise-control/noise-control/):
-  atenuación en conductos, ruido de flujo y pérdida de inserción de
+  atenuación en conductos, ruido de flujo y pérdida por inserción de
   cerramientos de máquina.
 
 ## Qué no cubre esta sección

--- a/site/src/content/docs/es/devices/noise-control/index.md
+++ b/site/src/content/docs/es/devices/noise-control/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Control de ruido"
-description: "Control de ruido industrial en el camino: el cálculo completo del ventilador a la sala y la cadena entre recintos frente a un criterio de diseño, más los modelos de elemento a los que llaman: silenciadores reactivos de cuatro polos, atenuación y ruido de flujo en conductos HVAC, y pérdida de inserción de cerramientos de máquina."
+description: "Control de ruido industrial en el camino: el cálculo completo del ventilador a la sala y la cadena entre recintos frente a un criterio de diseño, más los modelos de elemento a los que llaman: silenciadores reactivos de cuatro polos, atenuación y ruido de flujo en conductos HVAC, y pérdida por inserción de cerramientos de máquina."
 ---
 
 Un problema de control de ruido es un **presupuesto**, no una elección de
@@ -15,13 +15,13 @@ salida frente a un criterio.
 Todo lo de aquí es una **predicción** a partir de una geometría declarada y de
 unos datos de material declarados. Eso importa cuando hay un catálogo abierto al
 lado de la pantalla: la cifra que publica un proveedor para el mismo dispositivo
-es una pérdida de inserción *medida*, obtenida en las condiciones de una norma
+es una pérdida por inserción *medida*, obtenida en las condiciones de una norma
 de medición — la ISO 7235 para un silenciador de conducto sobre un banco de
 laboratorio con y sin flujo de aire, que da además el ruido de flujo regenerado
 y la pérdida de carga, la ISO 11691 para el método de control sin flujo, la
 ISO 11820 para un silenciador in situ, y la ISO 11546-1 y -2 para un
 cerramiento en laboratorio y in situ. Una pérdida por transmisión calculada
-y una pérdida de inserción de catálogo no son la misma magnitud. Ninguna de las
+y una pérdida por inserción de catálogo no son la misma magnitud. Ninguna de las
 dos está mal; responden a preguntas distintas, y un diseño que las mezcla sin
 decirlo no es defendible.
 
@@ -50,7 +50,7 @@ cuarto de onda y de tubo extendido) con su pérdida de transmisión y de
 inserción, y la elección entre reflexión y disipación, mientras que
 [Control de ruido industrial](/phonometry/es/devices/noise-control/noise-control/) se queda
 con la atenuación y el ruido de flujo de los conductos HVAC de una
-instalación y con la pérdida de inserción de un cerramiento de máquina.
+instalación y con la pérdida por inserción de un cerramiento de máquina.
 
 Si el ruido viaja por un conducto, empieza por
 [Ruido por conductos](/phonometry/es/devices/noise-control/duct-path/); si viaja a
@@ -81,7 +81,7 @@ límite laboral que corresponda, en [Exposición al ruido en el trabajo
   transmisión que necesita una partición o un cerramiento para cumplir un
   criterio de ruido de fondo.
 - [Control de ruido industrial: HVAC y cerramientos](/phonometry/es/devices/noise-control/noise-control/):
-  atenuación en conductos, ruido de flujo y pérdida de inserción de
+  atenuación en conductos, ruido de flujo y pérdida por inserción de
   cerramientos de máquina.
 
 ## Qué no cubre esta sección

--- a/site/src/content/docs/es/devices/noise-control/silencers.mdx
+++ b/site/src/content/docs/es/devices/noise-control/silencers.mdx
@@ -816,7 +816,7 @@ próxima está a más del doble de distancia que el micrófono.
 El procedimiento son luego dos series sin cambiar nada más. Se determina
 $L_{pI}$ con el objeto de ensayo instalado y $L_{pII}$ con el conducto de
 sustitución en su lugar, en puntos o recorridos idénticos y con un espectro de
-fuente inalterado, y la pérdida por inserción es $D_i = L_{pI} - L_{pII}$ tercio
+fuente inalterado, y la pérdida por inserción es $D_i = L_{pII} - L_{pI}$ tercio
 de octava a tercio de octava (6.2.1). En un conducto de ensayo el promedio
 espacial toma **al menos tres posiciones equiespaciadas** sobre una recta
 inclinada respecto al eje del conducto, a la mitad de su longitud

--- a/site/src/content/docs/es/devices/noise-control/silencers.mdx
+++ b/site/src/content/docs/es/devices/noise-control/silencers.mdx
@@ -32,7 +32,7 @@ references:
     title: "Acoustics — Laboratory measurement procedures for ducted silencers and air-terminal units — Insertion loss, flow noise and total pressure loss"
     designation: "ISO 7235:2003 (EN ISO 7235:2009)"
     url: "https://www.iso.org/standard/28379.html"
-    note: "La medición por sustitución del apartado 3: la fuente, el filtro modal, la transición y el conducto de sustitución del apartado 5.2, las tres disposiciones del lado receptor del 5.2.4, las dos series del 6.2.1 con los límites de dispersión de la Tabla 6, y la pérdida de inserción límite del apartado 7.4 y el Anexo C."
+    note: "La medición por sustitución del apartado 3: la fuente, el filtro modal, la transición y el conducto de sustitución del apartado 5.2, las tres disposiciones del lado receptor del 5.2.4, las dos series del 6.2.1 con los límites de dispersión de la Tabla 6, y la pérdida por inserción límite del apartado 7.4 y el Anexo C."
 ---
 
 import ThemeImage from '../../../../../components/ThemeImage.astro';
@@ -92,7 +92,7 @@ $$
 \qquad Z_c = \frac{\rho c}{S},
 $$
 
-y la **pérdida de inserción** para una impedancia de fuente $Z_s$ y una de
+y la **pérdida por inserción** para una impedancia de fuente $Z_s$ y una de
 radiación $Z_r$ es la atenuación adicional frente a una conexión directa.
 
 ### Cámara de expansión
@@ -122,7 +122,7 @@ print(round(float(res.transmission_loss[np.argmin(res.transmission_loss)]), 6))
 ```
 
 Una sola línea, `res.plot()`, dibuja la pérdida de transmisión de la cámara (y
-su pérdida de inserción cuando se dan las impedancias de fuente y radiación).
+su pérdida por inserción cuando se dan las impedancias de fuente y radiación).
 La figura de abajo barre en cambio la relación de áreas: un desajuste $m$ mayor
 eleva todos los máximos, pero las caídas permanecen en 0 dB y los máximos
 permanecen en las mismas frecuencias, fijadas solo por la longitud de la
@@ -148,7 +148,7 @@ from phonometry import expansion_chamber
 
 freqs = np.linspace(20.0, 2000.0, 2000)
 
-# Una línea para una cámara: TL vs frecuencia, más la pérdida de inserción
+# Una línea para una cámara: TL vs frecuencia, más la pérdida por inserción
 # cuando se dan las dos impedancias acústicas (Pa.s/m3; de dónde salen, en el
 # subapartado siguiente). Con las dos puestas a rho c / S = 4.14e4 para este
 # tubo de 0.01 m2 las dos curvas coinciden, que es lo que significa «puertos
@@ -204,7 +204,7 @@ plt.show()
 
 </details>
 
-### Pérdida de transmisión, pérdida de inserción y cuál cita una hoja de características
+### Pérdida de transmisión, pérdida por inserción y cuál cita una hoja de características
 
 Circulan tres magnitudes y no son intercambiables. La **pérdida de transmisión**
 compara la potencia incidente que entra en el elemento con la que sale de él
@@ -212,9 +212,9 @@ hacia una terminación sin reflexiones, así que es una propiedad del elemento
 por sí solo, que es justo lo que permite calcularla a partir de la geometría y la razón
 de que la fórmula de arriba fije $Z_1 = \rho c/S_\text{in}$ y
 $Z_n = \rho c/S_\text{out}$ sin preguntar a qué está conectado el silenciador. La
-**pérdida de inserción** compara el nivel en un punto fijo con y sin el elemento
+**pérdida por inserción** compara el nivel en un punto fijo con y sin el elemento
 puesto, así que depende de la fuente y de aquello a lo que el conducto radia, y
-una misma cámara presenta pérdidas de inserción distintas en dos instalaciones.
+una misma cámara presenta pérdidas por inserción distintas en dos instalaciones.
 La **reducción de ruido** es la diferencia de niveles a secas a través del
 elemento, que es lo que devuelve una medición con dos micrófonos en un conducto
 en servicio.
@@ -235,20 +235,20 @@ del dominio de electroacústica como `radiating_piston(...).resistance` y
 impedancia *mecánica* $\rho c S(R_1 + jX_1)$ en N·s/m, a un factor $S^2$ de
 distancia, y es fácil meterlas por equivocación). La impedancia de la fuente de
 un ventilador o de un motor, en cambio, rara vez se conoce y depende mucho de la
-frecuencia, que es precisamente por lo que en la práctica la pérdida de
+frecuencia, que es precisamente por lo que en la práctica la pérdida por
 inserción es una magnitud *medida*.
 
-<ThemeImage src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/silencer_insertion_loss_es.svg" alt="Atenuación frente a la frecuencia de 20 a 880 Hz de una cámara de expansión de 0,3 m y relación de áreas 4. Una curva gruesa da la pérdida de transmisión, una joroba suave entre 0 y 6,5 dB con un cero en 572 Hz. Dos curvas más finas dan la pérdida de inserción de esa misma cámara descargando por la impedancia de radiación de su extremo abierto, una para una fuente adaptada al tubo y otra para una fuente veinte veces más rígida: las dos bajan muy por debajo de cero cerca de 180 Hz, hasta menos 9,3 y menos 22,6 dB, vuelven a bajar cerca de 645 Hz hasta menos 2,9 y menos 8,5 dB, y se reencuentran con la pérdida de transmisión en la parte alta de la banda" width="88%" />
+<ThemeImage src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/silencer_insertion_loss_es.svg" alt="Atenuación frente a la frecuencia de 20 a 880 Hz de una cámara de expansión de 0,3 m y relación de áreas 4. Una curva gruesa da la pérdida de transmisión, una joroba suave entre 0 y 6,5 dB con un cero en 572 Hz. Dos curvas más finas dan la pérdida por inserción de esa misma cámara descargando por la impedancia de radiación de su extremo abierto, una para una fuente adaptada al tubo y otra para una fuente veinte veces más rígida: las dos bajan muy por debajo de cero cerca de 180 Hz, hasta menos 9,3 y menos 22,6 dB, vuelven a bajar cerca de 645 Hz hasta menos 2,9 y menos 8,5 dB, y se reencuentran con la pérdida de transmisión en la parte alta de la banda" width="88%" />
 
 *La misma cámara, tres respuestas. La pérdida de transmisión nunca baja de cero,
-porque está definida contra una terminación que no refleja nada. La de inserción
-sí puede: cerca de 180 Hz esta cámara y el extremo abierto por el que descarga
-resuenan juntos, y la instalación es **más ruidosa** con el silenciador puesto
-que sin él — 9,3 dB más para una fuente adaptada al tubo y 22,6 dB para una
-rígida —, allí donde la pérdida de transmisión marca unos cómodos +5 dB. Por eso
-un catálogo publica una pérdida de inserción dinámica medida con el caudal de
-diseño y en el sentido de diseño, y por eso una TL calculada es una herramienta
-de dimensionado y no una especificación.*
+porque está definida contra una terminación que no refleja nada. La pérdida
+por inserción sí puede: cerca de 180 Hz esta cámara y el extremo abierto por el
+que descarga resuenan juntos, y la instalación es **más ruidosa** con el
+silenciador puesto que sin él — 9,3 dB más para una fuente adaptada al tubo y
+22,6 dB para una rígida —, allí donde la pérdida de transmisión marca unos
+cómodos +5 dB. Por eso un catálogo publica una pérdida por inserción dinámica
+medida con el caudal de diseño y en el sentido de diseño, y por eso una TL
+calculada es una herramienta de dimensionado y no una especificación.*
 
 <details>
 <summary>Mostrar el código de esta figura</summary>
@@ -269,7 +269,7 @@ x = 2.0 * (2.0 * np.pi * freqs / c) * a
 z_r = z0 * ((1.0 - 2.0 * special.j1(x) / x)
             + 1j * (2.0 * special.struve(1, x) / x))
 
-# Una línea: el resultado dibuja la pérdida de inserción junto a la de
+# Una línea: el resultado dibuja la pérdida por inserción junto a la de
 # transmisión siempre que se den las dos impedancias.
 expansion_chamber(freqs, 0.3, 0.04, pipe_area,
                   source_impedance=z0, radiation_impedance=z_r).plot(language="es")
@@ -282,7 +282,7 @@ ax.plot(freqs, expansion_chamber(freqs, 0.3, 0.04, pipe_area).transmission_loss,
 for factor, label in ((20.0, "fuente rígida"), (1.0, "fuente adaptada")):
     res = expansion_chamber(freqs, 0.3, 0.04, pipe_area,
                             source_impedance=factor * z0, radiation_impedance=z_r)
-    ax.plot(freqs, res.insertion_loss, label=f"Pérdida de inserción, {label}")
+    ax.plot(freqs, res.insertion_loss, label=f"Pérdida por inserción, {label}")
 ax.set_xlabel("Frecuencia [Hz]"); ax.set_ylabel("Atenuación [dB]")
 ax.legend()
 plt.show()
@@ -291,8 +291,8 @@ plt.show()
 </details>
 
 La regla que se sigue de ahí es corta: **no compares una pérdida de transmisión
-calculada con una pérdida de inserción publicada.** Escribe los requisitos en
-pérdida de inserción con la terminación declarada, toma la cifra del
+calculada con una pérdida por inserción publicada.** Escribe los requisitos en
+pérdida por inserción con la terminación declarada, toma la cifra del
 suministrador o de un ensayo (apartado 3), y trata la pérdida de transmisión que
 calcula esta página como la herramienta que dice qué geometría hay que pedir.
 
@@ -577,7 +577,7 @@ $c(T) = 343\sqrt{T/293}$ con $T$ en kelvin, así que un escape a 500 °C
 para 285,8 Hz con valores de aire frío canta a 464 Hz en cuanto el tubo se
 calienta. Hay que pasar los valores de trabajo — `speed_of_sound=` y
 `density=`, porque la densidad escala toda impedancia característica y por
-tanto la pérdida de inserción. La llamada con `speed_of_sound=557.0` del
+tanto la pérdida por inserción. La llamada con `speed_of_sound=557.0` del
 fragmento del apartado 1 es ese reajuste, y devuelve 464,2 Hz para el mismo
 tubo de 0,3 m.
 
@@ -629,7 +629,7 @@ dispositivo construido se comporta como la curva. La **envolvente** de una
 cámara es un radiador grande de pared delgada: si su propia pérdida de
 transmisión queda por debajo de la del silenciador, el sonido se marcha por la
 envolvente y el dispositivo entrega la cifra de la envolvente, que es la versión
-en obra de la pérdida de inserción límite del apartado 3. Los dos **saltos de
+en obra de la pérdida por inserción límite del apartado 3. Los dos **saltos de
 área llevan correcciones de extremo**, igual que el cuello de un resonador, así
 que la longitud acústica supera a la geométrica y las caídas medidas quedan un
 poco por debajo del $c/2L$ que aquí se imprime: una sintonía de tanteo hay que
@@ -645,9 +645,10 @@ una página con la disposición de una hoja de prestaciones de silenciador, con
 la línea de base metodológica que nombra el método de cuatro polos de onda
 plana (Munjal Ec. (3.27); Bies §8.8-8.9), una cabecera de metadatos opcional
 (cliente, dispositivo, entorno de ensayo, instrumentación, clima, fecha), la
-tabla por bandas de la pérdida de transmisión (y de la de inserción cuando se
-dieron las impedancias) junto a esas mismas curvas, la pérdida de transmisión
-media sobre las bandas de análisis en su recuadro con el valor de pico y el
+tabla por bandas de la pérdida de transmisión (y de la pérdida por inserción
+cuando se dieron las impedancias) junto a esas mismas curvas, la pérdida de
+transmisión media sobre las bandas de análisis en su recuadro con el valor de
+pico y el
 tipo de dispositivo, y un veredicto opcional frente a una pérdida de
 transmisión media mínima declarada. El renderizado necesita reportlab y, para
 la figura que incrusta la ficha, matplotlib (`pip install
@@ -765,7 +766,7 @@ para la unidad de bafles.
 
 phonometry modela la familia reactiva en forma cerrada en esta página. El
 lado disipativo entra por los datos de instalación de los
-[métodos HVAC](/phonometry/es/devices/noise-control/noise-control/): la pérdida de inserción
+[métodos HVAC](/phonometry/es/devices/noise-control/noise-control/): la pérdida por inserción
 del codo revestido y la atenuación del plenum revestido del método de Wells,
 ambas a partir de datos ASHRAE interpolados y no de un modelo de
 revestimiento. La física porosa que necesitaría un cálculo de revestimiento
@@ -778,12 +779,12 @@ la resistividad al flujo de aire, es la misma teoría de materiales que
 ## 3. Cómo se mide un silenciador (ISO 7235)
 
 Todo lo anterior se calcula a partir de la geometría. La cifra que publica un
-suministrador, no: es una **pérdida de inserción medida por sustitución**, y la
+suministrador, no: es una **pérdida por inserción medida por sustitución**, y la
 ISO 7235:2003 (publicada en Europa como EN ISO 7235:2009) es el método que hay
 detrás. Leer la ficha de esta página sin saberlo es la forma de acabar poniendo
 en la misma frase unos 8,9 dB calculados y los «25 dB» de un catálogo.
 
-<ThemeImage src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_silencer_iso7235_es.svg" alt="Dos montajes apilados sobre un mismo eje de conducto. En el de arriba, la serie uno: una caja de altavoces estanca y revestida alimenta un filtro modal, después una transición, después el objeto de ensayo, y después un conducto de ensayo con terminación anecoica de cuñas que lleva tres posiciones de micrófono sobre una recta inclinada respecto al eje del conducto. El montaje de abajo, la serie dos, es idéntico salvo que el objeto de ensayo se sustituye por un conducto de sustitución vacío. Se marcan con trazo discontinuo los planos de cualificación en el objeto de ensayo y en el conducto receptor. Debajo, la pérdida de inserción se da como la diferencia de los dos niveles del lado receptor, tercio de octava a tercio de octava, con la atenuación del filtro modal, el límite del coeficiente de reflexión, la tolerancia del conducto de sustitución y la regla de relación señal-ruido de fondo enumerados con los números de apartado de la propia norma" width="92%" />
+<ThemeImage src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_silencer_iso7235_es.svg" alt="Dos montajes apilados sobre un mismo eje de conducto. En el de arriba, la serie uno: una caja de altavoces estanca y revestida alimenta un filtro modal, después una transición, después el objeto de ensayo, y después un conducto de ensayo con terminación anecoica de cuñas que lleva tres posiciones de micrófono sobre una recta inclinada respecto al eje del conducto. El montaje de abajo, la serie dos, es idéntico salvo que el objeto de ensayo se sustituye por un conducto de sustitución vacío. Se marcan con trazo discontinuo los planos de cualificación en el objeto de ensayo y en el conducto receptor. Debajo, la pérdida por inserción se da como la diferencia de los dos niveles del lado receptor, tercio de octava a tercio de octava, con la atenuación del filtro modal, el límite del coeficiente de reflexión, la tolerancia del conducto de sustitución y la regla de relación señal-ruido de fondo enumerados con los números de apartado de la propia norma" width="92%" />
 
 El banco tiene cuatro partes y cada una lleva su requisito. La **fuente** es un
 generador de ruido aleatorio y un amplificador que atacan unos altavoces
@@ -815,7 +816,7 @@ próxima está a más del doble de distancia que el micrófono.
 El procedimiento son luego dos series sin cambiar nada más. Se determina
 $L_{pI}$ con el objeto de ensayo instalado y $L_{pII}$ con el conducto de
 sustitución en su lugar, en puntos o recorridos idénticos y con un espectro de
-fuente inalterado, y la pérdida de inserción es $D_i = L_{pI} - L_{pII}$ tercio
+fuente inalterado, y la pérdida por inserción es $D_i = L_{pI} - L_{pII}$ tercio
 de octava a tercio de octava (6.2.1). En un conducto de ensayo el promedio
 espacial toma **al menos tres posiciones equiespaciadas** sobre una recta
 inclinada respecto al eje del conducto, a la mitad de su longitud
@@ -827,17 +828,17 @@ conformes a IEC 61260 (5.2.4.6) y se verifica con un calibrador de clase 1 con
 $\pm 0{,}3$ dB antes y después de cada serie (6.1).
 
 La cifra lleva aparejadas dos consecuencias. La primera, que lo que se declara es una
-**pérdida de inserción frente a un conducto de sustitución**, no una pérdida de
+**pérdida por inserción frente a un conducto de sustitución**, no una pérdida de
 transmisión, así que no es la magnitud que calcula esta página y las dos no
 deben compararse directamente. La segunda, que toda instalación tiene una
-**pérdida de inserción límite**: el techo que le impone la transmisión por flancos
+**pérdida por inserción límite**: el techo que le impone la transmisión por flancos
 a través de las paredes de su propio conducto, medido con el conducto de sustitución bloqueado
 acústicamente y registrado en función de la frecuencia (7.4). Una cifra de
 catálogo muy grande dice tanto de la disposición de ensayo como del
 dispositivo, que es la razón de que la disposición tenga que constar en el
 informe. Para hacerse una idea de lo repetible que es todo esto, las
 desviaciones típicas de reproducibilidad que da la propia norma para la
-pérdida de inserción son 1,5 dB de 50 a 100 Hz, 1 dB de 125 a 500 Hz, 2 dB de
+pérdida por inserción son 1,5 dB de 50 a 100 Hz, 1 dB de 125 a 500 Hz, 2 dB de
 630 Hz a 1,25 kHz y 3 dB por encima (Tabla 7), con la incertidumbre expandida
 al doble de esos valores.
 
@@ -876,7 +877,7 @@ los bloques `duct_matrix`/`shunt_matrix`/`cascade`/`transmission_loss`/
 dibujo a escala `.plot_geometry()`, contrastados con la simulación FDTD
 independiente; el `plane_wave_limit` que acota a todos ellos; y, como prosa y
 no como código, la medición por sustitución de ISO 7235 que produce la pérdida
-de inserción que publica un suministrador.
+por inserción que publica un suministrador.
 
 **No cubierto.** Solo se calculan elementos reactivos: los silenciadores
 disipativos (absorbentes, con revestimiento interior) se discuten para la

--- a/site/src/content/docs/es/perception/speech/objective-intelligibility.mdx
+++ b/site/src/content/docs/es/perception/speech/objective-intelligibility.mdx
@@ -76,7 +76,7 @@ comparación. La frecuencia de muestreo de las entradas es libre, la biblioteca
 remuestrea internamente.
 
 Ambas medidas están definidas para **habla continua**, y el procesado inicial es
-donde muerde esa suposición: la regla de los 40 dB se apoya en el margen dinámico
+donde muerde esa suposición: la regla de los 40 dB se apoya en el rango dinámico
 de la señal *limpia*, así que existe para impedir que las pausas entre palabras
 dominen la correlación. Una señal sin pausas, ruido estacionario, un tono
 sostenido o música sin huecos, no pierde nada por ella y el índice pierde su

--- a/site/src/content/docs/es/perception/speech/speech-transmission.mdx
+++ b/site/src/content/docs/es/perception/speech/speech-transmission.mdx
@@ -607,7 +607,7 @@ modulación y la correspondencia m a STI (apartados A.5.2 a A.5.6), el método
 indirecto de STI completo desde una respuesta al impulso medida mediante
 `speech.sti_from_impulse_response()`, el método directo STIPA del Anexo B
 mediante `speech.stipa_signal()` y `speech.stipa()`, el espectro de la señal
-de ensayo masculina de la Ed. 5 del apartado A.6.1, las correcciones de
+de ensayo masculina de la Ed.5 del apartado A.6.1, las correcciones de
 enmascaramiento auditivo dependiente del nivel y de umbral de recepción de las
 Tablas A.2 y A.3 (`level=` y `ambient=`), y las letras de valoración del
 Anexo F devueltas como `STIResult.rating`.

--- a/site/src/content/docs/es/signals/levels/levels.mdx
+++ b/site/src/content/docs/es/signals/levels/levels.mdx
@@ -684,8 +684,8 @@ plt.show()
 | `lex_8h(x, fs, duration_hours=None, ...)` | misma semántica de muestreo | $L_{EX,8h}$ [dB] | IEC 61252 ($\equiv L_{EP,d}$) |
 
 `lex_8h` valora *una* grabación; componer una jornada laboral completa a
-partir de muestras por tarea o por función, con el presupuesto normativo de
-incertidumbre de la ISO 9612, continúa en
+partir de muestras por tarea o por función, con el balance de incertidumbre
+normativo de la ISO 9612, continúa en
 [Exposición al ruido en el trabajo](/phonometry/es/perception/hearing/occupational-exposure/).
 
 Convertir estos niveles en los indicadores regulatorios día-tarde-noche y
@@ -694,7 +694,7 @@ declararlos con garantías es
 descriptores $L_{den}$ y $L_{dn}$, los niveles de evaluación compuestos de
 ISO 1996-1
 con sus ajustes por carácter, y la cadena de determinación de ISO 1996-2 con
-el ajuste tonal, la corrección de ruido residual y el presupuesto de
+el ajuste tonal, la corrección de ruido residual y el balance de
 incertidumbre de medida.
 
 ## Espectrograma de octavas (niveles vs tiempo)
@@ -715,10 +715,10 @@ levels, freq, times = bank.spectrogram(recording, window_time=0.125, overlap=0.5
 # levels: (bandas, ventanas) — listo para pcolormesh(times, freq, levels)
 ```
 
-<ThemeImage src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/spectrogram_example_es.webp" alt="Espectrograma en doceavos de octava de un barrido logarítmico con dos ráfagas tonales" width="80%" />
+<ThemeImage src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/spectrogram_example_es.webp" alt="Espectrograma en bandas de 1/12 de octava de un barrido logarítmico con dos ráfagas tonales" width="80%" />
 
 *Un barrido logarítmico y dos ráfagas tonales, resueltos en el tiempo y en
-bandas normalizadas de doceavo de octava.*
+bandas normalizadas de 1/12 de octava.*
 
 <details>
 <summary>Mostrar el código de esta figura</summary>

--- a/site/src/content/docs/es/signals/levels/special-weightings.mdx
+++ b/site/src/content/docs/es/signals/levels/special-weightings.mdx
@@ -185,7 +185,7 @@ En exteriores hay un tercer problema, y por debajo de 20 Hz suele ser el mayor:
 el viento sobre el diafragma genera más infrasonido que la fuente. Por eso el
 micrófono se coloca en el centro de una placa rígida sobre el suelo, dentro de
 un paravientos primario de espuma, con una pantalla hemisférica secundaria
-añadida cuando hay viento y con su pérdida de inserción documentada y corregida.
+añadida cuando hay viento y con su pérdida por inserción documentada y corregida.
 
 <ThemeImage src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/diagram_infrasound_chain_es.svg" alt="La cadena de medida de infrasonido: una vista en sección de una cápsula de medida enrasada en el centro de una placa rígida sobre el suelo, con una llamada sobre su orificio de compensación de presión estática y el punto de corte de primer orden que ese orificio impone, un paravientos primario de espuma encima y una pantalla hemisférica secundaria alrededor; después la cadena eléctrica en tres bloques, un preamplificador cuyo punto de corte está muy por debajo de 0,25 Hz, un grabador con el conmutador de corte de graves desactivado, y la ponderación G seguida de un integrador de al menos 10 segundos; a la derecha, un recuadro con la respuesta de 0,1 Hz a 1 kHz que muestra la curva G de ISO 7196 con su tramo de 0,25 a 315 Hz sombreado y el punto de corte del paso alto de la propia cadena dibujado con línea discontinua sobre ella, con el solape anotado como banda utilizable" width="94%" />
 

--- a/site/src/content/docs/es/signals/levels/weighting.mdx
+++ b/site/src/content/docs/es/signals/levels/weighting.mdx
@@ -413,7 +413,7 @@ instrumento, no en el código.
 Un micrófono de campo libre está calibrado para el sonido que llega desde su
 dirección de referencia, así que hay que apuntarlo a la fuente; en interiores,
 en campo difuso, esa cápsula lee alto en altas frecuencias y lo correcto es una
-cápsula de incidencia aleatoria. Un paravientos lleva su propia pérdida de
+cápsula de incidencia aleatoria. Un paravientos lleva su propia pérdida por
 inserción dependiente de la frecuencia, que IEC 61672-1 trata como parte del
 instrumento (apartado 5.3.3, «Windscreens») y cuya corrección declarada hay que
 aplicar antes de que signifique nada un nivel de banda en alta frecuencia, o

--- a/site/src/content/docs/es/signals/metrology/calibration.mdx
+++ b/site/src/content/docs/es/signals/metrology/calibration.mdx
@@ -206,7 +206,7 @@ de la frecuencia del calibrador sale de los datos de campo libre del propio
 micrófono, no de esta comprobación: las tres sensibilidades y dónde se aplica
 cada una están en
 [Micrófonos](/phonometry/es/devices/electroacoustics/microphones/). Vuelve a poner
-la pantalla antiviento antes de medir, y recuerda que tiene su propia pérdida de
+la pantalla antiviento antes de medir, y recuerda que tiene su propia pérdida por
 inserción de unas décimas de decibelio en alta frecuencia, que la calibración no
 ha visto.
 

--- a/site/src/content/docs/es/signals/spectra/time-frequency.mdx
+++ b/site/src/content/docs/es/signals/spectra/time-frequency.mdx
@@ -252,7 +252,7 @@ transforma el registro entero). El
 zoom refina el muestreo del mismo espectro subyacente; solo un registro
 más largo separa tonos más próximos.
 
-**El margen dinámico es otra cuestión, y el zoom no ayuda con ella.** La
+**El rango dinámico es otra cuestión, y el zoom no ayuda con ella.** La
 chirp-Z sigue evaluando la DFT del *registro entero con su ventana*, así que una
 componente fuerte fuera de la banda ampliada se cuela dentro por los lóbulos
 laterales de la ventana exactamente igual que en una FFT corriente: la banda

--- a/site/src/content/docs/es/underwater/marine-mammal-exposure.mdx
+++ b/site/src/content/docs/es/underwater/marine-mammal-exposure.mdx
@@ -441,7 +441,7 @@ kilohercios.
 le da, así que un registro corto simplemente informa de un SEL acumulado
 menor, sin dar ningún aviso. La mitad de pico sin ponderar de la métrica dual
 tiene que salir de ese mismo registro sin recorte y con margen de sobra, que
-es la razón por la que la ISO 18406 hace del margen dinámico un requisito de
+es la razón por la que la ISO 18406 hace del rango dinámico un requisito de
 campaña: una captura saturada se lee como un pico conforme.
 
 ```python

--- a/site/src/content/docs/es/underwater/underwater-acoustics.mdx
+++ b/site/src/content/docs/es/underwater/underwater-acoustics.mdx
@@ -381,7 +381,7 @@ profundidad total medida desde la superficie, porque el campo depende mucho de
 la profundidad en la parte alta de la columna (apartado 5.2.1); en aguas
 interiores, en puertos y estuarios, se fija a la mitad de la profundidad del
 agua (apartado 5.2.2). Dos hidrófonos son mejor que uno (redundancia, dos
-sensibilidades para cubrir el margen dinámico y promediado espacial), colocados
+sensibilidades para cubrir el rango dinámico y promediado espacial), colocados
 a dos profundidades de la mitad inferior, idealmente cerca de ½ y ¾ de la
 profundidad total y con la separación maximizada (apartado 5.2.3). Las
 posiciones adicionales no se acercan más de **tres veces la profundidad local
@@ -398,7 +398,7 @@ de al menos 10 dB y el ruido propio del sistema queda al menos 10 dB por debajo
 del nivel más bajo que se vaya a medir, lo que es una restricción real para el
 trabajo de fondo: el ruido propio de un registrador corriente se acerca a los
 niveles de estado de la mar cero cerca de 63 Hz y 125 Hz (apartados 4.2.4,
-4.2.5). El margen dinámico se elige para que la presión máxima esperada se
+4.2.5). El rango dinámico se elige para que la presión máxima esperada se
 registre sin saturación, y se prefieren más de 60 dB (apartado 4.2.6): el nivel
 de pico es una métrica regulada y el recorte lo destruye en silencio mientras
 sigue devolviendo un número plausible.

--- a/tests/test_figure_i18n_comma.py
+++ b/tests/test_figure_i18n_comma.py
@@ -1,0 +1,103 @@
+#  Copyright (c) 2026. Jose Manuel Requena Plens
+"""The save-time decimal-comma pass of the Spanish figure edition.
+
+``scripts/figures/i18n.py`` rewrites ``digit.digit`` into ``digit,digit`` on
+every non-mathtext string of a Spanish figure. A clause, equation, table or
+annex NUMBER is not a decimal: the Spanish pages write "apartado 7.4" with the
+dot, so the figures must too. These tests pin the reference guard (which
+strings keep their dots) and the decimal behaviour it must NOT disturb.
+"""
+
+import pathlib
+import sys
+
+import pytest
+
+_SCRIPTS = str(pathlib.Path(__file__).resolve().parent.parent / "scripts")
+if _SCRIPTS not in sys.path:
+    sys.path.insert(0, _SCRIPTS)
+
+from figures.i18n import _decimal_comma
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        # Two-part reference numbers after a singular token keep the dot
+        # (the committed defect: these shipped as "7,4", "8,2", ...).
+        "apartado 7.4",
+        "(véase el apartado 5.4)",
+        "apartado 8.2:  r >= 100 kPa.s",
+        "capítulo 4.1, f ≥ 3 kHz",
+        "cláusula 4.2",
+        "Anexo 5.1",
+        "Tabla 13.8",
+        "Tabla 8.14",
+        "tabla 5.1",  # lowercase, as shipped in infinite_mobilities
+        "tabla 3.1",
+        "Fórmula 3.1",
+        "Formula 3.1",
+        "Fórm. 3.1",
+        "Form. 3.1",
+        "Ec. 8.252",
+        "Ec. 14.31",
+        "Ec. 13.1  (peor Δ 13 dB)",
+        "§ 7.4",
+        "§7.4",
+        # Compound references: every number of the list is a reference.
+        "Bies Ecs. 8.44, 8.46",
+        "Ecs. 13.27-13.33",
+        "Ecs. 8.44, 8.46 y 8.50",
+        "apartados 6.2 y 6.3",
+        "capítulos 5.1.2 y 5.1.4",
+        "cláusulas 4.2 y 4.3",
+        # Dash-joined ranges read as reference-to-reference even after a
+        # singular token.
+        "apartado 4.1-4.3",
+        # Pre-existing exemptions, locked in: three-part numbers and
+        # letter-adjacent standard designations never took the comma.
+        "apartado 7.4.3",
+        "S3.5",
+        "ANSI S1.11",
+    ],
+)
+def test_reference_numbers_keep_their_dots(text: str) -> None:
+    assert _decimal_comma(text) == text
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        # Plain decimals still take the comma.
+        ("3.5 dB", "3,5 dB"),
+        ("de 0.5 a 1.2 kHz", "de 0,5 a 1,2 kHz"),
+        ("0.08 c0", "0,08 c0"),
+        ("8.0 sone_HMS", "8,0 sone_HMS"),
+        # A decimal after the reference, in another syntactic position,
+        # is still a decimal.
+        ("Ec. 10.2: máximo 3.7 vacil", "Ec. 10.2: máximo 3,7 vacil"),
+        ("apartado 8.2, 0.5 dB de margen", "apartado 8.2, 0,5 dB de margen"),
+        ("Tabla 2 (±0.25 dB)", "Tabla 2 (±0,25 dB)"),
+        ("Tabla 2 -0.5 dB", "Tabla 2 -0,5 dB"),
+        # A letter-numbered table or annex does not shield what follows.
+        ("Tabla A.6, α = 0.05", "Tabla A.6, α = 0,05"),
+        ("Anexo E: 118.4 y 137.3 Hz", "Anexo E: 118,4 y 137,3 Hz"),
+        # An integer reference is untouched either way; the decimal beside
+        # it converts ("y"-lists only bind after a PLURAL token).
+        ("Fórmula 7, eps = 0.9", "Fórmula 7, eps = 0,9"),
+        ("Tabla 5 y 0.5 dB de margen", "Tabla 5 y 0,5 dB de margen"),
+        # Token lookalikes are not tokens.
+        ("Forma cerrada (FOM = 82.7 dB)", "Forma cerrada (FOM = 82,7 dB)"),
+        ("la fórmula da 0.5", "la fórmula da 0,5"),
+        ("la espec. 3.5 pide margen", "la espec. 3,5 pide margen"),
+        # Already-Spanish strings pass through unchanged.
+        ("ya son 3,5 dB", "ya son 3,5 dB"),
+        # Bare numbers (the tick-label path).
+        ("12.5", "12,5"),
+        ("1000", "1000"),
+    ],
+)
+def test_legitimate_decimals_still_take_the_comma(
+    text: str, expected: str
+) -> None:
+    assert _decimal_comma(text) == expected


### PR DESCRIPTION
Eight translation waves recorded Spanish-tree defects they deliberately did not fix because the English change did not pass through them. This closes the ledger, and with it the last piece of the documentation overhaul.

## Two terms settled the way the method demands

**Insertion loss is pérdida por inserción.** UNE-EN ISO 7235 carries it in its own title and uses it 71 times, UNE-EN ISO 11820 agrees, and Harris, Möser and Perera side with them; only UNE-EN ISO 11821 dissents, three times. Thirty-three occurrences unified across six files, including a heading, with the standards fetched into plan/ so the evidence outlives the decision.

**Dynamic range is rango dinámico.** Harris, Voetmann, Salesa and the Spanish Proakis carry it without exception; the dissenting margen lives in electronics translations, which weigh less by the register rule. Both decisions enter the glossary with their sources, and the checker gains their discarded forms so nobody relitigates them silently.

## Clause numbers are references, not quantities

The decimal-comma pass that writes the Spanish figure variants turned apartado 7.4 into apartado 7,4, and eighteen figures had shipped that way. The guard was written test-first, forty-seven cases, thirty that must keep the dot and seventeen that must keep the comma, including the compound lists (Bies Ecs. 8.44, 8.46), the y-joined ranges, and the lookalikes that must not match (Forma cerrada; Fórmula 7, eps = 0,9). The full regeneration then caught two more the census grep had missed, lowercase ec. citations, which is the gate doing exactly what it exists to do. The diff audit shows every changed character inside a guarded span, no legitimate decimal without its comma, and no English variant moved.

## The rest of the ledger

The split-line uncertainty budget the line-based checker could not see. Twelfths of an octave written as a doubtful partitive. An edition abbreviation out of step with its twin. A mirror hedge aligned with the measured vacil range. A paragraph that existed only in Spanish, ported to English because parity is the contract in both directions. Seven parity flags adjudicated rather than fixed: all seven are comparator artefacts, documented with their evidence. And two rules the waves kept deciding page by page are now written into the method: a code comment translates only its prose, and a translator's note is admissible when shaped as one.

## Checked

The full local run of every CI gate, clean: comprobar.py at zero warnings over 158 pages with the new patterns active, the figure-language baseline still at zero, and all 2772 committed figures matching within tolerance.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified fluctuation-strength estimates for steady broadband noise.
  * Standardized Spanish terminology for noise control, dynamic range, uncertainty, windscreens, and measurement.
  * Expanded insertion-loss guidance, including measurement, reproducibility, installation effects, and distinctions from transmission loss.

* **Bug Fixes**
  * Corrected the ISO 7235 insertion-loss equation.
  * Improved Spanish decimal formatting while preserving reference numbers.

* **Tests**
  * Added coverage for decimal conversion, reference numbers, units, symbols, tick labels, and existing values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->