### PR TITLE
Carry the corrected insertion loss subtraction into the mirror

### DIFF
--- a/docs/devices/noise-control/silencers.md
+++ b/docs/devices/noise-control/silencers.md
@@ -320,7 +320,7 @@ from the declared geometry. The figure a supplier publishes is an **insertion
 loss measured by substitution** to ISO 7235:2003: two series with everything
 else unchanged, one with the test object installed and one with a substitution
 duct in its place, differenced third octave by third octave as
-`D_i = L_pI - L_pII`. The rig carries its own requirements — a sealed, lined
+`D_i = L_pII - L_pI`. The rig carries its own requirements — a sealed, lined
 loudspeaker box driving at least 6 dB and preferably 10 dB above the background,
 a modal filter attenuating the fundamental by at least 3 dB and higher-order
 modes by at least 5 dB above cut-on, a substitution duct matched within 5 % in

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -18553,7 +18553,7 @@ from the declared geometry. The figure a supplier publishes is an **insertion
 loss measured by substitution** to ISO 7235:2003: two series with everything
 else unchanged, one with the test object installed and one with a substitution
 duct in its place, differenced third octave by third octave as
-`D_i = L_pI - L_pII`. The rig carries its own requirements — a sealed, lined
+`D_i = L_pII - L_pI`. The rig carries its own requirements — a sealed, lined
 loudspeaker box driving at least 6 dB and preferably 10 dB above the background,
 a modal filter attenuating the fundamental by at least 3 dB and higher-order
 modes by at least 5 dB above cut-on, a substitution duct matched within 5 % in

--- a/site/public/llms/llms-devices-noise-control.txt
+++ b/site/public/llms/llms-devices-noise-control.txt
@@ -1671,7 +1671,7 @@ from the declared geometry. The figure a supplier publishes is an **insertion
 loss measured by substitution** to ISO 7235:2003: two series with everything
 else unchanged, one with the test object installed and one with a substitution
 duct in its place, differenced third octave by third octave as
-`D_i = L_pI - L_pII`. The rig carries its own requirements — a sealed, lined
+`D_i = L_pII - L_pI`. The rig carries its own requirements — a sealed, lined
 loudspeaker box driving at least 6 dB and preferably 10 dB above the background,
 a modal filter attenuating the fundamental by at least 3 dB and higher-order
 modes by at least 5 dB above cut-on, a substitution duct matched within 5 % in


### PR DESCRIPTION
Follow-up to the review finding on #526. The site formula was corrected to D_i = L_pII - L_pI per UNE-EN ISO 7235:2010 Equation 1, but the GitHub mirror writes the formula in backtick form without braces, L_pI - L_pII, which is exactly why the sweep for remaining copies missed it, and both llms artifacts derive from the mirror. All three copies now agree with the standard and with the site.

Checked: markdown hazards clean, llms regeneration stable, and a lax-pattern sweep over every spelling of the subtraction finds no inverted copy left anywhere in the corpus.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the ISO 7235:2003 insertion-loss and substitution measurement formula.
  * Updated the pressure-level subtraction order to `Dᵢ = LₚII − LₚI` across the relevant documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->