### PR TITLE
Describe ReportMetadata's numeric fields by their real ranges

### DIFF
--- a/docs/buildings/insulation/insulation-ratings.md
+++ b/docs/buildings/insulation/insulation-ratings.md
@@ -295,7 +295,8 @@ $R(f)$ and writes its fiche in one call.
 
 The report metadata is supplied as a `ReportMetadata` frozen dataclass (every
 field optional; only the supplied fields are rendered, and the numeric fields
-must be finite and positive). Passing `metadata=None` produces a lightweight
+must satisfy their field-specific physical ranges, detailed in the table
+below). Passing `metadata=None` produces a lightweight
 prediction fiche (body, result and disclaimer only). When
 `metadata.requirement` is set, a verdict row is added: an airborne rating passes
 when it is at or above the requirement, an impact rating when it is at or below
@@ -368,7 +369,7 @@ numeric fields are validated on construction by physical range.
 | `source_temperature`, `source_relative_humidity`, `receiving_temperature`, `receiving_relative_humidity` | `float` | Per-room climate when source and receiving rooms are reported separately (same ranges as above) |
 | `test_room`, `mounting`, `measurement_standard`, `test_date` | `str` | Facility, mounting condition, the measurement standard (forms the standard-basis line) and the test date |
 | `laboratory`, `operator`, `report_id`, `notes` | `str` | Footer: institute, operator signature line, report number and free-form remarks |
-| `requirement` | `float > 0` | Target single number; adds the verdict row (airborne passes at or above it, impact at or below it) |
+| `requirement` | `float` | Target single number; adds the verdict row (airborne passes at or above it, impact at or below it) |
 
 ## Quick answers
 

--- a/docs/buildings/insulation/insulation-ratings.md
+++ b/docs/buildings/insulation/insulation-ratings.md
@@ -365,7 +365,8 @@ numeric fields are validated on construction by physical range.
 | `specimen`, `client`, `mounted_by`, `manufacturer` | `str` | Header identity of the tested element and who it was tested for / mounted by |
 | `area`, `mass_per_area` | `float > 0` | Sample area $S$ (m²) and measured mass per unit area (kg/m²) |
 | `source_volume`, `receiving_volume` | `float > 0` | Room volumes (m³) |
-| `temperature`, `relative_humidity`, `pressure` | `float` | Single representative climate: air temperature (°C, any sign), relative humidity (0–100 %), ambient pressure (kPa, > 0) |
+| `temperature`, `relative_humidity` | `float` | Single representative climate: air temperature (°C, any sign), relative humidity (0–100 %) |
+| `pressure` | `float > 0` | Ambient (static) air pressure during the test (kPa) |
 | `source_temperature`, `source_relative_humidity`, `receiving_temperature`, `receiving_relative_humidity` | `float` | Per-room climate when source and receiving rooms are reported separately (same ranges as above) |
 | `test_room`, `mounting`, `measurement_standard`, `test_date` | `str` | Facility, mounting condition, the measurement standard (forms the standard-basis line) and the test date |
 | `laboratory`, `operator`, `report_id`, `notes` | `str` | Footer: institute, operator signature line, report number and free-form remarks |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8109,7 +8109,8 @@ $R(f)$ and writes its fiche in one call.
 
 The report metadata is supplied as a `ReportMetadata` frozen dataclass (every
 field optional; only the supplied fields are rendered, and the numeric fields
-must be finite and positive). Passing `metadata=None` produces a lightweight
+must satisfy their field-specific physical ranges, detailed in the table
+below). Passing `metadata=None` produces a lightweight
 prediction fiche (body, result and disclaimer only). When
 `metadata.requirement` is set, a verdict row is added: an airborne rating passes
 when it is at or above the requirement, an impact rating when it is at or below
@@ -8182,7 +8183,7 @@ numeric fields are validated on construction by physical range.
 | `source_temperature`, `source_relative_humidity`, `receiving_temperature`, `receiving_relative_humidity` | `float` | Per-room climate when source and receiving rooms are reported separately (same ranges as above) |
 | `test_room`, `mounting`, `measurement_standard`, `test_date` | `str` | Facility, mounting condition, the measurement standard (forms the standard-basis line) and the test date |
 | `laboratory`, `operator`, `report_id`, `notes` | `str` | Footer: institute, operator signature line, report number and free-form remarks |
