### PR TITLE
Keep the STIX glyphs out of the font normalization

### DIFF
--- a/.github/images/infinite_mobilities.svg
+++ b/.github/images/infinite_mobilities.svg
@@ -1389,7 +1389,7 @@ z
       <tspan x="35.053711" y="-0.228125" style="font-style: oblique; font-size: 10px; font-family: sans-serif">Y</tspan>
       <tspan x="81.074051" y="-0.329375" style="font-style: oblique; font-size: 10px; font-family: sans-serif">B</tspan>
       <tspan x="90.834708" y="-0.329375" style="font-style: oblique; font-size: 10px; font-family: sans-serif">m</tspan>
-      <tspan x="73.432617" y="-2.009375" style="font-size: 6.048393px; font-family: sans-serif">√</tspan>
+      <tspan x="73.432617" y="-2.009375" style="font-size: 6.048393px; font-family: 'STIXSizeOneSym'">√</tspan>
       <tspan x="88.636955" y="-4.459375" style="font-size: 7px; font-family: sans-serif">0</tspan>
       <tspan x="101.040034" y="-4.459375" style="font-size: 7px; font-family: sans-serif">0</tspan>
       <tspan x="102.96435" y="-4.459375" style="font-size: 7px; font-family: sans-serif">0</tspan>

--- a/.github/images/infinite_mobilities_dark.svg
+++ b/.github/images/infinite_mobilities_dark.svg
@@ -1389,7 +1389,7 @@ z
       <tspan x="35.053711" y="-0.228125" style="font-style: oblique; font-size: 10px; font-family: sans-serif; fill: #ffffff">Y</tspan>
       <tspan x="81.074051" y="-0.329375" style="font-style: oblique; font-size: 10px; font-family: sans-serif; fill: #ffffff">B</tspan>
       <tspan x="90.834708" y="-0.329375" style="font-style: oblique; font-size: 10px; font-family: sans-serif; fill: #ffffff">m</tspan>
-      <tspan x="73.432617" y="-2.009375" style="font-size: 6.048393px; font-family: sans-serif; fill: #ffffff">√</tspan>
+      <tspan x="73.432617" y="-2.009375" style="font-size: 6.048393px; font-family: 'STIXSizeOneSym'; fill: #ffffff">√</tspan>
       <tspan x="88.636955" y="-4.459375" style="font-size: 7px; font-family: sans-serif; fill: #ffffff">0</tspan>
       <tspan x="101.040034" y="-4.459375" style="font-size: 7px; font-family: sans-serif; fill: #ffffff">0</tspan>
       <tspan x="102.96435" y="-4.459375" style="font-size: 7px; font-family: sans-serif; fill: #ffffff">0</tspan>

--- a/.github/images/infinite_mobilities_es.svg
+++ b/.github/images/infinite_mobilities_es.svg
@@ -1388,7 +1388,7 @@ z
       <tspan x="33.427734" y="-0.228125" style="font-style: oblique; font-size: 10px; font-family: sans-serif">Y</tspan>
       <tspan x="79.448074" y="-0.329375" style="font-style: oblique; font-size: 10px; font-family: sans-serif">B</tspan>
       <tspan x="89.208732" y="-0.329375" style="font-style: oblique; font-size: 10px; font-family: sans-serif">m</tspan>
-      <tspan x="71.806641" y="-2.009375" style="font-size: 6.048393px; font-family: sans-serif">√</tspan>
+      <tspan x="71.806641" y="-2.009375" style="font-size: 6.048393px; font-family: 'STIXSizeOneSym'">√</tspan>
       <tspan x="87.010978" y="-4.459375" style="font-size: 7px; font-family: sans-serif">0</tspan>
       <tspan x="99.414057" y="-4.459375" style="font-size: 7px; font-family: sans-serif">0</tspan>
       <tspan x="101.338374" y="-4.459375" style="font-size: 7px; font-family: sans-serif">0</tspan>

--- a/.github/images/infinite_mobilities_es_dark.svg
+++ b/.github/images/infinite_mobilities_es_dark.svg
@@ -1388,7 +1388,7 @@ z
       <tspan x="33.427734" y="-0.228125" style="font-style: oblique; font-size: 10px; font-family: sans-serif; fill: #ffffff">Y</tspan>
       <tspan x="79.448074" y="-0.329375" style="font-style: oblique; font-size: 10px; font-family: sans-serif; fill: #ffffff">B</tspan>
       <tspan x="89.208732" y="-0.329375" style="font-style: oblique; font-size: 10px; font-family: sans-serif; fill: #ffffff">m</tspan>
-      <tspan x="71.806641" y="-2.009375" style="font-size: 6.048393px; font-family: sans-serif; fill: #ffffff">√</tspan>
+      <tspan x="71.806641" y="-2.009375" style="font-size: 6.048393px; font-family: 'STIXSizeOneSym'; fill: #ffffff">√</tspan>
       <tspan x="87.010978" y="-4.459375" style="font-size: 7px; font-family: sans-serif; fill: #ffffff">0</tspan>
       <tspan x="99.414057" y="-4.459375" style="font-size: 7px; font-family: sans-serif; fill: #ffffff">0</tspan>
       <tspan x="101.338374" y="-4.459375" style="font-size: 7px; font-family: sans-serif; fill: #ffffff">0</tspan>

