### PR TITLE
Cite ISO 9613-1 where enclosed-space-absorption already uses it

### DIFF
--- a/docs/buildings/rooms/enclosed-space-absorption.md
+++ b/docs/buildings/rooms/enclosed-space-absorption.md
@@ -242,6 +242,9 @@ repository. Click the preview to open the PDF:
   $D_{nT} = D + 10\lg(T/T_0)$ and $R' = D + 10\lg(S/A)$.
 - [Conformance report](https://github.com/jmrplens/phonometry/blob/main/docs/CONFORMANCE.md):
   the three Annex E cases these implementations are checked against.
+- [Outdoor Sound Propagation](../../environment/propagation/outdoor-propagation.md): the full ISO 9613-1
+  atmospheric-absorption model, for conditions or frequencies the six
+  built-in climate profiles do not cover.
 - API reference: [`room.enclosed_space_absorption`](https://jmrplens.github.io/phonometry/reference/api/rooms/enclosed-space-absorption/).
 - Theory: [Absorption in enclosed spaces](../../reference/theory/rooms-buildings.md#absorption-in-enclosed-spaces-en-12354-6): the equivalent-absorption-area definition the EN 12354-6 procedure computes.
 
@@ -267,4 +270,8 @@ EN 12354-6:2003, *Building acoustics — Estimation of acoustic
 performance of buildings from the performance of elements — Part 6: Sound
 absorption in enclosed spaces*: the total equivalent absorption area
 (clause 4.3, Formulae 1-4, Table 1) and the reverberation time (clause 4.4,
-Formula 5), validated against the three worked cases of Annex E.
+Formula 5), validated against the three worked cases of Annex E. The Table 1
+climate-condition power attenuation coefficients (125 Hz-8 kHz octave bands)
+are derived from ISO 9613-1:1993; the full atmospheric-absorption model for
+arbitrary conditions and frequencies is covered in [Outdoor Sound
+Propagation](../../environment/propagation/outdoor-propagation.md).

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -9099,6 +9099,9 @@ repository. Click the preview to open the PDF:
   $D_{nT} = D + 10\lg(T/T_0)$ and $R' = D + 10\lg(S/A)$.
 - [Conformance report](https://github.com/jmrplens/phonometry/blob/main/docs/CONFORMANCE.md):
   the three Annex E cases these implementations are checked against.
+- [Outdoor Sound Propagation](https://jmrplens.github.io/phonometry/environment/propagation/outdoor-propagation/): the full ISO 9613-1
+  atmospheric-absorption model, for conditions or frequencies the six
+  built-in climate profiles do not cover.
 - API reference: [`room.enclosed_space_absorption`](https://jmrplens.github.io/phonometry/reference/api/rooms/enclosed-space-absorption/).
 - Theory: [Absorption in enclosed spaces](https://jmrplens.github.io/phonometry/reference/theory/rooms-buildings/#absorption-in-enclosed-spaces-en-12354-6): the equivalent-absorption-area definition the EN 12354-6 procedure computes.
 
@@ -9124,7 +9127,11 @@ EN 12354-6:2003, *Building acoustics — Estimation of acoustic
 performance of buildings from the performance of elements — Part 6: Sound
 absorption in enclosed spaces*: the total equivalent absorption area
 (clause 4.3, Formulae 1-4, Table 1) and the reverberation time (clause 4.4,
-Formula 5), validated against the three worked cases of Annex E.
+Formula 5), validated against the three worked cases of Annex E. The Table 1
+climate-condition power attenuation coefficients (125 Hz-8 kHz octave bands)
+are derived from ISO 9613-1:1993; the full atmospheric-absorption model for
+arbitrary conditions and frequencies is covered in [Outdoor Sound
+Propagation](https://jmrplens.github.io/phonometry/environment/propagation/outdoor-propagation/).
 
 ---
 

--- a/site/public/llms/llms-buildings-rooms.txt
+++ b/site/public/llms/llms-buildings-rooms.txt
@@ -2771,6 +2771,9 @@ repository. Click the preview to open the PDF:
   $D_{nT} = D + 10\lg(T/T_0)$ and $R' = D + 10\lg(S/A)$.
 - [Conformance report](https://github.com/jmrplens/phonometry/blob/main/docs/CONFORMANCE.md):
   the three Annex E cases these implementations are checked against.
+- [Outdoor Sound Propagation](https://jmrplens.github.io/phonometry/environment/propagation/outdoor-propagation/): the full ISO 9613-1
+  atmospheric-absorption model, for conditions or frequencies the six
+  built-in climate profiles do not cover.
 - API reference: [`room.enclosed_space_absorption`](https://jmrplens.github.io/phonometry/reference/api/rooms/enclosed-space-absorption/).
 - Theory: [Absorption in enclosed spaces](https://jmrplens.github.io/phonometry/reference/theory/rooms-buildings/#absorption-in-enclosed-spaces-en-12354-6): the equivalent-absorption-area definition the EN 12354-6 procedure computes.
 
@@ -2796,6 +2799,10 @@ EN 12354-6:2003, *Building acoustics — Estimation of acoustic
 performance of buildings from the performance of elements — Part 6: Sound
 absorption in enclosed spaces*: the total equivalent absorption area
 (clause 4.3, Formulae 1-4, Table 1) and the reverberation time (clause 4.4,
-Formula 5), validated against the three worked cases of Annex E.
+Formula 5), validated against the three worked cases of Annex E. The Table 1
+climate-condition power attenuation coefficients (125 Hz-8 kHz octave bands)
+are derived from ISO 9613-1:1993; the full atmospheric-absorption model for
+arbitrary conditions and frequencies is covered in [Outdoor Sound
+Propagation](https://jmrplens.github.io/phonometry/environment/propagation/outdoor-propagation/).
 
 ---

--- a/site/src/content/docs/buildings/rooms/enclosed-space-absorption.mdx
+++ b/site/src/content/docs/buildings/rooms/enclosed-space-absorption.mdx
@@ -16,6 +16,13 @@ references:
     designation: "ISO 354:2003"
     url: "https://www.iso.org/standard/34545.html"
     note: "The laboratory measurement the surface and array coefficients come from."
+  - type: standard
+    organization: "International Organization for Standardization"
+    year: 1993
+    title: "Acoustics — Attenuation of sound during propagation outdoors — Part 1: Calculation of the absorption of sound by the atmosphere"
+    designation: "ISO 9613-1:1993"
+    url: "https://www.iso.org/standard/17426.html"
+    note: "Only the six climate-condition power attenuation coefficients of EN 12354-6 Table 1, derived from this standard for the 125 Hz-8 kHz octave bands; the full atmospheric-absorption model for arbitrary conditions and frequencies lives in the Outdoor Sound Propagation guide."
   - type: book
     authors: ["Kuttruff, H."]
     year: 2016
@@ -584,5 +591,9 @@ only.
   $D_{nT} = D + 10\lg(T/T_0)$ and $R' = D + 10\lg(S/A)$.
 - [Conformance report](https://github.com/jmrplens/phonometry/blob/main/docs/CONFORMANCE.md):
   the three Annex E cases these implementations are checked against.
+- [Outdoor Sound Propagation](/phonometry/environment/propagation/outdoor-propagation/):
+  the full ISO 9613-1 atmospheric-absorption model, for conditions or
+  frequencies the six built-in climate profiles do not cover, via
+  `environment.propagation.air_absorption`.
 - API reference: [`room.enclosed_space_absorption`](/phonometry/reference/api/rooms/enclosed-space-absorption/).
 - Theory: [Sound insulation and absorption, predicted](/phonometry/reference/theory/rooms-buildings/#sound-insulation-and-absorption-predicted-en-12354-1-2-6-bies-cremer-hopkins): the equivalent-absorption-area definition the EN 12354-6 procedure computes.

--- a/site/src/content/docs/es/buildings/rooms/enclosed-space-absorption.mdx
+++ b/site/src/content/docs/es/buildings/rooms/enclosed-space-absorption.mdx
@@ -16,6 +16,13 @@ references:
     designation: "ISO 354:2003"
     url: "https://www.iso.org/standard/34545.html"
     note: "La medición de laboratorio de la que salen los coeficientes de superficies y conjuntos."
+  - type: standard
+    organization: "International Organization for Standardization"
+    year: 1993
+    title: "Acoustics — Attenuation of sound during propagation outdoors — Part 1: Calculation of the absorption of sound by the atmosphere"
+    designation: "ISO 9613-1:1993"
+    url: "https://www.iso.org/standard/17426.html"
+    note: "Solo los seis coeficientes de atenuación de potencia por condición climática de la Tabla 1 de la EN 12354-6, derivados de esta norma para las bandas de octava de 125 Hz a 8 kHz; el modelo completo de absorción atmosférica para condiciones y frecuencias arbitrarias está en la guía de propagación del sonido en exteriores."
   - type: book
     authors: ["Kuttruff, H."]
     year: 2016
@@ -607,5 +614,9 @@ como línea de referencia.
 - [Informe de conformidad](https://github.com/jmrplens/phonometry/blob/main/docs/CONFORMANCE.md):
   los tres casos del Anexo E frente a los que se comprueban estas
   implementaciones.
+- [Propagación del sonido en exteriores](/phonometry/es/environment/propagation/outdoor-propagation/):
+  el modelo completo de absorción atmosférica de ISO 9613-1, para
+  condiciones o frecuencias que los seis perfiles climáticos integrados no
+  cubren, mediante `environment.propagation.air_absorption`.
 - Referencia de la API: [`room.enclosed_space_absorption`](/phonometry/es/reference/api/rooms/enclosed-space-absorption/).
 - Teoría: [Aislamiento acústico y absorción, predichos](/phonometry/es/reference/theory/rooms-buildings/#aislamiento-acústico-y-absorción-predichos-en-12354-1-2-6-bies-cremer-hopkins): la definición de área de absorción equivalente que calcula el procedimiento de EN 12354-6.


### PR DESCRIPTION
The enclosed-space absorption guide leans on ISO 9613-1 in its prose (the air attenuation entry of the total absorption budget) but never declared the standard in its references, and offered no path to the page that hosts the full atmospheric absorption model. Both gaps close here.

The references block gains ISO 9613-1:1993 with a scope note that matches what the module actually does: it carries only the six climate-condition power attenuation coefficients of EN 12354-6 Table 1, which are derived from this standard for the 125 Hz to 8 kHz octave bands, while the full model lives in the outdoor sound propagation guide. The See also section now links there. English page, Spanish twin and the docs mirror all updated, with the llms artifacts regenerated.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