-| `requirement` | `float > 0` | Target single number; adds the verdict row (airborne passes at or above it, impact at or below it) |
+| `requirement` | `float` | Target single number; adds the verdict row (airborne passes at or above it, impact at or below it) |
 
 ## Quick answers
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8179,7 +8179,8 @@ numeric fields are validated on construction by physical range.
 | `specimen`, `client`, `mounted_by`, `manufacturer` | `str` | Header identity of the tested element and who it was tested for / mounted by |
 | `area`, `mass_per_area` | `float > 0` | Sample area $S$ (m²) and measured mass per unit area (kg/m²) |
 | `source_volume`, `receiving_volume` | `float > 0` | Room volumes (m³) |
-| `temperature`, `relative_humidity`, `pressure` | `float` | Single representative climate: air temperature (°C, any sign), relative humidity (0–100 %), ambient pressure (kPa, > 0) |
+| `temperature`, `relative_humidity` | `float` | Single representative climate: air temperature (°C, any sign), relative humidity (0–100 %) |
+| `pressure` | `float > 0` | Ambient (static) air pressure during the test (kPa) |
 | `source_temperature`, `source_relative_humidity`, `receiving_temperature`, `receiving_relative_humidity` | `float` | Per-room climate when source and receiving rooms are reported separately (same ranges as above) |
 | `test_room`, `mounting`, `measurement_standard`, `test_date` | `str` | Facility, mounting condition, the measurement standard (forms the standard-basis line) and the test date |
 | `laboratory`, `operator`, `report_id`, `notes` | `str` | Footer: institute, operator signature line, report number and free-form remarks |

--- a/site/public/llms/llms-buildings-insulation-ratings.txt
+++ b/site/public/llms/llms-buildings-insulation-ratings.txt
@@ -372,7 +372,8 @@ numeric fields are validated on construction by physical range.
 | `specimen`, `client`, `mounted_by`, `manufacturer` | `str` | Header identity of the tested element and who it was tested for / mounted by |
 | `area`, `mass_per_area` | `float > 0` | Sample area $S$ (m²) and measured mass per unit area (kg/m²) |
 | `source_volume`, `receiving_volume` | `float > 0` | Room volumes (m³) |
-| `temperature`, `relative_humidity`, `pressure` | `float` | Single representative climate: air temperature (°C, any sign), relative humidity (0–100 %), ambient pressure (kPa, > 0) |
+| `temperature`, `relative_humidity` | `float` | Single representative climate: air temperature (°C, any sign), relative humidity (0–100 %) |
+| `pressure` | `float > 0` | Ambient (static) air pressure during the test (kPa) |
 | `source_temperature`, `source_relative_humidity`, `receiving_temperature`, `receiving_relative_humidity` | `float` | Per-room climate when source and receiving rooms are reported separately (same ranges as above) |
 | `test_room`, `mounting`, `measurement_standard`, `test_date` | `str` | Facility, mounting condition, the measurement standard (forms the standard-basis line) and the test date |
 | `laboratory`, `operator`, `report_id`, `notes` | `str` | Footer: institute, operator signature line, report number and free-form remarks |

--- a/site/public/llms/llms-buildings-insulation-ratings.txt
+++ b/site/public/llms/llms-buildings-insulation-ratings.txt
@@ -302,7 +302,8 @@ $R(f)$ and writes its fiche in one call.
 
 The report metadata is supplied as a `ReportMetadata` frozen dataclass (every
 field optional; only the supplied fields are rendered, and the numeric fields
-must be finite and positive). Passing `metadata=None` produces a lightweight
+must satisfy their field-specific physical ranges, detailed in the table
+below). Passing `metadata=None` produces a lightweight
 prediction fiche (body, result and disclaimer only). When
 `metadata.requirement` is set, a verdict row is added: an airborne rating passes
 when it is at or above the requirement, an impact rating when it is at or below