--- a/.github/images/psd_segment_tradeoff.svg
+++ b/.github/images/psd_segment_tradeoff.svg
@@ -1130,7 +1130,7 @@ L 619.389922 51.735117
        <tspan x="133.865494" y="-0.071246" style="font-size: 8.5px; font-family: sans-serif">d</tspan>
        <tspan x="139.261002" y="-0.071246" style="font-size: 8.5px; font-family: sans-serif">B</tspan>
        <tspan x="145.0923" y="-0.071246" style="font-size: 8.5px; font-family: sans-serif">]</tspan>
-       <tspan x="107.989014" y="-0.115" style="font-size: 4.759659px; font-family: sans-serif">√</tspan>
+       <tspan x="107.989014" y="-0.115" style="font-size: 4.759659px; font-family: 'STIXSizeOneSym'">√</tspan>
        <tspan x="114.072281" y="0.296875" style="font-style: oblique; font-size: 8.5px; font-family: sans-serif">n</tspan>
        <tspan x="119.459488" y="1.571871" style="font-style: oblique; font-size: 5.95px; font-family: sans-serif">d</tspan>
       </text>

--- a/.github/images/psd_segment_tradeoff_dark.svg
+++ b/.github/images/psd_segment_tradeoff_dark.svg
@@ -1130,7 +1130,7 @@ L 619.389922 51.735117
        <tspan x="133.865494" y="-0.071246" style="font-size: 8.5px; font-family: sans-serif; fill: #ffffff">d</tspan>
        <tspan x="139.261002" y="-0.071246" style="font-size: 8.5px; font-family: sans-serif; fill: #ffffff">B</tspan>
        <tspan x="145.0923" y="-0.071246" style="font-size: 8.5px; font-family: sans-serif; fill: #ffffff">]</tspan>
-       <tspan x="107.989014" y="-0.115" style="font-size: 4.759659px; font-family: sans-serif; fill: #ffffff">√</tspan>
+       <tspan x="107.989014" y="-0.115" style="font-size: 4.759659px; font-family: 'STIXSizeOneSym'; fill: #ffffff">√</tspan>
        <tspan x="114.072281" y="0.296875" style="font-style: oblique; font-size: 8.5px; font-family: sans-serif; fill: #ffffff">n</tspan>
        <tspan x="119.459488" y="1.571871" style="font-style: oblique; font-size: 5.95px; font-family: sans-serif; fill: #ffffff">d</tspan>
       </text>

--- a/.github/images/psd_segment_tradeoff_es.svg
+++ b/.github/images/psd_segment_tradeoff_es.svg
@@ -1137,7 +1137,7 @@ L 609.912422 52.075117
        <tspan x="138.49733" y="-0.071246" style="font-size: 8.5px; font-family: sans-serif">d</tspan>
        <tspan x="143.892838" y="-0.071246" style="font-size: 8.5px; font-family: sans-serif">B</tspan>
        <tspan x="149.724136" y="-0.071246" style="font-size: 8.5px; font-family: sans-serif">]</tspan>
-       <tspan x="112.62085" y="-0.115" style="font-size: 4.759659px; font-family: sans-serif">√</tspan>
+       <tspan x="112.62085" y="-0.115" style="font-size: 4.759659px; font-family: 'STIXSizeOneSym'">√</tspan>
        <tspan x="118.704117" y="0.296875" style="font-style: oblique; font-size: 8.5px; font-family: sans-serif">n</tspan>
        <tspan x="124.091324" y="1.571871" style="font-style: oblique; font-size: 5.95px; font-family: sans-serif">d</tspan>
       </text>

--- a/.github/images/psd_segment_tradeoff_es_dark.svg
+++ b/.github/images/psd_segment_tradeoff_es_dark.svg
@@ -1137,7 +1137,7 @@ L 609.912422 52.075117
        <tspan x="138.49733" y="-0.071246" style="font-size: 8.5px; font-family: sans-serif; fill: #ffffff">d</tspan>
        <tspan x="143.892838" y="-0.071246" style="font-size: 8.5px; font-family: sans-serif; fill: #ffffff">B</tspan>
        <tspan x="149.724136" y="-0.071246" style="font-size: 8.5px; font-family: sans-serif; fill: #ffffff">]</tspan>
-       <tspan x="112.62085" y="-0.115" style="font-size: 4.759659px; font-family: sans-serif; fill: #ffffff">√</tspan>
+       <tspan x="112.62085" y="-0.115" style="font-size: 4.759659px; font-family: 'STIXSizeOneSym'; fill: #ffffff">√</tspan>
        <tspan x="118.704117" y="0.296875" style="font-style: oblique; font-size: 8.5px; font-family: sans-serif; fill: #ffffff">n</tspan>
        <tspan x="124.091324" y="1.571871" style="font-style: oblique; font-size: 5.95px; font-family: sans-serif; fill: #ffffff">d</tspan>
       </text>

