### PR TITLE
Map the compliance evidence in one guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,7 @@ Every other section consumes it.
 **[Calibration and uncertainty](signals/metrology/index.md)**
 
 - [Calibration and dBFS](signals/metrology/calibration.md): physical SPL and digital analysis
+- [Compliance and verification](signals/metrology/compliance-verification.md): what a performance class asserts in IEC 61672-1 and IEC 61260-1, the public verifiers that grade weightings, filter banks and intensity spectra against their tolerance tables, how to read the numerical conformance report, and the verified scope of the pattern-evaluation and periodic-test parts (IEC 61672-2/-3, IEC 61260-2/-3) that only a laboratory can run
 - [Measurement uncertainty](signals/metrology/gum-uncertainty.md): the GUM law of propagation of uncertainty and the Monte Carlo method (ISO/IEC Guide 98-3:2008 and Supplement 1): combined and expanded uncertainty, Welch–Satterthwaite effective degrees of freedom, and probabilistically symmetric coverage intervals
 - [Data qualification](signals/metrology/data-qualification.md): the Bendat & Piersol stationarity tests (reverse arrangements with the Table A.6 acceptance regions, runs about the median with the exact Wald-Wolfowitz distribution) on segment mean squares, and the Rice statistics of level crossings, apparent frequency, peak rates and the irregularity factor that places the peak-height distribution between Rayleigh and Gaussian
 

--- a/docs/signals/index.md
+++ b/docs/signals/index.md
@@ -154,6 +154,10 @@ What the numbers mean and how much to trust them.
 - [Calibration and dBFS](metrology/calibration.md): physical SPL
   calibration from a calibrator tone (IEC 60942), the stability check it applies
   to that recording, and the digital dBFS mode.
+- [Compliance and Verification](metrology/compliance-verification.md):
+  what a performance class asserts, the verifiers that grade each stage
+  against its tolerance tables, how to read the conformance report, and the
+  scope of IEC 61672-2/-3 and IEC 61260-2/-3.
 - [Measurement uncertainty (GUM and Monte Carlo)](metrology/gum-uncertainty.md):
   the law of propagation of uncertainty and the Monte Carlo method of
   ISO/IEC Guide 98-3, with expanded uncertainty and coverage intervals.
@@ -167,9 +171,12 @@ Four things a reader reasonably expects here are absent, and each guide says so
 in its own "Not covered" block. **No instrument is verified.**
 `verify_filter_class` and `verify_weighting_class` check a designed digital
 response against the tolerance tables of IEC 61260-1 and IEC 61672-1; the
-IEC 61672-3 pattern-evaluation tests a physical meter needs for type approval,
-and the IEC 60942 conformance tests of the calibrator itself, are not run, so a
-class verdict here describes the algorithm and not a built device. **No file is
+IEC 61672-2 pattern-evaluation tests a physical meter needs for type approval,
+the IEC 61672-3 periodic tests it receives in service, and the IEC 60942
+conformance tests of the calibrator itself, are not run, so a class verdict
+here describes the algorithm and not a built device;
+[Compliance and Verification](metrology/compliance-verification.md)
+draws that boundary part by part. **No file is
 opened.** Nothing in the library decodes WAV, FLAC or any other container:
 every function takes an array you have already read, which is why `fs` is
 always an argument. **No array processing.** Correlation and time delay model

--- a/docs/signals/index.md
+++ b/docs/signals/index.md
@@ -154,7 +154,7 @@ What the numbers mean and how much to trust them.
 - [Calibration and dBFS](metrology/calibration.md): physical SPL
   calibration from a calibrator tone (IEC 60942), the stability check it applies
   to that recording, and the digital dBFS mode.
-- [Compliance and Verification](metrology/compliance-verification.md):
+- [Compliance and verification](metrology/compliance-verification.md):
   what a performance class asserts, the verifiers that grade each stage
   against its tolerance tables, how to read the conformance report, and the
   scope of IEC 61672-2/-3 and IEC 61260-2/-3.
@@ -175,7 +175,7 @@ IEC 61672-2 pattern-evaluation tests a physical meter needs for type approval,
 the IEC 61672-3 periodic tests it receives in service, and the IEC 60942
 conformance tests of the calibrator itself, are not run, so a class verdict
 here describes the algorithm and not a built device;
-[Compliance and Verification](metrology/compliance-verification.md)
+[Compliance and verification](metrology/compliance-verification.md)
 draws that boundary part by part. **No file is
 opened.** Nothing in the library decodes WAV, FLAC or any other container:
 every function takes an array you have already read, which is why `fs` is

--- a/docs/signals/metrology/compliance-verification.md
+++ b/docs/signals/metrology/compliance-verification.md
@@ -1,0 +1,175 @@
+← [Documentation index](../../README.md)
+
+# Compliance and verification
+
+Three kinds of evidence back a number computed with this library. The
+**verifiers** are public functions that grade a filter or weighting you
+configured against the acceptance limits of its governing standard. The
+**conformance report** ([docs/CONFORMANCE.md](../../CONFORMANCE.md)) pins the
+shipped implementation to the standards' own expected values and is
+regenerated on every change. And the **scope notes** on each guide say where
+the software's claim ends and a laboratory's begins. This page is the map of
+the three.
+
+## What a performance class asserts
+
+IEC 61672-1:2013 (sound level meters) and IEC 61260-1:2014 (fractional-octave
+filters) both specify two performance categories, **class 1 and class 2**,
+and both define them the same way: the two classes share the *same design
+goals* and differ mainly in the **acceptance limits** around those goals and
+in the range of operational temperature; class 2 limits are greater than or
+equal to class 1 limits everywhere (IEC 61672-1:2013 clause 1;
+IEC 61260-1:2014 subclause 1.2).
+
+A class is therefore not a quality grade but a **worst-case error bound
+under stated conditions**, and the bound chains: a class 1 measurement needs
+every stage at class 1, from the [calibrator](calibration.md) through the
+weighting to the band filter. One class 2 stage bounds the chain at class 2.
+
+Two vocabulary edges: **class 0** belongs to the withdrawn IEC 61260:1995 /
+ANSI S1.11-2004 masks, not to the 2014 edition (see
+[Filter class verification](../filters/filter-compliance.md)); and a class
+belongs to a specification, so the honest claim is "class 1 per
+IEC 61672-1:2013 Table 3" or "class 1 per IEC 61260-1:2014 Table 1", never
+"class 1" alone.
+
+## The verifiers: which function proves what
+
+One verifier per instrument stage, all sharing the same verdict vocabulary:
+`overall_class` (the strictest class met, or `None`), per-band margins in
+decibels to the nearest limit, and a `range_limited` flag when part of the
+standard's frequency range could not be demonstrated at your sample rate.
+
+| Stage | Verifier | Acceptance limits |
+| :--- | :--- | :--- |
+| Frequency weighting (A, C, Z) | `verify_weighting_class` | IEC 61672-1:2013 Table 3 |
+| Weightings B and AU | `verify_weighting_class` | ANSI S1.4-1983 Tables IV/V; IEC 61012:1990 Table 1 |
+| Fractional-octave filter bank | `verify_filter_class` | IEC 61260-1:2014 Table 1 (1995 mask via `edition="1995"`) |
+| Intensity instrument spectrum | `verify_intensity_class` | IEC 61043:1993 Table 2 |
+
+The masks are public too: `weighting_class_limits(1)` returns the Table 3
+corridor and `class_limits(fraction, filter_class, omega)` the Table 1 one,
+so a report can draw the limits a verdict was judged against. Verifying a
+whole chain, in the configuration the conformance suite itself pins
+(48 kHz, order 6, one-third-octave, 100 Hz to 10 kHz):
+
+```python
+from phonometry import filters
+
+wf = filters.WeightingFilter(48000, "A")
+weighting = filters.verify_weighting_class(wf)
+print(weighting["overall_class"])       # 1
+print(weighting["range_limited"])       # False
+
+bank = filters.OctaveFilterBank(fs=48000, fraction=3, order=6,
+                                limits=[100, 10000])
+bands = filters.verify_filter_class(bank)
+print(bands["overall_class"])           # 1
+print(bands["range_limited"])           # True for a decimated bank
+```
+
+Read the flags, not just the class: `range_limited` is `True` on the
+decimated bank because a band cannot be evaluated beyond its own processing
+Nyquist, so the far stopband rests on the anti-alias argument rather than on
+the band filter itself. The details, including why a +0.400 dB margin is the
+ceiling for a passing Butterworth bank, are in
+[Filter class verification](../filters/filter-compliance.md); the weighting
+side is section 6 of [Frequency weighting](../levels/weighting.md).
+
+<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/weighting_class_mask_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/weighting_class_mask.svg" alt="A and C weighting deviations at 48 kHz threading within the IEC 61672-1 Table 3 class 1 acceptance corridor, with the wider class 2 limits dotted" width="80%"></picture>
+
+When the verdict has to leave the console, `filter_class_compliance` wraps
+the same verification as a result object with `.plot()` and `.report()`, the
+one-page accredited fiche with an optional PASS/FAIL row against a required
+class; `intensity_class_compliance` does the same for the IEC 61043
+residual-index verdict:
+
+```python
+from phonometry import OctaveFilterBank, ReportMetadata, filter_class_compliance
+
+bank_11 = OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[125, 4000])
+result = filter_class_compliance(bank_11)   # result.overall_class == 1
+result.report(
+    "iec61260.pdf",
+    metadata=ReportMetadata(
+        specimen="1/1-octave filter bank",
+        measurement_standard="IEC 61260-1:2014",
+        required_class=1,
+    ),
+)                                            # -> Class 1 - COMPLIES, PASS
+```
+
+## Reading the conformance report
+
+The verifiers grade *your* configuration; the
+[conformance report](../../CONFORMANCE.md) is the complementary evidence for
+the implementation as shipped: each row pins one implemented quantity to the
+governing standard's own expected value (a worked example or a
+tolerance-table entry, not a regression baseline), with the computed value,
+the signed delta and a pass/fail verdict. It is regenerated on every pull
+request and CI fails if it drifts from the code.
+
+Use it in three ways: find the row for a metric before trusting it (the row
+names the standard, edition and clause the implementation was held to); note
+that the class rows walk one pinned configuration, so section 2's verifiers
+are how the claim transfers to your own bank; and cite the report of the
+exact library version you pinned. Defects the re-derivation exposed in the
+published standards themselves are in the [errata registry](../../ERRATA.md).
+
+## What only a laboratory can attest
+
+Both instrument series continue past their Part 1 with two test regimes, and
+neither is something a software library can run on itself.
+
+**Pattern evaluation** (IEC 61672-2:2013 for meters, IEC 61260-2:2016 for
+filters) is the type-approval regime a *model* passes once: the tests
+necessary to verify conformance to **all mandatory specifications** of the
+Part 1 (IEC 61672-2:2013 clause 1; IEC 61260-2:2016 subclause 1.1), on
+physical specimens — IEC 61260-2 requires at least three of them
+(subclause 4.1). That includes everything a transfer function does not have:
+static pressure, air temperature and humidity influence, electrostatic and
+radio-frequency immunity, directional response, acoustical tests of the
+weightings with the microphone in the sound field, level linearity of real
+electronics, self-generated noise, tonebursts and overload behaviour
+(IEC 61672-2:2013 clauses 7 to 9; IEC 61260-2:2016 clauses 7 to 9).
+
+**Periodic tests** (IEC 61672-3:2013, IEC 61260-3:2016) are what a *working
+instrument* receives in the laboratory every year or two, on a limited set
+of key tests "restricted to the minimum considered necessary", valid for the
+environmental conditions of the day (IEC 61672-3:2013 clause 1;
+IEC 61260-3:2016 subclauses 1.2 and 1.3). Both Part 3 scopes end with the
+same caveat: passing every periodic test supports **no general conclusion of
+conformance** to the Part 1 unless the model's pattern approval is on record
+(IEC 61672-3:2013 clause 1; IEC 61260-3:2016 subclause 1.5).
+
+The same honesty applies to this library, in both directions. A verifier
+verdict is a statement about a *design*: the digital transfer function you
+configured fits the Part 1 acceptance mask, with the reported margins, over
+the checked range; every measurement made wholly in software inherits it. It
+is *not* a pattern evaluation, a periodic test, or a certificate for any
+physical device: nothing here has a microphone, a temperature or a serial
+number, and a real front end brings its own paper — the meter's periodic
+test per IEC 61672-3 and the calibrator's conformance per IEC 60942, both
+discussed in [Calibration and dBFS](calibration.md). A defensible report
+names both verdicts: the library's design verdict with the version and its
+conformance report, and the instrument's test record with its date.
+
+## Standards
+
+IEC 61672-1:2013, *Sound level meters — Part 1: Specifications*: the two
+performance categories and the Table 3 acceptance limits checked by
+`verify_weighting_class`.
+IEC 61672-2:2013 (*Pattern evaluation tests*) and IEC 61672-3:2013
+(*Periodic tests*): the instrument test regimes delimited above, not run.
+IEC 61260-1:2014, *Octave-band and fractional-octave-band filters — Part 1:
+Specifications*: the Table 1 acceptance limits checked by
+`verify_filter_class`.
+IEC 61260-2:2016 (*Pattern-evaluation tests*) and IEC 61260-3:2016
+(*Periodic tests*): the filter-set test regimes delimited above, not run.
+IEC 61043:1993, *Instruments for the measurement of sound intensity*: the
+class limits behind `verify_intensity_class`.
+
+**Not covered.** The verification mathematics of each stage belongs to that
+stage's own page; and every test of the Parts 2 and 3 themselves is
+delimited here but not performed: no environmental, immunity, acoustical or
+linearity test is run, and no physical instrument is assigned a class.

--- a/docs/signals/metrology/compliance-verification.md
+++ b/docs/signals/metrology/compliance-verification.md
@@ -134,10 +134,10 @@ electronics, self-generated noise, tonebursts and overload behaviour
 (IEC 61672-2:2013 clauses 7 to 9; IEC 61260-2:2016 clauses 7 to 9).
 
 **Periodic tests** (IEC 61672-3:2013, IEC 61260-3:2016) are what a *working
-instrument* receives in the laboratory every year or two, on a limited set
-of key tests "restricted to the minimum considered necessary", valid for the
-environmental conditions of the day (IEC 61672-3:2013 clause 1;
-IEC 61260-3:2016 subclauses 1.2 and 1.3). Both Part 3 scopes end with the
+instrument* receives in the laboratory, typically every year or two, on a
+limited set of key tests "restricted to the minimum considered necessary",
+valid for the environmental conditions of the day (IEC 61672-3:2013
+clause 1; IEC 61260-3:2016 subclauses 1.2 and 1.3). Both Part 3 scopes end with the
 same caveat: passing every periodic test supports **no general conclusion of
 conformance** to the Part 1 unless the model's pattern approval is on record
 (IEC 61672-3:2013 clause 1; IEC 61260-3:2016 subclause 1.5).

--- a/docs/signals/metrology/index.md
+++ b/docs/signals/metrology/index.md
@@ -30,7 +30,7 @@ intervals that stay honest when the model is non-linear or the inputs are far
 from Gaussian. The page shows both on the same models, including where they
 diverge and why.
 
-[Compliance and Verification](compliance-verification.md)
+[Compliance and verification](compliance-verification.md)
 carries the evidence story: what a performance class actually claims in
 IEC 61672-1 and IEC 61260-1 (same design goals, different acceptance limits),
 which public verifier grades each stage of a measurement chain against its
@@ -64,7 +64,7 @@ budgets that are specialisations of the GUM machinery described here.
 - [Calibration and dBFS](calibration.md): physical SPL
   calibration from a calibrator tone, the stability check it applies to that
   recording, and the digital full-scale mode.
-- [Compliance and Verification](compliance-verification.md):
+- [Compliance and verification](compliance-verification.md):
   what a performance class asserts, the verifiers that grade weightings,
   filter banks and intensity spectra against their tolerance tables, the
   conformance report, and the scope of IEC 61672-2/-3 and IEC 61260-2/-3.
@@ -82,7 +82,7 @@ tests of the calibrator itself — generated level, frequency, distortion, and
 the corrections for static pressure and temperature — are not implemented, so
 pass an already corrected `target_spl` when the manual asks for one, and the
 IEC 61672-3 periodic tests are cited as laboratory practice rather than run;
-[Compliance and Verification](compliance-verification.md)
+[Compliance and verification](compliance-verification.md)
 draws that boundary precisely, part by part.
 The dBFS half of the calibration page sits outside any standard and makes no
 physical claim: it is a reference frame, not a measurement. Data qualification

--- a/docs/signals/metrology/index.md
+++ b/docs/signals/metrology/index.md
@@ -6,7 +6,10 @@ A level printed by software is not yet a measurement. Three things separate
 the one from the other: knowing that the record deserves to be **averaged at
 all**, knowing what the digital samples mean **physically**, and knowing how
 much the result could reasonably be **wrong**. This section covers all three,
-and they apply transversally to every other page of the documentation.
+and they apply transversally to every other page of the documentation. A
+fourth page maps the evidence that backs the numbers: what a performance
+**class** asserts, the verifiers that grade a chain, and the published
+conformance report.
 
 [Calibration and dBFS](calibration.md) handles the
 physical meaning. phonometry works in two reference frames: physical **dB
@@ -26,6 +29,15 @@ propagates whole probability distributions numerically and yields coverage
 intervals that stay honest when the model is non-linear or the inputs are far
 from Gaussian. The page shows both on the same models, including where they
 diverge and why.
+
+[Compliance and Verification](compliance-verification.md)
+carries the evidence story: what a performance class actually claims in
+IEC 61672-1 and IEC 61260-1 (same design goals, different acceptance limits),
+which public verifier grades each stage of a measurement chain against its
+tolerance tables, how to read and cite the numerical conformance report the
+site publishes, and the honest boundary against the pattern-evaluation and
+periodic tests of IEC 61672-2/-3 and IEC 61260-2/-3, which need an
+instrument in a laboratory rather than a library.
 
 [Data qualification](data-qualification.md) guards the gate
 in front of both: every average - a Leq, a Welch PSD, every averaged input