@@ -375,7 +376,7 @@ numeric fields are validated on construction by physical range.
 | `source_temperature`, `source_relative_humidity`, `receiving_temperature`, `receiving_relative_humidity` | `float` | Per-room climate when source and receiving rooms are reported separately (same ranges as above) |
 | `test_room`, `mounting`, `measurement_standard`, `test_date` | `str` | Facility, mounting condition, the measurement standard (forms the standard-basis line) and the test date |
 | `laboratory`, `operator`, `report_id`, `notes` | `str` | Footer: institute, operator signature line, report number and free-form remarks |
-| `requirement` | `float > 0` | Target single number; adds the verdict row (airborne passes at or above it, impact at or below it) |
+| `requirement` | `float` | Target single number; adds the verdict row (airborne passes at or above it, impact at or below it) |
 
 ## Quick answers
 

--- a/site/src/content/docs/buildings/insulation/insulation-ratings.mdx
+++ b/site/src/content/docs/buildings/insulation/insulation-ratings.mdx
@@ -483,7 +483,8 @@ so it is the one entry point here whose input was never measured.
 
 The report metadata is supplied as a `ReportMetadata` frozen dataclass (every
 field optional; only the supplied fields are rendered, and the numeric fields
-must be finite and positive). Passing `metadata=None` produces a lightweight
+must satisfy their field-specific physical ranges, detailed in the table
+below). Passing `metadata=None` produces a lightweight
 prediction fiche (body, result and disclaimer only). When
 `metadata.requirement` is set, a verdict row is added: an airborne rating passes
 when it is at or above the requirement, an impact rating when it is at or below
@@ -562,7 +563,7 @@ numeric fields are validated on construction by physical range.
 | `source_temperature`, `source_relative_humidity`, `receiving_temperature`, `receiving_relative_humidity` | `float` | Per-room climate when source and receiving rooms are reported separately (same ranges as above) |
 | `test_room`, `mounting`, `measurement_standard`, `test_date` | `str` | Facility, mounting condition, the measurement standard (forms the standard-basis line) and the test date |
 | `laboratory`, `operator`, `report_id`, `notes` | `str` | Footer: institute, operator signature line, report number and free-form remarks |
-| `requirement` | `float > 0` | Target single number; adds the verdict row (airborne passes at or above it, impact at or below it) |
+| `requirement` | `float` | Target single number; adds the verdict row (airborne passes at or above it, impact at or below it) |
 
 ## What this guide covers
 

--- a/site/src/content/docs/buildings/insulation/insulation-ratings.mdx
+++ b/site/src/content/docs/buildings/insulation/insulation-ratings.mdx
@@ -559,7 +559,8 @@ numeric fields are validated on construction by physical range.
 | `specimen`, `client`, `mounted_by`, `manufacturer` | `str` | Header identity of the tested element and who it was tested for / mounted by |
 | `area`, `mass_per_area` | `float > 0` | Sample area $S$ (m²) and measured mass per unit area (kg/m²) |
 | `source_volume`, `receiving_volume` | `float > 0` | Room volumes (m³) |
-| `temperature`, `relative_humidity`, `pressure` | `float` | Single representative climate: air temperature (°C, any sign), relative humidity (0–100 %), ambient pressure (kPa, > 0) |
+| `temperature`, `relative_humidity` | `float` | Single representative climate: air temperature (°C, any sign), relative humidity (0–100 %) |
+| `pressure` | `float > 0` | Ambient (static) air pressure during the test (kPa) |
 | `source_temperature`, `source_relative_humidity`, `receiving_temperature`, `receiving_relative_humidity` | `float` | Per-room climate when source and receiving rooms are reported separately (same ranges as above) |
 | `test_room`, `mounting`, `measurement_standard`, `test_date` | `str` | Facility, mounting condition, the measurement standard (forms the standard-basis line) and the test date |
 | `laboratory`, `operator`, `report_id`, `notes` | `str` | Footer: institute, operator signature line, report number and free-form remarks |