--- a/.github/images/rice_nongaussian_screen.svg
+++ b/.github/images/rice_nongaussian_screen.svg
@@ -1347,7 +1347,7 @@ L 519.671191 330.444844
        <tspan x="113.587357" y="-0.085" style="font-size: 9px; font-family: sans-serif">7</tspan>
        <tspan x="119.313431" y="-0.085" style="font-size: 9px; font-family: sans-serif">4</tspan>
        <tspan x="125.039505" y="-0.085" style="font-size: 9px; font-family: sans-serif">5</tspan>
-       <tspan x="69.569824" y="-1.475625" style="font-size: 5.142857px; font-family: sans-serif">√</tspan>
+       <tspan x="69.569824" y="-1.475625" style="font-size: 5.142857px; font-family: 'STIXSizeOneSym'">√</tspan>
       </text>
       <rect x="75.003372" y="-10.4375" width="7.976074" height="0.5625"/>
      </g>

--- a/.github/images/rice_nongaussian_screen_dark.svg
+++ b/.github/images/rice_nongaussian_screen_dark.svg
@@ -1347,7 +1347,7 @@ L 519.671191 330.444844
        <tspan x="113.587357" y="-0.085" style="font-size: 9px; font-family: sans-serif; fill: #ffffff">7</tspan>
        <tspan x="119.313431" y="-0.085" style="font-size: 9px; font-family: sans-serif; fill: #ffffff">4</tspan>
        <tspan x="125.039505" y="-0.085" style="font-size: 9px; font-family: sans-serif; fill: #ffffff">5</tspan>
-       <tspan x="69.569824" y="-1.475625" style="font-size: 5.142857px; font-family: sans-serif; fill: #ffffff">√</tspan>
+       <tspan x="69.569824" y="-1.475625" style="font-size: 5.142857px; font-family: 'STIXSizeOneSym'; fill: #ffffff">√</tspan>
       </text>
       <rect x="75.003372" y="-10.4375" width="7.976074" height="0.5625"/>
      </g>

--- a/.github/images/rice_nongaussian_screen_es.svg
+++ b/.github/images/rice_nongaussian_screen_es.svg
@@ -1359,7 +1359,7 @@ L 519.671191 330.084844
        <tspan x="117.885208" y="-0.085" style="font-size: 9px; font-family: sans-serif">7</tspan>
        <tspan x="123.611282" y="-0.085" style="font-size: 9px; font-family: sans-serif">4</tspan>
        <tspan x="129.337357" y="-0.085" style="font-size: 9px; font-family: sans-serif">5</tspan>
-       <tspan x="73.867676" y="-1.475625" style="font-size: 5.142857px; font-family: sans-serif">√</tspan>
+       <tspan x="73.867676" y="-1.475625" style="font-size: 5.142857px; font-family: 'STIXSizeOneSym'">√</tspan>
       </text>
       <rect x="79.301224" y="-10.4375" width="7.976074" height="0.5625"/>
      </g>

--- a/.github/images/rice_nongaussian_screen_es_dark.svg
+++ b/.github/images/rice_nongaussian_screen_es_dark.svg
@@ -1359,7 +1359,7 @@ L 519.671191 330.084844
        <tspan x="117.885208" y="-0.085" style="font-size: 9px; font-family: sans-serif; fill: #ffffff">7</tspan>
        <tspan x="123.611282" y="-0.085" style="font-size: 9px; font-family: sans-serif; fill: #ffffff">4</tspan>
        <tspan x="129.337357" y="-0.085" style="font-size: 9px; font-family: sans-serif; fill: #ffffff">5</tspan>
-       <tspan x="73.867676" y="-1.475625" style="font-size: 5.142857px; font-family: sans-serif; fill: #ffffff">√</tspan>
+       <tspan x="73.867676" y="-1.475625" style="font-size: 5.142857px; font-family: 'STIXSizeOneSym'; fill: #ffffff">√</tspan>
       </text>
       <rect x="79.301224" y="-10.4375" width="7.976074" height="0.5625"/>
      </g>

--- a/.github/images/rice_peak_distribution.svg
+++ b/.github/images/rice_peak_distribution.svg
@@ -2888,7 +2888,7 @@ L 705.498437 28.318125
       <tspan x="81.845703" y="-0.630625" style="font-style: oblique; font-size: 8.5px; font-family: sans-serif">N</tspan>
       <tspan x="100.493823" y="-0.630625" style="font-style: oblique; font-size: 8.5px; font-family: sans-serif">M</tspan>
       <tspan x="88.204102" y="0.644371" style="font-size: 5.95px; font-family: sans-serif">0</tspan>
