### PR TITLE
Complete the ICASSP citation and pin the citation metadata to the release

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,6 +10,8 @@ authors:
 repository-code: "https://github.com/jmrplens/phonometry"
 url: "https://jmrplens.github.io/phonometry/"
 doi: "10.5281/zenodo.21215280"
+version: 3.3.0
+date-released: "2026-07-27"
 license: MIT
 keywords:
   - acoustics

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -72,10 +72,12 @@
 @inproceedings{drakopoulos2023,
   title     = {A {DNN}-based hearing-aid strategy for real-time processing:
                one size fits all},
-  author    = {Drakopoulos, Fotis and Verhulst, Sarah},
+  author    = {Drakopoulos, Fotios and Van Den Broucke, Arthur and Verhulst,
+               Sarah},
   year      = {2023},
   booktitle = {Proceedings of the IEEE International Conference on Acoustics,
                Speech and Signal Processing (ICASSP 2023)},
+  pages     = {1--5},
   doi       = {10.1109/ICASSP49357.2023.10094887}
 }
 

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -41,9 +41,10 @@ into the test suite as oracles: the IEC 61672-1 weighting tolerances
 [@iec61672], the IEC 61260-1 filter class limits [@iec61260], the ISO 532-1
 loudness test signals [@iso532], the ISO 717 rating examples [@iso717], and
 hundreds more. At the time of writing, continuous integration enforces 533