--- a/site/src/content/docs/es/buildings/insulation/insulation-ratings.mdx
+++ b/site/src/content/docs/es/buildings/insulation/insulation-ratings.mdx
@@ -578,7 +578,8 @@ rango físico.
 | `specimen`, `client`, `mounted_by`, `manufacturer` | `str` | Identidad de cabecera del elemento ensayado y para quién / quién lo montó |
 | `area`, `mass_per_area` | `float > 0` | Superficie del elemento de ensayo $S$ (m²) y masa por unidad de superficie medida (kg/m²) |
 | `source_volume`, `receiving_volume` | `float > 0` | Volúmenes de las salas (m³) |
-| `temperature`, `relative_humidity`, `pressure` | `float` | Clima representativo único: temperatura del aire (°C, cualquier signo), humedad relativa (0–100 %), presión ambiente (kPa, > 0) |
+| `temperature`, `relative_humidity` | `float` | Clima representativo único: temperatura del aire (°C, cualquier signo), humedad relativa (0–100 %) |
+| `pressure` | `float > 0` | Presión (estática) ambiente durante el ensayo (kPa) |
 | `source_temperature`, `source_relative_humidity`, `receiving_temperature`, `receiving_relative_humidity` | `float` | Clima por recinto cuando el recinto emisor y el receptor se informan por separado (mismos rangos que arriba) |
 | `test_room`, `mounting`, `measurement_standard`, `test_date` | `str` | Instalación, condición de montaje, norma de medición (forma la línea de base normativa) y fecha de ensayo |
 | `laboratory`, `operator`, `report_id`, `notes` | `str` | Pie: institución, línea de firma del operador, número de informe y observaciones libres |

--- a/site/src/content/docs/es/buildings/insulation/insulation-ratings.mdx
+++ b/site/src/content/docs/es/buildings/insulation/insulation-ratings.mdx
@@ -499,7 +499,8 @@ midió.
 
 Los metadatos del informe se pasan como una dataclase congelada `ReportMetadata`
 (todos los campos opcionales; solo se representan los suministrados y los campos
-numéricos deben ser finitos y positivos). Pasar `metadata=None` genera una ficha
+numéricos deben cumplir su rango físico específico, detallado en la tabla de más
+abajo). Pasar `metadata=None` genera una ficha
 de predicción ligera (solo el cuerpo, el resultado y el descargo). Cuando se
 define `metadata.requirement` se añade una fila de veredicto: una valoración
 aérea aprueba cuando iguala o supera el requisito y una de impactos cuando lo
@@ -581,7 +582,7 @@ rango físico.
 | `source_temperature`, `source_relative_humidity`, `receiving_temperature`, `receiving_relative_humidity` | `float` | Clima por recinto cuando el recinto emisor y el receptor se informan por separado (mismos rangos que arriba) |
 | `test_room`, `mounting`, `measurement_standard`, `test_date` | `str` | Instalación, condición de montaje, norma de medición (forma la línea de base normativa) y fecha de ensayo |
 | `laboratory`, `operator`, `report_id`, `notes` | `str` | Pie: institución, línea de firma del operador, número de informe y observaciones libres |
-| `requirement` | `float > 0` | Valor objetivo de un solo número; añade la fila de veredicto (el aéreo cumple si es mayor o igual, el de impactos si es menor o igual) |
+| `requirement` | `float` | Valor objetivo de un solo número; añade la fila de veredicto (el aéreo cumple si es mayor o igual, el de impactos si es menor o igual) |
 
 ## Qué cubre esta guía
 


### PR DESCRIPTION
The insulation ratings guide claimed that every numeric field of ReportMetadata "must be finite and positive". The validator has never worked that way: temperatures and the requirement target only need to be finite (a negative LUFS target is the documented example), relative humidity accepts zero within its 0 to 100 range, and only the geometric and physical magnitudes (area, mass per area, volumes, pressure, tube diameter, microphone spacing, thickness) demand strictly positive values.

The sentence now defers to the field table, the requirement row drops its false "> 0", and pressure gets its own row with the explicit "float > 0" type instead of hiding its constraint inside the prose of a shared climate row. English page, Spanish twin and the docs mirror updated together, llms artifacts regenerated, and every remaining row of the table checked against the validator so the whole table now states exactly what the code enforces.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