-      <tspan x="118.261646" y="-1.943125" style="font-size: 4.868028px; font-family: sans-serif">√</tspan>
+      <tspan x="118.261646" y="-1.943125" style="font-size: 4.868028px; font-family: 'STIXSizeOneSym'">√</tspan>
      </text>
      <rect x="123.398074" y="-10.46875" width="7.532959" height="0.53125"/>
     </g>

--- a/.github/images/rice_peak_distribution_dark.svg
+++ b/.github/images/rice_peak_distribution_dark.svg
@@ -2888,7 +2888,7 @@ L 705.498437 28.318125
       <tspan x="81.845703" y="-0.630625" style="font-style: oblique; font-size: 8.5px; font-family: sans-serif; fill: #ffffff">N</tspan>
       <tspan x="100.493823" y="-0.630625" style="font-style: oblique; font-size: 8.5px; font-family: sans-serif; fill: #ffffff">M</tspan>
       <tspan x="88.204102" y="0.644371" style="font-size: 5.95px; font-family: sans-serif; fill: #ffffff">0</tspan>
-      <tspan x="118.261646" y="-1.943125" style="font-size: 4.868028px; font-family: sans-serif; fill: #ffffff">√</tspan>
+      <tspan x="118.261646" y="-1.943125" style="font-size: 4.868028px; font-family: 'STIXSizeOneSym'; fill: #ffffff">√</tspan>
      </text>
      <rect x="123.398074" y="-10.46875" width="7.532959" height="0.53125"/>
     </g>

--- a/.github/images/rice_peak_distribution_es.svg
+++ b/.github/images/rice_peak_distribution_es.svg
@@ -2897,7 +2897,7 @@ L 705.498437 28.798125
       <tspan x="85.136963" y="-0.630625" style="font-style: oblique; font-size: 8.5px; font-family: sans-serif">N</tspan>
       <tspan x="103.785083" y="-0.630625" style="font-style: oblique; font-size: 8.5px; font-family: sans-serif">M</tspan>
       <tspan x="91.495361" y="0.644371" style="font-size: 5.95px; font-family: sans-serif">0</tspan>
-      <tspan x="121.552905" y="-1.943125" style="font-size: 4.868028px; font-family: sans-serif">√</tspan>
+      <tspan x="121.552905" y="-1.943125" style="font-size: 4.868028px; font-family: 'STIXSizeOneSym'">√</tspan>
      </text>
      <rect x="126.689334" y="-10.46875" width="7.532959" height="0.53125"/>
     </g>

--- a/.github/images/rice_peak_distribution_es_dark.svg
+++ b/.github/images/rice_peak_distribution_es_dark.svg
@@ -2897,7 +2897,7 @@ L 705.498437 28.798125
       <tspan x="85.136963" y="-0.630625" style="font-style: oblique; font-size: 8.5px; font-family: sans-serif; fill: #ffffff">N</tspan>
       <tspan x="103.785083" y="-0.630625" style="font-style: oblique; font-size: 8.5px; font-family: sans-serif; fill: #ffffff">M</tspan>
       <tspan x="91.495361" y="0.644371" style="font-size: 5.95px; font-family: sans-serif; fill: #ffffff">0</tspan>
-      <tspan x="121.552905" y="-1.943125" style="font-size: 4.868028px; font-family: sans-serif; fill: #ffffff">√</tspan>
+      <tspan x="121.552905" y="-1.943125" style="font-size: 4.868028px; font-family: 'STIXSizeOneSym'; fill: #ffffff">√</tspan>
      </text>
      <rect x="126.689334" y="-10.46875" width="7.532959" height="0.53125"/>
     </g>

--- a/.github/images/shock_dose_measures.svg
+++ b/.github/images/shock_dose_measures.svg
@@ -7765,8 +7765,8 @@ L 72.005469 466.17287
      <!-- $\left(\int_0^t a_w^4\,dt\right)^{1/4}$ -->
      <g transform="translate(79.205469 469.32287)">
       <text>
-       <tspan x="0" y="0.465078" style="font-size: 9.130386px; font-family: sans-serif">(</tspan>
-       <tspan x="37.457841" y="0.465078" style="font-size: 9.130386px; font-family: sans-serif">)</tspan>
+       <tspan x="0" y="0.465078" style="font-size: 9.130386px; font-family: 'STIXSizeTwoSym'">(</tspan>
+       <tspan x="37.457841" y="0.465078" style="font-size: 9.130386px; font-family: 'STIXSizeTwoSym'">)</tspan>
        <tspan x="5.374619" y="-0.228672" style="font-size: 9px; font-family: sans-serif">∫</tspan>
        <tspan x="13.182548" y="-9.419297" style="font-style: oblique; font-size: 6.3px; font-family: sans-serif">t</tspan>
        <tspan x="21.356249" y="2.552328" style="font-style: oblique; font-size: 6.3px; font-family: sans-serif">w</tspan>

--- a/.github/images/shock_dose_measures_dark.svg
+++ b/.github/images/shock_dose_measures_dark.svg
@@ -7765,8 +7765,8 @@ L 72.005469 466.17287
      <!-- $\left(\int_0^t a_w^4\,dt\right)^{1/4}$ -->
      <g style="fill: #ffffff" transform="translate(79.205469 469.32287)">
       <text>