-numerical conformance checks against 362 referenced standards on every change,
-and the per-check report (standard and clause, normative expected value,
-computed value, delta, verdict) is published with the documentation
+numerical conformance checks across 57 domains against 362 referenced
+standards on every change, and the per-check report (standard and clause,
+normative expected value, computed value, delta, verdict) is published with
+the documentation
 (<https://jmrplens.github.io/phonometry/reference/conformance/>), alongside a
 bibliography of every source the guides cite, standards included with their
 catalogue records

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -40,12 +40,13 @@ examples, tolerance tables or nominal responses, those numbers are transcribed
 into the test suite as oracles: the IEC 61672-1 weighting tolerances
 [@iec61672], the IEC 61260-1 filter class limits [@iec61260], the ISO 532-1
 loudness test signals [@iso532], the ISO 717 rating examples [@iso717], and
-hundreds more. At the time of writing, continuous integration enforces 427
-numerical conformance checks against 278 referenced standards on every change,
+hundreds more. At the time of writing, continuous integration enforces 533
+numerical conformance checks against 362 referenced standards on every change,
 and the per-check report (standard and clause, normative expected value,
 computed value, delta, verdict) is published with the documentation
 (<https://jmrplens.github.io/phonometry/reference/conformance/>), alongside a
-bibliography listing all 278 referenced standards with their editions
+bibliography of every source the guides cite, standards included with their
+catalogue records
 (<https://jmrplens.github.io/phonometry/reference/bibliography/>). A
 regression that moves a computed value outside a standard's acceptance limit
 fails the build, so the conformance claim cannot silently stop being true
@@ -142,7 +143,7 @@ test expectations, and the published conformance report is generated from the
 same run that gates merges. The alternative, a hand-maintained validation
 report, was rejected because it can silently drift from the code; here the
 report cannot exist in a state the tests did not produce. The library is
-organised in twelve domain namespaces over a flat API that remains importable
+organised in eighteen domain namespaces over a flat API that remains importable
 directly, and the documentation, in English and Spanish, pairs every metric
 with a guide that teaches the method and a reference page that cites the
 exact clauses and formula numbers implemented; machine-readable copies of

--- a/site/src/data/citation.mjs
+++ b/site/src/data/citation.mjs
@@ -5,16 +5,18 @@
  * `CITATION.cff` in the repository root is the authoritative metadata: it is
  * what GitHub's "Cite this repository" widget renders and what Zenodo reads
  * when a release is archived. So the author, the title, the DOI, the URL and
- * the licence are read from it rather than restated here, and the version is
- * read from the root `VERSION` file, which is the single source astro.config
- * already uses and the file whose change drives a release.
+ * the licence are read from it rather than restated here, and the version
+ * cited on the site is read from the root `VERSION` file, which is the single
+ * source astro.config already uses and the file whose change drives a
+ * release: `CITATION.cff` also carries `version` and `date-released` now (a
+ * JOSS review checklist reads them directly from the file), but this module
+ * still prefers `VERSION` so a forgotten CFF bump on release day cannot stamp
+ * the site with a stale version.
  *
- * That leaves the year, which neither file carries: `CITATION.cff` deliberately
- * omits `version` and `date-released` because Zenodo stamps those per release
- * from the tag, and adding them here would be a second version of the truth to
- * keep in step by hand. The release date of the version in `VERSION` is already
- * written down once, in the `CHANGELOG.md` heading for that version, so that is
- * where the year comes from.
+ * That leaves the year, which `VERSION` does not carry. The release date of
+ * the version in `VERSION` is already written down once, in the
+ * `CHANGELOG.md` heading for that version, so that is where the year comes
+ * from rather than from `CITATION.cff`'s `date-released`.
  */
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';

--- a/site/src/data/citation.mjs
+++ b/site/src/data/citation.mjs
@@ -8,10 +8,20 @@
  * the licence are read from it rather than restated here, and the version
  * cited on the site is read from the root `VERSION` file, which is the single
  * source astro.config already uses and the file whose change drives a
- * release: `CITATION.cff` also carries `version` and `date-released` now (a
- * JOSS review checklist reads them directly from the file), but this module
- * still prefers `VERSION` so a forgotten CFF bump on release day cannot stamp
- * the site with a stale version.
+ * release.
+ *
+ * `CITATION.cff` also carries its own `version` and `date-released`, mostly
+ * for tools that read the file directly instead of building the site (a JOSS
+ * review checklist, GitHub's own widget, Zenodo). That is a second copy of
+ * the version and release date, which is exactly what drifts if a release
+ * bumps `VERSION` and `CHANGELOG.md` without also touching the CFF, so this
+ * module does not take it on faith: it asserts `cff.version` equals `VERSION`
+ * and that `cff['date-released']` is not later than the `CHANGELOG.md`
+ * heading for that version, and fails the build with a clear message the
+ * moment either stops holding. The site's own citation keeps reading
+ * `VERSION` and `CHANGELOG.md` rather than the CFF fields regardless, so a
+ * stale CFF cannot stamp the site itself with the wrong version, on top of
+ * the assertion below stopping the build for it.
  *
  * That leaves the year, which `VERSION` does not carry. The release date of
  * the version in `VERSION` is already written down once, in the
@@ -106,13 +116,25 @@ const unquote = (value) => value.trim().replace(/^(["'])(.*)\1$/, '$2');
 
 const cff = readCitationFile(readFileSync(root('CITATION.cff'), 'utf8'));
 
-for (const field of ['title', 'doi', 'url', 'license', 'authors']) {
+for (const field of ['title', 'doi', 'url', 'license', 'authors', 'version', 'date-released']) {
   if (!cff[field]?.length) {
     throw new Error(`CITATION.cff: missing "${field}", which the citation needs.`);
   }
 }
 
 export const version = readFileSync(root('VERSION'), 'utf8').trim();
+
+/**
+ * `CITATION.cff`'s own `version` is a second copy of this value, kept for
+ * tools that read the CFF directly. Assert it agrees with `VERSION` rather
+ * than let the two drift unnoticed until someone reads the file by hand.
+ */
+if (cff.version !== version) {
+  throw new Error(
+    `CITATION.cff: version "${cff.version}" does not match VERSION "${version}". ` +
+      'Bump both together on release.',
+  );
+}
 
 /**
  * The Zenodo *concept* DOI, which resolves to the newest archived release.
@@ -129,25 +151,54 @@ export const doi = cff.doi;
 export const doiUrl = `https://doi.org/${doi}`;
 
 /**
- * The year of the release named by `VERSION`, taken from its changelog heading
- * (`## [3.3.0] - 2026-07-27`). Between releases those always agree, because the
- * commit that bumps `VERSION` is the one that dates the heading. If they ever
- * do not, the newest dated heading is used and the build says so, rather than
- * stamping the citation with whatever day the site happened to be rebuilt.
+ * Every dated release heading in `CHANGELOG.md` (`## [3.3.0] - 2026-07-27`),
+ * in file order (newest first). Parsed once and shared by the release year
+ * below and by the `date-released` consistency check that follows it, so
+ * both read the same headings rather than two independent regexes that could
+ * disagree about what a heading says.
+ */
+const changelogHeadings = (() => {
+  const changelog = readFileSync(root('CHANGELOG.md'), 'utf8');
+  return [...changelog.matchAll(/^## \[([^\]]+)\] - (\d{4}-\d{2}-\d{2})$/gm)].map(
+    ([, headingVersion, date]) => ({ version: headingVersion, date }),
+  );
+})();
+
+/** The heading for the version named by `VERSION`, if `CHANGELOG.md` has one. */
+const changelogEntry = changelogHeadings.find((heading) => heading.version === version);
+
+/**
+ * The year of the release named by `VERSION`, taken from its changelog heading.
+ * Between releases those always agree, because the commit that bumps `VERSION`
+ * is the one that dates the heading. If they ever do not, the newest dated
+ * heading is used and the build says so, rather than stamping the citation
+ * with whatever day the site happened to be rebuilt.
  */
 const releaseYear = (() => {
-  const changelog = readFileSync(root('CHANGELOG.md'), 'utf8');
-  const headings = [...changelog.matchAll(/^## \[([^\]]+)\] - (\d{4})-\d{2}-\d{2}$/gm)];
-  const exact = headings.find(([, released]) => released === version);
-  if (exact) return exact[2];
-  const [newest] = headings;
+  if (changelogEntry) return changelogEntry.date.slice(0, 4);
+  const [newest] = changelogHeadings;
   if (!newest) throw new Error('CHANGELOG.md: no dated release heading to take the year from.');
   console.warn(
     `\n⚠ [citation] CHANGELOG.md has no dated heading for version ${version};` +
-      ` citing the year of ${newest[1]} (${newest[2]}) instead.\n`,
+      ` citing the year of ${newest.version} (${newest.date.slice(0, 4)}) instead.\n`,
   );
-  return newest[2];
+  return newest.date.slice(0, 4);
 })();
+
+/**
+ * `CITATION.cff`'s `date-released` should not claim the release happened
+ * later than `CHANGELOG.md` says it did; equal or earlier is fine (the
+ * changelog entry can be written before the tag that dates the CFF, the same
+ * day). Checked only when `CHANGELOG.md` actually carries a dated heading for
+ * this version — when it does not, the warning above already flags that gap,
+ * and there is nothing to compare `date-released` against.
+ */
+if (changelogEntry && cff['date-released'] > changelogEntry.date) {
+  throw new Error(
+    `CITATION.cff: date-released "${cff['date-released']}" is later than ` +
+      `the CHANGELOG.md date for ${version} (${changelogEntry.date}).`,
+  );
+}
 
 /**
  * Latin-1 letters carrying an accent, written as BibTeX writes them.


### PR DESCRIPTION
Three related fixes to the citation surfaces.

The ICASSP 2023 reference (Drakopoulos et al.) was missing its second author, Arthur Van Den Broucke, and misspelled the first author's given name; both now match the Crossref record for 10.1109/ICASSP49357.2023.10094887, with pages added.

The paper's summary figures had fallen behind the tree: the conformance suite now stands at 533 checks across 57 domains and 362 standards, the package exposes eighteen public domain namespaces, and the bibliography page groups sources with their catalogue records and verified links rather than listing implemented standards only. The text now says what the repository actually contains.

CITATION.cff gains version and date-released. The site's citation module previously omitted them on purpose so the version could not drift from VERSION; that concern is now enforced instead of avoided: the build-time consistency checks assert that CITATION.cff's version equals VERSION and that date-released is not ahead of the CHANGELOG date for that version, so a release that forgets to bump the citation metadata fails the build. Both failure modes were exercised and then restored.

## Summary by Sourcery

Align citation metadata across the site, paper, and CITATION.cff so releases carry complete, consistent citation information and ICASSP 2023 is correctly referenced.

New Features:
- Add build-time checks that enforce consistency between CITATION.cff, VERSION, and CHANGELOG.md for version and release date.

Bug Fixes:
- Correct the ICASSP 2023 bibliographic entry to include the missing author, fix the first author name spelling, and add page numbers.
- Update the paper text so the reported number of conformance checks, referenced standards, domain namespaces, and bibliography description match the current repository state.

Enhancements:
- Extend the site citation loader to require version and date-released fields in CITATION.cff and centralize CHANGELOG.md heading parsing for reuse.
- Prevent stale citation metadata from affecting the site by keeping the site’s displayed version and year sourced from VERSION and CHANGELOG.md while failing the build when CFF drifts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated published verification figures to 533 checks across 362 standards and eighteen domain namespaces.
  * Improved bibliography details and descriptions of catalogue records.
* **Release Metadata**
  * Added version 3.3.0 release information.
  * Added consistency checks to ensure release metadata, version, and dates remain synchronized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->