### PR TITLE
Flag the ISO 3382-3:2022 revision everywhere the 2012 edition is cited

### DIFF
--- a/docs/buildings/rooms/open-plan-acoustics.md
+++ b/docs/buildings/rooms/open-plan-acoustics.md
@@ -335,7 +335,8 @@ absorption or where in the room a given table sits.
 
 - International Organization for Standardization. (2012). *Acoustics —
   Measurement of room acoustic parameters — Part 3: Open plan offices*
-  (ISO 3382-3:2012).
+  (ISO 3382-3:2012; since revised as
+  [ISO 3382-3:2022](https://www.iso.org/standard/77437.html)).
   [iso.org catalogue](https://www.iso.org/standard/46520.html).
   The open-plan speech-privacy quantities this page implements.
 - Long, M. (2014). *Architectural acoustics* (2nd ed.). Academic Press.
@@ -347,7 +348,11 @@ absorption or where in the room a given table sits.
 ISO 3382-3:2012 (open-plan office speech metrics: the spatial decay rate
 $D_{2,S}$, the A-weighted speech level at 4 m, and the distraction and
 privacy distances from STI). Validated against the standard's own quantity
-definitions in the [conformance report](../../CONFORMANCE.md).
+definitions in the [conformance report](../../CONFORMANCE.md). The
+implemented edition is frozen at ISO 3382-3:2012; the superseding
+ISO 3382-3:2022 revision removes the privacy distance $r_P$, adds the
+comfort distance $r_C$ and moves the per-position STI to the indirect
+IEC 60268-16 method, and is not the one checked here.
 
 ## See also
 

--- a/docs/reference/bibliography.md
+++ b/docs/reference/bibliography.md
@@ -390,7 +390,8 @@ it; the list grows as guides gain their References sections.
   Cited by [Room Acoustics](../buildings/rooms/room-acoustics.md).
 - International Organization for Standardization. (2012). *Acoustics —
   Measurement of room acoustic parameters — Part 3: Open plan offices*
-  (ISO 3382-3:2012).
+  (ISO 3382-3:2012; since revised as
+  [ISO 3382-3:2022](https://www.iso.org/standard/77437.html)).
   [iso.org catalogue](https://www.iso.org/standard/46520.html).
   The open-plan speech-privacy quantities.
   Cited by [Room Acoustics](../buildings/rooms/room-acoustics.md).

--- a/docs/reference/theory/rooms-buildings.md
+++ b/docs/reference/theory/rooms-buildings.md
@@ -416,7 +416,8 @@ usage.
   validity section.
 - International Organization for Standardization. (2012). *Acoustics —
   Measurement of room acoustic parameters — Part 3: Open plan offices*
-  (ISO 3382-3:2012).
+  (ISO 3382-3:2012; since revised as
+  [ISO 3382-3:2022](https://www.iso.org/standard/77437.html)).
   [iso.org catalogue](https://www.iso.org/standard/46520.html).
   The open-plan spatial decay and the distraction and privacy distances.
 - International Organization for Standardization. (2014). *Acoustics — Field

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -9592,7 +9592,8 @@ absorption or where in the room a given table sits.
 
 - International Organization for Standardization. (2012). *Acoustics —
   Measurement of room acoustic parameters — Part 3: Open plan offices*
-  (ISO 3382-3:2012).
+  (ISO 3382-3:2012; since revised as
+  [ISO 3382-3:2022](https://www.iso.org/standard/77437.html)).
   [iso.org catalogue](https://www.iso.org/standard/46520.html).
   The open-plan speech-privacy quantities this page implements.
 - Long, M. (2014). *Architectural acoustics* (2nd ed.). Academic Press.
@@ -9604,7 +9605,11 @@ absorption or where in the room a given table sits.
 ISO 3382-3:2012 (open-plan office speech metrics: the spatial decay rate
 $D_{2,S}$, the A-weighted speech level at 4 m, and the distraction and
 privacy distances from STI). Validated against the standard's own quantity
-definitions in the [conformance report](https://jmrplens.github.io/phonometry/reference/conformance/).
+definitions in the [conformance report](https://jmrplens.github.io/phonometry/reference/conformance/). The
+implemented edition is frozen at ISO 3382-3:2012; the superseding
+ISO 3382-3:2022 revision removes the privacy distance $r_P$, adds the
+comfort distance $r_C$ and moves the per-position STI to the indirect
+IEC 60268-16 method, and is not the one checked here.
 
 ## See also
 
@@ -33571,7 +33576,8 @@ it; the list grows as guides gain their References sections.
   Cited by [Room Acoustics](https://jmrplens.github.io/phonometry/buildings/rooms/room-acoustics/).
 - International Organization for Standardization. (2012). *Acoustics —
   Measurement of room acoustic parameters — Part 3: Open plan offices*
-  (ISO 3382-3:2012).
+  (ISO 3382-3:2012; since revised as
+  [ISO 3382-3:2022](https://www.iso.org/standard/77437.html)).
   [iso.org catalogue](https://www.iso.org/standard/46520.html).
   The open-plan speech-privacy quantities.
   Cited by [Room Acoustics](https://jmrplens.github.io/phonometry/buildings/rooms/room-acoustics/).
@@ -36427,7 +36433,8 @@ usage.
   validity section.
 - International Organization for Standardization. (2012). *Acoustics —
   Measurement of room acoustic parameters — Part 3: Open plan offices*
-  (ISO 3382-3:2012).
+  (ISO 3382-3:2012; since revised as
+  [ISO 3382-3:2022](https://www.iso.org/standard/77437.html)).
   [iso.org catalogue](https://www.iso.org/standard/46520.html).
   The open-plan spatial decay and the distraction and privacy distances.
 - International Organization for Standardization. (2014). *Acoustics — Field

--- a/site/public/llms/llms-buildings-rooms.txt
+++ b/site/public/llms/llms-buildings-rooms.txt
@@ -1205,7 +1205,8 @@ absorption or where in the room a given table sits.
 
 - International Organization for Standardization. (2012). *Acoustics —
   Measurement of room acoustic parameters — Part 3: Open plan offices*
-  (ISO 3382-3:2012).
+  (ISO 3382-3:2012; since revised as
+  [ISO 3382-3:2022](https://www.iso.org/standard/77437.html)).
   [iso.org catalogue](https://www.iso.org/standard/46520.html).
   The open-plan speech-privacy quantities this page implements.
 - Long, M. (2014). *Architectural acoustics* (2nd ed.). Academic Press.
@@ -1217,7 +1218,11 @@ absorption or where in the room a given table sits.
 ISO 3382-3:2012 (open-plan office speech metrics: the spatial decay rate
 $D_{2,S}$, the A-weighted speech level at 4 m, and the distraction and
 privacy distances from STI). Validated against the standard's own quantity
-definitions in the [conformance report](https://jmrplens.github.io/phonometry/reference/conformance/).
+definitions in the [conformance report](https://jmrplens.github.io/phonometry/reference/conformance/). The
+implemented edition is frozen at ISO 3382-3:2012; the superseding
+ISO 3382-3:2022 revision removes the privacy distance $r_P$, adds the
+comfort distance $r_C$ and moves the per-position STI to the indirect
+IEC 60268-16 method, and is not the one checked here.
 
 ## See also
 

--- a/site/public/llms/llms-reference.txt
+++ b/site/public/llms/llms-reference.txt
@@ -397,7 +397,8 @@ it; the list grows as guides gain their References sections.
   Cited by [Room Acoustics](https://jmrplens.github.io/phonometry/buildings/rooms/room-acoustics/).
 - International Organization for Standardization. (2012). *Acoustics —
   Measurement of room acoustic parameters — Part 3: Open plan offices*
-  (ISO 3382-3:2012).
+  (ISO 3382-3:2012; since revised as
+  [ISO 3382-3:2022](https://www.iso.org/standard/77437.html)).
   [iso.org catalogue](https://www.iso.org/standard/46520.html).
   The open-plan speech-privacy quantities.
   Cited by [Room Acoustics](https://jmrplens.github.io/phonometry/buildings/rooms/room-acoustics/).

--- a/site/public/llms/llms-start.txt
+++ b/site/public/llms/llms-start.txt
@@ -2262,7 +2262,8 @@ usage.
   validity section.
 - International Organization for Standardization. (2012). *Acoustics —
   Measurement of room acoustic parameters — Part 3: Open plan offices*
-  (ISO 3382-3:2012).
+  (ISO 3382-3:2012; since revised as
+  [ISO 3382-3:2022](https://www.iso.org/standard/77437.html)).
   [iso.org catalogue](https://www.iso.org/standard/46520.html).
   The open-plan spatial decay and the distraction and privacy distances.
 - International Organization for Standardization. (2014). *Acoustics — Field

--- a/site/src/content/docs/buildings/rooms/open-plan-acoustics.mdx
+++ b/site/src/content/docs/buildings/rooms/open-plan-acoustics.mdx
@@ -8,7 +8,7 @@ references:
     title: "Acoustics — Measurement of room acoustic parameters — Part 3: Open plan offices"
     designation: "ISO 3382-3:2012"
     url: "https://www.iso.org/standard/46520.html"
-    note: "The open-plan speech-privacy quantities this page implements."
+    note: "The open-plan speech-privacy quantities this page implements. Since revised as ISO 3382-3:2022 (https://www.iso.org/standard/77437.html); the 2012 edition is the implemented one."
   - type: book
     authors: ["Long, M."]
     year: 2014
@@ -680,6 +680,10 @@ Nothing **checks** the measurement conditions of clauses 5.1 and 5.2 either:
 the function consumes distances, levels and STI values wherever they came
 from, so the source directivity, the furnished-and-unoccupied state and the
 background capture are the operator's responsibility, not the library's. The
+implemented edition is frozen at ISO 3382-3:2012; the superseding
+ISO 3382-3:2022 revision removes the privacy distance $r_P$, adds the
+comfort distance $r_C$ and moves the per-position STI to the indirect
+IEC 60268-16 method, and is not the one checked here. The
 crowd self-noise model is a *design* calculation and
 deliberately does not model the Lombard reflex: it cancels out of $L_{SN}$ as
 long as everyone raises their voice equally, so the model explains why the

--- a/site/src/content/docs/es/buildings/rooms/open-plan-acoustics.mdx
+++ b/site/src/content/docs/es/buildings/rooms/open-plan-acoustics.mdx
@@ -8,7 +8,7 @@ references:
     title: "Acoustics — Measurement of room acoustic parameters — Part 3: Open plan offices"
     designation: "ISO 3382-3:2012"
     url: "https://www.iso.org/standard/46520.html"
-    note: "Las magnitudes de privacidad del habla en oficinas diáfanas que esta página implementa."
+    note: "Las magnitudes de privacidad del habla en oficinas diáfanas que esta página implementa. Revisada después como ISO 3382-3:2022 (https://www.iso.org/standard/77437.html); la edición de 2012 es la implementada."
   - type: book
     authors: ["Long, M."]
     year: 2014
@@ -698,7 +698,11 @@ Tampoco **se comprueba** ninguna de las condiciones de medición de los
 apartados 5.1 y 5.2: la función consume distancias, niveles y valores de STI
 vengan de donde vengan, así que la directividad de la fuente, el estado amueblado
 y desocupado y la captura del ruido de fondo son responsabilidad del operador y
-no de la biblioteca. El modelo de ruido autogenerado es un
+no de la biblioteca. La edición implementada está fijada en la
+ISO 3382-3:2012; la revisión sucesora ISO 3382-3:2022 retira la distancia de
+privacidad $r_P$, añade la distancia de confort $r_C$ y traslada el STI por
+posición al método indirecto de la IEC 60268-16, y no es la comprobada aquí.
+El modelo de ruido autogenerado es un
 cálculo de *diseño* y deliberadamente no modela el reflejo de Lombard: se
 cancela en $L_{SN}$ mientras todo el mundo alce la voz por igual, de modo que
 el modelo explica por qué el nivel se dispara en una sala dura, no dónde se

--- a/site/src/content/docs/es/reference/bibliography.md
+++ b/site/src/content/docs/es/reference/bibliography.md
@@ -526,7 +526,8 @@ se reparte la absorción, que es justo donde discrepan los cinco.
   Citado por [Acústica de salas](/phonometry/es/buildings/rooms/room-acoustics/).
 - International Organization for Standardization. (2012). *Acoustics —
   Measurement of room acoustic parameters — Part 3: Open plan offices*
-  (ISO 3382-3:2012).
+  (ISO 3382-3:2012; revisada después como
+  [ISO 3382-3:2022](https://www.iso.org/standard/77437.html)).
   [Catálogo iso.org](https://www.iso.org/standard/46520.html).
   Las magnitudes de privacidad del habla en oficinas diáfanas.
   Citado por [Acústica de oficinas diáfanas](/phonometry/es/buildings/rooms/open-plan-acoustics/).

--- a/site/src/content/docs/es/reference/theory/rooms-buildings.mdx
+++ b/site/src/content/docs/es/reference/theory/rooms-buildings.mdx
@@ -98,7 +98,7 @@ references:
     title: "Acoustics — Measurement of room acoustic parameters — Part 3: Open plan offices"
     designation: "ISO 3382-3:2012"
     url: "https://www.iso.org/standard/46520.html"
-    note: "El decaimiento espacial en oficinas diáfanas y las distancias de distracción y privacidad."
+    note: "El decaimiento espacial en oficinas diáfanas y las distancias de distracción y privacidad. Revisada después como ISO 3382-3:2022 (https://www.iso.org/standard/77437.html); la edición de 2012 es la implementada."
   - type: standard
     organization: "International Organization for Standardization"
     year: 2014

--- a/site/src/content/docs/reference/bibliography.md
+++ b/site/src/content/docs/reference/bibliography.md
@@ -504,7 +504,8 @@ distributed, which is exactly where the five disagree.
   Cited by [Room Acoustics](/phonometry/buildings/rooms/room-acoustics/).
 - International Organization for Standardization. (2012). *Acoustics —
   Measurement of room acoustic parameters — Part 3: Open plan offices*
-  (ISO 3382-3:2012).
+  (ISO 3382-3:2012; since revised as
+  [ISO 3382-3:2022](https://www.iso.org/standard/77437.html)).
   [iso.org catalogue](https://www.iso.org/standard/46520.html).
   The open-plan speech-privacy quantities.
   Cited by [Open-Plan Office Acoustics](/phonometry/buildings/rooms/open-plan-acoustics/).

--- a/site/src/content/docs/reference/theory/rooms-buildings.mdx
+++ b/site/src/content/docs/reference/theory/rooms-buildings.mdx
@@ -98,7 +98,7 @@ references:
     title: "Acoustics — Measurement of room acoustic parameters — Part 3: Open plan offices"
     designation: "ISO 3382-3:2012"
     url: "https://www.iso.org/standard/46520.html"
-    note: "The open-plan spatial decay and the distraction and privacy distances."
+    note: "The open-plan spatial decay and the distraction and privacy distances. Since revised as ISO 3382-3:2022 (https://www.iso.org/standard/77437.html); the 2012 edition is the implemented one."
   - type: standard
     organization: "International Organization for Standardization"
     year: 2014


### PR DESCRIPTION
The open-plan office metrics implement ISO 3382-3:2012, and the standard has since been revised as ISO 3382-3:2022. This adds the edition note the site already uses for revised standards (the AES17-2015/2020 pattern) everywhere the 2012 edition is presented: the open-plan acoustics guide (EN and ES), the theory page, the central bibliography, and the docs tree.

The note states what actually changed for users of this module: the 2022 revision removes the privacy distance r_P (implemented and printed on the module's report fiche), adds the comfort distance r_C as a reported quantity, and moves the STI measurement to the indirect IEC 60268-16 method. The distraction distance r_D, the spatial decay rate D2,S and Lp,A,S,4m are numerically identical in both editions, which is why the implementation stays declared as 2012 rather than silently relabelled.

No designation changes: every ":2012" stays ":2012". The llms artifacts are regenerated from the updated pages.

## Summary by Sourcery

Flag the ISO 3382-3:2022 revision wherever the ISO 3382-3:2012 open-plan office standard is cited and clarify which edition the library implements.

Documentation:
- Document that ISO 3382-3:2012 has been superseded by ISO 3382-3:2022 in all relevant English and Spanish open-plan acoustics guides and theory pages, including notes on the implemented edition and key changes in the revision (removal of r_P, addition of r_C, STI method change).

Chores:
- Regenerate LLMS text artifacts to reflect the updated documentation.