-       <tspan x="0" y="0.465078" style="font-size: 9.130386px; font-family: sans-serif; fill: #ffffff">(</tspan>
-       <tspan x="37.457841" y="0.465078" style="font-size: 9.130386px; font-family: sans-serif; fill: #ffffff">)</tspan>
+       <tspan x="0" y="0.465078" style="font-size: 9.130386px; font-family: 'STIXSizeTwoSym'; fill: #ffffff">(</tspan>
+       <tspan x="37.457841" y="0.465078" style="font-size: 9.130386px; font-family: 'STIXSizeTwoSym'; fill: #ffffff">)</tspan>
        <tspan x="5.374619" y="-0.228672" style="font-size: 9px; font-family: sans-serif; fill: #ffffff">∫</tspan>
        <tspan x="13.182548" y="-9.419297" style="font-style: oblique; font-size: 6.3px; font-family: sans-serif; fill: #ffffff">t</tspan>
        <tspan x="21.356249" y="2.552328" style="font-style: oblique; font-size: 6.3px; font-family: sans-serif; fill: #ffffff">w</tspan>

--- a/.github/images/shock_dose_measures_es.svg
+++ b/.github/images/shock_dose_measures_es.svg
@@ -7772,8 +7772,8 @@ L 72.005469 466.57287
      <!-- $\left(\int_0^t a_w^4\,dt\right)^{1/4}$ -->
      <g transform="translate(79.205469 469.72287)">
       <text>
-       <tspan x="0" y="0.465078" style="font-size: 9.130386px; font-family: sans-serif">(</tspan>
-       <tspan x="37.457841" y="0.465078" style="font-size: 9.130386px; font-family: sans-serif">)</tspan>
+       <tspan x="0" y="0.465078" style="font-size: 9.130386px; font-family: 'STIXSizeTwoSym'">(</tspan>
+       <tspan x="37.457841" y="0.465078" style="font-size: 9.130386px; font-family: 'STIXSizeTwoSym'">)</tspan>
        <tspan x="5.374619" y="-0.228672" style="font-size: 9px; font-family: sans-serif">∫</tspan>
        <tspan x="13.182548" y="-9.419297" style="font-style: oblique; font-size: 6.3px; font-family: sans-serif">t</tspan>
        <tspan x="21.356249" y="2.552328" style="font-style: oblique; font-size: 6.3px; font-family: sans-serif">w</tspan>

--- a/.github/images/shock_dose_measures_es_dark.svg
+++ b/.github/images/shock_dose_measures_es_dark.svg
@@ -7772,8 +7772,8 @@ L 72.005469 466.57287
      <!-- $\left(\int_0^t a_w^4\,dt\right)^{1/4}$ -->
      <g style="fill: #ffffff" transform="translate(79.205469 469.72287)">
       <text>
-       <tspan x="0" y="0.465078" style="font-size: 9.130386px; font-family: sans-serif; fill: #ffffff">(</tspan>
-       <tspan x="37.457841" y="0.465078" style="font-size: 9.130386px; font-family: sans-serif; fill: #ffffff">)</tspan>
+       <tspan x="0" y="0.465078" style="font-size: 9.130386px; font-family: 'STIXSizeTwoSym'; fill: #ffffff">(</tspan>
+       <tspan x="37.457841" y="0.465078" style="font-size: 9.130386px; font-family: 'STIXSizeTwoSym'; fill: #ffffff">)</tspan>
        <tspan x="5.374619" y="-0.228672" style="font-size: 9px; font-family: sans-serif; fill: #ffffff">∫</tspan>
        <tspan x="13.182548" y="-9.419297" style="font-style: oblique; font-size: 6.3px; font-family: sans-serif; fill: #ffffff">t</tspan>
        <tspan x="21.356249" y="2.552328" style="font-style: oblique; font-size: 6.3px; font-family: sans-serif; fill: #ffffff">w</tspan>

--- a/.github/images/synchronous_average.svg
+++ b/.github/images/synchronous_average.svg
@@ -994,7 +994,7 @@ L 379.220625 26.318125
       <tspan x="92.083344" y="-0.630625" style="font-size: 8.5px; font-family: sans-serif">u</tspan>
       <tspan x="97.470551" y="-0.630625" style="font-size: 8.5px; font-family: sans-serif">d</tspan>
       <tspan x="102.866058" y="-0.630625" style="font-size: 8.5px; font-family: sans-serif">e</tspan>
-      <tspan x="38.436768" y="-2.0525" style="font-size: 4.800299px; font-family: sans-serif">√</tspan>
+      <tspan x="38.436768" y="-2.0525" style="font-size: 4.800299px; font-family: 'STIXSizeOneSym'">√</tspan>
       <tspan x="44.569672" y="-0.265625" style="font-style: oblique; font-size: 8.5px; font-family: sans-serif">N</tspan>
      </text>
      <rect x="43.507172" y="-10.46875" width="8.483398" height="0.53125"/>