@@ -52,6 +64,10 @@ budgets that are specialisations of the GUM machinery described here.
 - [Calibration and dBFS](calibration.md): physical SPL
   calibration from a calibrator tone, the stability check it applies to that
   recording, and the digital full-scale mode.
+- [Compliance and Verification](compliance-verification.md):
+  what a performance class asserts, the verifiers that grade weightings,
+  filter banks and intensity spectra against their tolerance tables, the
+  conformance report, and the scope of IEC 61672-2/-3 and IEC 61260-2/-3.
 - [Measurement uncertainty (GUM and Monte Carlo)](gum-uncertainty.md):
   the law of propagation of uncertainty and the Monte Carlo method, expanded
   uncertainty and coverage intervals.
@@ -65,7 +81,9 @@ Nothing here checks an instrument or a calibrator. The IEC 60942 conformance
 tests of the calibrator itself — generated level, frequency, distortion, and
 the corrections for static pressure and temperature — are not implemented, so
 pass an already corrected `target_spl` when the manual asks for one, and the
-IEC 61672-3 periodic tests are cited as laboratory practice rather than run.
+IEC 61672-3 periodic tests are cited as laboratory practice rather than run;
+[Compliance and Verification](compliance-verification.md)
+draws that boundary precisely, part by part.
 The dBFS half of the calibration page sits outside any standard and makes no
 physical claim: it is a reference frame, not a measurement. Data qualification
 implements the quantitative core of Bendat & Piersol's section 10.3 only —

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -39032,7 +39032,7 @@ What the numbers mean and how much to trust them.
 - [Calibration and dBFS](https://jmrplens.github.io/phonometry/signals/metrology/calibration/): physical SPL
   calibration from a calibrator tone (IEC 60942), the stability check it applies
   to that recording, and the digital dBFS mode.
-- [Compliance and Verification](https://jmrplens.github.io/phonometry/signals/metrology/compliance-verification/):
+- [Compliance and verification](https://jmrplens.github.io/phonometry/signals/metrology/compliance-verification/):
   what a performance class asserts, the verifiers that grade each stage
   against its tolerance tables, how to read the conformance report, and the
   scope of IEC 61672-2/-3 and IEC 61260-2/-3.
@@ -39053,7 +39053,7 @@ IEC 61672-2 pattern-evaluation tests a physical meter needs for type approval,
 the IEC 61672-3 periodic tests it receives in service, and the IEC 60942
 conformance tests of the calibrator itself, are not run, so a class verdict
 here describes the algorithm and not a built device;
-[Compliance and Verification](https://jmrplens.github.io/phonometry/signals/metrology/compliance-verification/)
+[Compliance and verification](https://jmrplens.github.io/phonometry/signals/metrology/compliance-verification/)
 draws that boundary part by part. **No file is
 opened.** Nothing in the library decodes WAV, FLAC or any other container:
 every function takes an array you have already read, which is why `fs` is
@@ -41957,7 +41957,7 @@ intervals that stay honest when the model is non-linear or the inputs are far
 from Gaussian. The page shows both on the same models, including where they
 diverge and why.
 
-[Compliance and Verification](https://jmrplens.github.io/phonometry/signals/metrology/compliance-verification/)
+[Compliance and verification](https://jmrplens.github.io/phonometry/signals/metrology/compliance-verification/)
 carries the evidence story: what a performance class actually claims in
 IEC 61672-1 and IEC 61260-1 (same design goals, different acceptance limits),
 which public verifier grades each stage of a measurement chain against its
@@ -41991,7 +41991,7 @@ budgets that are specialisations of the GUM machinery described here.
 - [Calibration and dBFS](https://jmrplens.github.io/phonometry/signals/metrology/calibration/): physical SPL
   calibration from a calibrator tone, the stability check it applies to that
   recording, and the digital full-scale mode.
-- [Compliance and Verification](https://jmrplens.github.io/phonometry/signals/metrology/compliance-verification/):
+- [Compliance and verification](https://jmrplens.github.io/phonometry/signals/metrology/compliance-verification/):
   what a performance class asserts, the verifiers that grade weightings,
   filter banks and intensity spectra against their tolerance tables, the
   conformance report, and the scope of IEC 61672-2/-3 and IEC 61260-2/-3.
@@ -42009,7 +42009,7 @@ tests of the calibrator itself — generated level, frequency, distortion, and
 the corrections for static pressure and temperature — are not implemented, so
 pass an already corrected `target_spl` when the manual asks for one, and the
 IEC 61672-3 periodic tests are cited as laboratory practice rather than run;
-[Compliance and Verification](https://jmrplens.github.io/phonometry/signals/metrology/compliance-verification/)
+[Compliance and verification](https://jmrplens.github.io/phonometry/signals/metrology/compliance-verification/)
 draws that boundary precisely, part by part.
 The dBFS half of the calibration page sits outside any standard and makes no
 physical claim: it is a reference frame, not a measurement. Data qualification

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -41142,10 +41142,10 @@ electronics, self-generated noise, tonebursts and overload behaviour
 (IEC 61672-2:2013 clauses 7 to 9; IEC 61260-2:2016 clauses 7 to 9).
 
 **Periodic tests** (IEC 61672-3:2013, IEC 61260-3:2016) are what a *working
-instrument* receives in the laboratory every year or two, on a limited set
-of key tests "restricted to the minimum considered necessary", valid for the
-environmental conditions of the day (IEC 61672-3:2013 clause 1;
-IEC 61260-3:2016 subclauses 1.2 and 1.3). Both Part 3 scopes end with the
+instrument* receives in the laboratory, typically every year or two, on a
+limited set of key tests "restricted to the minimum considered necessary",
+valid for the environmental conditions of the day (IEC 61672-3:2013
+clause 1; IEC 61260-3:2016 subclauses 1.2 and 1.3). Both Part 3 scopes end with the
 same caveat: passing every periodic test supports **no general conclusion of
 conformance** to the Part 1 unless the model's pattern approval is on record
 (IEC 61672-3:2013 clause 1; IEC 61260-3:2016 subclause 1.5).

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -82,6 +82,7 @@ If you are an AI assistant setting this up for a user: install from PyPI (no sys
 - [Overview](https://jmrplens.github.io/phonometry/signals/metrology/) · [full text](https://jmrplens.github.io/phonometry/llms/llms-signals-metrology.txt)
 - [Calibration and dBFS](https://jmrplens.github.io/phonometry/signals/metrology/calibration/)
 - [Measurement uncertainty (GUM and Monte Carlo)](https://jmrplens.github.io/phonometry/signals/metrology/gum-uncertainty/)
+- [Compliance and verification](https://jmrplens.github.io/phonometry/signals/metrology/compliance-verification/)
 - [Data qualification: stationarity, level crossings and peaks (Bendat & Piersol)](https://jmrplens.github.io/phonometry/signals/metrology/data-qualification/)
 
 ## Hearing and perception
@@ -39031,6 +39032,10 @@ What the numbers mean and how much to trust them.
 - [Calibration and dBFS](https://jmrplens.github.io/phonometry/signals/metrology/calibration/): physical SPL
   calibration from a calibrator tone (IEC 60942), the stability check it applies
   to that recording, and the digital dBFS mode.
+- [Compliance and Verification](https://jmrplens.github.io/phonometry/signals/metrology/compliance-verification/):
+  what a performance class asserts, the verifiers that grade each stage
+  against its tolerance tables, how to read the conformance report, and the
+  scope of IEC 61672-2/-3 and IEC 61260-2/-3.
 - [Measurement uncertainty (GUM and Monte Carlo)](https://jmrplens.github.io/phonometry/signals/metrology/gum-uncertainty/):
   the law of propagation of uncertainty and the Monte Carlo method of
   ISO/IEC Guide 98-3, with expanded uncertainty and coverage intervals.
@@ -39044,9 +39049,12 @@ Four things a reader reasonably expects here are absent, and each guide says so
 in its own "Not covered" block. **No instrument is verified.**
 `verify_filter_class` and `verify_weighting_class` check a designed digital
 response against the tolerance tables of IEC 61260-1 and IEC 61672-1; the
-IEC 61672-3 pattern-evaluation tests a physical meter needs for type approval,
-and the IEC 60942 conformance tests of the calibrator itself, are not run, so a
-class verdict here describes the algorithm and not a built device. **No file is
+IEC 61672-2 pattern-evaluation tests a physical meter needs for type approval,
+the IEC 61672-3 periodic tests it receives in service, and the IEC 60942
+conformance tests of the calibrator itself, are not run, so a class verdict
+here describes the algorithm and not a built device;
+[Compliance and Verification](https://jmrplens.github.io/phonometry/signals/metrology/compliance-verification/)
+draws that boundary part by part. **No file is
 opened.** Nothing in the library decodes WAV, FLAC or any other container:
 every function takes an array you have already read, which is why `fs` is
 always an argument. **No array processing.** Correlation and time delay model
@@ -40997,6 +41005,186 @@ class 1 limits per nominal frequency).
 ---
 
 
+<!-- source: docs/signals/metrology/compliance-verification.md | canonical: https://jmrplens.github.io/phonometry/signals/metrology/compliance-verification/ -->
+Source: https://jmrplens.github.io/phonometry/signals/metrology/compliance-verification/
+
+# Compliance and verification
+
+Three kinds of evidence back a number computed with this library. The
+**verifiers** are public functions that grade a filter or weighting you
+configured against the acceptance limits of its governing standard. The
+**conformance report** ([docs/CONFORMANCE.md](https://jmrplens.github.io/phonometry/reference/conformance/)) pins the
+shipped implementation to the standards' own expected values and is
+regenerated on every change. And the **scope notes** on each guide say where
+the software's claim ends and a laboratory's begins. This page is the map of
+the three.
+
+## What a performance class asserts
+
+IEC 61672-1:2013 (sound level meters) and IEC 61260-1:2014 (fractional-octave
+filters) both specify two performance categories, **class 1 and class 2**,
+and both define them the same way: the two classes share the *same design
+goals* and differ mainly in the **acceptance limits** around those goals and
+in the range of operational temperature; class 2 limits are greater than or
+equal to class 1 limits everywhere (IEC 61672-1:2013 clause 1;
+IEC 61260-1:2014 subclause 1.2).
+
+A class is therefore not a quality grade but a **worst-case error bound
+under stated conditions**, and the bound chains: a class 1 measurement needs
+every stage at class 1, from the [calibrator](https://jmrplens.github.io/phonometry/signals/metrology/calibration/) through the
+weighting to the band filter. One class 2 stage bounds the chain at class 2.
+
+Two vocabulary edges: **class 0** belongs to the withdrawn IEC 61260:1995 /
+ANSI S1.11-2004 masks, not to the 2014 edition (see
+[Filter class verification](https://jmrplens.github.io/phonometry/signals/filters/filter-compliance/)); and a class
+belongs to a specification, so the honest claim is "class 1 per
+IEC 61672-1:2013 Table 3" or "class 1 per IEC 61260-1:2014 Table 1", never
+"class 1" alone.
+
+## The verifiers: which function proves what
+
+One verifier per instrument stage, all sharing the same verdict vocabulary:
+`overall_class` (the strictest class met, or `None`), per-band margins in
+decibels to the nearest limit, and a `range_limited` flag when part of the
+standard's frequency range could not be demonstrated at your sample rate.
+
+| Stage | Verifier | Acceptance limits |
+| :--- | :--- | :--- |
+| Frequency weighting (A, C, Z) | `verify_weighting_class` | IEC 61672-1:2013 Table 3 |
+| Weightings B and AU | `verify_weighting_class` | ANSI S1.4-1983 Tables IV/V; IEC 61012:1990 Table 1 |
+| Fractional-octave filter bank | `verify_filter_class` | IEC 61260-1:2014 Table 1 (1995 mask via `edition="1995"`) |
+| Intensity instrument spectrum | `verify_intensity_class` | IEC 61043:1993 Table 2 |
+
+The masks are public too: `weighting_class_limits(1)` returns the Table 3
+corridor and `class_limits(fraction, filter_class, omega)` the Table 1 one,
+so a report can draw the limits a verdict was judged against. Verifying a
+whole chain, in the configuration the conformance suite itself pins
+(48 kHz, order 6, one-third-octave, 100 Hz to 10 kHz):
+
+```python
+from phonometry import filters
+
+wf = filters.WeightingFilter(48000, "A")
+weighting = filters.verify_weighting_class(wf)
+print(weighting["overall_class"])       # 1
+print(weighting["range_limited"])       # False
+
+bank = filters.OctaveFilterBank(fs=48000, fraction=3, order=6,
+                                limits=[100, 10000])
+bands = filters.verify_filter_class(bank)
+print(bands["overall_class"])           # 1
+print(bands["range_limited"])           # True for a decimated bank
+```
+
+Read the flags, not just the class: `range_limited` is `True` on the
+decimated bank because a band cannot be evaluated beyond its own processing
+Nyquist, so the far stopband rests on the anti-alias argument rather than on
+the band filter itself. The details, including why a +0.400 dB margin is the
+ceiling for a passing Butterworth bank, are in
+[Filter class verification](https://jmrplens.github.io/phonometry/signals/filters/filter-compliance/); the weighting
+side is section 6 of [Frequency weighting](https://jmrplens.github.io/phonometry/signals/levels/weighting/).
+
+<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/weighting_class_mask_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/weighting_class_mask.svg" alt="A and C weighting deviations at 48 kHz threading within the IEC 61672-1 Table 3 class 1 acceptance corridor, with the wider class 2 limits dotted" width="80%"></picture>
+
+When the verdict has to leave the console, `filter_class_compliance` wraps
+the same verification as a result object with `.plot()` and `.report()`, the
+one-page accredited fiche with an optional PASS/FAIL row against a required
+class; `intensity_class_compliance` does the same for the IEC 61043
+residual-index verdict:
+
+```python
+from phonometry import OctaveFilterBank, ReportMetadata, filter_class_compliance
+
+bank_11 = OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[125, 4000])
+result = filter_class_compliance(bank_11)   # result.overall_class == 1
+result.report(
+    "iec61260.pdf",
+    metadata=ReportMetadata(
+        specimen="1/1-octave filter bank",
+        measurement_standard="IEC 61260-1:2014",
+        required_class=1,
+    ),
+)                                            # -> Class 1 - COMPLIES, PASS
+```
+
+## Reading the conformance report
+
+The verifiers grade *your* configuration; the
+[conformance report](https://jmrplens.github.io/phonometry/reference/conformance/) is the complementary evidence for
+the implementation as shipped: each row pins one implemented quantity to the
+governing standard's own expected value (a worked example or a
+tolerance-table entry, not a regression baseline), with the computed value,
+the signed delta and a pass/fail verdict. It is regenerated on every pull
+request and CI fails if it drifts from the code.
+
+Use it in three ways: find the row for a metric before trusting it (the row
+names the standard, edition and clause the implementation was held to); note
+that the class rows walk one pinned configuration, so section 2's verifiers
+are how the claim transfers to your own bank; and cite the report of the
+exact library version you pinned. Defects the re-derivation exposed in the
+published standards themselves are in the [errata registry](https://jmrplens.github.io/phonometry/reference/errata/).
+
+## What only a laboratory can attest
+
+Both instrument series continue past their Part 1 with two test regimes, and
+neither is something a software library can run on itself.
+
+**Pattern evaluation** (IEC 61672-2:2013 for meters, IEC 61260-2:2016 for
+filters) is the type-approval regime a *model* passes once: the tests
+necessary to verify conformance to **all mandatory specifications** of the
+Part 1 (IEC 61672-2:2013 clause 1; IEC 61260-2:2016 subclause 1.1), on
+physical specimens — IEC 61260-2 requires at least three of them
+(subclause 4.1). That includes everything a transfer function does not have:
+static pressure, air temperature and humidity influence, electrostatic and
+radio-frequency immunity, directional response, acoustical tests of the
+weightings with the microphone in the sound field, level linearity of real
+electronics, self-generated noise, tonebursts and overload behaviour
+(IEC 61672-2:2013 clauses 7 to 9; IEC 61260-2:2016 clauses 7 to 9).
+
+**Periodic tests** (IEC 61672-3:2013, IEC 61260-3:2016) are what a *working
+instrument* receives in the laboratory every year or two, on a limited set
+of key tests "restricted to the minimum considered necessary", valid for the
+environmental conditions of the day (IEC 61672-3:2013 clause 1;
+IEC 61260-3:2016 subclauses 1.2 and 1.3). Both Part 3 scopes end with the
+same caveat: passing every periodic test supports **no general conclusion of
+conformance** to the Part 1 unless the model's pattern approval is on record
+(IEC 61672-3:2013 clause 1; IEC 61260-3:2016 subclause 1.5).
+
+The same honesty applies to this library, in both directions. A verifier
+verdict is a statement about a *design*: the digital transfer function you
+configured fits the Part 1 acceptance mask, with the reported margins, over
+the checked range; every measurement made wholly in software inherits it. It
+is *not* a pattern evaluation, a periodic test, or a certificate for any
+physical device: nothing here has a microphone, a temperature or a serial
+number, and a real front end brings its own paper — the meter's periodic
+test per IEC 61672-3 and the calibrator's conformance per IEC 60942, both
+discussed in [Calibration and dBFS](https://jmrplens.github.io/phonometry/signals/metrology/calibration/). A defensible report
+names both verdicts: the library's design verdict with the version and its
+conformance report, and the instrument's test record with its date.
+
+## Standards
+
+IEC 61672-1:2013, *Sound level meters — Part 1: Specifications*: the two
+performance categories and the Table 3 acceptance limits checked by
+`verify_weighting_class`.
+IEC 61672-2:2013 (*Pattern evaluation tests*) and IEC 61672-3:2013
+(*Periodic tests*): the instrument test regimes delimited above, not run.
+IEC 61260-1:2014, *Octave-band and fractional-octave-band filters — Part 1:
+Specifications*: the Table 1 acceptance limits checked by
+`verify_filter_class`.
+IEC 61260-2:2016 (*Pattern-evaluation tests*) and IEC 61260-3:2016
+(*Periodic tests*): the filter-set test regimes delimited above, not run.
+IEC 61043:1993, *Instruments for the measurement of sound intensity*: the
+class limits behind `verify_intensity_class`.
+
+**Not covered.** The verification mathematics of each stage belongs to that
+stage's own page; and every test of the Parts 2 and 3 themselves is
+delimited here but not performed: no environmental, immunity, acoustical or
+linearity test is run, and no physical instrument is assigned a class.
+
+---
+
+
 <!-- source: docs/signals/metrology/data-qualification.md | canonical: https://jmrplens.github.io/phonometry/signals/metrology/data-qualification/ -->
 Source: https://jmrplens.github.io/phonometry/signals/metrology/data-qualification/
 
@@ -41745,7 +41933,10 @@ A level printed by software is not yet a measurement. Three things separate
 the one from the other: knowing that the record deserves to be **averaged at
 all**, knowing what the digital samples mean **physically**, and knowing how
 much the result could reasonably be **wrong**. This section covers all three,
-and they apply transversally to every other page of the documentation.
+and they apply transversally to every other page of the documentation. A
+fourth page maps the evidence that backs the numbers: what a performance
+**class** asserts, the verifiers that grade a chain, and the published
+conformance report.
 
 [Calibration and dBFS](https://jmrplens.github.io/phonometry/signals/metrology/calibration/) handles the
 physical meaning. phonometry works in two reference frames: physical **dB
@@ -41765,6 +41956,15 @@ propagates whole probability distributions numerically and yields coverage
 intervals that stay honest when the model is non-linear or the inputs are far
 from Gaussian. The page shows both on the same models, including where they
 diverge and why.
+
+[Compliance and Verification](https://jmrplens.github.io/phonometry/signals/metrology/compliance-verification/)
+carries the evidence story: what a performance class actually claims in
+IEC 61672-1 and IEC 61260-1 (same design goals, different acceptance limits),
+which public verifier grades each stage of a measurement chain against its
+tolerance tables, how to read and cite the numerical conformance report the
+site publishes, and the honest boundary against the pattern-evaluation and
+periodic tests of IEC 61672-2/-3 and IEC 61260-2/-3, which need an
+instrument in a laboratory rather than a library.
 
 [Data qualification](https://jmrplens.github.io/phonometry/signals/metrology/data-qualification/) guards the gate
 in front of both: every average - a Leq, a Welch PSD, every averaged input
@@ -41791,6 +41991,10 @@ budgets that are specialisations of the GUM machinery described here.
 - [Calibration and dBFS](https://jmrplens.github.io/phonometry/signals/metrology/calibration/): physical SPL
   calibration from a calibrator tone, the stability check it applies to that
   recording, and the digital full-scale mode.
+- [Compliance and Verification](https://jmrplens.github.io/phonometry/signals/metrology/compliance-verification/):
+  what a performance class asserts, the verifiers that grade weightings,
+  filter banks and intensity spectra against their tolerance tables, the
+  conformance report, and the scope of IEC 61672-2/-3 and IEC 61260-2/-3.
 - [Measurement uncertainty (GUM and Monte Carlo)](https://jmrplens.github.io/phonometry/signals/metrology/gum-uncertainty/):
   the law of propagation of uncertainty and the Monte Carlo method, expanded
   uncertainty and coverage intervals.
@@ -41804,7 +42008,9 @@ Nothing here checks an instrument or a calibrator. The IEC 60942 conformance
 tests of the calibrator itself — generated level, frequency, distortion, and
 the corrections for static pressure and temperature — are not implemented, so
 pass an already corrected `target_spl` when the manual asks for one, and the
-IEC 61672-3 periodic tests are cited as laboratory practice rather than run.
+IEC 61672-3 periodic tests are cited as laboratory practice rather than run;
+[Compliance and Verification](https://jmrplens.github.io/phonometry/signals/metrology/compliance-verification/)
+draws that boundary precisely, part by part.
 The dBFS half of the calibration page sits outside any standard and makes no
 physical claim: it is a reference frame, not a measurement. Data qualification
 implements the quantitative core of Bendat & Piersol's section 10.3 only —

--- a/llms.txt
+++ b/llms.txt
@@ -82,6 +82,7 @@ If you are an AI assistant setting this up for a user: install from PyPI (no sys
 - [Overview](https://jmrplens.github.io/phonometry/signals/metrology/) · [full text](https://jmrplens.github.io/phonometry/llms/llms-signals-metrology.txt)
 - [Calibration and dBFS](https://jmrplens.github.io/phonometry/signals/metrology/calibration/)
 - [Measurement uncertainty (GUM and Monte Carlo)](https://jmrplens.github.io/phonometry/signals/metrology/gum-uncertainty/)
+- [Compliance and verification](https://jmrplens.github.io/phonometry/signals/metrology/compliance-verification/)
 - [Data qualification: stationarity, level crossings and peaks (Bendat & Piersol)](https://jmrplens.github.io/phonometry/signals/metrology/data-qualification/)
 
 ## Hearing and perception

--- a/site/public/llms/llms-signals-metrology.txt
+++ b/site/public/llms/llms-signals-metrology.txt
@@ -837,10 +837,10 @@ electronics, self-generated noise, tonebursts and overload behaviour
 (IEC 61672-2:2013 clauses 7 to 9; IEC 61260-2:2016 clauses 7 to 9).
 
 **Periodic tests** (IEC 61672-3:2013, IEC 61260-3:2016) are what a *working
-instrument* receives in the laboratory every year or two, on a limited set
-of key tests "restricted to the minimum considered necessary", valid for the
-environmental conditions of the day (IEC 61672-3:2013 clause 1;
-IEC 61260-3:2016 subclauses 1.2 and 1.3). Both Part 3 scopes end with the
+instrument* receives in the laboratory, typically every year or two, on a
+limited set of key tests "restricted to the minimum considered necessary",
+valid for the environmental conditions of the day (IEC 61672-3:2013
+clause 1; IEC 61260-3:2016 subclauses 1.2 and 1.3). Both Part 3 scopes end with the
 same caveat: passing every periodic test supports **no general conclusion of
 conformance** to the Part 1 unless the model's pattern approval is on record
 (IEC 61672-3:2013 clause 1; IEC 61260-3:2016 subclause 1.5).

--- a/site/public/llms/llms-signals-metrology.txt
+++ b/site/public/llms/llms-signals-metrology.txt
@@ -37,7 +37,7 @@ intervals that stay honest when the model is non-linear or the inputs are far
 from Gaussian. The page shows both on the same models, including where they
 diverge and why.
 
-[Compliance and Verification](https://jmrplens.github.io/phonometry/signals/metrology/compliance-verification/)
+[Compliance and verification](https://jmrplens.github.io/phonometry/signals/metrology/compliance-verification/)
 carries the evidence story: what a performance class actually claims in
 IEC 61672-1 and IEC 61260-1 (same design goals, different acceptance limits),
 which public verifier grades each stage of a measurement chain against its
@@ -71,7 +71,7 @@ budgets that are specialisations of the GUM machinery described here.
 - [Calibration and dBFS](https://jmrplens.github.io/phonometry/signals/metrology/calibration/): physical SPL
   calibration from a calibrator tone, the stability check it applies to that
   recording, and the digital full-scale mode.
-- [Compliance and Verification](https://jmrplens.github.io/phonometry/signals/metrology/compliance-verification/):
+- [Compliance and verification](https://jmrplens.github.io/phonometry/signals/metrology/compliance-verification/):
   what a performance class asserts, the verifiers that grade weightings,
   filter banks and intensity spectra against their tolerance tables, the
   conformance report, and the scope of IEC 61672-2/-3 and IEC 61260-2/-3.
@@ -89,7 +89,7 @@ tests of the calibrator itself — generated level, frequency, distortion, and
 the corrections for static pressure and temperature — are not implemented, so
 pass an already corrected `target_spl` when the manual asks for one, and the
 IEC 61672-3 periodic tests are cited as laboratory practice rather than run;
-[Compliance and Verification](https://jmrplens.github.io/phonometry/signals/metrology/compliance-verification/)
+[Compliance and verification](https://jmrplens.github.io/phonometry/signals/metrology/compliance-verification/)
 draws that boundary precisely, part by part.
 The dBFS half of the calibration page sits outside any standard and makes no
 physical claim: it is a reference frame, not a measurement. Data qualification

--- a/site/public/llms/llms-signals-metrology.txt
+++ b/site/public/llms/llms-signals-metrology.txt
@@ -13,7 +13,10 @@ A level printed by software is not yet a measurement. Three things separate
 the one from the other: knowing that the record deserves to be **averaged at
 all**, knowing what the digital samples mean **physically**, and knowing how
 much the result could reasonably be **wrong**. This section covers all three,
-and they apply transversally to every other page of the documentation.
+and they apply transversally to every other page of the documentation. A
+fourth page maps the evidence that backs the numbers: what a performance
+**class** asserts, the verifiers that grade a chain, and the published
+conformance report.
 
 [Calibration and dBFS](https://jmrplens.github.io/phonometry/signals/metrology/calibration/) handles the
 physical meaning. phonometry works in two reference frames: physical **dB
@@ -33,6 +36,15 @@ propagates whole probability distributions numerically and yields coverage
 intervals that stay honest when the model is non-linear or the inputs are far
 from Gaussian. The page shows both on the same models, including where they
 diverge and why.
+
+[Compliance and Verification](https://jmrplens.github.io/phonometry/signals/metrology/compliance-verification/)
+carries the evidence story: what a performance class actually claims in
+IEC 61672-1 and IEC 61260-1 (same design goals, different acceptance limits),
+which public verifier grades each stage of a measurement chain against its
+tolerance tables, how to read and cite the numerical conformance report the
+site publishes, and the honest boundary against the pattern-evaluation and
+periodic tests of IEC 61672-2/-3 and IEC 61260-2/-3, which need an
+instrument in a laboratory rather than a library.
 
 [Data qualification](https://jmrplens.github.io/phonometry/signals/metrology/data-qualification/) guards the gate
 in front of both: every average - a Leq, a Welch PSD, every averaged input
@@ -59,6 +71,10 @@ budgets that are specialisations of the GUM machinery described here.
 - [Calibration and dBFS](https://jmrplens.github.io/phonometry/signals/metrology/calibration/): physical SPL
   calibration from a calibrator tone, the stability check it applies to that
   recording, and the digital full-scale mode.
+- [Compliance and Verification](https://jmrplens.github.io/phonometry/signals/metrology/compliance-verification/):
+  what a performance class asserts, the verifiers that grade weightings,
+  filter banks and intensity spectra against their tolerance tables, the
+  conformance report, and the scope of IEC 61672-2/-3 and IEC 61260-2/-3.
 - [Measurement uncertainty (GUM and Monte Carlo)](https://jmrplens.github.io/phonometry/signals/metrology/gum-uncertainty/):
   the law of propagation of uncertainty and the Monte Carlo method, expanded
   uncertainty and coverage intervals.
@@ -72,7 +88,9 @@ Nothing here checks an instrument or a calibrator. The IEC 60942 conformance
 tests of the calibrator itself — generated level, frequency, distortion, and
 the corrections for static pressure and temperature — are not implemented, so
 pass an already corrected `target_spl` when the manual asks for one, and the
-IEC 61672-3 periodic tests are cited as laboratory practice rather than run.
+IEC 61672-3 periodic tests are cited as laboratory practice rather than run;
+[Compliance and Verification](https://jmrplens.github.io/phonometry/signals/metrology/compliance-verification/)
+draws that boundary precisely, part by part.
 The dBFS half of the calibration page sits outside any standard and makes no
 physical claim: it is a reference frame, not a measurement. Data qualification
 implements the quantitative core of Bendat & Piersol's section 10.3 only —
@@ -678,6 +696,186 @@ Welch–Satterthwaite effective degrees of freedom (Annex G.4). ISO/IEC
 Guide 98-3-1:2008, *Supplement 1 — Propagation of distributions using a Monte
 Carlo method*: the numerical propagation and the probabilistically symmetric
 coverage interval (clause 7).
+
+---
+
+
+<!-- source: docs/signals/metrology/compliance-verification.md | canonical: https://jmrplens.github.io/phonometry/signals/metrology/compliance-verification/ -->
+Source: https://jmrplens.github.io/phonometry/signals/metrology/compliance-verification/
+
+# Compliance and verification
+
+Three kinds of evidence back a number computed with this library. The
+**verifiers** are public functions that grade a filter or weighting you
+configured against the acceptance limits of its governing standard. The
+**conformance report** ([docs/CONFORMANCE.md](https://jmrplens.github.io/phonometry/reference/conformance/)) pins the
+shipped implementation to the standards' own expected values and is
+regenerated on every change. And the **scope notes** on each guide say where
+the software's claim ends and a laboratory's begins. This page is the map of
+the three.
+
+## What a performance class asserts
+
+IEC 61672-1:2013 (sound level meters) and IEC 61260-1:2014 (fractional-octave
+filters) both specify two performance categories, **class 1 and class 2**,
+and both define them the same way: the two classes share the *same design
+goals* and differ mainly in the **acceptance limits** around those goals and
+in the range of operational temperature; class 2 limits are greater than or
+equal to class 1 limits everywhere (IEC 61672-1:2013 clause 1;
+IEC 61260-1:2014 subclause 1.2).
+
+A class is therefore not a quality grade but a **worst-case error bound
+under stated conditions**, and the bound chains: a class 1 measurement needs
+every stage at class 1, from the [calibrator](https://jmrplens.github.io/phonometry/signals/metrology/calibration/) through the
+weighting to the band filter. One class 2 stage bounds the chain at class 2.
+
+Two vocabulary edges: **class 0** belongs to the withdrawn IEC 61260:1995 /
+ANSI S1.11-2004 masks, not to the 2014 edition (see
+[Filter class verification](https://jmrplens.github.io/phonometry/signals/filters/filter-compliance/)); and a class
+belongs to a specification, so the honest claim is "class 1 per
+IEC 61672-1:2013 Table 3" or "class 1 per IEC 61260-1:2014 Table 1", never
+"class 1" alone.
+
+## The verifiers: which function proves what
+
+One verifier per instrument stage, all sharing the same verdict vocabulary:
+`overall_class` (the strictest class met, or `None`), per-band margins in
+decibels to the nearest limit, and a `range_limited` flag when part of the
+standard's frequency range could not be demonstrated at your sample rate.
+
+| Stage | Verifier | Acceptance limits |
+| :--- | :--- | :--- |
+| Frequency weighting (A, C, Z) | `verify_weighting_class` | IEC 61672-1:2013 Table 3 |
+| Weightings B and AU | `verify_weighting_class` | ANSI S1.4-1983 Tables IV/V; IEC 61012:1990 Table 1 |
+| Fractional-octave filter bank | `verify_filter_class` | IEC 61260-1:2014 Table 1 (1995 mask via `edition="1995"`) |
+| Intensity instrument spectrum | `verify_intensity_class` | IEC 61043:1993 Table 2 |
+
+The masks are public too: `weighting_class_limits(1)` returns the Table 3
+corridor and `class_limits(fraction, filter_class, omega)` the Table 1 one,
+so a report can draw the limits a verdict was judged against. Verifying a
+whole chain, in the configuration the conformance suite itself pins
+(48 kHz, order 6, one-third-octave, 100 Hz to 10 kHz):
+
+```python
+from phonometry import filters
+
+wf = filters.WeightingFilter(48000, "A")
+weighting = filters.verify_weighting_class(wf)
+print(weighting["overall_class"])       # 1
+print(weighting["range_limited"])       # False
+
+bank = filters.OctaveFilterBank(fs=48000, fraction=3, order=6,
+                                limits=[100, 10000])
+bands = filters.verify_filter_class(bank)
+print(bands["overall_class"])           # 1
+print(bands["range_limited"])           # True for a decimated bank
+```
+
+Read the flags, not just the class: `range_limited` is `True` on the
+decimated bank because a band cannot be evaluated beyond its own processing
+Nyquist, so the far stopband rests on the anti-alias argument rather than on
+the band filter itself. The details, including why a +0.400 dB margin is the
+ceiling for a passing Butterworth bank, are in
+[Filter class verification](https://jmrplens.github.io/phonometry/signals/filters/filter-compliance/); the weighting
+side is section 6 of [Frequency weighting](https://jmrplens.github.io/phonometry/signals/levels/weighting/).
+
+<picture><source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/weighting_class_mask_dark.svg"><img src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/weighting_class_mask.svg" alt="A and C weighting deviations at 48 kHz threading within the IEC 61672-1 Table 3 class 1 acceptance corridor, with the wider class 2 limits dotted" width="80%"></picture>
+
+When the verdict has to leave the console, `filter_class_compliance` wraps
+the same verification as a result object with `.plot()` and `.report()`, the
+one-page accredited fiche with an optional PASS/FAIL row against a required
+class; `intensity_class_compliance` does the same for the IEC 61043
+residual-index verdict:
+
+```python
+from phonometry import OctaveFilterBank, ReportMetadata, filter_class_compliance
+
+bank_11 = OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[125, 4000])
+result = filter_class_compliance(bank_11)   # result.overall_class == 1
+result.report(
+    "iec61260.pdf",
+    metadata=ReportMetadata(
+        specimen="1/1-octave filter bank",
+        measurement_standard="IEC 61260-1:2014",
+        required_class=1,
+    ),
+)                                            # -> Class 1 - COMPLIES, PASS
+```
+
+## Reading the conformance report
+
+The verifiers grade *your* configuration; the
+[conformance report](https://jmrplens.github.io/phonometry/reference/conformance/) is the complementary evidence for
+the implementation as shipped: each row pins one implemented quantity to the
+governing standard's own expected value (a worked example or a
+tolerance-table entry, not a regression baseline), with the computed value,
+the signed delta and a pass/fail verdict. It is regenerated on every pull
+request and CI fails if it drifts from the code.
+
+Use it in three ways: find the row for a metric before trusting it (the row
+names the standard, edition and clause the implementation was held to); note
+that the class rows walk one pinned configuration, so section 2's verifiers
+are how the claim transfers to your own bank; and cite the report of the
+exact library version you pinned. Defects the re-derivation exposed in the
+published standards themselves are in the [errata registry](https://jmrplens.github.io/phonometry/reference/errata/).
+
+## What only a laboratory can attest
+
+Both instrument series continue past their Part 1 with two test regimes, and
+neither is something a software library can run on itself.
+
+**Pattern evaluation** (IEC 61672-2:2013 for meters, IEC 61260-2:2016 for
+filters) is the type-approval regime a *model* passes once: the tests
+necessary to verify conformance to **all mandatory specifications** of the
+Part 1 (IEC 61672-2:2013 clause 1; IEC 61260-2:2016 subclause 1.1), on
+physical specimens — IEC 61260-2 requires at least three of them
+(subclause 4.1). That includes everything a transfer function does not have:
+static pressure, air temperature and humidity influence, electrostatic and
+radio-frequency immunity, directional response, acoustical tests of the
+weightings with the microphone in the sound field, level linearity of real
+electronics, self-generated noise, tonebursts and overload behaviour
+(IEC 61672-2:2013 clauses 7 to 9; IEC 61260-2:2016 clauses 7 to 9).
+
+**Periodic tests** (IEC 61672-3:2013, IEC 61260-3:2016) are what a *working
+instrument* receives in the laboratory every year or two, on a limited set
+of key tests "restricted to the minimum considered necessary", valid for the
+environmental conditions of the day (IEC 61672-3:2013 clause 1;
+IEC 61260-3:2016 subclauses 1.2 and 1.3). Both Part 3 scopes end with the
+same caveat: passing every periodic test supports **no general conclusion of
+conformance** to the Part 1 unless the model's pattern approval is on record
+(IEC 61672-3:2013 clause 1; IEC 61260-3:2016 subclause 1.5).
+
+The same honesty applies to this library, in both directions. A verifier
+verdict is a statement about a *design*: the digital transfer function you
+configured fits the Part 1 acceptance mask, with the reported margins, over
+the checked range; every measurement made wholly in software inherits it. It
+is *not* a pattern evaluation, a periodic test, or a certificate for any
+physical device: nothing here has a microphone, a temperature or a serial
+number, and a real front end brings its own paper — the meter's periodic
+test per IEC 61672-3 and the calibrator's conformance per IEC 60942, both
+discussed in [Calibration and dBFS](https://jmrplens.github.io/phonometry/signals/metrology/calibration/). A defensible report
+names both verdicts: the library's design verdict with the version and its
+conformance report, and the instrument's test record with its date.
+
+## Standards
+
+IEC 61672-1:2013, *Sound level meters — Part 1: Specifications*: the two
+performance categories and the Table 3 acceptance limits checked by
+`verify_weighting_class`.
+IEC 61672-2:2013 (*Pattern evaluation tests*) and IEC 61672-3:2013
+(*Periodic tests*): the instrument test regimes delimited above, not run.
+IEC 61260-1:2014, *Octave-band and fractional-octave-band filters — Part 1:
+Specifications*: the Table 1 acceptance limits checked by
+`verify_filter_class`.
+IEC 61260-2:2016 (*Pattern-evaluation tests*) and IEC 61260-3:2016
+(*Periodic tests*): the filter-set test regimes delimited above, not run.
+IEC 61043:1993, *Instruments for the measurement of sound intensity*: the
+class limits behind `verify_intensity_class`.
+
+**Not covered.** The verification mathematics of each stage belongs to that
+stage's own page; and every test of the Parts 2 and 3 themselves is
+delimited here but not performed: no environmental, immunity, acoustical or
+linearity test is run, and no physical instrument is assigned a class.
 
 ---
 

--- a/site/public/llms/llms-signals.txt
+++ b/site/public/llms/llms-signals.txt
@@ -161,7 +161,7 @@ What the numbers mean and how much to trust them.
 - [Calibration and dBFS](https://jmrplens.github.io/phonometry/signals/metrology/calibration/): physical SPL
   calibration from a calibrator tone (IEC 60942), the stability check it applies
   to that recording, and the digital dBFS mode.
-- [Compliance and Verification](https://jmrplens.github.io/phonometry/signals/metrology/compliance-verification/):
+- [Compliance and verification](https://jmrplens.github.io/phonometry/signals/metrology/compliance-verification/):
   what a performance class asserts, the verifiers that grade each stage
   against its tolerance tables, how to read the conformance report, and the
   scope of IEC 61672-2/-3 and IEC 61260-2/-3.
@@ -182,7 +182,7 @@ IEC 61672-2 pattern-evaluation tests a physical meter needs for type approval,
 the IEC 61672-3 periodic tests it receives in service, and the IEC 60942
 conformance tests of the calibrator itself, are not run, so a class verdict
 here describes the algorithm and not a built device;
-[Compliance and Verification](https://jmrplens.github.io/phonometry/signals/metrology/compliance-verification/)
+[Compliance and verification](https://jmrplens.github.io/phonometry/signals/metrology/compliance-verification/)
 draws that boundary part by part. **No file is
 opened.** Nothing in the library decodes WAV, FLAC or any other container:
 every function takes an array you have already read, which is why `fs` is

--- a/site/public/llms/llms-signals.txt
+++ b/site/public/llms/llms-signals.txt
@@ -161,6 +161,10 @@ What the numbers mean and how much to trust them.
 - [Calibration and dBFS](https://jmrplens.github.io/phonometry/signals/metrology/calibration/): physical SPL
   calibration from a calibrator tone (IEC 60942), the stability check it applies
   to that recording, and the digital dBFS mode.
+- [Compliance and Verification](https://jmrplens.github.io/phonometry/signals/metrology/compliance-verification/):
+  what a performance class asserts, the verifiers that grade each stage
+  against its tolerance tables, how to read the conformance report, and the
+  scope of IEC 61672-2/-3 and IEC 61260-2/-3.
 - [Measurement uncertainty (GUM and Monte Carlo)](https://jmrplens.github.io/phonometry/signals/metrology/gum-uncertainty/):
   the law of propagation of uncertainty and the Monte Carlo method of
   ISO/IEC Guide 98-3, with expanded uncertainty and coverage intervals.
@@ -174,9 +178,12 @@ Four things a reader reasonably expects here are absent, and each guide says so
 in its own "Not covered" block. **No instrument is verified.**
 `verify_filter_class` and `verify_weighting_class` check a designed digital
 response against the tolerance tables of IEC 61260-1 and IEC 61672-1; the
-IEC 61672-3 pattern-evaluation tests a physical meter needs for type approval,
-and the IEC 60942 conformance tests of the calibrator itself, are not run, so a
-class verdict here describes the algorithm and not a built device. **No file is
+IEC 61672-2 pattern-evaluation tests a physical meter needs for type approval,
+the IEC 61672-3 periodic tests it receives in service, and the IEC 60942
+conformance tests of the calibrator itself, are not run, so a class verdict
+here describes the algorithm and not a built device;
+[Compliance and Verification](https://jmrplens.github.io/phonometry/signals/metrology/compliance-verification/)
+draws that boundary part by part. **No file is
 opened.** Nothing in the library decodes WAV, FLAC or any other container:
 every function takes an array you have already read, which is why `fs` is
 always an argument. **No array processing.** Correlation and time delay model

--- a/site/src/content/docs/es/signals/index.md
+++ b/site/src/content/docs/es/signals/index.md
@@ -167,6 +167,10 @@ Qué significan los números y cuánto fiarse de ellos.
 - [Calibración y dBFS](/phonometry/es/signals/metrology/calibration/): calibración SPL
   física a partir de un tono de calibrador (IEC 60942), la comprobación de
   estabilidad que aplica a esa grabación, y el modo digital dBFS.
+- [Conformidad y verificación](/phonometry/es/signals/metrology/compliance-verification/):
+  qué afirma una clase de prestaciones, los verificadores que califican cada
+  etapa frente a sus tablas de tolerancias, cómo leer el informe de
+  conformidad, y el alcance de IEC 61672-2/-3 e IEC 61260-2/-3.
 - [Incertidumbre de medida (GUM y Monte Carlo)](/phonometry/es/signals/metrology/gum-uncertainty/):
   la ley de propagación de la incertidumbre y el método de Monte Carlo de
   ISO/IEC Guide 98-3, con incertidumbre expandida e intervalos de cobertura.
@@ -181,10 +185,13 @@ Faltan cuatro cosas que un lector espera razonablemente encontrar aquí, y cada
 guía lo dice en su propio bloque «No cubierto». **Aquí no se verifica ningún
 instrumento.** `verify_filter_class` y `verify_weighting_class` comprueban una
 respuesta digital diseñada frente a las tablas de tolerancias de IEC 61260-1 y
-de IEC 61672-1; los ensayos de evaluación de patrón de IEC 61672-3 que un
-sonómetro físico necesita para su aprobación de tipo, y los ensayos de
-conformidad del propio calibrador de IEC 60942, no se ejecutan, así que un
-veredicto de clase de aquí describe el algoritmo y no un aparato construido.
+de IEC 61672-1; los ensayos de tipo de IEC 61672-2 que un sonómetro físico
+necesita para su aprobación de tipo, los ensayos periódicos de IEC 61672-3
+que recibe en servicio, y los ensayos de conformidad del propio calibrador de
+IEC 60942, no se ejecutan, así que un veredicto de clase de aquí describe el
+algoritmo y no un aparato construido;
+[Conformidad y verificación](/phonometry/es/signals/metrology/compliance-verification/)
+traza esa frontera parte por parte.
 **Aquí no se abre ningún archivo.** Nada en la biblioteca decodifica WAV, FLAC
 ni ningún otro contenedor: toda función toma un array que ya has leído, que es
 la razón de que `fs` sea siempre un argumento. **Aquí no hay procesado de

--- a/site/src/content/docs/es/signals/metrology/compliance-verification.mdx
+++ b/site/src/content/docs/es/signals/metrology/compliance-verification.mdx
@@ -43,7 +43,7 @@ references:
     title: "Electroacoustics — Octave-band and fractional-octave-band filters — Part 3: Periodic tests"
     designation: "IEC 61260-3:2016"
     url: "https://webstore.iec.ch/en/publication/24561"
-    note: "Los ensayos periódicos de un analizador en servicio: atenuación relativa en el centro de banda o desviación del ancho de banda efectivo, el rango lineal de funcionamiento con su control de rango de nivel e indicador de sobrecarga, y el límite inferior de ese rango."
+    note: "Los ensayos periódicos de un analizador en servicio: atenuación relativa en el centro de banda o desviación del ancho de banda efectivo, el rango lineal de funcionamiento con su control de rango de nivel e indicador de sobrecarga, el límite inferior de ese rango, y el ensayo de atenuación relativa del apartado 13 en las frecuencias normalizadas de la Tabla 1 sobre tres filtros seleccionados."
   - type: standard
     organization: "International Electrotechnical Commission"
     year: 1993
@@ -276,9 +276,10 @@ Tres hábitos lo vuelven útil en lugar de decorativo:
   sometió la implementación, que es exactamente la cita que necesita un
   informe.
 - **Fíjate en la configuración de las filas de clase.** La sección de
-  filtros y ponderaciones recorre las cinco arquitecturas de filtro y las
-  curvas de ponderación con los mismos verificadores que documenta esta
-  página, en una configuración anclada: orden 6, tercio de octava, 100 Hz a
+  filtros y ponderaciones recorre las
+  [cinco arquitecturas de filtro](/phonometry/es/signals/filters/filter-gallery/)
+  y las curvas de ponderación con los mismos verificadores que documenta
+  esta página, en una configuración anclada: orden 6, tercio de octava, 100 Hz a
   10 kHz, 48 kHz. El informe demuestra la implementación; para cualquier
   otra fracción, orden o frecuencia de muestreo, la sección 2 es cómo se
   traslada la afirmación a *tu* banco.
@@ -319,16 +320,19 @@ sobrecarga (IEC 61672-2:2013, apartados 7 a 9; IEC 61260-2:2016, apartados
 7 a 9).
 
 Los **ensayos periódicos** (IEC 61672-3:2013, IEC 61260-3:2016) son lo que
-recibe en laboratorio un *instrumento en servicio* cada año o dos. Su
+recibe en laboratorio un *instrumento en servicio*, normalmente cada año o
+dos. Su
 alcance es deliberadamente lo contrario de exhaustivo: un conjunto limitado
 de ensayos clave, válido para las condiciones ambientales del día,
 «restringido al mínimo considerado necesario» (IEC 61672-3:2013, apartado 1;
 IEC 61260-3:2016, apartados 1.2 y 1.3). Para un juego de filtros eso
 significa la atenuación relativa en la frecuencia central de cada filtro o
 la desviación del ancho de banda efectivo, el rango lineal de funcionamiento
-con su control de rango de nivel e indicador de sobrecarga, y el límite
-inferior de ese rango (IEC 61260-3:2016, apartados 10 a 12); para un
-sonómetro, la comprobación con calibrador, el ruido autogenerado, las
+con su control de rango de nivel e indicador de sobrecarga, el límite
+inferior de ese rango, y un ensayo de atenuación relativa en las frecuencias
+normalizadas de la propia Tabla 1 de la norma sobre los tres filtros
+seleccionados para los ensayos de linealidad (IEC 61260-3:2016, apartados
+10 a 13); para un sonómetro, la comprobación con calibrador, el ruido autogenerado, las
 ponderaciones con señales acústicas y eléctricas, la linealidad, las ráfagas
 tonales, el pico con ponderación C y la sobrecarga (IEC 61672-3:2013,
 apartados 9 a 21). Los dos alcances de la Parte 3 terminan con la misma

--- a/site/src/content/docs/es/signals/metrology/compliance-verification.mdx
+++ b/site/src/content/docs/es/signals/metrology/compliance-verification.mdx
@@ -1,0 +1,442 @@
+---
+title: "Conformidad y verificación"
+description: "Qué afirma una clase de prestaciones según IEC 61672-1 e IEC 61260-1, los verificadores públicos que califican una cadena diseñada frente a las tablas de tolerancias, cómo leer el informe de conformidad publicado, y la frontera honesta que trazan las partes de ensayo de tipo y de ensayos periódicos que solo un laboratorio puede ejecutar."
+references:
+  - type: standard
+    organization: "International Electrotechnical Commission"
+    year: 2013
+    title: "Electroacoustics — Sound level meters — Part 1: Specifications"
+    designation: "IEC 61672-1:2013"
+    url: "https://webstore.iec.ch/en/publication/5708"
+    note: "Las dos categorías de prestaciones del apartado 1 (mismos objetivos de diseño, distintos límites de aceptación y rango de temperatura de funcionamiento) y los límites de aceptación de las ponderaciones frecuenciales de la Tabla 3 que comprueba verify_weighting_class."
+  - type: standard
+    organization: "International Electrotechnical Commission"
+    year: 2013
+    title: "Electroacoustics — Sound level meters — Part 2: Pattern evaluation tests"
+    designation: "IEC 61672-2:2013"
+    url: "https://webstore.iec.ch/en/publication/5709"
+    note: "El régimen completo de aprobación de tipo de un sonómetro físico: todas las especificaciones obligatorias de la Parte 1, incluidos los ensayos de influencia ambiental, electrostática y de radiofrecuencia, ejercidos sobre especímenes presentados. Nada de esta página lo realiza."
+  - type: standard
+    organization: "International Electrotechnical Commission"
+    year: 2013
+    title: "Electroacoustics — Sound level meters — Part 3: Periodic tests"
+    designation: "IEC 61672-3:2013"
+    url: "https://webstore.iec.ch/en/publication/5710"
+    note: "El conjunto deliberadamente restringido de ensayos clave que recibe en laboratorio un sonómetro en servicio, y la salvedad del apartado 1: los resultados periódicos por sí solos no sostienen ninguna conclusión general de conformidad. Se cita aquí como modelo de lo que un veredicto de clase no dice."
+  - type: standard
+    organization: "International Electrotechnical Commission"
+    year: 2014
+    title: "Electroacoustics — Octave-band and fractional-octave-band filters — Part 1: Specifications"
+    designation: "IEC 61260-1:2014"
+    url: "https://webstore.iec.ch/en/publication/5063"
+    note: "Los límites de aceptación de atenuación relativa de clase 1 / clase 2 de la Tabla 1 que comprueba verify_filter_class, y la declaración del apartado 1.2 de qué separa las dos clases."
+  - type: standard
+    organization: "International Electrotechnical Commission"
+    year: 2016
+    title: "Electroacoustics — Octave-band and fractional-octave-band filters — Part 2: Pattern-evaluation tests"
+    designation: "IEC 61260-2:2016"
+    url: "https://webstore.iec.ch/en/publication/24560"
+    note: "El régimen de ensayo de tipo de un juego de filtros físico: al menos tres especímenes presentados, el recorrido completo de la Tabla 1, linealidad, compatibilidad electromagnética y sensibilidad climática. Nada de esta página lo realiza."
+  - type: standard
+    organization: "International Electrotechnical Commission"
+    year: 2016
+    title: "Electroacoustics — Octave-band and fractional-octave-band filters — Part 3: Periodic tests"
+    designation: "IEC 61260-3:2016"
+    url: "https://webstore.iec.ch/en/publication/24561"
+    note: "Los ensayos periódicos de un analizador en servicio: atenuación relativa en el centro de banda o desviación del ancho de banda efectivo, el rango lineal de funcionamiento con su control de rango de nivel e indicador de sobrecarga, y el límite inferior de ese rango."
+  - type: standard
+    organization: "International Electrotechnical Commission"
+    year: 1993
+    title: "Electroacoustics — Instruments for the measurement of sound intensity — Measurements with pairs of pressure sensing microphones"
+    designation: "IEC 61043:1993"
+    url: "https://webstore.iec.ch/en/publication/4353"
+    note: "Los límites de clase sobre el índice de intensidad residual de presión detrás de verify_intensity_class, la tercera familia de verificadores que inventaría esta página."
+---
+
+import ThemeImage from '../../../../../components/ThemeImage.astro';
+import ReportPreview from '../../../../../components/ReportPreview.astro';
+import { totalChecks, domains, standards } from '../../../../../data/conformance-stats.mjs';
+
+Tres clases de evidencia respaldan un número calculado con esta biblioteca, y
+viven en páginas distintas. Los **verificadores** son funciones públicas que
+califican un filtro o una ponderación que tú configuraste frente a los
+límites de aceptación de su norma de referencia. El **informe de
+conformidad** es la tabla publicada de {totalChecks} comprobaciones que ancla
+la implementación distribuida a los valores esperados de las propias normas,
+regenerada con cada cambio. Y las **notas de alcance** de cada guía dicen
+dónde termina la afirmación del software y dónde empieza la del laboratorio.
+Esta página es el mapa de las tres: qué afirma realmente una clase de
+prestaciones, qué función verifica qué, cómo leer el informe, y exactamente
+qué partes de las series IEC 61672 e IEC 61260 puede y no puede reclamar una
+biblioteca.
+
+## 1. Qué afirma una clase de prestaciones
+
+IEC 61672-1:2013 (sonómetros) e IEC 61260-1:2014 (filtros de banda de octava
+y de fracción de octava) especifican ambas **dos categorías de prestaciones,
+clase 1 y clase 2**, y ambas las definen igual: la clase 1 y la clase 2
+comparten los *mismos objetivos de diseño* y difieren sobre todo en los
+**límites de aceptación** alrededor de esos objetivos y en el rango de
+temperatura de funcionamiento; los límites de clase 2 son mayores o iguales
+que los de clase 1 en todas partes (IEC 61672-1:2013, apartado 1;
+IEC 61260-1:2014, apartado 1.2).
+
+Así que una clase no es una nota de calidad de la lectura. Es una **cota de
+error de peor caso bajo condiciones declaradas**: una ponderación A de
+clase 1 puede desviarse de la respuesta objetivo en 1 kHz como mucho
+±0,7 dB, una de clase 2 ±1,0 dB, y cada banda de un filtro de tercio de
+octava de clase 1 lee un tono centrado en la banda a menos de ±0,4 dB de su
+nivel verdadero. La cota es lo que se encadena: una medición de clase 1
+necesita que todas las etapas sostengan la clase 1, desde el
+[calibrador](/phonometry/es/signals/metrology/calibration/) pasando por la
+ponderación hasta el filtro de banda, porque la tolerancia de cada etapa
+entra en el nivel que entrega a la siguiente. Una sola etapa de clase 2
+acota la cadena en clase 2, atestigüe lo que atestigüe el resto.
+
+Dos bordes del vocabulario conviene fijarlos antes de verificar nada:
+
+- **La clase 0 no es una clase de 2014.** La clase de filtro más estricta
+  pertenece a las máscaras retiradas de IEC 61260:1995 / ANSI S1.11-2004;
+  IEC 61260-1:2014 define solo las clases 1 y 2. Los verificadores mantienen
+  viva la máscara antigua tras `edition="1995"`, y
+  [Verificación de clase de filtros](/phonometry/es/signals/filters/filter-compliance/#2-clase-0-iec-612601995--ansi-s111-2004)
+  cubre cuándo es honesta una afirmación de clase 0 y cómo citarla.
+- **Una clase pertenece a una especificación, no a un número.** «Clase 1» a
+  secas no dice nada; la afirmación es «clase 1 según la Tabla 3 de
+  IEC 61672-1:2013» o «clase 1 según la Tabla 1 de IEC 61260-1:2014», y las
+  dos máscaras son objetos distintos comprobados por funciones distintas,
+  que es la sección siguiente.
+
+## 2. Los verificadores: qué función demuestra qué
+
+La biblioteca expone un verificador por etapa de instrumento. Cada uno
+comprueba un diseño que tú configuraste, banda a banda o frecuencia a
+frecuencia, frente a los límites de aceptación transcritos de la norma de
+referencia, y cada uno devuelve el mismo vocabulario de veredicto: un
+`overall_class` (la clase más estricta cumplida, o `None`), márgenes por
+banda en decibelios hasta el límite más cercano, y una bandera
+`range_limited` cuando parte del rango de frecuencias de la norma no pudo
+demostrarse a tu frecuencia de muestreo.
+
+| Etapa | Verificador | Límites de aceptación | En detalle |
+| :--- | :--- | :--- | :--- |
+| Ponderación frecuencial (A, C, Z) | `verify_weighting_class` | IEC 61672-1:2013, Tabla 3 | [Ponderación frecuencial, sección 6](/phonometry/es/signals/levels/weighting/#6-verificación-frente-a-las-tablas-de-tolerancias-iec-61672-1) |
+| Ponderaciones B y AU | `verify_weighting_class` | ANSI S1.4-1983, Tablas IV/V; IEC 61012:1990, Tabla 1 | [Ponderaciones especiales](/phonometry/es/signals/levels/special-weightings/) |
+| Banco de filtros de fracción de octava | `verify_filter_class` | IEC 61260-1:2014, Tabla 1 (máscara de 1995 vía `edition="1995"`) | [Verificación de clase de filtros](/phonometry/es/signals/filters/filter-compliance/) |
+| Espectro de instrumento de intensidad | `verify_intensity_class` | IEC 61043:1993, Tabla 2 | [Intensidad acústica](/phonometry/es/devices/emission/intensity/) |
+
+Las propias máscaras también son públicas: `weighting_class_limits(1)`
+devuelve las 34 frecuencias nominales de la Tabla 3 con los límites de
+desviación de clase 1, y `class_limits(fraction, filter_class, omega)`
+devuelve el corredor de atenuación relativa de la Tabla 1, de modo que un
+informe puede dibujar los mismos límites con los que se juzgó el veredicto.
+
+Verificar una cadena de medición completa son dos llamadas. La configuración
+de abajo es la que ancla el propio banco de conformidad, una cadena a
+48 kHz con el banco Butterworth de orden 6 por defecto entre 100 Hz y
+10 kHz:
+
+```python
+from phonometry import filters
+
+wf = filters.WeightingFilter(48000, "A")
+weighting = filters.verify_weighting_class(wf)
+print(weighting["overall_class"])       # 1
+print(weighting["range_limited"])       # False
+
+bank = filters.OctaveFilterBank(fs=48000, fraction=3, order=6,
+                                limits=[100, 10000])
+bands = filters.verify_filter_class(bank)
+print(bands["overall_class"])           # 1
+print(bands["range_limited"])           # True en un banco diezmado
+```
+
+Lee las banderas, no solo la clase. `range_limited` en el banco es `True`
+porque una banda diezmada no puede evaluarse más allá de su propio Nyquist
+de proceso, así que la banda atenuada lejana descansa en el argumento del
+antialias y no en el propio filtro de banda; la ponderación a 48 kHz
+comprueba las 34 frecuencias nominales e informa `False`. Los márgenes dicen
+cuánto le faltó al veredicto:
+
+```python
+worst = min(bands["bands"], key=lambda b: b["margin_class1_db"])
+print(round(worst["margin_class1_db"], 3))   # 0.4
+print(weighting["bands"][20])
+# {'freq': 1000.0, 'class': 1, 'deviation_db': 0.0, 'margin_class1_db': 0.7, 'margin_class2_db': 1.0}
+```
+
+Un margen de +0,400 dB en un banco Butterworth que cumple es la propia
+semianchura del corredor de banda de paso, lo mejor que puede informar un
+diseño conforme, no un resultado que mejorar;
+[Verificación de clase de filtros](/phonometry/es/signals/filters/filter-compliance/#1-verificar-la-clase-frente-a-iec-61260-12014)
+explica qué restricción manda y por qué subir el orden deja de ayudar en
+cuanto el veredicto se vuelve positivo.
+
+<ThemeImage src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/weighting_class_mask_es.svg" alt="Desviaciones de las ponderaciones A y C a 48 kHz dentro del corredor de aceptación de clase 1 de la Tabla 3 de IEC 61672-1, con los límites más amplios de clase 2 punteados" width="80%" />
+
+*Lo que comprueba de verdad un verificador, dibujado para las ponderaciones:
+la desviación de la respuesta diseñada respecto del objetivo de diseño
+(marcadores) debe quedarse dentro del corredor de clase 1 (sombreado) en
+cada frecuencia nominal. El equivalente para bancos de filtros, un corredor
+de atenuación relativa alrededor de cada frecuencia central, está dibujado
+en [Verificación de clase de filtros](/phonometry/es/signals/filters/filter-compliance/).*
+
+<details>
+<summary>Muestra el código de esta figura</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+
+freqs, lower1, upper1 = filters.weighting_class_limits(1)
+_, lower2, upper2 = filters.weighting_class_limits(2)
+lo1, lo2 = np.clip(lower1, -7, 7), np.clip(lower2, -7, 7)
+
+fig, ax = plt.subplots(figsize=(10, 6.5))
+ax.fill_between(freqs, lo1, upper1, step="mid", alpha=0.10,
+                label="Región de aceptación de clase 1")
+ax.plot(freqs, upper1, drawstyle="steps-mid",
+        label="Límite superior/inferior de clase 1")
+ax.plot(freqs, lo1, drawstyle="steps-mid", color="C1")
+ax.plot(freqs, upper2, ":", drawstyle="steps-mid",
+        label="Límite superior/inferior de clase 2")
+ax.plot(freqs, lo2, ":", drawstyle="steps-mid", color="C2")
+
+for curve, marker in (("A", "o"), ("C", "s")):
+    verdict = filters.verify_weighting_class(filters.WeightingFilter(48000, curve))
+    f = [b["freq"] for b in verdict["bands"]]
+    dev = [b["deviation_db"] for b in verdict["bands"]]
+    ax.plot(f, dev, marker=marker,
+            label=f"Desviación de la ponderación {curve} (48 kHz)")
+
+ax.set(xscale="log", xlim=(10, 20000), ylim=(-7, 7),
+       xlabel="Frecuencia [Hz]",
+       ylabel="Desviación respecto del objetivo [dB]")
+ax.legend(fontsize=8, ncol=2)
+plt.show()
+```
+
+</details>
+
+Cuando el veredicto tiene que salir de la consola, `filter_class_compliance`
+envuelve la misma verificación en un objeto resultado con `.plot()` (la
+banda de peor margen dibujada sobre su corredor de clase) y `.report()`, la
+ficha acreditada de una página con una fila opcional de CUMPLE/NO CUMPLE
+frente a una clase exigida:
+
+```python
+from phonometry import OctaveFilterBank, ReportMetadata, filter_class_compliance
+
+bank = OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[125, 4000])
+result = filter_class_compliance(bank)   # result.overall_class == 1
+result.report(
+    "iec61260_es.pdf",
+    metadata=ReportMetadata(
+        specimen="Banco de filtros de 1/1 de octava",
+        measurement_standard="IEC 61260-1:2014",
+        required_class=1,
+    ),
+    language="es",
+)                                        # -> Clase 1 - CUMPLE
+```
+
+<ReportPreview
+	name="iec61260_filter_example"
+	title="Informe de ejemplo de conformidad de clase de filtro IEC 61260-1 (PDF)"
+	description="Ficha de conformidad de clase de filtro de una página: una cabecera de metadatos, una tabla de clasificación por bandas con la clase alcanzada y el margen vinculante de cada banda de octava, la atenuación relativa medida de la banda de peor margen superpuesta sobre el corredor de aceptación verde de clase 1, el resultado encuadrado Class 1 - COMPLIES (margin +0.40 dB) y un veredicto CUMPLE frente a la clase 1 exigida."
+	caption="El veredicto como documento: la ficha declara la clase alcanzada por banda, el margen vinculante y el corredor con el que se juzgó, que es todo lo que la sección 4 dice que puede afirmar una declaración a nivel de diseño."
+/>
+
+El verificador de intensidad sigue el mismo patrón un dominio más allá:
+`verify_intensity_class` califica un espectro medido del índice de
+intensidad residual de presión frente a los límites de clase de IEC 61043, y
+`intensity_class_compliance` lo envuelve con `.plot()` y su propia ficha,
+con la física del índice residual explicada en
+[Intensidad acústica](/phonometry/es/devices/emission/intensity/).
+
+## 3. Leer el informe de conformidad
+
+Los verificadores califican *tu* configuración. El
+[informe de conformidad](/phonometry/es/reference/conformance/) es la
+evidencia complementaria: {totalChecks} comprobaciones numéricas a través de
+{domains} dominios y {standards} normas, cada fila anclando una magnitud
+implementada al valor esperado de la propia norma de referencia, con el
+valor calculado, la diferencia con signo y un veredicto de pasa/falla al
+lado. Se regenera con cada pull request y la construcción falla si deriva
+respecto del código, así que la tabla publicada siempre describe la
+biblioteca tal como se distribuye.
+
+Tres hábitos lo vuelven útil en lugar de decorativo:
+
+- **Encuentra la fila antes de fiarte de la función.** Cada tabla es
+  `Standard | Quantity | Expected | Computed | Delta | Status`, agrupada por
+  dominio, y el valor esperado es el ejemplo resuelto o la entrada de la
+  tabla de tolerancias de la norma, no una línea base de regresión. La fila
+  de una métrica de la que dependes te dice a qué apartado de qué edición se
+  sometió la implementación, que es exactamente la cita que necesita un
+  informe.
+- **Fíjate en la configuración de las filas de clase.** La sección de
+  filtros y ponderaciones recorre las cinco arquitecturas de filtro y las
+  curvas de ponderación con los mismos verificadores que documenta esta
+  página, en una configuración anclada: orden 6, tercio de octava, 100 Hz a
+  10 kHz, 48 kHz. El informe demuestra la implementación; para cualquier
+  otra fracción, orden o frecuencia de muestreo, la sección 2 es cómo se
+  traslada la afirmación a *tu* banco.
+- **Cita la versión que se ejecutó.** El informe describe la versión exacta
+  de la biblioteca que lo generó, así que una cita defendible fija la
+  versión y cita el informe de esa versión, como detalla
+  [Sobre este proyecto](/phonometry/es/start/about/).
+
+Donde rederivar una norma tan de cerca ha destapado defectos en los propios
+documentos publicados, la evidencia vive en el
+[registro de erratas](/phonometry/es/reference/errata/), que el informe
+enlaza fila a fila donde aplica.
+
+## 4. Qué solo puede atestiguar un laboratorio
+
+Las dos series de instrumentos continúan más allá de su Parte 1 con dos
+regímenes de ensayo, y ninguno de los dos es algo que una biblioteca de
+software pueda ejecutar sobre sí misma. La delimitación de abajo está
+verificada contra los cuatro documentos; el resumen de una línea es que **la
+biblioteca comprueba diseños frente a los límites de aceptación de la
+Parte 1, mientras que las Partes 2 y 3 comprueban instrumentos físicos** — y
+las dos afirmaciones no son intercambiables.
+
+El **ensayo de tipo** (IEC 61672-2:2013 para sonómetros, IEC 61260-2:2016
+para filtros) es el régimen de aprobación de tipo que un *modelo* supera una
+sola vez. Su alcance declarado son los ensayos necesarios para verificar la
+conformidad con **todas las especificaciones obligatorias** de la Parte 1
+(IEC 61672-2:2013, apartado 1; IEC 61260-2:2016, apartado 1.1), sobre
+especímenes físicos: IEC 61260-2 exige presentar al menos tres especímenes
+del modelo a ensayo (apartado 4.1). Eso incluye todo lo que una función de
+transferencia no tiene: la influencia de la presión estática, la temperatura
+del aire y la humedad relativa, la inmunidad a descargas electrostáticas y a
+campos de frecuencia de red y de radiofrecuencia, la respuesta direccional y
+los ensayos acústicos de las ponderaciones con el micrófono en el campo
+sonoro, la linealidad de nivel de la electrónica real, el ruido
+autogenerado, la respuesta a ráfagas tonales, el comportamiento ante
+sobrecarga (IEC 61672-2:2013, apartados 7 a 9; IEC 61260-2:2016, apartados
+7 a 9).
+
+Los **ensayos periódicos** (IEC 61672-3:2013, IEC 61260-3:2016) son lo que
+recibe en laboratorio un *instrumento en servicio* cada año o dos. Su
+alcance es deliberadamente lo contrario de exhaustivo: un conjunto limitado
+de ensayos clave, válido para las condiciones ambientales del día,
+«restringido al mínimo considerado necesario» (IEC 61672-3:2013, apartado 1;
+IEC 61260-3:2016, apartados 1.2 y 1.3). Para un juego de filtros eso
+significa la atenuación relativa en la frecuencia central de cada filtro o
+la desviación del ancho de banda efectivo, el rango lineal de funcionamiento
+con su control de rango de nivel e indicador de sobrecarga, y el límite
+inferior de ese rango (IEC 61260-3:2016, apartados 10 a 12); para un
+sonómetro, la comprobación con calibrador, el ruido autogenerado, las
+ponderaciones con señales acústicas y eléctricas, la linealidad, las ráfagas
+tonales, el pico con ponderación C y la sobrecarga (IEC 61672-3:2013,
+apartados 9 a 21). Los dos alcances de la Parte 3 terminan con la misma
+salvedad: como el alcance es limitado, superar todos los ensayos periódicos
+no sostiene **ninguna conclusión general de conformidad** con la Parte 1
+salvo que conste la aprobación de tipo del modelo (IEC 61672-3:2013,
+apartado 1; IEC 61260-3:2016, apartado 1.5).
+
+La misma honestidad se aplica a esta biblioteca, en las dos direcciones:
+
+- **Qué es un veredicto de verificador.** Una afirmación sobre un *diseño*:
+  la función de transferencia digital que configuraste cabe en la máscara de
+  aceptación de la Parte 1, con los márgenes informados, sobre el rango de
+  frecuencias comprobado. Toda medición hecha íntegramente en software lo
+  hereda, y por eso el
+  [recorrido del sonómetro](/phonometry/es/signals/sound-level-meter/)
+  termina ejecutando los verificadores sobre la cadena que acaba de montar.
+- **Qué no es.** Un ensayo de tipo, un ensayo periódico ni un certificado de
+  ningún equipo físico. Nada aquí tiene un micrófono, una temperatura ni un
+  número de serie; los ensayos de magnitudes de influencia, de inmunidad y
+  acústicos de arriba no están implementados, y ningún veredicto verde de la
+  sección 2 dice nada del hardware que grabó tus muestras. Un front-end real
+  trae su propio papel: el ensayo periódico del sonómetro según IEC 61672-3
+  y la conformidad del calibrador según IEC 60942, ambos tratados con el
+  ritual de campo en
+  [Calibración y dBFS](/phonometry/es/signals/metrology/calibration/).
+- **Nombra los dos veredictos en un informe.** «Niveles de banda calculados
+  con filtros verificados clase 1 según la Tabla 1 de IEC 61260-1:2014
+  (versión X de la biblioteca, véase su informe de conformidad); cadena de
+  adquisición con ensayo periódico según IEC 61672-3:2013 en fecha Y» es una
+  afirmación que un revisor puede comprobar de punta a punta. Cada mitad por
+  separado toma prestada en silencio la autoridad de la otra.
+
+## Qué cubre esta guía
+
+**Cubierto.** Qué afirma una clase de prestaciones en IEC 61672-1:2013 e
+IEC 61260-1:2014 y cómo la afirmación se encadena a través de una medición;
+los verificadores públicos (`verify_weighting_class`, `verify_filter_class`,
+`verify_intensity_class`, con `weighting_class_limits` y `class_limits`
+publicando las máscaras, y `filter_class_compliance` /
+`intensity_class_compliance` añadiendo `.plot()` y la ficha acreditada);
+cómo leer y citar el informe de conformidad publicado; y el alcance
+verificado de las partes de ensayo de tipo y de ensayos periódicos.
+
+**No cubierto.** Las matemáticas de verificación de cada etapa, que
+pertenecen a la guía de esa etapa
+([Ponderación frecuencial](/phonometry/es/signals/levels/weighting/),
+[Ponderaciones especiales](/phonometry/es/signals/levels/special-weightings/),
+[Verificación de clase de filtros](/phonometry/es/signals/filters/filter-compliance/),
+[Intensidad acústica](/phonometry/es/devices/emission/intensity/)); y todos los
+ensayos de las propias Partes 2 y 3, que esta página delimita pero la
+biblioteca no realiza: no se ejecuta ningún ensayo ambiental, de inmunidad,
+acústico ni de linealidad, y a ningún instrumento físico se le asigna una
+clase.
+
+## Véase también
+
+- [Ponderación frecuencial](/phonometry/es/signals/levels/weighting/): las
+  curvas A/C/Z y la verificación de la sección 6 frente a la Tabla 3 de
+  IEC 61672-1.
+- [Verificación de clase de filtros](/phonometry/es/signals/filters/filter-compliance/):
+  la máscara de IEC 61260-1 banda a banda, la clase 0 y la ficha de
+  conformidad en detalle.
+- [Construye un sonómetro](/phonometry/es/signals/sound-level-meter/): la cadena
+  completa montada y después verificada en clase con los verificadores de
+  esta página.
+- [Calibración y dBFS](/phonometry/es/signals/metrology/calibration/): el lado
+  del calibrador en la cadena de clase, y la práctica de laboratorio
+  IEC 60942 / IEC 61672-3 a su alrededor.
+- [Informe de conformidad](/phonometry/es/reference/conformance/): la tabla
+  publicada que esta página enseña a leer.
+- Referencia de la API:
+  [`filters.compliance`](/phonometry/es/reference/api/filters/compliance/),
+  [`filters.weighting_compliance`](/phonometry/es/reference/api/filters/weighting-compliance/)
+  y [`emission.intensity_compliance`](/phonometry/es/reference/api/power/intensity-compliance/).
+
+## Respuestas rápidas
+
+### ¿Puede phonometry certificar mi sonómetro o analizador como clase 1?
+
+No. Los verificadores califican el diseño digital que se les da frente a los
+límites de aceptación de la Tabla 3 de IEC 61672-1:2013 o de la Tabla 1 de
+IEC 61260-1:2014; la clase de un instrumento físico sale del ensayo de tipo
+(IEC 61672-2:2013 / IEC 61260-2:2016) y se mantiene creíble mediante los
+ensayos periódicos (IEC 61672-3:2013 / IEC 61260-3:2016), y todos necesitan
+el equipo en un laboratorio. Una medición hecha con un front-end de hardware
+lleva dos veredictos, el veredicto de diseño de la biblioteca y el registro
+de ensayos del instrumento, y un informe defendible nombra los dos.
+
+### ¿Qué diferencia hay entre el ensayo de tipo y los ensayos periódicos?
+
+El ensayo de tipo (Parte 2 de cada serie) verifica un *modelo* frente a
+todas las especificaciones obligatorias de la Parte 1 una sola vez, sobre
+especímenes presentados, incluidos los ensayos de influencia ambiental y
+electromagnética. Los ensayos periódicos (Parte 3) recomprueban un
+*instrumento en servicio* con un conjunto limitado y deliberadamente mínimo
+de ensayos clave, válido para las condiciones del día; los dos alcances de
+la Parte 3 declaran que superarlos no sostiene ninguna conclusión general de
+conformidad salvo que conste la aprobación de tipo del modelo.
+
+### ¿Qué funciones comprueban la conformidad con normas en phonometry?
+
+`verify_weighting_class` comprueba una ponderación frecuencial frente a la
+Tabla 3 de IEC 61672-1:2013 (B y AU frente a ANSI S1.4-1983 e
+IEC 61012:1990), `verify_filter_class` comprueba un banco de fracción de
+octava frente a la Tabla 1 de IEC 61260-1:2014 (la máscara de clase 0 de
+1995 vía `edition="1995"`), y `verify_intensity_class` comprueba el espectro
+del índice residual de un instrumento de intensidad frente a IEC 61043:1993.
+Las tres informan una clase por banda con márgenes en dB, y
+`filter_class_compliance` / `intensity_class_compliance` empaquetan el
+veredicto con `.plot()` y una ficha acreditada `.report()`.

--- a/site/src/content/docs/es/signals/metrology/index.md
+++ b/site/src/content/docs/es/signals/metrology/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Calibración e incertidumbre"
-description: "Las tres disciplinas que convierten un nivel calculado en una medición defendible: calibración SPL física frente a análisis digital en dBFS, la propagación de la incertidumbre de medida por GUM y Monte Carlo, y las estadísticas de estacionariedad y de picos que cualifican un registro antes de promediar nada de él."
+description: "Las disciplinas que convierten un nivel calculado en una medición defendible: calibración SPL física frente a análisis digital en dBFS, la propagación de la incertidumbre de medida por GUM y Monte Carlo, las estadísticas de estacionariedad y de picos que cualifican un registro antes de promediar nada de él, y los verificadores de clase con el informe de conformidad detrás de cada número."
 ---
 
 Un nivel impreso por un programa no es todavía una medición. Tres cosas
@@ -8,7 +8,10 @@ separan lo uno de lo otro: saber que el registro merece **promediarse
 siquiera**, saber qué significan **físicamente** las muestras digitales, y
 saber cuánto podría razonablemente **equivocarse** el resultado. Esta sección
 cubre las tres, y las tres se aplican transversalmente a todas las demás
-páginas de la documentación.
+páginas de la documentación. Una cuarta página traza el mapa de la evidencia
+que respalda los números: qué afirma una **clase** de prestaciones, los
+verificadores que califican una cadena, y el informe de conformidad
+publicado.
 
 [Calibración y dBFS](/phonometry/es/signals/metrology/calibration/) se ocupa del
 significado físico. phonometry trabaja en dos marcos de referencia: los
@@ -29,6 +32,16 @@ distribuciones de probabilidad completas y produce intervalos de cobertura
 que siguen siendo honestos cuando el modelo es no lineal o las entradas
 distan de ser gaussianas. La página muestra ambas sobre los mismos modelos,
 incluyendo dónde divergen y por qué.
+
+[Conformidad y verificación](/phonometry/es/signals/metrology/compliance-verification/)
+lleva el relato de la evidencia: qué afirma de verdad una clase de
+prestaciones en IEC 61672-1 e IEC 61260-1 (mismos objetivos de diseño,
+distintos límites de aceptación), qué verificador público califica cada
+etapa de una cadena de medición frente a sus tablas de tolerancias, cómo
+leer y citar el informe numérico de conformidad que publica el sitio, y la
+frontera honesta frente a los ensayos de tipo y periódicos de
+IEC 61672-2/-3 e IEC 61260-2/-3, que necesitan un instrumento en un
+laboratorio y no una biblioteca.
 
 [Cualificación de datos](/phonometry/es/signals/metrology/data-qualification/) guarda la
 puerta delante de ambas: todo promedio - un Leq, una PSD de Welch, toda
@@ -59,6 +72,11 @@ la maquinaria GUM descrita aquí.
 - [Calibración y dBFS](/phonometry/es/signals/metrology/calibration/): calibración SPL
   física desde un tono de calibrador, la comprobación de estabilidad que
   aplica a esa grabación, y el modo digital de fondo de escala.
+- [Conformidad y verificación](/phonometry/es/signals/metrology/compliance-verification/):
+  qué afirma una clase de prestaciones, los verificadores que califican
+  ponderaciones, bancos de filtros y espectros de intensidad frente a sus
+  tablas de tolerancias, el informe de conformidad, y el alcance de
+  IEC 61672-2/-3 e IEC 61260-2/-3.
 - [Incertidumbre de medida (GUM y Monte Carlo)](/phonometry/es/signals/metrology/gum-uncertainty/):
   la ley de propagación de la incertidumbre y el método de Monte Carlo,
   incertidumbre expandida e intervalos de cobertura.
@@ -74,7 +92,9 @@ conformidad de IEC 60942 sobre el propio calibrador (nivel generado,
 frecuencia, distorsión y las correcciones por presión estática y temperatura)
 no están implementados, así que pasa un `target_spl` ya corregido cuando el
 manual lo pida, y los ensayos periódicos de IEC 61672-3 se citan como práctica
-de laboratorio, no se ejecutan. La parte de dBFS de la página de calibración
+de laboratorio, no se ejecutan;
+[Conformidad y verificación](/phonometry/es/signals/metrology/compliance-verification/)
+traza esa frontera con precisión, parte por parte. La parte de dBFS de la página de calibración
 queda fuera de cualquier norma y no hace ninguna afirmación física: es un
 marco de referencia, no una medición. La cualificación de datos implementa solo
 el núcleo cuantitativo del apartado 10.3 de Bendat y Piersol: clasificar el

--- a/site/src/content/docs/es/start/guides.md
+++ b/site/src/content/docs/es/start/guides.md
@@ -1,6 +1,6 @@
 ---
 title: "Guías"
-description: "Las 105 guías de phonometry, agrupadas en los diez temas que cubre la biblioteca: para qué sirve cada área, las normas que implementa y un resumen de una línea de cada guía que contiene."
+description: "Las 106 guías de phonometry, agrupadas en los diez temas que cubre la biblioteca: para qué sirve cada área, las normas que implementa y un resumen de una línea de cada guía que contiene."
 head:
   - tag: script
     attrs:
@@ -97,7 +97,7 @@ hay ninguna panorámica del campo: cada página es la documentación de trabajo 
 un módulo, escrita para que un resultado se pueda defender apartado por
 apartado en lugar de darlo por bueno.
 
-Esta página es el mapa. Ciento cinco guías repartidas en diez temas, y cada
+Esta página es el mapa. Ciento seis guías repartidas en diez temas, y cada
 área tiene su propio índice con el relato largo de cómo encajan sus piezas. Si
 llegas sin una pregunta concreta, lee primero la
 [introducción](/phonometry/es/start/getting-started/): recorre una señal por toda la
@@ -230,6 +230,9 @@ ISO 1996-1, IEC 60942 y la GUM.
 - [Calibración y dBFS](/phonometry/es/signals/metrology/calibration/): calibración SPL
   física a partir de un tono de calibrador o de una sensibilidad conocida, y el
   modo digital de escala completa.
+- [Conformidad y verificación](/phonometry/es/signals/metrology/compliance-verification/):
+  qué afirma una clase de prestaciones, los verificadores por etapa, el
+  informe de conformidad, y el alcance de los ensayos de tipo y periódicos.
 - [Incertidumbre de medida (GUM y Monte Carlo)](/phonometry/es/signals/metrology/gum-uncertainty/):
   la ley de propagación de la incertidumbre y el método de Monte Carlo, con
   incertidumbre expandida e intervalos de cobertura.

--- a/site/src/content/docs/signals/index.md
+++ b/site/src/content/docs/signals/index.md
@@ -155,6 +155,10 @@ What the numbers mean and how much to trust them.
 - [Calibration and dBFS](/phonometry/signals/metrology/calibration/): physical SPL
   calibration from a calibrator tone (IEC 60942), the stability check it applies
   to that recording, and the digital dBFS mode.
+- [Compliance and Verification](/phonometry/signals/metrology/compliance-verification/):
+  what a performance class asserts, the verifiers that grade each stage
+  against its tolerance tables, how to read the conformance report, and the
+  scope of IEC 61672-2/-3 and IEC 61260-2/-3.
 - [Measurement uncertainty (GUM and Monte Carlo)](/phonometry/signals/metrology/gum-uncertainty/):
   the law of propagation of uncertainty and the Monte Carlo method of
   ISO/IEC Guide 98-3, with expanded uncertainty and coverage intervals.
@@ -168,9 +172,12 @@ Four things a reader reasonably expects here are absent, and each guide says so
 in its own "Not covered" block. **No instrument is verified.**
 `verify_filter_class` and `verify_weighting_class` check a designed digital
 response against the tolerance tables of IEC 61260-1 and IEC 61672-1; the
-IEC 61672-3 pattern-evaluation tests a physical meter needs for type approval,
-and the IEC 60942 conformance tests of the calibrator itself, are not run, so a
-class verdict here describes the algorithm and not a built device. **No file is
+IEC 61672-2 pattern-evaluation tests a physical meter needs for type approval,
+the IEC 61672-3 periodic tests it receives in service, and the IEC 60942
+conformance tests of the calibrator itself, are not run, so a class verdict
+here describes the algorithm and not a built device;
+[Compliance and Verification](/phonometry/signals/metrology/compliance-verification/)
+draws that boundary part by part. **No file is
 opened.** Nothing in the library decodes WAV, FLAC or any other container:
 every function takes an array you have already read, which is why `fs` is
 always an argument. **No array processing.** Correlation and time delay model

--- a/site/src/content/docs/signals/index.md
+++ b/site/src/content/docs/signals/index.md
@@ -155,7 +155,7 @@ What the numbers mean and how much to trust them.
 - [Calibration and dBFS](/phonometry/signals/metrology/calibration/): physical SPL
   calibration from a calibrator tone (IEC 60942), the stability check it applies
   to that recording, and the digital dBFS mode.
-- [Compliance and Verification](/phonometry/signals/metrology/compliance-verification/):
+- [Compliance and verification](/phonometry/signals/metrology/compliance-verification/):
   what a performance class asserts, the verifiers that grade each stage
   against its tolerance tables, how to read the conformance report, and the
   scope of IEC 61672-2/-3 and IEC 61260-2/-3.
@@ -176,7 +176,7 @@ IEC 61672-2 pattern-evaluation tests a physical meter needs for type approval,
 the IEC 61672-3 periodic tests it receives in service, and the IEC 60942
 conformance tests of the calibrator itself, are not run, so a class verdict
 here describes the algorithm and not a built device;
-[Compliance and Verification](/phonometry/signals/metrology/compliance-verification/)
+[Compliance and verification](/phonometry/signals/metrology/compliance-verification/)
 draws that boundary part by part. **No file is
 opened.** Nothing in the library decodes WAV, FLAC or any other container:
 every function takes an array you have already read, which is why `fs` is

--- a/site/src/content/docs/signals/metrology/compliance-verification.mdx
+++ b/site/src/content/docs/signals/metrology/compliance-verification.mdx
@@ -1,0 +1,406 @@
+---
+title: "Compliance and Verification"
+description: "What a performance class claims under IEC 61672-1 and IEC 61260-1, the public verifiers that grade a designed chain against the tolerance tables, how to read the published conformance report, and the honest boundary drawn by the pattern-evaluation and periodic-test parts that only a laboratory can run."
+references:
+  - type: standard
+    organization: "International Electrotechnical Commission"
+    year: 2013
+    title: "Electroacoustics — Sound level meters — Part 1: Specifications"
+    designation: "IEC 61672-1:2013"
+    url: "https://webstore.iec.ch/en/publication/5708"
+    note: "The two performance categories of clause 1 (same design goals, different acceptance limits and operational temperature range) and the Table 3 frequency-weighting acceptance limits checked by verify_weighting_class."
+  - type: standard
+    organization: "International Electrotechnical Commission"
+    year: 2013
+    title: "Electroacoustics — Sound level meters — Part 2: Pattern evaluation tests"
+    designation: "IEC 61672-2:2013"
+    url: "https://webstore.iec.ch/en/publication/5709"
+    note: "The full type-approval regime for a physical sound level meter: every mandatory specification of Part 1, including the environmental, electrostatic and radio-frequency influence tests, exercised on submitted specimens. Nothing on this page performs it."
+  - type: standard
+    organization: "International Electrotechnical Commission"
+    year: 2013
+    title: "Electroacoustics — Sound level meters — Part 3: Periodic tests"
+    designation: "IEC 61672-3:2013"
+    url: "https://webstore.iec.ch/en/publication/5710"
+    note: "The deliberately restricted set of key tests a working meter receives in the laboratory, and the clause 1 caveat that periodic results alone support no general conformance conclusion. Cited here as the model for what a class verdict does not say."
+  - type: standard
+    organization: "International Electrotechnical Commission"
+    year: 2014
+    title: "Electroacoustics — Octave-band and fractional-octave-band filters — Part 1: Specifications"
+    designation: "IEC 61260-1:2014"
+    url: "https://webstore.iec.ch/en/publication/5063"
+    note: "The class 1 / class 2 relative-attenuation acceptance limits of Table 1 checked by verify_filter_class, and the subclause 1.2 statement of what separates the two classes."
+  - type: standard
+    organization: "International Electrotechnical Commission"
+    year: 2016
+    title: "Electroacoustics — Octave-band and fractional-octave-band filters — Part 2: Pattern-evaluation tests"
+    designation: "IEC 61260-2:2016"
+    url: "https://webstore.iec.ch/en/publication/24560"
+    note: "The pattern-evaluation regime for a physical filter set: at least three submitted specimens, the full Table 1 walk, linearity, electromagnetic compatibility and climate sensitivity. Nothing on this page performs it."
+  - type: standard
+    organization: "International Electrotechnical Commission"
+    year: 2016
+    title: "Electroacoustics — Octave-band and fractional-octave-band filters — Part 3: Periodic tests"
+    designation: "IEC 61260-3:2016"
+    url: "https://webstore.iec.ch/en/publication/24561"
+    note: "The periodic tests of a working analyser: midband relative attenuation or effective bandwidth deviation, the linear operating range with its level range control and overload indicator, and the lower limit of that range."
+  - type: standard
+    organization: "International Electrotechnical Commission"
+    year: 1993
+    title: "Electroacoustics — Instruments for the measurement of sound intensity — Measurements with pairs of pressure sensing microphones"
+    designation: "IEC 61043:1993"
+    url: "https://webstore.iec.ch/en/publication/4353"
+    note: "The class limits on the pressure-residual intensity index behind verify_intensity_class, the third verifier family this page inventories."
+---
+
+import ThemeImage from '../../../../components/ThemeImage.astro';
+import ReportPreview from '../../../../components/ReportPreview.astro';
+import { totalChecks, domains, standards } from '../../../../data/conformance-stats.mjs';
+
+Three kinds of evidence back a number computed with this library, and they
+live on different pages. The **verifiers** are public functions that grade a
+filter or weighting you configured against the acceptance limits of its
+governing standard. The **conformance report** is the published table of
+{totalChecks} checks that pins the shipped implementation to the standards'
+own expected values, regenerated on every change. And the **scope notes** on
+each guide say where the software's claim ends and a laboratory's begins.
+This page is the map of the three: what a performance class actually asserts,
+which function verifies what, how to read the report, and exactly which parts
+of the IEC 61672 and IEC 61260 series a library can and cannot claim.
+
+## 1. What a performance class asserts
+
+IEC 61672-1:2013 (sound level meters) and IEC 61260-1:2014 (octave-band and
+fractional-octave-band filters) both specify **two performance categories,
+class 1 and class 2**, and both define them the same way: class 1 and class 2
+share the *same design goals* and differ mainly in the **acceptance limits**
+around those goals and in the range of operational temperature; class 2
+limits are greater than or equal to class 1 limits everywhere (IEC 61672-1:2013,
+clause 1; IEC 61260-1:2014, subclause 1.2).
+
+So a class is not a quality grade of the reading. It is a **worst-case error
+bound under stated conditions**: a class 1 A-weighting may deviate from the
+design-goal response at 1 kHz by at most ±0.7 dB, a class 2 one by ±1.0 dB,
+and every band of a class 1 one-third-octave filter reads a mid-band tone
+within ±0.4 dB of its true level. The bound is what chains: a class 1
+measurement needs every stage to hold class 1, from the
+[calibrator](/phonometry/signals/metrology/calibration/) through the weighting to the
+band filter, because each stage's tolerance enters the level it hands on. One
+class 2 stage bounds the chain at class 2, whatever the rest attests.
+
+Two edges of the vocabulary are worth pinning down before verifying anything:
+
+- **Class 0 is not a 2014 class.** The strictest filter class belongs to the
+  withdrawn IEC 61260:1995 / ANSI S1.11-2004 masks; IEC 61260-1:2014 defines
+  classes 1 and 2 only. The verifiers keep the old mask alive behind
+  `edition="1995"`, and [Filter Class Verification](/phonometry/signals/filters/filter-compliance/#2-class-0-iec-612601995--ansi-s111-2004)
+  covers when a class 0 claim is honest and how to cite it.
+- **A class belongs to a specification, not to a number.** "Class 1" written
+  alone says nothing; the claim is "class 1 per IEC 61672-1:2013 Table 3" or
+  "class 1 per IEC 61260-1:2014 Table 1", and the two masks are different
+  objects checked by different functions, which is the next section.
+
+## 2. The verifiers: which function proves what
+
+The library exposes one verifier per instrument stage. Each checks a design
+you configured, band by band or frequency by frequency, against the
+acceptance limits transcribed from the governing standard, and each returns
+the same verdict vocabulary: an `overall_class` (the strictest class met, or
+`None`), per-band margins in decibels to the nearest limit, and a
+`range_limited` flag when part of the standard's frequency range could not be
+demonstrated at your sample rate.
+
+| Stage | Verifier | Acceptance limits | Deep dive |
+| :--- | :--- | :--- | :--- |
+| Frequency weighting (A, C, Z) | `verify_weighting_class` | IEC 61672-1:2013 Table 3 | [Frequency Weighting, section 6](/phonometry/signals/levels/weighting/#6-verifying-against-the-tolerance-tables-iec-61672-1) |
+| Weightings B and AU | `verify_weighting_class` | ANSI S1.4-1983 Tables IV/V; IEC 61012:1990 Table 1 | [Special Weightings](/phonometry/signals/levels/special-weightings/) |
+| Fractional-octave filter bank | `verify_filter_class` | IEC 61260-1:2014 Table 1 (1995 mask via `edition="1995"`) | [Filter Class Verification](/phonometry/signals/filters/filter-compliance/) |
+| Intensity instrument spectrum | `verify_intensity_class` | IEC 61043:1993 Table 2 | [Sound Intensity](/phonometry/devices/emission/intensity/) |
+
+The masks themselves are public too: `weighting_class_limits(1)` returns the
+34 nominal frequencies of Table 3 with the class 1 deviation limits, and
+`class_limits(fraction, filter_class, omega)` returns the Table 1
+relative-attenuation corridor, so a report can draw the same limits the
+verdict was judged against.
+
+Verifying a whole measurement chain is two calls. The configuration below is
+the one the conformance suite itself pins, a 48 kHz chain with the default
+order-6 Butterworth bank over 100 Hz to 10 kHz:
+
+```python
+from phonometry import filters
+
+wf = filters.WeightingFilter(48000, "A")
+weighting = filters.verify_weighting_class(wf)
+print(weighting["overall_class"])       # 1
+print(weighting["range_limited"])       # False
+
+bank = filters.OctaveFilterBank(fs=48000, fraction=3, order=6,
+                                limits=[100, 10000])
+bands = filters.verify_filter_class(bank)
+print(bands["overall_class"])           # 1
+print(bands["range_limited"])           # True for a decimated bank
+```
+
+Read the flags, not just the class. `range_limited` on the bank is `True`
+because a decimated band cannot be evaluated beyond its own processing
+Nyquist, so the far stopband rests on the anti-alias argument rather than on
+the band filter itself; the weighting at 48 kHz checks all 34 nominal
+frequencies and reports `False`. The margins say how close the verdict came:
+
+```python
+worst = min(bands["bands"], key=lambda b: b["margin_class1_db"])
+print(round(worst["margin_class1_db"], 3))   # 0.4
+print(weighting["bands"][20])
+# {'freq': 1000.0, 'class': 1, 'deviation_db': 0.0, 'margin_class1_db': 0.7, 'margin_class2_db': 1.0}
+```
+
+A margin of +0.400 dB on a passing Butterworth bank is the passband
+half-corridor itself, the best a compliant design can report, not a result to
+improve; [Filter Class Verification](/phonometry/signals/filters/filter-compliance/#1-verifying-the-class-against-iec-61260-12014)
+explains which constraint binds and why raising the order stops helping the
+moment the verdict turns positive.
+
+<ThemeImage src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/weighting_class_mask.svg" alt="A and C weighting deviations at 48 kHz threading within the IEC 61672-1 Table 3 class 1 acceptance corridor, with the wider class 2 limits dotted" width="80%" />
+
+*What a verifier actually checks, drawn for the weightings: the deviation of
+the designed response from the design goal (markers) must stay inside the
+class 1 corridor (shaded) at every nominal frequency. The filter-bank
+equivalent, a relative-attenuation corridor around each mid-band frequency,
+is drawn in [Filter Class Verification](/phonometry/signals/filters/filter-compliance/).*
+
+<details>
+<summary>Show the code for this figure</summary>
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+
+freqs, lower1, upper1 = filters.weighting_class_limits(1)
+_, lower2, upper2 = filters.weighting_class_limits(2)
+lo1, lo2 = np.clip(lower1, -7, 7), np.clip(lower2, -7, 7)
+
+fig, ax = plt.subplots(figsize=(10, 6.5))
+ax.fill_between(freqs, lo1, upper1, step="mid", alpha=0.10,
+                label="Class 1 acceptance region")
+ax.plot(freqs, upper1, drawstyle="steps-mid", label="Class 1 upper/lower limit")
+ax.plot(freqs, lo1, drawstyle="steps-mid", color="C1")
+ax.plot(freqs, upper2, ":", drawstyle="steps-mid", label="Class 2 upper/lower limit")
+ax.plot(freqs, lo2, ":", drawstyle="steps-mid", color="C2")
+
+for curve, marker in (("A", "o"), ("C", "s")):
+    verdict = filters.verify_weighting_class(filters.WeightingFilter(48000, curve))
+    f = [b["freq"] for b in verdict["bands"]]
+    dev = [b["deviation_db"] for b in verdict["bands"]]
+    ax.plot(f, dev, marker=marker, label=f"{curve} weighting deviation (48 kHz)")
+
+ax.set(xscale="log", xlim=(10, 20000), ylim=(-7, 7),
+       xlabel="Frequency [Hz]", ylabel="Deviation from design goal [dB]")
+ax.legend(fontsize=8, ncol=2)
+plt.show()
+```
+
+</details>
+
+When the verdict has to leave the console, `filter_class_compliance` wraps
+the same verification as a result object with `.plot()` (the worst-margin
+band drawn on its class corridor) and `.report()`, the one-page accredited
+fiche with an optional PASS/FAIL row against a required class:
+
+```python
+from phonometry import OctaveFilterBank, ReportMetadata, filter_class_compliance
+
+bank = OctaveFilterBank(fs=48000, fraction=1, order=6, limits=[125, 4000])
+result = filter_class_compliance(bank)   # result.overall_class == 1
+result.report(
+    "iec61260.pdf",
+    metadata=ReportMetadata(
+        specimen="1/1-octave filter bank",
+        measurement_standard="IEC 61260-1:2014",
+        required_class=1,
+    ),
+)                                        # -> Class 1 - COMPLIES, PASS
+```
+
+<ReportPreview
+	name="iec61260_filter_example"
+	title="IEC 61260-1 filter class compliance example report (PDF)"
+	description="One-page filter-class-compliance fiche: a metadata header, a per-band classification table listing each octave band's achieved class and binding margin, the worst-margin band's measured relative attenuation overlaid on the green class-1 acceptance corridor, the boxed Class 1 - COMPLIES (margin +0.40 dB) result and a PASS verdict against the required class 1."
+	caption="The verdict as a document: the fiche states the achieved class per band, the binding margin and the corridor it was judged against, which is everything section 4 says a design-level claim may assert."
+/>
+
+The intensity verifier follows the same pattern one domain over:
+`verify_intensity_class` grades a measured pressure-residual intensity index
+spectrum against the IEC 61043 class limits, and `intensity_class_compliance`
+wraps it with `.plot()` and its own fiche, with the residual-index physics
+explained in [Sound Intensity](/phonometry/devices/emission/intensity/).
+
+## 3. Reading the conformance report
+
+The verifiers grade *your* configuration. The
+[conformance report](/phonometry/reference/conformance/) is the complementary
+evidence: {totalChecks} numerical checks across {domains} domains and
+{standards} standards, each row pinning one implemented quantity to the
+governing standard's own expected value, with the computed value, the signed
+delta and a pass/fail verdict beside it. It is regenerated on every pull
+request and the build fails if it drifts from the code, so the published
+table always describes the library as shipped.
+
+Three habits make it useful rather than decorative:
+
+- **Find the row before trusting the feature.** Every table is
+  `Standard | Quantity | Expected | Computed | Delta | Status`, grouped by
+  domain, and the expected value is the standard's worked example or
+  tolerance-table entry, not a regression baseline. The row for a metric you
+  rely on tells you which clause of which edition the implementation was held
+  to, which is exactly the citation a report needs.
+- **Note the configuration of the class rows.** The filters-and-weightings
+  section walks the five filter architectures and the weighting curves
+  through the same verifiers this page documents, in one pinned
+  configuration: order 6, one-third-octave, 100 Hz to 10 kHz, 48 kHz. The
+  report proves the implementation; for any other fraction, order or sample
+  rate, section 2 is how the claim transfers to *your* bank.
+- **Cite the version that ran.** The report describes the exact library
+  version that generated it, so a defensible citation pins the version and
+  quotes the report of that version, as
+  [About this project](/phonometry/start/about/) spells out.
+
+Where re-deriving a standard this closely has exposed defects in the
+published documents themselves, the evidence lives in the
+[errata registry](/phonometry/reference/errata/), which the report links row
+by row where it applies.
+
+## 4. What only a laboratory can attest
+
+Both instrument series continue past their Part 1 with two test regimes, and
+neither regime is something a software library can run on itself. The
+delimitation below is verified against the four documents; the one-line
+summary is that **the library checks designs against Part 1 acceptance
+limits, while Parts 2 and 3 check physical instruments** — and the two claims
+are not interchangeable.
+
+**Pattern evaluation** (IEC 61672-2:2013 for meters, IEC 61260-2:2016 for
+filters) is the type-approval regime a *model* passes once. Its stated scope
+is the tests necessary to verify conformance to **all mandatory
+specifications** of the Part 1 (IEC 61672-2:2013, clause 1; IEC 61260-2:2016,
+subclause 1.1), on physical specimens: IEC 61260-2 requires at least three
+specimens of the pattern submitted for testing (subclause 4.1). That includes
+everything a transfer function does not have: the influence of static
+pressure, air temperature and relative humidity, immunity to electrostatic
+discharge and to power-frequency and radio-frequency fields, directional
+response and the acoustical tests of the frequency weightings with the
+microphone in the sound field, level linearity of the real electronics,
+self-generated noise, toneburst response, overload behaviour
+(IEC 61672-2:2013, clauses 7 to 9; IEC 61260-2:2016, clauses 7 to 9).
+
+**Periodic tests** (IEC 61672-3:2013, IEC 61260-3:2016) are what a *working
+instrument* receives in the laboratory every year or two. Their scope is
+deliberately the opposite of exhaustive: a limited set of key tests, valid
+for the environmental conditions of the day, "restricted to the minimum
+considered necessary" (IEC 61672-3:2013, clause 1; IEC 61260-3:2016,
+subclauses 1.2 and 1.3). For a filter set that means the relative attenuation
+at the midband frequency of every filter or the effective bandwidth
+deviation, the linear operating range with its level range control and
+overload indicator, and the lower limit of that range (IEC 61260-3:2016,
+clauses 10 to 12); for a meter, the calibrator check, self-generated noise,
+weightings by acoustical and electrical signals, linearity, tonebursts,
+C-weighted peak and overload (IEC 61672-3:2013, clauses 9 to 21). Both Part 3
+scopes end with the same caveat: because the extent is limited, passing every
+periodic test supports **no general conclusion of conformance** to the Part 1
+unless the model's pattern approval is on record (IEC 61672-3:2013, clause 1;
+IEC 61260-3:2016, subclause 1.5).
+
+The same honesty applies to this library, in both directions:
+
+- **What a verifier verdict is.** A statement about a *design*: the digital
+  transfer function you configured fits the Part 1 acceptance mask, with the
+  reported margins, over the checked frequency range. Every measurement made
+  wholly in software inherits it, which is why the
+  [sound level meter walkthrough](/phonometry/signals/sound-level-meter/) ends by
+  running the verifiers on the chain it just built.
+- **What it is not.** A pattern evaluation, a periodic test, or a certificate
+  for any physical device. Nothing here has a microphone, a temperature or a
+  serial number; the influence-quantity, immunity and acoustical tests above
+  are not implemented, and no green verdict from section 2 says anything
+  about the hardware that recorded your samples. A real front end brings its
+  own paper: the meter's periodic test per IEC 61672-3 and the calibrator's
+  conformance per IEC 60942, both discussed with the field ritual in
+  [Calibration and dBFS](/phonometry/signals/metrology/calibration/).
+- **Name both verdicts in a report.** "Band levels computed with filters
+  verified class 1 per IEC 61260-1:2014 Table 1 (library version X, see its
+  conformance report); acquisition chain periodically tested per
+  IEC 61672-3:2013 on date Y" is a claim a reviewer can check end to end.
+  Either half alone quietly borrows the other's authority.
+
+## What this guide covers
+
+**Covered.** What a performance class asserts in IEC 61672-1:2013 and
+IEC 61260-1:2014 and how the claim chains through a measurement; the public
+verifiers (`verify_weighting_class`, `verify_filter_class`,
+`verify_intensity_class`, with `weighting_class_limits` and `class_limits`
+publishing the masks, and `filter_class_compliance` /
+`intensity_class_compliance` adding `.plot()` and the accredited fiche); how
+to read and cite the published conformance report; and the verified scope of
+the pattern-evaluation and periodic-test parts.
+
+**Not covered.** The verification mathematics of each stage, which belongs
+to the stage's own guide ([Frequency Weighting](/phonometry/signals/levels/weighting/),
+[Special Weightings](/phonometry/signals/levels/special-weightings/),
+[Filter Class Verification](/phonometry/signals/filters/filter-compliance/),
+[Sound Intensity](/phonometry/devices/emission/intensity/)); and every test of
+Parts 2 and 3 themselves, which this page delimits but the library does not
+perform: no environmental, immunity, acoustical or linearity test is run,
+and no physical instrument is assigned a class.
+
+## See also
+
+- [Frequency Weighting](/phonometry/signals/levels/weighting/): the A/C/Z
+  curves and the section 6 verification against IEC 61672-1 Table 3.
+- [Filter Class Verification](/phonometry/signals/filters/filter-compliance/):
+  the IEC 61260-1 mask band by band, class 0, and the compliance fiche in
+  detail.
+- [Build a sound level meter](/phonometry/signals/sound-level-meter/): the whole
+  chain assembled and then class-checked with the verifiers of this page.
+- [Calibration and dBFS](/phonometry/signals/metrology/calibration/): the calibrator
+  side of the class chain, and the IEC 60942 / IEC 61672-3 laboratory
+  practice around it.
+- [Conformance report](/phonometry/reference/conformance/): the published table
+  this page teaches how to read.
+- API reference: [`filters.compliance`](/phonometry/reference/api/filters/compliance/),
+  [`filters.weighting_compliance`](/phonometry/reference/api/filters/weighting-compliance/)
+  and [`emission.intensity_compliance`](/phonometry/reference/api/power/intensity-compliance/).
+
+## Quick answers
+
+### Can phonometry certify my sound level meter or analyser as class 1?
+
+No. The verifiers grade the digital design they are given against the
+IEC 61672-1:2013 Table 3 or IEC 61260-1:2014 Table 1 acceptance limits; a
+class for a physical instrument comes from pattern evaluation
+(IEC 61672-2:2013 / IEC 61260-2:2016) and stays credible through periodic
+tests (IEC 61672-3:2013 / IEC 61260-3:2016), all of which need the device in
+a laboratory. A measurement made with a hardware front end carries two
+verdicts, the library's design verdict and the instrument's test record, and
+a defensible report names both.
+
+### What is the difference between pattern evaluation and periodic tests?
+
+Pattern evaluation (Part 2 of each series) verifies a *model* against every
+mandatory specification of Part 1 once, on submitted specimens, including
+environmental and electromagnetic influence tests. Periodic tests (Part 3)
+re-check a *working instrument* on a limited, deliberately minimal set of key
+tests, valid for the conditions of the day; both Part 3 scopes state that
+passing them supports no general conformance conclusion unless the model's
+pattern approval is on record.
+
+### Which functions check standards compliance in phonometry?
+
+`verify_weighting_class` checks a frequency weighting against
+IEC 61672-1:2013 Table 3 (B and AU against ANSI S1.4-1983 and
+IEC 61012:1990), `verify_filter_class` checks a fractional-octave bank
+against IEC 61260-1:2014 Table 1 (the 1995 class 0 mask via
+`edition="1995"`), and `verify_intensity_class` checks an intensity
+instrument's residual-index spectrum against IEC 61043:1993. All three report
+a per-band class with margins in dB, and `filter_class_compliance` /
+`intensity_class_compliance` package the verdict with `.plot()` and an
+accredited `.report()` fiche.

--- a/site/src/content/docs/signals/metrology/compliance-verification.mdx
+++ b/site/src/content/docs/signals/metrology/compliance-verification.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Compliance and Verification"
+title: "Compliance and verification"
 description: "What a performance class claims under IEC 61672-1 and IEC 61260-1, the public verifiers that grade a designed chain against the tolerance tables, how to read the published conformance report, and the honest boundary drawn by the pattern-evaluation and periodic-test parts that only a laboratory can run."
 references:
   - type: standard

--- a/site/src/content/docs/signals/metrology/compliance-verification.mdx
+++ b/site/src/content/docs/signals/metrology/compliance-verification.mdx
@@ -43,7 +43,7 @@ references:
     title: "Electroacoustics — Octave-band and fractional-octave-band filters — Part 3: Periodic tests"
     designation: "IEC 61260-3:2016"
     url: "https://webstore.iec.ch/en/publication/24561"
-    note: "The periodic tests of a working analyser: midband relative attenuation or effective bandwidth deviation, the linear operating range with its level range control and overload indicator, and the lower limit of that range."
+    note: "The periodic tests of a working analyser: midband relative attenuation or effective bandwidth deviation, the linear operating range with its level range control and overload indicator, the lower limit of that range, and the clause 13 relative-attenuation test at the Table 1 normalized frequencies on three selected filters."
   - type: standard
     organization: "International Electrotechnical Commission"
     year: 1993
@@ -255,8 +255,10 @@ Three habits make it useful rather than decorative:
   rely on tells you which clause of which edition the implementation was held
   to, which is exactly the citation a report needs.
 - **Note the configuration of the class rows.** The filters-and-weightings
-  section walks the five filter architectures and the weighting curves
-  through the same verifiers this page documents, in one pinned
+  section walks the
+  [five filter architectures](/phonometry/signals/filters/filter-gallery/) and
+  the weighting curves through the same verifiers this page documents, in one
+  pinned
   configuration: order 6, one-third-octave, 100 Hz to 10 kHz, 48 kHz. The
   report proves the implementation; for any other fraction, order or sample
   rate, section 2 is how the claim transfers to *your* bank.
@@ -294,15 +296,18 @@ self-generated noise, toneburst response, overload behaviour
 (IEC 61672-2:2013, clauses 7 to 9; IEC 61260-2:2016, clauses 7 to 9).
 
 **Periodic tests** (IEC 61672-3:2013, IEC 61260-3:2016) are what a *working
-instrument* receives in the laboratory every year or two. Their scope is
+instrument* receives in the laboratory, typically every year or two. Their
+scope is
 deliberately the opposite of exhaustive: a limited set of key tests, valid
 for the environmental conditions of the day, "restricted to the minimum
 considered necessary" (IEC 61672-3:2013, clause 1; IEC 61260-3:2016,
 subclauses 1.2 and 1.3). For a filter set that means the relative attenuation
 at the midband frequency of every filter or the effective bandwidth
 deviation, the linear operating range with its level range control and
-overload indicator, and the lower limit of that range (IEC 61260-3:2016,
-clauses 10 to 12); for a meter, the calibrator check, self-generated noise,
+overload indicator, the lower limit of that range, and a
+relative-attenuation test at the normalized frequencies of the standard's
+own Table 1 on the three filters selected for the linearity tests
+(IEC 61260-3:2016, clauses 10 to 13); for a meter, the calibrator check, self-generated noise,
 weightings by acoustical and electrical signals, linearity, tonebursts,
 C-weighted peak and overload (IEC 61672-3:2013, clauses 9 to 21). Both Part 3
 scopes end with the same caveat: because the extent is limited, passing every

--- a/site/src/content/docs/signals/metrology/index.md
+++ b/site/src/content/docs/signals/metrology/index.md
@@ -1,13 +1,16 @@
 ---
 title: "Calibration and uncertainty"
-description: "The three disciplines that make a computed level a defensible measurement: physical SPL calibration against digital dBFS analysis, the GUM and Monte Carlo propagation of measurement uncertainty, and the stationarity and peak statistics that qualify a record before any of it is averaged."
+description: "The disciplines that make a computed level a defensible measurement: physical SPL calibration against digital dBFS analysis, the GUM and Monte Carlo propagation of measurement uncertainty, the stationarity and peak statistics that qualify a record before any of it is averaged, and the class verifiers with the conformance report behind every number."
 ---
 
 A level printed by software is not yet a measurement. Three things separate
 the one from the other: knowing that the record deserves to be **averaged at
 all**, knowing what the digital samples mean **physically**, and knowing how
 much the result could reasonably be **wrong**. This section covers all three,
-and they apply transversally to every other page of the documentation.
+and they apply transversally to every other page of the documentation. A
+fourth page maps the evidence that backs the numbers: what a performance
+**class** asserts, the verifiers that grade a chain, and the published
+conformance report.
 
 [Calibration and dBFS](/phonometry/signals/metrology/calibration/) handles the
 physical meaning. phonometry works in two reference frames: physical **dB
@@ -27,6 +30,15 @@ propagates whole probability distributions numerically and yields coverage
 intervals that stay honest when the model is non-linear or the inputs are far
 from Gaussian. The page shows both on the same models, including where they
 diverge and why.
+
+[Compliance and Verification](/phonometry/signals/metrology/compliance-verification/)
+carries the evidence story: what a performance class actually claims in
+IEC 61672-1 and IEC 61260-1 (same design goals, different acceptance limits),
+which public verifier grades each stage of a measurement chain against its
+tolerance tables, how to read and cite the numerical conformance report the
+site publishes, and the honest boundary against the pattern-evaluation and
+periodic tests of IEC 61672-2/-3 and IEC 61260-2/-3, which need an
+instrument in a laboratory rather than a library.
 
 [Data qualification](/phonometry/signals/metrology/data-qualification/) guards the gate
 in front of both: every average - a Leq, a Welch PSD, every averaged input
@@ -53,6 +65,10 @@ budgets that are specialisations of the GUM machinery described here.
 - [Calibration and dBFS](/phonometry/signals/metrology/calibration/): physical SPL
   calibration from a calibrator tone, the stability check it applies to that
   recording, and the digital full-scale mode.
+- [Compliance and Verification](/phonometry/signals/metrology/compliance-verification/):
+  what a performance class asserts, the verifiers that grade weightings,
+  filter banks and intensity spectra against their tolerance tables, the
+  conformance report, and the scope of IEC 61672-2/-3 and IEC 61260-2/-3.
 - [Measurement uncertainty (GUM and Monte Carlo)](/phonometry/signals/metrology/gum-uncertainty/):
   the law of propagation of uncertainty and the Monte Carlo method, expanded
   uncertainty and coverage intervals.
@@ -66,7 +82,9 @@ Nothing here checks an instrument or a calibrator. The IEC 60942 conformance
 tests of the calibrator itself — generated level, frequency, distortion, and
 the corrections for static pressure and temperature — are not implemented, so
 pass an already corrected `target_spl` when the manual asks for one, and the
-IEC 61672-3 periodic tests are cited as laboratory practice rather than run.
+IEC 61672-3 periodic tests are cited as laboratory practice rather than run;
+[Compliance and Verification](/phonometry/signals/metrology/compliance-verification/)
+draws that boundary precisely, part by part.
 The dBFS half of the calibration page sits outside any standard and makes no
 physical claim: it is a reference frame, not a measurement. Data qualification
 implements the quantitative core of Bendat & Piersol's section 10.3 only —

--- a/site/src/content/docs/signals/metrology/index.md
+++ b/site/src/content/docs/signals/metrology/index.md
@@ -31,7 +31,7 @@ intervals that stay honest when the model is non-linear or the inputs are far
 from Gaussian. The page shows both on the same models, including where they
 diverge and why.
 
-[Compliance and Verification](/phonometry/signals/metrology/compliance-verification/)
+[Compliance and verification](/phonometry/signals/metrology/compliance-verification/)
 carries the evidence story: what a performance class actually claims in
 IEC 61672-1 and IEC 61260-1 (same design goals, different acceptance limits),
 which public verifier grades each stage of a measurement chain against its
@@ -65,7 +65,7 @@ budgets that are specialisations of the GUM machinery described here.
 - [Calibration and dBFS](/phonometry/signals/metrology/calibration/): physical SPL
   calibration from a calibrator tone, the stability check it applies to that
   recording, and the digital full-scale mode.
-- [Compliance and Verification](/phonometry/signals/metrology/compliance-verification/):
+- [Compliance and verification](/phonometry/signals/metrology/compliance-verification/):
   what a performance class asserts, the verifiers that grade weightings,
   filter banks and intensity spectra against their tolerance tables, the
   conformance report, and the scope of IEC 61672-2/-3 and IEC 61260-2/-3.
@@ -83,7 +83,7 @@ tests of the calibrator itself — generated level, frequency, distortion, and
 the corrections for static pressure and temperature — are not implemented, so
 pass an already corrected `target_spl` when the manual asks for one, and the
 IEC 61672-3 periodic tests are cited as laboratory practice rather than run;
-[Compliance and Verification](/phonometry/signals/metrology/compliance-verification/)
+[Compliance and verification](/phonometry/signals/metrology/compliance-verification/)
 draws that boundary precisely, part by part.
 The dBFS half of the calibration page sits outside any standard and makes no
 physical claim: it is a reference frame, not a measurement. Data qualification

--- a/site/src/content/docs/start/guides.md
+++ b/site/src/content/docs/start/guides.md
@@ -1,6 +1,6 @@
 ---
 title: "Guides"
-description: "The 105 guides of phonometry, grouped into the ten topics the library covers: what each area is for, the standards implemented in it, and a one-line summary of every guide inside it."
+description: "The 106 guides of phonometry, grouped into the ten topics the library covers: what each area is for, the standards implemented in it, and a one-line summary of every guide inside it."
 head:
   - tag: script
     attrs:
@@ -96,7 +96,7 @@ makes, then runnable code and the figure it draws. Nothing here is a survey of
 the field; each page is the working documentation of a module, written so that
 a result can be defended clause by clause rather than trusted.
 
-This page is the map. A hundred and five guides sit in ten topics, and each topic has its
+This page is the map. A hundred and six guides sit in ten topics, and each topic has its
 own overview page with the longer story of how its pieces fit together. If you
 are arriving without a specific question, read
 [Getting Started](/phonometry/start/getting-started/) first: it runs one signal
@@ -219,6 +219,9 @@ IEC 61252, ISO 1996-1, IEC 60942 and the GUM.
 - [Calibration and dBFS](/phonometry/signals/metrology/calibration/): physical SPL
   calibration from a calibrator tone or a known sensitivity, and the digital
   full-scale mode.
+- [Compliance and Verification](/phonometry/signals/metrology/compliance-verification/):
+  what a performance class asserts, the verifiers per stage, the conformance
+  report, and the scope of the pattern-evaluation and periodic-test parts.
 - [Measurement uncertainty (GUM and Monte Carlo)](/phonometry/signals/metrology/gum-uncertainty/):
   the law of propagation of uncertainty and the Monte Carlo method, with
   expanded uncertainty and coverage intervals.

--- a/site/src/content/docs/start/guides.md
+++ b/site/src/content/docs/start/guides.md
@@ -219,7 +219,7 @@ IEC 61252, ISO 1996-1, IEC 60942 and the GUM.
 - [Calibration and dBFS](/phonometry/signals/metrology/calibration/): physical SPL
   calibration from a calibrator tone or a known sensitivity, and the digital
   full-scale mode.
-- [Compliance and Verification](/phonometry/signals/metrology/compliance-verification/):
+- [Compliance and verification](/phonometry/signals/metrology/compliance-verification/):
   what a performance class asserts, the verifiers per stage, the conformance
   report, and the scope of the pattern-evaluation and periodic-test parts.
 - [Measurement uncertainty (GUM and Monte Carlo)](/phonometry/signals/metrology/gum-uncertainty/):

--- a/site/src/data/topics.mjs
+++ b/site/src/data/topics.mjs
@@ -113,6 +113,7 @@ export const topics = [
         items: [
           { slug: 'signals/metrology', label: 'Overview', translations: { es: 'Resumen' } },
           'signals/metrology/calibration',
+          'signals/metrology/compliance-verification',
           'signals/metrology/gum-uncertainty',
           'signals/metrology/data-qualification',
         ],


### PR DESCRIPTION
The library ships three kinds of compliance evidence that until now lived apart: the published conformance report, the public verifiers (verify_weighting_class for IEC 61672-1 acceptance limits, filter_class_compliance for IEC 61260-1 classes), and the scattered notes about what the maintenance parts of those standards actually ask for. This adds the guide that connects them, in signals/metrology next to weighting and calibration, with its Spanish twin and the docs mirror.

The guide explains what a class claim means in IEC 61672-1:2013 and IEC 61260-1:2014, walks the verifiers with executable snippets at realistic values, shows how to read the published conformance report, and then puts the scope boundary on record: pattern evaluation under IEC 61672-2:2013 and IEC 61260-2:2016 covers every mandatory specification (including the environmental, EMC and field tests a laboratory runs on hardware), periodic testing under IEC 61672-3:2013 and IEC 61260-3:2016 is the deliberately restricted maintenance set (clauses 9 to 21 for a sound level meter, 10 to 13 for a filter set, relative attenuation at the normalized Table 1 frequencies included), and what this library can verify is the electroacoustic mathematics of those chains, not the hardware tests. Every clause claim was written against the six standard documents.

While placing the guide, one real misattribution surfaced and is fixed here: the signals index credited type approval tests to IEC 61672-3 when they belong to IEC 61672-2, in both languages.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