--- a/.github/images/synchronous_average_dark.svg
+++ b/.github/images/synchronous_average_dark.svg
@@ -994,7 +994,7 @@ L 379.220625 26.318125
       <tspan x="92.083344" y="-0.630625" style="font-size: 8.5px; font-family: sans-serif; fill: #ffffff">u</tspan>
       <tspan x="97.470551" y="-0.630625" style="font-size: 8.5px; font-family: sans-serif; fill: #ffffff">d</tspan>
       <tspan x="102.866058" y="-0.630625" style="font-size: 8.5px; font-family: sans-serif; fill: #ffffff">e</tspan>
-      <tspan x="38.436768" y="-2.0525" style="font-size: 4.800299px; font-family: sans-serif; fill: #ffffff">√</tspan>
+      <tspan x="38.436768" y="-2.0525" style="font-size: 4.800299px; font-family: 'STIXSizeOneSym'; fill: #ffffff">√</tspan>
       <tspan x="44.569672" y="-0.265625" style="font-style: oblique; font-size: 8.5px; font-family: sans-serif; fill: #ffffff">N</tspan>
      </text>
      <rect x="43.507172" y="-10.46875" width="8.483398" height="0.53125"/>

--- a/.github/images/synchronous_average_es.svg
+++ b/.github/images/synchronous_average_es.svg
@@ -987,7 +987,7 @@ L 379.220625 26.798125
       <tspan x="66.500336" y="-0.630625" style="font-size: 8.5px; font-family: sans-serif">t</tspan>
       <tspan x="69.833099" y="-0.630625" style="font-size: 8.5px; font-family: sans-serif">u</tspan>
       <tspan x="75.220306" y="-0.630625" style="font-size: 8.5px; font-family: sans-serif">d</tspan>
-      <tspan x="13.318604" y="-2.0525" style="font-size: 4.800299px; font-family: sans-serif">√</tspan>
+      <tspan x="13.318604" y="-2.0525" style="font-size: 4.800299px; font-family: 'STIXSizeOneSym'">√</tspan>
       <tspan x="19.451508" y="-0.265625" style="font-style: oblique; font-size: 8.5px; font-family: sans-serif">N</tspan>
      </text>
      <rect x="18.389008" y="-10.46875" width="8.483398" height="0.53125"/>

--- a/.github/images/synchronous_average_es_dark.svg
+++ b/.github/images/synchronous_average_es_dark.svg
@@ -987,7 +987,7 @@ L 379.220625 26.798125
       <tspan x="66.500336" y="-0.630625" style="font-size: 8.5px; font-family: sans-serif; fill: #ffffff">t</tspan>
       <tspan x="69.833099" y="-0.630625" style="font-size: 8.5px; font-family: sans-serif; fill: #ffffff">u</tspan>
       <tspan x="75.220306" y="-0.630625" style="font-size: 8.5px; font-family: sans-serif; fill: #ffffff">d</tspan>
-      <tspan x="13.318604" y="-2.0525" style="font-size: 4.800299px; font-family: sans-serif; fill: #ffffff">√</tspan>
+      <tspan x="13.318604" y="-2.0525" style="font-size: 4.800299px; font-family: 'STIXSizeOneSym'; fill: #ffffff">√</tspan>
       <tspan x="19.451508" y="-0.265625" style="font-style: oblique; font-size: 8.5px; font-family: sans-serif; fill: #ffffff">N</tspan>
      </text>
      <rect x="18.389008" y="-10.46875" width="8.483398" height="0.53125"/>

--- a/.github/images/tsa_noise_reduction.svg
+++ b/.github/images/tsa_noise_reduction.svg
@@ -645,7 +645,7 @@ L 705.498438 32.52
       <tspan x="325.85556" y="-0.826875" style="font-weight: 700; font-size: 12px; font-family: sans-serif">8</tspan>
       <tspan x="334.20517" y="-0.826875" style="font-weight: 700; font-size: 12px; font-family: sans-serif">7</tspan>
       <tspan x="342.554779" y="-0.826875" style="font-weight: 700; font-size: 12px; font-family: sans-serif">)</tspan>
-      <tspan x="175.986328" y="-2.81125" style="font-size: 6.765328px; font-family: sans-serif">√</tspan>
+      <tspan x="175.986328" y="-2.81125" style="font-size: 6.765328px; font-family: 'STIXSizeOneSym'">√</tspan>
       <tspan x="184.621185" y="-0.5" style="font-style: oblique; font-size: 12px; font-family: sans-serif">N</tspan>
      </text>
      <rect x="183.121185" y="-14.25" width="11.976562" height="0.75"/>
@@ -696,7 +696,7 @@ L 530.120781 60.960703
        <tspan x="30.484863" y="-0.100625" style="font-size: 9px; font-family: sans-serif">/</tspan>
        <tspan x="24.780762" y="-0.100625" style="font-style: oblique; font-size: 9px; font-family: sans-serif">σ</tspan>
        <tspan x="39.99324" y="0.125" style="font-style: oblique; font-size: 9px; font-family: sans-serif">N</tspan>
-       <tspan x="33.51709" y="-1.600625" style="font-size: 5.075188px; font-family: sans-serif">√</tspan>
+       <tspan x="33.51709" y="-1.600625" style="font-size: 5.075188px; font-family: 'STIXSizeOneSym'">√</tspan>
       </text>
       <rect x="38.86824" y="-10.4375" width="8.982422" height="0.5625"/>
      </g>

--- a/.github/images/tsa_noise_reduction_dark.svg
+++ b/.github/images/tsa_noise_reduction_dark.svg
@@ -645,7 +645,7 @@ L 705.498438 32.52
       <tspan x="325.85556" y="-0.826875" style="font-weight: 700; font-size: 12px; font-family: sans-serif; fill: #ffffff">8</tspan>
       <tspan x="334.20517" y="-0.826875" style="font-weight: 700; font-size: 12px; font-family: sans-serif; fill: #ffffff">7</tspan>
       <tspan x="342.554779" y="-0.826875" style="font-weight: 700; font-size: 12px; font-family: sans-serif; fill: #ffffff">)</tspan>
-      <tspan x="175.986328" y="-2.81125" style="font-size: 6.765328px; font-family: sans-serif; fill: #ffffff">√</tspan>
+      <tspan x="175.986328" y="-2.81125" style="font-size: 6.765328px; font-family: 'STIXSizeOneSym'; fill: #ffffff">√</tspan>
       <tspan x="184.621185" y="-0.5" style="font-style: oblique; font-size: 12px; font-family: sans-serif; fill: #ffffff">N</tspan>
      </text>
      <rect x="183.121185" y="-14.25" width="11.976562" height="0.75"/>
@@ -696,7 +696,7 @@ L 530.120781 60.960703
        <tspan x="30.484863" y="-0.100625" style="font-size: 9px; font-family: sans-serif; fill: #ffffff">/</tspan>
        <tspan x="24.780762" y="-0.100625" style="font-style: oblique; font-size: 9px; font-family: sans-serif; fill: #ffffff">σ</tspan>
        <tspan x="39.99324" y="0.125" style="font-style: oblique; font-size: 9px; font-family: sans-serif; fill: #ffffff">N</tspan>
-       <tspan x="33.51709" y="-1.600625" style="font-size: 5.075188px; font-family: sans-serif; fill: #ffffff">√</tspan>
+       <tspan x="33.51709" y="-1.600625" style="font-size: 5.075188px; font-family: 'STIXSizeOneSym'; fill: #ffffff">√</tspan>
       </text>
       <rect x="38.86824" y="-10.4375" width="8.982422" height="0.5625"/>
      </g>

--- a/.github/images/tsa_noise_reduction_es.svg
+++ b/.github/images/tsa_noise_reduction_es.svg
@@ -667,7 +667,7 @@ L 705.498438 32.52
       <tspan x="470.875092" y="-0.826875" style="font-weight: 700; font-size: 12px; font-family: sans-serif">8</tspan>
       <tspan x="479.224701" y="-0.826875" style="font-weight: 700; font-size: 12px; font-family: sans-serif">7</tspan>
       <tspan x="487.57431" y="-0.826875" style="font-weight: 700; font-size: 12px; font-family: sans-serif">)</tspan>
-      <tspan x="352.013672" y="-2.81125" style="font-size: 6.765328px; font-family: sans-serif">√</tspan>
+      <tspan x="352.013672" y="-2.81125" style="font-size: 6.765328px; font-family: 'STIXSizeOneSym'">√</tspan>
       <tspan x="360.648529" y="-0.5" style="font-style: oblique; font-size: 12px; font-family: sans-serif">N</tspan>
      </text>
      <rect x="359.148529" y="-14.25" width="11.976562" height="0.75"/>
@@ -718,7 +718,7 @@ L 546.849531 60.960703
        <tspan x="34.144119" y="-0.100625" style="font-size: 9px; font-family: sans-serif">e</tspan>
        <tspan x="39.681229" y="-0.100625" style="font-size: 9px; font-family: sans-serif">a</tspan>
        <tspan x="45.196365" y="-0.100625" style="font-size: 9px; font-family: sans-serif">l</tspan>
-       <tspan x="8.736328" y="-1.600625" style="font-size: 5.075188px; font-family: sans-serif">√</tspan>
+       <tspan x="8.736328" y="-1.600625" style="font-size: 5.075188px; font-family: 'STIXSizeOneSym'">√</tspan>
       </text>
       <rect x="14.087479" y="-10.4375" width="8.982422" height="0.5625"/>
      </g>

--- a/.github/images/tsa_noise_reduction_es_dark.svg
+++ b/.github/images/tsa_noise_reduction_es_dark.svg
@@ -667,7 +667,7 @@ L 705.498438 32.52
       <tspan x="470.875092" y="-0.826875" style="font-weight: 700; font-size: 12px; font-family: sans-serif; fill: #ffffff">8</tspan>
       <tspan x="479.224701" y="-0.826875" style="font-weight: 700; font-size: 12px; font-family: sans-serif; fill: #ffffff">7</tspan>
       <tspan x="487.57431" y="-0.826875" style="font-weight: 700; font-size: 12px; font-family: sans-serif; fill: #ffffff">)</tspan>
-      <tspan x="352.013672" y="-2.81125" style="font-size: 6.765328px; font-family: sans-serif; fill: #ffffff">√</tspan>
+      <tspan x="352.013672" y="-2.81125" style="font-size: 6.765328px; font-family: 'STIXSizeOneSym'; fill: #ffffff">√</tspan>
       <tspan x="360.648529" y="-0.5" style="font-style: oblique; font-size: 12px; font-family: sans-serif; fill: #ffffff">N</tspan>
      </text>
      <rect x="359.148529" y="-14.25" width="11.976562" height="0.75"/>
@@ -718,7 +718,7 @@ L 546.849531 60.960703
        <tspan x="34.144119" y="-0.100625" style="font-size: 9px; font-family: sans-serif; fill: #ffffff">e</tspan>
        <tspan x="39.681229" y="-0.100625" style="font-size: 9px; font-family: sans-serif; fill: #ffffff">a</tspan>
        <tspan x="45.196365" y="-0.100625" style="font-size: 9px; font-family: sans-serif; fill: #ffffff">l</tspan>
-       <tspan x="8.736328" y="-1.600625" style="font-size: 5.075188px; font-family: sans-serif; fill: #ffffff">√</tspan>
+       <tspan x="8.736328" y="-1.600625" style="font-size: 5.075188px; font-family: 'STIXSizeOneSym'; fill: #ffffff">√</tspan>
       </text>
       <rect x="14.087479" y="-10.4375" width="8.982422" height="0.5625"/>
      </g>

--- a/scripts/figures/theme.py
+++ b/scripts/figures/theme.py
@@ -224,9 +224,23 @@ def save_figure(output_dir: str, filename: str, **kwargs: Any) -> None:
         # plain <text> (full chain ending in sans-serif) stays sans. Normalise
         # every declaration to the generic 'sans-serif' so all text renders in
         # the viewer's native sans font, consistently and viewer-independently.
+        # Exception: mathtext draws radicals and extensible delimiters with a
+        # dedicated 'STIXSizeOneSym' run sized to match the glyph next to it
+        # (e.g. the bar over \sqrt{...}); rewriting that run to sans-serif
+        # swaps in the reader's sans glyph at the wrong size, so the radical
+        # bar no longer lines up with the symbol it covers. Leave any
+        # declaration whose family starts with 'STIX' untouched. The
+        # lookahead sits before the optional whitespace (not inside
+        # ``\s*``): matplotlib emits a space after the colon, and a
+        # trailing ``\s*(?!'STIX)`` would backtrack to zero width and test
+        # the lookahead against that leading space instead of the quote,
+        # matching (and clobbering) the STIX declaration it was meant to
+        # protect.
         import re as _re
         svg_text = pathlib.Path(path).read_text(encoding="utf-8")
-        svg_text = _re.sub(r"font-family:\s*[^;\"]+", "font-family: sans-serif", svg_text)
+        svg_text = _re.sub(
+            r"font-family:(?!\s*'STIX)\s*[^;\"]+", "font-family: sans-serif", svg_text
+        )
         pathlib.Path(path).write_text(svg_text, encoding="utf-8")
         return
     import io


### PR DESCRIPTION
The SVG font normalization rewrites every font-family declaration to the generic sans-serif the site standardizes on. That rewrite was also catching the STIXSizeOneSym and STIXSizeTwoSym runs matplotlib emits for radical signs and extensible delimiters, which replaced purpose-built stretched glyphs with ordinary text ones: the square root bar floated detached from its symbol, and tall parentheses rendered flat and undersized. The defect ships today in seven figures.

The exclusion is one pattern change with a subtlety worth recording: placing the negative lookahead after optional whitespace lets the regex backtrack the whitespace to zero width and test the lookahead against the space instead of the quote, so it still clobbers STIX. The lookahead now sits before the whitespace and was verified against matplotlib's real output in both spacing styles, with non-STIX families still rewritten.

Seven assets regenerate across their four language and theme variants (28 files), each diff touching only the font-family of the affected glyph runs. Before and after renders confirm the radical bars sit flush and the extensible parentheses reach their full height in both themes, and regeneration is byte-stable.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated SVG font-family processing in `scripts/figures/theme.py` to preserve 'STIX' font declarations.</li>
<li>Modified regex to prevent overwriting 'STIXSizeOneSym' font-family declarations, ensuring mathematical symbols like radicals render correctly.</li>
<li>Applied the font fix to numerous SVG files in `.github/images/` by updating the font-family attribute for square root symbols.</li>
</ul></div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SVG font handling to preserve specialized STIX math fonts.
  * Standardized other font declarations to use the generic sans-serif family.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->