### PR TITLE
Make the coverage claims true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Every piece of vector artwork draws its own text. The figures' SVGs used to
+  ship live text positioned glyph by glyph from DejaVu metrics while asking the
+  viewer for a generic sans, so any label carrying mathematics arrived
+  letter-spaced on every machine without DejaVu, which is all of them; the
+  plates asked for Segoe UI first, a face neither the maintainer's machine nor
+  CI has ever had. Both now bake outlines: the figures from the DejaVu that
+  matplotlib ships, the plates from a vendored Liberation Sans whose metrics
+  are the ones the hand-tuned compositions were adjusted against (measured:
+  width ratio 1.000 over all 6,550 drawn strings, against 1.14 for DejaVu,
+  which would have broken ninety-five plates), with a deterministic per-glyph
+  fallback and a hard error for a character no face covers. Three plates
+  rendered under an emptied fontconfig are pixel-identical to the normal
+  render, which is the property the whole change exists for.
+- The corpus typography is finished end to end: figure titles at text weight
+  (the ISO 80000 justification for mixed weights dissolved on reading the
+  standard, which regulates slope and never weight), the prime composed as a
+  superscript everywhere mathtext draws (typed U+2032 sits at x-height,
+  collides with ascenders and takes the following subscript with it), range
+  hyphens restored inside mathematics where an ASCII hyphen sets as a spaced
+  binary minus, negative readings signed with U+2212 through the shared
+  helpers in figures, plots and fiches alike, and the library renderers'
+  symbols moved into mathematics with descriptive subscripts upright, their
+  Spanish keys moving in lockstep in both translation tables.
+- Fifty-five layout collisions repaired across nineteen figures, each found by
+  opening all 427 figures in both languages, confirmed at pixel level, fixed,
+  and looked at again; two systemic causes fixed at the root (the frequency
+  axis labels every third octave past four decades, the seawater relaxation
+  labels hold inside the axis). All forty-two clips re-rendered with the
+  wave's typography and the visual audit's parked recompositions, every WebM
+  variant probed as AV1.
+- Two new gates guard what no existing gate could see: every `$...$` in the
+  sources must parse (an unparseable label aborts generation and used to be
+  reported as staleness), and no Spanish translation value may keep a decimal
+  point that the save-time comma pass cannot reach past a dollar sign. Both
+  wired into `make figures` and CI ahead of the regeneration, both proven red
+  against the real defect before being trusted.
 - The scope sections of every guide are set apart from the prose and made
   auditable. Each "what this covers" and "what this does not cover" section now
   renders as a specification panel: one claim per row, a screen-printed legend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1018,6 +1018,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   font: the type is converted from the committed font file at generation time,
   so nothing is fetched and nothing reflows once the page has painted.
 
+### Fixed
+
+- The coverage claims tell the truth again, all 582 of them audited claim by
+  claim against the code. The errors ran almost entirely in one direction: the
+  documentation undersold the library. Five claims denied functionality that
+  ships and is tested (the Directive 2003/10/EC exposure verdict of the ISO
+  9612 fiche, the Directive 2002/44/EC assessment with its PASS/FAIL banner,
+  the IEC 60268 device parts implemented since electroacoustics landed,
+  binaural summation, internal position averaging); a cluster of section
+  indexes compressed their children's carefully drawn boundaries into false
+  generalizations the child pages state correctly; three pages called Wells'
+  closed-form plenum an interpolated table; and two Spanish twins had drifted
+  from their English originals. The one flattering error, the ray solver's
+  travel times that it does not compute, is corrected the other way. Thirty-one
+  corrections over 17 English and 19 Spanish pages; no claim changed status,
+  only its text became true.
+
 ### Changed
 
 - Every entry of `docs/ERRATA.md` was checked again against the page it

--- a/docs/buildings/design/index.md
+++ b/docs/buildings/design/index.md
@@ -149,12 +149,16 @@ Pages elsewhere on the site that this section leans on:
 ## What this section does not cover
 
 **A prediction is only as good as the element data you feed it, and the
-library takes that data as given.** The element ratings, the junction indices,
-the covering improvement and the structure-to-airborne adjustment terms of EN
-12354-5 Annexes D and F are inputs you supply from measurement or from the
-standards' own annexes; none of them is derived here. The simplified
-prediction page stops at the weighted single numbers by design, and the
-detailed page is where the per-band models live.
+library takes that data as given.** The element ratings, the junction indices
+and the covering improvements are parameters the entry points consume,
+supplied from measurement or computed with this section's own estimators —
+the Annex E junction catalogue, the floating-floor and lining improvement
+laws, the Annex B homogeneous-element chain and the panel-physics models —
+and nothing checks the numbers you pass. Only the structure-to-airborne
+adjustment terms of EN 12354-5 Annexes D and F have no estimator here at all
+and must come from the standard's own tables. The simplified prediction page
+stops at the weighted single numbers by design, and the detailed page is
+where the per-band models live.
 
 Every panel model carries a validity range it does not extend past, and the
 guides flag each: Sharp's single-panel method is not valid below about 1.5

--- a/docs/buildings/index.md
+++ b/docs/buildings/index.md
@@ -108,14 +108,16 @@ and from the physics of the element itself.
 ## What this section does not cover
 
 **The library starts after the microphone and stops before the geometry.** On
-the measurement side, every function takes band levels already averaged over
-positions and already corrected for background noise: the position counts, the
-low-frequency procedures, the signal-to-background floors and the
-test-facility qualifications of ISO 16283, ISO 10140 and ISO 3382 are the
-operator's job, and nothing here checks that they were done. On the prediction
-side, the element ratings, the junction indices and the covering improvements
-are inputs you supply from measurement or from a standard's own annex; none is
-derived from a drawing.
+the measurement side, position averaging happens once positions are supplied
+— the insulation functions energy-average per-position spectra for you — but
+nothing verifies how the measurement was made: the position counts and
+placements, the low-frequency procedures and the test-facility qualifications
+of ISO 16283, ISO 10140 and ISO 3382 are the operator's job. So is measuring
+the background noise: only the ISO 10140-4 laboratory correction is
+implemented, warning when its 6 dB floor is broken, and field levels must
+arrive already corrected. On the prediction side, the element ratings, the
+junction indices and the covering improvements are inputs you supply from
+measurement or from a standard's own annex; none is derived from a drawing.
 
 **Nothing here is a wave solver or a room model.** There is no geometry
 importer, no material database, no ray tracer and no auralisation: the room

--- a/docs/buildings/insulation/index.md
+++ b/docs/buildings/insulation/index.md
@@ -95,9 +95,12 @@ related EN 12354-5, lives in
 
 ## What this section does not cover
 
-**The library starts after the microphone.** Every function here accepts
-per-position spectra and energy-averages them for you, but nothing verifies
-how the measurement was made: not the number and placement of the source and
+**The library starts after the microphone.** The field, laboratory, survey and
+intensity routines that form an insulation index accept per-position spectra
+and energy-average them for you; the heavy-impact standardization, the
+flanking indices, the ISO 717 ratings and the background-noise helpers take
+their per-band input already formed. Either way, nothing verifies how the
+measurement was made: not the number and placement of the source and
 microphone positions behind those spectra, not the low-frequency procedures
 of ISO 16283-1/-2, and not the test-facility and mounting requirements of
 ISO 10140-1. Those are the operator's responsibility and the report's, and

--- a/docs/buildings/insulation/index.md
+++ b/docs/buildings/insulation/index.md
@@ -95,18 +95,22 @@ related EN 12354-5, lives in
 
 ## What this section does not cover
 
-**The library starts after the microphone.** Every function here takes band
-levels that were already energy-averaged over positions and already corrected
-for background noise, and nothing verifies how the measurement was made: not
-the number and placement of source and microphone positions, not the
-low-frequency procedures of ISO 16283-1/-2, not the 6 dB signal-to-background
-floor, and not the test-facility and mounting requirements of ISO 10140-1.
-Those are the operator's responsibility and the report's, and they are what
-makes the numbers here mean something. Two consequences worth naming: the
-field and laboratory background corrections are *different* rules, so a
-laboratory helper must not be applied to field data; and the intensity route
-takes both the pressure and the intensity level as inputs, with the scanning
-probe and its phase-mismatch calibration outside the library.
+**The library starts after the microphone.** Every function here accepts
+per-position spectra and energy-averages them for you, but nothing verifies
+how the measurement was made: not the number and placement of the source and
+microphone positions behind those spectra, not the low-frequency procedures
+of ISO 16283-1/-2, and not the test-facility and mounting requirements of
+ISO 10140-1. Those are the operator's responsibility and the report's, and
+they are what makes the numbers here mean something. Background noise is the
+one correction genuinely left to the caller: field levels must arrive already
+corrected, their 6 dB signal-to-background floor checked by the operator,
+while the ISO 10140-4 laboratory helper applies its rule itself, warning when
+its own floor is broken and capping the correction. Two consequences worth
+naming: the field and laboratory background corrections are *different*
+rules, so that laboratory helper must not be applied to field data; and the
+intensity route takes both the pressure and the intensity level as inputs,
+with the scanning probe and its phase-mismatch calibration outside the
+library.
 
 **Coverage inside the standards is partial in two places.** Of ISO 10848 only
 the Part 1 formulae are implemented generically, plus the Part 4 modal-overlap

--- a/docs/devices/electroacoustics/index.md
+++ b/docs/devices/electroacoustics/index.md
@@ -90,9 +90,9 @@ produced them. Two implemented editions are pinned rather than current: the
 distortion metrics follow AES17-2015 and not the 2020 revision, and the
 microphone report follows IEC 60268-4:2014 and not the 2018 one. Thiele-Small
 parameter extraction from an impedance curve is not implemented, and the
-electrical and mechanical power-handling ratings of IEC 60268-5 clause 17 are
-stated by the manufacturer rather than computed. The feedback criterion is
-level bookkeeping, not an acoustic model: it consumes two direct-field levels
+electrical and mechanical power-handling ratings of IEC 60268-5 clauses 17 and
+18 are stated by the manufacturer rather than computed. The feedback criterion
+is level bookkeeping, not an acoustic model: it consumes two direct-field levels
 you supply, does not compute them from a coverage pattern, and predicts
 neither the ring frequency nor the effect of an equaliser or frequency
 shifter. And IEC 60268-16, the speech transmission index, is not part of this

--- a/docs/devices/index.md
+++ b/docs/devices/index.md
@@ -107,8 +107,9 @@ Three specific absences are worth knowing before you plan a job. ISO 9614-1's
 discrete fixed-point power summation is **not implemented at all** — only its
 field indicators are, reused by the scanning routes. Dissipative duct-lining
 silencers are **not modelled from liner properties** anywhere: the reactive
-elements are computed exactly, and the lined-elbow and plenum figures are
-interpolated installation tables. And no page here predicts a panel's
+elements are computed exactly, and the lined-elbow figure is a table lookup
+(Bies Table 8.11) and the plenum Wells' closed form driven by a declared mean
+absorption — neither is a liner model. And no page here predicts a panel's
 transmission loss: `enclosure_insertion_loss` combines a value you supply with
 the interior correction, and the prediction itself is [Insulation
 design](../buildings/design/index.md).

--- a/docs/devices/index.md
+++ b/docs/devices/index.md
@@ -107,11 +107,12 @@ Three specific absences are worth knowing before you plan a job. ISO 9614-1's
 discrete fixed-point power summation is **not implemented at all** — only its
 field indicators are, reused by the scanning routes. Dissipative duct-lining
 silencers are **not modelled from liner properties** anywhere: the reactive
-elements are computed exactly, and the lined-elbow figure is a table lookup
-(Bies Table 8.11) and the plenum Wells' closed form driven by a declared mean
-absorption — neither is a liner model. And no page here predicts a panel's
-transmission loss: `enclosure_insertion_loss` combines a value you supply with
-the interior correction, and the prediction itself is [Insulation
+elements are computed exactly within the no-flow plane-wave model, and the
+lined-elbow figure is a table lookup (Bies Table 8.11) and the plenum Wells'
+closed form driven by a declared mean absorption — neither is a liner model.
+And no page here predicts a panel's transmission loss:
+`enclosure_insertion_loss` combines a value you supply with the interior
+correction, and the prediction itself is [Insulation
 design](../buildings/design/index.md).
 
 Editions are pinned rather than current in two places: the distortion metrics

--- a/docs/devices/index.md
+++ b/docs/devices/index.md
@@ -108,8 +108,8 @@ discrete fixed-point power summation is **not implemented at all** — only its
 field indicators are, reused by the scanning routes. Dissipative duct-lining
 silencers are **not modelled from liner properties** anywhere: the reactive
 elements are computed exactly within the no-flow plane-wave model, and the
-lined-elbow figure is a table lookup (Bies Table 8.11) and the plenum Wells'
-closed form driven by a declared mean absorption — neither is a liner model.
+lined-elbow figure is a table lookup (Bies Table 8.11) and the plenum
+attenuation Wells' closed form driven by a declared mean absorption — neither is a liner model.
 And no page here predicts a panel's transmission loss:
 `enclosure_insertion_loss` combines a value you supply with the interior
 correction, and the prediction itself is [Insulation

--- a/docs/devices/noise-control/index.md
+++ b/docs/devices/noise-control/index.md
@@ -82,8 +82,8 @@ source of a supplier's figures, not implemented. Within the predictions, three
 limits are structural. **Only reactive silencer elements are computed** —
 dissipative duct-lining silencers are discussed for selection but are not
 modelled from liner properties anywhere in the library, and on the HVAC page
-the lined-elbow figure is a table lookup (Bies Table 8.11) and the plenum is
-Wells' closed form driven by a declared mean absorption — neither is a liner
+the lined-elbow figure is a table lookup (Bies Table 8.11) and the plenum
+attenuation is Wells' closed form driven by a declared mean absorption — neither is a liner
 model. **Mean flow is outside the element matrices**:
 convection, temperature gradients and the flow-dependent impedance of
 perforates do not appear, so a silencer carrying significant flow is predicted

--- a/docs/devices/noise-control/index.md
+++ b/docs/devices/noise-control/index.md
@@ -81,9 +81,10 @@ declared data, and the measurement standards named above are cited as the
 source of a supplier's figures, not implemented. Within the predictions, three
 limits are structural. **Only reactive silencer elements are computed** —
 dissipative duct-lining silencers are discussed for selection but are not
-modelled from liner properties anywhere in the library, and the lined-elbow
-and plenum figures on the HVAC page are interpolated installation tables
-rather than a liner model. **Mean flow is outside the element matrices**:
+modelled from liner properties anywhere in the library, and on the HVAC page
+the lined-elbow figure is a table lookup (Bies Table 8.11) and the plenum is
+Wells' closed form driven by a declared mean absorption — neither is a liner
+model. **Mean flow is outside the element matrices**:
 convection, temperature gradients and the flow-dependent impedance of
 perforates do not appear, so a silencer carrying significant flow is predicted
 as though it were not. And `enclosure_insertion_loss` **never predicts the

--- a/docs/devices/noise-control/noise-control.md
+++ b/docs/devices/noise-control/noise-control.md
@@ -292,8 +292,9 @@ over interior volume) — the two numbers a prediction never captures.
 ## What this guide covers
 
 **Covered.** The Bies §8.11-8.17 / ASHRAE HVAC methods —
-`hvac.end_reflection_loss` and `hvac.elbow_insertion_loss` (interpolated
-tables), `hvac.plenum_attenuation` (Wells' closed form) and
+`hvac.end_reflection_loss` (interpolated table) and
+`hvac.elbow_insertion_loss` (Table 8.11 lookup),
+`hvac.plenum_attenuation` (Wells' closed form) and
 `hvac.flow_noise_straight_duct` / `flow_noise_bend` (VDI 2081) — and the
 machine-enclosure insertion loss of Bies §7.4, Eqs. (7.103) and (7.111),
 through `enclosure_insertion_loss`, which combines a supplied panel
@@ -302,9 +303,11 @@ transmission loss with the interior room-constant correction, together with the
 
 **Not covered.** The reactive elements — expansion chambers, side branches,
 extended tubes — live in [Silencers](silencers.md). Dissipative duct-lining
-silencers are modelled from liner properties nowhere in the library; the lined
-elbow and the plenum here are interpolated installation tables. Nothing on this
-page is a measurement: the ISO 11546 procedure of section 2 is described so a
+silencers are modelled from liner properties nowhere in the library: the
+lined-elbow figure here is a table lookup (Bies Table 8.11) and the plenum is
+Wells' closed form driven by a declared mean absorption — neither is a liner
+model. Nothing on this page is a measurement: the ISO 11546 procedure of
+section 2 is described so a
 declared figure can be read, not implemented. Structure-borne transmission from
 a machine into its enclosure or its slab is outside every model here.
 

--- a/docs/devices/noise-control/silencers.md
+++ b/docs/devices/noise-control/silencers.md
@@ -364,10 +364,10 @@ matters for selection:
   pressure drop the silencer becomes the noise source.
 
 phonometry models the reactive family in closed form on this page. The
-dissipative side enters through the installation data of the
-[HVAC methods](noise-control.md): the lined-elbow insertion loss and the
-lined plenum attenuation of Wells' method, both from interpolated ASHRAE
-data rather than a liner model. The porous physics that a first-principles
+dissipative side enters at installation level, through the
+[HVAC methods](noise-control.md): the lined-elbow insertion loss read from
+tabulated ASHRAE data and the lined plenum attenuation from Wells' closed
+form, neither of them a liner model. The porous physics that a first-principles
 liner calculation needs, the equivalent-fluid models fed by the airflow
 resistivity, is the same material theory as
 [Porous and Multilayer Absorbers](../../materials/absorbers/porous-absorbers.md).
@@ -405,9 +405,10 @@ the insertion loss a supplier publishes.
 
 **Not covered.** Reactive elements only. Dissipative (absorptive, duct-lining)
 silencers are discussed for selection but never modelled from liner properties,
-and the lined-elbow and plenum data of the
-[HVAC methods](noise-control.md) are interpolated installation tables, not a
-liner model. Mean-flow effects — convection, temperature gradients, the
+and in the [HVAC methods](noise-control.md) the lined-elbow figure is a table
+lookup (Bies Table 8.11) and the plenum is Wells' closed form driven by a
+declared mean absorption — neither is a liner model.
+Mean-flow effects — convection, temperature gradients, the
 flow-dependent impedance of perforates — are outside the no-flow element
 matrices used here. Nothing on this page is a measurement: no part of ISO 7235
 is implemented, shell breakout and the end corrections at the area jumps are

--- a/docs/perception/hearing/index.md
+++ b/docs/perception/hearing/index.md
@@ -69,9 +69,13 @@ In the order the chain runs.
 **Nothing here is a verdict about a person.** ISO 1999 does not define a
 hearing handicap or a compensable fence — that line is set by national
 regulation, and the library applies none of it, so you supply and check the
-criterion yourself. The same is true of the exposure action values: the LEX,8h
-and its one-sided 95 % upper limit come out of ISO 9612, and the numbers they
-are compared against are in your jurisdiction's directive, not here.
+criterion yourself. The exposure side stops one step later: the LEX,8h and its
+one-sided 95 % upper limit come out of ISO 9612, and the fiche written by
+`ExposureResult.report()` does compare the LEX,8h against the Directive
+2003/10/EC action and limit values (80, 85 and 87 dB(A)) and issues the
+PASS/FAIL verdict against the limit value — but that is a verdict on an
+unprotected exposure, not on a person: the effective exposure behind hearing
+protectors, and any stricter national transposition, are still yours to check.
 
 Two implementation boundaries follow the standards. Only **database A** is
 implemented for ISO 1999: `htlan` always draws its age component from ISO

--- a/docs/underwater/index.md
+++ b/docs/underwater/index.md
@@ -89,8 +89,8 @@ pile-driving noise has no closed form here or anywhere in the library.
 fluid-fluid Rayleigh reflection, so sediment attenuation is out of scope, and
 all three solvers assume a **range-independent** water column with no
 absorbing or elastic bottom and no real bathymetry — which rules out
-range-dependent problems entirely. The ray solver returns paths and travel
-times but not amplitudes (no ray-tube intensity, no caustic correction), and
+range-dependent problems entirely. The ray solver returns paths but not
+travel times or amplitudes (no ray-tube intensity, no caustic correction), and
 the parabolic equation is the standard small-angle Tappert form rather than a
 wide-angle Padé variant. For the elastic seabed physics these fluid solvers
 leave out, the [elastic wave solver](../simulation/elastic-waves.md) is

--- a/docs/underwater/underwater-solvers.md
+++ b/docs/underwater/underwater-solvers.md
@@ -143,7 +143,7 @@ print(round(float(modes.wavenumbers[0]), 5))    # 0.20885  computed kr1
 print(round(np.sqrt(k**2 - (np.pi / 200.0) ** 2), 5))   # 0.20885  exact
 ```
 
-## 3. Ray tracing: travel times and convergence zones
+## 3. Ray tracing: turning points and convergence zones
 
 In the high-frequency limit the Helmholtz equation collapses to the eikonal
 equation, and its characteristics are **rays**: trajectories integrated from
@@ -184,7 +184,7 @@ print(round(z_turn, 1))                     # 583.3  analytic turning depth
 print(round(float(rays.depths.max()), 1))   # 583.7  traced
 ```
 
-Rays buy geometry: eigenray paths, travel times and convergence-zone ranges
+Rays buy geometry: paths, turning depths and convergence-zone ranges
 at a cost independent of frequency. What they do not carry here is a full
 amplitude: the geometric ray-tube intensity diverges at caustics, so the
 result object returns the paths and leaves the level to the modal or PE
@@ -290,12 +290,12 @@ and boundaries decide the answer, pick the solver by frequency and geometry
 
 | Solver | Natural regime | What it buys you |
 |---|---|---|
-| `ray_trace` | High frequency (water depth ≫ λ), deep water | Eigenray geometry, travel times, convergence zones; cost independent of frequency |
+| `ray_trace` | High frequency (water depth ≫ λ), deep water | Ray-path geometry, turning depths, convergence zones; cost independent of frequency |
 | `normal_modes` | Low frequency, shallow water, range-independent | Finite-difference modal sum with few propagating modes ($m < kD/\pi$); the reference solution for its regime, validated against the ideal waveguide's exact modes |
 | `parabolic_equation` | Low frequency, long one-way paths | Full-field TL($z$,$r$) with refraction, marched in range over the range-independent $c(z)$ all three solvers assume |
 
 The boundaries blur in practice: rays remain usable at surprisingly low
-frequencies for travel-time work, and the PE remains the workhorse well above
+frequencies for path-geometry work, and the PE remains the workhorse well above
 its formal small-angle regime. When two of the three agree on a case, as the
 modes and the PE do in the section 1 figure, that agreement is the practical
 convergence test.
@@ -320,7 +320,7 @@ equation is why they all live in one module.
 ### Which underwater propagation solver should I use?
 
 Pick by frequency and geometry (Jensen et al. 2011, Ch. 1): rays for high
-frequency and deep water (eigenray geometry and travel times at a cost
+frequency and deep water (ray-path geometry and convergence zones at a cost
 independent of frequency), normal modes for low frequency in shallow water
 (few propagating modes, $m < kD/\pi$, the reference solution for its
 regime) and the parabolic equation for low-frequency, long one-way paths

--- a/docs/vibration/human/index.md
+++ b/docs/vibration/human/index.md
@@ -66,7 +66,9 @@ for less severe seated exposures is distributed separately by ISO and is not
 implemented, which is what makes the 1 g delineation above a routing decision
 rather than a preference.
 
-And no exposure verdict is issued. The action and limit values of Directive
-2002/44/EC are stated so that an A(8) can be read against them, but the
-library applies no national implementation of the directive, and a
-risk-assessment conclusion is not a number this section produces.
+And the verdict stops at the directive itself. An A(8) is assessed against
+the action and limit values of Directive 2002/44/EC — each marked exceeded or
+not, the exposure zone named, and a PASS/FAIL verdict issued against the
+limit value — but the library applies no national transposition of the
+directive, and the conclusion of a workplace risk assessment is not a number
+this section produces.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -6847,9 +6847,12 @@ related EN 12354-5, lives in
 
 ## What this section does not cover
 
-**The library starts after the microphone.** Every function here accepts
-per-position spectra and energy-averages them for you, but nothing verifies
-how the measurement was made: not the number and placement of the source and
+**The library starts after the microphone.** The field, laboratory, survey and
+intensity routines that form an insulation index accept per-position spectra
+and energy-average them for you; the heavy-impact standardization, the
+flanking indices, the ISO 717 ratings and the background-noise helpers take
+their per-band input already formed. Either way, nothing verifies how the
+measurement was made: not the number and placement of the source and
 microphone positions behind those spectra, not the low-frequency procedures
 of ISO 16283-1/-2, and not the test-facility and mounting requirements of
 ISO 10140-1. Those are the operator's responsibility and the report's, and
@@ -16730,11 +16733,12 @@ Three specific absences are worth knowing before you plan a job. ISO 9614-1's
 discrete fixed-point power summation is **not implemented at all** — only its
 field indicators are, reused by the scanning routes. Dissipative duct-lining
 silencers are **not modelled from liner properties** anywhere: the reactive
-elements are computed exactly, and the lined-elbow figure is a table lookup
-(Bies Table 8.11) and the plenum Wells' closed form driven by a declared mean
-absorption — neither is a liner model. And no page here predicts a panel's
-transmission loss: `enclosure_insertion_loss` combines a value you supply with
-the interior correction, and the prediction itself is [Insulation
+elements are computed exactly within the no-flow plane-wave model, and the
+lined-elbow figure is a table lookup (Bies Table 8.11) and the plenum Wells'
+closed form driven by a declared mean absorption — neither is a liner model.
+And no page here predicts a panel's transmission loss:
+`enclosure_insertion_loss` combines a value you supply with the interior
+correction, and the prediction itself is [Insulation
 design](https://jmrplens.github.io/phonometry/buildings/design/).
 
 Editions are pinned rather than current in two places: the distortion metrics
@@ -17953,8 +17957,9 @@ over interior volume) — the two numbers a prediction never captures.
 ## What this guide covers
 
 **Covered.** The Bies §8.11-8.17 / ASHRAE HVAC methods —
-`hvac.end_reflection_loss` and `hvac.elbow_insertion_loss` (interpolated
-tables), `hvac.plenum_attenuation` (Wells' closed form) and
+`hvac.end_reflection_loss` (interpolated table) and
+`hvac.elbow_insertion_loss` (Table 8.11 lookup),
+`hvac.plenum_attenuation` (Wells' closed form) and
 `hvac.flow_noise_straight_duct` / `flow_noise_bend` (VDI 2081) — and the
 machine-enclosure insertion loss of Bies §7.4, Eqs. (7.103) and (7.111),
 through `enclosure_insertion_loss`, which combines a supplied panel
@@ -17963,9 +17968,11 @@ transmission loss with the interior room-constant correction, together with the
 
 **Not covered.** The reactive elements — expansion chambers, side branches,
 extended tubes — live in [Silencers](https://jmrplens.github.io/phonometry/devices/noise-control/silencers/). Dissipative duct-lining
-silencers are modelled from liner properties nowhere in the library; the lined
-elbow and the plenum here are interpolated installation tables. Nothing on this
-page is a measurement: the ISO 11546 procedure of section 2 is described so a
+silencers are modelled from liner properties nowhere in the library: the
+lined-elbow figure here is a table lookup (Bies Table 8.11) and the plenum is
+Wells' closed form driven by a declared mean absorption — neither is a liner
+model. Nothing on this page is a measurement: the ISO 11546 procedure of
+section 2 is described so a
 declared figure can be read, not implemented. Structure-borne transmission from
 a machine into its enclosure or its slab is outside every model here.
 
@@ -18827,10 +18834,10 @@ matters for selection:
   pressure drop the silencer becomes the noise source.
 
 phonometry models the reactive family in closed form on this page. The
-dissipative side enters through the installation data of the
-[HVAC methods](https://jmrplens.github.io/phonometry/devices/noise-control/noise-control/): the lined-elbow insertion loss and the
-lined plenum attenuation of Wells' method, both from interpolated ASHRAE
-data rather than a liner model. The porous physics that a first-principles
+dissipative side enters at installation level, through the
+[HVAC methods](https://jmrplens.github.io/phonometry/devices/noise-control/noise-control/): the lined-elbow insertion loss read from
+tabulated ASHRAE data and the lined plenum attenuation from Wells' closed
+form, neither of them a liner model. The porous physics that a first-principles
 liner calculation needs, the equivalent-fluid models fed by the airflow
 resistivity, is the same material theory as
 [Porous and Multilayer Absorbers](https://jmrplens.github.io/phonometry/materials/absorbers/porous-absorbers/).
@@ -18868,9 +18875,10 @@ the insertion loss a supplier publishes.
 
 **Not covered.** Reactive elements only. Dissipative (absorptive, duct-lining)
 silencers are discussed for selection but never modelled from liner properties,
-and the lined-elbow and plenum data of the
-[HVAC methods](https://jmrplens.github.io/phonometry/devices/noise-control/noise-control/) are interpolated installation tables, not a
-liner model. Mean-flow effects — convection, temperature gradients, the
+and in the [HVAC methods](https://jmrplens.github.io/phonometry/devices/noise-control/noise-control/) the lined-elbow figure is a table
+lookup (Bies Table 8.11) and the plenum is Wells' closed form driven by a
+declared mean absorption — neither is a liner model.
+Mean-flow effects — convection, temperature gradients, the
 flow-dependent impedance of perforates — are outside the no-flow element
 matrices used here. Nothing on this page is a measurement: no part of ISO 7235
 is implemented, shell breakout and the end corrections at the area jumps are
@@ -49126,7 +49134,7 @@ print(round(float(modes.wavenumbers[0]), 5))    # 0.20885  computed kr1
 print(round(np.sqrt(k**2 - (np.pi / 200.0) ** 2), 5))   # 0.20885  exact
 ```
 
-## 3. Ray tracing: travel times and convergence zones
+## 3. Ray tracing: turning points and convergence zones
 
 In the high-frequency limit the Helmholtz equation collapses to the eikonal
 equation, and its characteristics are **rays**: trajectories integrated from
@@ -49167,7 +49175,7 @@ print(round(z_turn, 1))                     # 583.3  analytic turning depth
 print(round(float(rays.depths.max()), 1))   # 583.7  traced
 ```
 
-Rays buy geometry: eigenray paths, travel times and convergence-zone ranges
+Rays buy geometry: paths, turning depths and convergence-zone ranges
 at a cost independent of frequency. What they do not carry here is a full
 amplitude: the geometric ray-tube intensity diverges at caustics, so the
 result object returns the paths and leaves the level to the modal or PE
@@ -49273,12 +49281,12 @@ and boundaries decide the answer, pick the solver by frequency and geometry
 
 | Solver | Natural regime | What it buys you |
 |---|---|---|
-| `ray_trace` | High frequency (water depth ≫ λ), deep water | Eigenray geometry, travel times, convergence zones; cost independent of frequency |
+| `ray_trace` | High frequency (water depth ≫ λ), deep water | Ray-path geometry, turning depths, convergence zones; cost independent of frequency |
 | `normal_modes` | Low frequency, shallow water, range-independent | Finite-difference modal sum with few propagating modes ($m < kD/\pi$); the reference solution for its regime, validated against the ideal waveguide's exact modes |
 | `parabolic_equation` | Low frequency, long one-way paths | Full-field TL($z$,$r$) with refraction, marched in range over the range-independent $c(z)$ all three solvers assume |
 
 The boundaries blur in practice: rays remain usable at surprisingly low
-frequencies for travel-time work, and the PE remains the workhorse well above
+frequencies for path-geometry work, and the PE remains the workhorse well above
 its formal small-angle regime. When two of the three agree on a case, as the
 modes and the PE do in the section 1 figure, that agreement is the practical
 convergence test.
@@ -49303,7 +49311,7 @@ equation is why they all live in one module.
 ### Which underwater propagation solver should I use?
 
 Pick by frequency and geometry (Jensen et al. 2011, Ch. 1): rays for high
-frequency and deep water (eigenray geometry and travel times at a cost
+frequency and deep water (ray-path geometry and convergence zones at a cost
 independent of frequency), normal modes for low frequency in shallow water
 (few propagating modes, $m < kD/\pi$, the reference solution for its
 regime) and the parabolic equation for low-frequency, long one-way paths

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -16734,8 +16734,8 @@ discrete fixed-point power summation is **not implemented at all** — only its
 field indicators are, reused by the scanning routes. Dissipative duct-lining
 silencers are **not modelled from liner properties** anywhere: the reactive
 elements are computed exactly within the no-flow plane-wave model, and the
-lined-elbow figure is a table lookup (Bies Table 8.11) and the plenum Wells'
-closed form driven by a declared mean absorption — neither is a liner model.
+lined-elbow figure is a table lookup (Bies Table 8.11) and the plenum
+attenuation Wells' closed form driven by a declared mean absorption — neither is a liner model.
 And no page here predicts a panel's transmission loss:
 `enclosure_insertion_loss` combines a value you supply with the interior
 correction, and the prediction itself is [Insulation
@@ -17646,8 +17646,8 @@ source of a supplier's figures, not implemented. Within the predictions, three
 limits are structural. **Only reactive silencer elements are computed** —
 dissipative duct-lining silencers are discussed for selection but are not
 modelled from liner properties anywhere in the library, and on the HVAC page
-the lined-elbow figure is a table lookup (Bies Table 8.11) and the plenum is
-Wells' closed form driven by a declared mean absorption — neither is a liner
+the lined-elbow figure is a table lookup (Bies Table 8.11) and the plenum
+attenuation is Wells' closed form driven by a declared mean absorption — neither is a liner
 model. **Mean flow is outside the element matrices**:
 convection, temperature gradients and the flow-dependent impedance of
 perforates do not appear, so a silencer carrying significant flow is predicted

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -3039,12 +3039,16 @@ Pages elsewhere on the site that this section leans on:
 ## What this section does not cover
 
 **A prediction is only as good as the element data you feed it, and the
-library takes that data as given.** The element ratings, the junction indices,
-the covering improvement and the structure-to-airborne adjustment terms of EN
-12354-5 Annexes D and F are inputs you supply from measurement or from the
-standards' own annexes; none of them is derived here. The simplified
-prediction page stops at the weighted single numbers by design, and the
-detailed page is where the per-band models live.
+library takes that data as given.** The element ratings, the junction indices
+and the covering improvements are parameters the entry points consume,
+supplied from measurement or computed with this section's own estimators —
+the Annex E junction catalogue, the floating-floor and lining improvement
+laws, the Annex B homogeneous-element chain and the panel-physics models —
+and nothing checks the numbers you pass. Only the structure-to-airborne
+adjustment terms of EN 12354-5 Annexes D and F have no estimator here at all
+and must come from the standard's own tables. The simplified prediction page
+stops at the weighted single numbers by design, and the detailed page is
+where the per-band models live.
 
 Every panel model carries a validity range it does not extend past, and the
 guides flag each: Sharp's single-panel method is not valid below about 1.5
@@ -5395,14 +5399,16 @@ and from the physics of the element itself.
 ## What this section does not cover
 
 **The library starts after the microphone and stops before the geometry.** On
-the measurement side, every function takes band levels already averaged over
-positions and already corrected for background noise: the position counts, the
-low-frequency procedures, the signal-to-background floors and the
-test-facility qualifications of ISO 16283, ISO 10140 and ISO 3382 are the
-operator's job, and nothing here checks that they were done. On the prediction
-side, the element ratings, the junction indices and the covering improvements
-are inputs you supply from measurement or from a standard's own annex; none is
-derived from a drawing.
+the measurement side, position averaging happens once positions are supplied
+— the insulation functions energy-average per-position spectra for you — but
+nothing verifies how the measurement was made: the position counts and
+placements, the low-frequency procedures and the test-facility qualifications
+of ISO 16283, ISO 10140 and ISO 3382 are the operator's job. So is measuring
+the background noise: only the ISO 10140-4 laboratory correction is
+implemented, warning when its 6 dB floor is broken, and field levels must
+arrive already corrected. On the prediction side, the element ratings, the
+junction indices and the covering improvements are inputs you supply from
+measurement or from a standard's own annex; none is derived from a drawing.
 
 **Nothing here is a wave solver or a room model.** There is no geometry
 importer, no material database, no ray tracer and no auralisation: the room
@@ -6841,18 +6847,22 @@ related EN 12354-5, lives in
 
 ## What this section does not cover
 
-**The library starts after the microphone.** Every function here takes band
-levels that were already energy-averaged over positions and already corrected
-for background noise, and nothing verifies how the measurement was made: not
-the number and placement of source and microphone positions, not the
-low-frequency procedures of ISO 16283-1/-2, not the 6 dB signal-to-background
-floor, and not the test-facility and mounting requirements of ISO 10140-1.
-Those are the operator's responsibility and the report's, and they are what
-makes the numbers here mean something. Two consequences worth naming: the
-field and laboratory background corrections are *different* rules, so a
-laboratory helper must not be applied to field data; and the intensity route
-takes both the pressure and the intensity level as inputs, with the scanning
-probe and its phase-mismatch calibration outside the library.
+**The library starts after the microphone.** Every function here accepts
+per-position spectra and energy-averages them for you, but nothing verifies
+how the measurement was made: not the number and placement of the source and
+microphone positions behind those spectra, not the low-frequency procedures
+of ISO 16283-1/-2, and not the test-facility and mounting requirements of
+ISO 10140-1. Those are the operator's responsibility and the report's, and
+they are what makes the numbers here mean something. Background noise is the
+one correction genuinely left to the caller: field levels must arrive already
+corrected, their 6 dB signal-to-background floor checked by the operator,
+while the ISO 10140-4 laboratory helper applies its rule itself, warning when
+its own floor is broken and capping the correction. Two consequences worth
+naming: the field and laboratory background corrections are *different*
+rules, so that laboratory helper must not be applied to field data; and the
+intensity route takes both the pressure and the intensity level as inputs,
+with the scanning probe and its phase-mismatch calibration outside the
+library.
 
 **Coverage inside the standards is partial in two places.** Of ISO 10848 only
 the Part 1 formulae are implemented generically, plus the Part 4 modal-overlap
@@ -12861,9 +12871,9 @@ produced them. Two implemented editions are pinned rather than current: the
 distortion metrics follow AES17-2015 and not the 2020 revision, and the
 microphone report follows IEC 60268-4:2014 and not the 2018 one. Thiele-Small
 parameter extraction from an impedance curve is not implemented, and the
-electrical and mechanical power-handling ratings of IEC 60268-5 clause 17 are
-stated by the manufacturer rather than computed. The feedback criterion is
-level bookkeeping, not an acoustic model: it consumes two direct-field levels
+electrical and mechanical power-handling ratings of IEC 60268-5 clauses 17 and
+18 are stated by the manufacturer rather than computed. The feedback criterion
+is level bookkeeping, not an acoustic model: it consumes two direct-field levels
 you supply, does not compute them from a coverage pattern, and predicts
 neither the ring frequency nor the effect of an equaliser or frequency
 shifter. And IEC 60268-16, the speech transmission index, is not part of this
@@ -16720,8 +16730,9 @@ Three specific absences are worth knowing before you plan a job. ISO 9614-1's
 discrete fixed-point power summation is **not implemented at all** — only its
 field indicators are, reused by the scanning routes. Dissipative duct-lining
 silencers are **not modelled from liner properties** anywhere: the reactive
-elements are computed exactly, and the lined-elbow and plenum figures are
-interpolated installation tables. And no page here predicts a panel's
+elements are computed exactly, and the lined-elbow figure is a table lookup
+(Bies Table 8.11) and the plenum Wells' closed form driven by a declared mean
+absorption — neither is a liner model. And no page here predicts a panel's
 transmission loss: `enclosure_insertion_loss` combines a value you supply with
 the interior correction, and the prediction itself is [Insulation
 design](https://jmrplens.github.io/phonometry/buildings/design/).
@@ -17630,9 +17641,10 @@ declared data, and the measurement standards named above are cited as the
 source of a supplier's figures, not implemented. Within the predictions, three
 limits are structural. **Only reactive silencer elements are computed** —
 dissipative duct-lining silencers are discussed for selection but are not
-modelled from liner properties anywhere in the library, and the lined-elbow
-and plenum figures on the HVAC page are interpolated installation tables
-rather than a liner model. **Mean flow is outside the element matrices**:
+modelled from liner properties anywhere in the library, and on the HVAC page
+the lined-elbow figure is a table lookup (Bies Table 8.11) and the plenum is
+Wells' closed form driven by a declared mean absorption — neither is a liner
+model. **Mean flow is outside the element matrices**:
 convection, temperature gradients and the flow-dependent impedance of
 perforates do not appear, so a silencer carrying significant flow is predicted
 as though it were not. And `enclosure_insertion_loss` **never predicts the
@@ -27846,9 +27858,13 @@ In the order the chain runs.
 **Nothing here is a verdict about a person.** ISO 1999 does not define a
 hearing handicap or a compensable fence — that line is set by national
 regulation, and the library applies none of it, so you supply and check the
-criterion yourself. The same is true of the exposure action values: the LEX,8h
-and its one-sided 95 % upper limit come out of ISO 9612, and the numbers they
-are compared against are in your jurisdiction's directive, not here.
+criterion yourself. The exposure side stops one step later: the LEX,8h and its
+one-sided 95 % upper limit come out of ISO 9612, and the fiche written by
+`ExposureResult.report()` does compare the LEX,8h against the Directive
+2003/10/EC action and limit values (80, 85 and 87 dB(A)) and issues the
+PASS/FAIL verdict against the limit value — but that is a verdict on an
+unprotected exposure, not on a person: the effective exposure behind hearing
+protectors, and any stricter national transposition, are still yours to check.
 
 Two implementation boundaries follow the standards. Only **database A** is
 implemented for ISO 1999: `htlan` always draws its age component from ISO
@@ -47696,8 +47712,8 @@ pile-driving noise has no closed form here or anywhere in the library.
 fluid-fluid Rayleigh reflection, so sediment attenuation is out of scope, and
 all three solvers assume a **range-independent** water column with no
 absorbing or elastic bottom and no real bathymetry — which rules out
-range-dependent problems entirely. The ray solver returns paths and travel
-times but not amplitudes (no ray-tube intensity, no caustic correction), and
+range-dependent problems entirely. The ray solver returns paths but not
+travel times or amplitudes (no ray-tube intensity, no caustic correction), and
 the parabolic equation is the standard small-angle Tappert form rather than a
 wide-angle Padé variant. For the elastic seabed physics these fluid solvers
 leave out, the [elastic wave solver](https://jmrplens.github.io/phonometry/simulation/elastic-waves/) is
@@ -49854,10 +49870,12 @@ for less severe seated exposures is distributed separately by ISO and is not
 implemented, which is what makes the 1 g delineation above a routing decision
 rather than a preference.
 
-And no exposure verdict is issued. The action and limit values of Directive
-2002/44/EC are stated so that an A(8) can be read against them, but the
-library applies no national implementation of the directive, and a
-risk-assessment conclusion is not a number this section produces.
+And the verdict stops at the directive itself. An A(8) is assessed against
+the action and limit values of Directive 2002/44/EC — each marked exceeded or
+not, the exposure zone named, and a PASS/FAIL verdict issued against the
+limit value — but the library applies no national transposition of the
+directive, and the conclusion of a workplace risk assessment is not a number
+this section produces.
 
 ---
 

--- a/site/public/llms/llms-buildings-design.txt
+++ b/site/public/llms/llms-buildings-design.txt
@@ -156,12 +156,16 @@ Pages elsewhere on the site that this section leans on:
 ## What this section does not cover
 
 **A prediction is only as good as the element data you feed it, and the
-library takes that data as given.** The element ratings, the junction indices,
-the covering improvement and the structure-to-airborne adjustment terms of EN
-12354-5 Annexes D and F are inputs you supply from measurement or from the
-standards' own annexes; none of them is derived here. The simplified
-prediction page stops at the weighted single numbers by design, and the
-detailed page is where the per-band models live.
+library takes that data as given.** The element ratings, the junction indices
+and the covering improvements are parameters the entry points consume,
+supplied from measurement or computed with this section's own estimators —
+the Annex E junction catalogue, the floating-floor and lining improvement
+laws, the Annex B homogeneous-element chain and the panel-physics models —
+and nothing checks the numbers you pass. Only the structure-to-airborne
+adjustment terms of EN 12354-5 Annexes D and F have no estimator here at all
+and must come from the standard's own tables. The simplified prediction page
+stops at the weighted single numbers by design, and the detailed page is
+where the per-band models live.
 
 Every panel model carries a validity range it does not extend past, and the
 guides flag each: Sharp's single-panel method is not valid below about 1.5

--- a/site/public/llms/llms-buildings-insulation.txt
+++ b/site/public/llms/llms-buildings-insulation.txt
@@ -102,9 +102,12 @@ related EN 12354-5, lives in
 
 ## What this section does not cover
 
-**The library starts after the microphone.** Every function here accepts
-per-position spectra and energy-averages them for you, but nothing verifies
-how the measurement was made: not the number and placement of the source and
+**The library starts after the microphone.** The field, laboratory, survey and
+intensity routines that form an insulation index accept per-position spectra
+and energy-average them for you; the heavy-impact standardization, the
+flanking indices, the ISO 717 ratings and the background-noise helpers take
+their per-band input already formed. Either way, nothing verifies how the
+measurement was made: not the number and placement of the source and
 microphone positions behind those spectra, not the low-frequency procedures
 of ISO 16283-1/-2, and not the test-facility and mounting requirements of
 ISO 10140-1. Those are the operator's responsibility and the report's, and

--- a/site/public/llms/llms-buildings-insulation.txt
+++ b/site/public/llms/llms-buildings-insulation.txt
@@ -102,18 +102,22 @@ related EN 12354-5, lives in
 
 ## What this section does not cover
 
-**The library starts after the microphone.** Every function here takes band
-levels that were already energy-averaged over positions and already corrected
-for background noise, and nothing verifies how the measurement was made: not
-the number and placement of source and microphone positions, not the
-low-frequency procedures of ISO 16283-1/-2, not the 6 dB signal-to-background
-floor, and not the test-facility and mounting requirements of ISO 10140-1.
-Those are the operator's responsibility and the report's, and they are what
-makes the numbers here mean something. Two consequences worth naming: the
-field and laboratory background corrections are *different* rules, so a
-laboratory helper must not be applied to field data; and the intensity route
-takes both the pressure and the intensity level as inputs, with the scanning
-probe and its phase-mismatch calibration outside the library.
+**The library starts after the microphone.** Every function here accepts
+per-position spectra and energy-averages them for you, but nothing verifies
+how the measurement was made: not the number and placement of the source and
+microphone positions behind those spectra, not the low-frequency procedures
+of ISO 16283-1/-2, and not the test-facility and mounting requirements of
+ISO 10140-1. Those are the operator's responsibility and the report's, and
+they are what makes the numbers here mean something. Background noise is the
+one correction genuinely left to the caller: field levels must arrive already
+corrected, their 6 dB signal-to-background floor checked by the operator,
+while the ISO 10140-4 laboratory helper applies its rule itself, warning when
+its own floor is broken and capping the correction. Two consequences worth
+naming: the field and laboratory background corrections are *different*
+rules, so that laboratory helper must not be applied to field data; and the
+intensity route takes both the pressure and the intensity level as inputs,
+with the scanning probe and its phase-mismatch calibration outside the
+library.
 
 **Coverage inside the standards is partial in two places.** Of ISO 10848 only
 the Part 1 formulae are implemented generically, plus the Part 4 modal-overlap

--- a/site/public/llms/llms-buildings.txt
+++ b/site/public/llms/llms-buildings.txt
@@ -115,14 +115,16 @@ and from the physics of the element itself.
 ## What this section does not cover
 
 **The library starts after the microphone and stops before the geometry.** On
-the measurement side, every function takes band levels already averaged over
-positions and already corrected for background noise: the position counts, the
-low-frequency procedures, the signal-to-background floors and the
-test-facility qualifications of ISO 16283, ISO 10140 and ISO 3382 are the
-operator's job, and nothing here checks that they were done. On the prediction
-side, the element ratings, the junction indices and the covering improvements
-are inputs you supply from measurement or from a standard's own annex; none is
-derived from a drawing.
+the measurement side, position averaging happens once positions are supplied
+— the insulation functions energy-average per-position spectra for you — but
+nothing verifies how the measurement was made: the position counts and
+placements, the low-frequency procedures and the test-facility qualifications
+of ISO 16283, ISO 10140 and ISO 3382 are the operator's job. So is measuring
+the background noise: only the ISO 10140-4 laboratory correction is
+implemented, warning when its 6 dB floor is broken, and field levels must
+arrive already corrected. On the prediction side, the element ratings, the
+junction indices and the covering improvements are inputs you supply from
+measurement or from a standard's own annex; none is derived from a drawing.
 
 **Nothing here is a wave solver or a room model.** There is no geometry
 importer, no material database, no ray tracer and no auralisation: the room

--- a/site/public/llms/llms-devices-electroacoustics.txt
+++ b/site/public/llms/llms-devices-electroacoustics.txt
@@ -97,9 +97,9 @@ produced them. Two implemented editions are pinned rather than current: the
 distortion metrics follow AES17-2015 and not the 2020 revision, and the
 microphone report follows IEC 60268-4:2014 and not the 2018 one. Thiele-Small
 parameter extraction from an impedance curve is not implemented, and the
-electrical and mechanical power-handling ratings of IEC 60268-5 clause 17 are
-stated by the manufacturer rather than computed. The feedback criterion is
-level bookkeeping, not an acoustic model: it consumes two direct-field levels
+electrical and mechanical power-handling ratings of IEC 60268-5 clauses 17 and
+18 are stated by the manufacturer rather than computed. The feedback criterion
+is level bookkeeping, not an acoustic model: it consumes two direct-field levels
 you supply, does not compute them from a coverage pattern, and predicts
 neither the ring frequency nor the effect of an equaliser or frequency
 shifter. And IEC 60268-16, the speech transmission index, is not part of this

--- a/site/public/llms/llms-devices-noise-control.txt
+++ b/site/public/llms/llms-devices-noise-control.txt
@@ -88,9 +88,10 @@ declared data, and the measurement standards named above are cited as the
 source of a supplier's figures, not implemented. Within the predictions, three
 limits are structural. **Only reactive silencer elements are computed** —
 dissipative duct-lining silencers are discussed for selection but are not
-modelled from liner properties anywhere in the library, and the lined-elbow
-and plenum figures on the HVAC page are interpolated installation tables
-rather than a liner model. **Mean flow is outside the element matrices**:
+modelled from liner properties anywhere in the library, and on the HVAC page
+the lined-elbow figure is a table lookup (Bies Table 8.11) and the plenum is
+Wells' closed form driven by a declared mean absorption — neither is a liner
+model. **Mean flow is outside the element matrices**:
 convection, temperature gradients and the flow-dependent impedance of
 perforates do not appear, so a silencer carrying significant flow is predicted
 as though it were not. And `enclosure_insertion_loss` **never predicts the

--- a/site/public/llms/llms-devices-noise-control.txt
+++ b/site/public/llms/llms-devices-noise-control.txt
@@ -1717,10 +1717,10 @@ matters for selection:
   pressure drop the silencer becomes the noise source.
 
 phonometry models the reactive family in closed form on this page. The
-dissipative side enters through the installation data of the
-[HVAC methods](https://jmrplens.github.io/phonometry/devices/noise-control/noise-control/): the lined-elbow insertion loss and the
-lined plenum attenuation of Wells' method, both from interpolated ASHRAE
-data rather than a liner model. The porous physics that a first-principles
+dissipative side enters at installation level, through the
+[HVAC methods](https://jmrplens.github.io/phonometry/devices/noise-control/noise-control/): the lined-elbow insertion loss read from
+tabulated ASHRAE data and the lined plenum attenuation from Wells' closed
+form, neither of them a liner model. The porous physics that a first-principles
 liner calculation needs, the equivalent-fluid models fed by the airflow
 resistivity, is the same material theory as
 [Porous and Multilayer Absorbers](https://jmrplens.github.io/phonometry/materials/absorbers/porous-absorbers/).
@@ -1758,9 +1758,10 @@ the insertion loss a supplier publishes.
 
 **Not covered.** Reactive elements only. Dissipative (absorptive, duct-lining)
 silencers are discussed for selection but never modelled from liner properties,
-and the lined-elbow and plenum data of the
-[HVAC methods](https://jmrplens.github.io/phonometry/devices/noise-control/noise-control/) are interpolated installation tables, not a
-liner model. Mean-flow effects — convection, temperature gradients, the
+and in the [HVAC methods](https://jmrplens.github.io/phonometry/devices/noise-control/noise-control/) the lined-elbow figure is a table
+lookup (Bies Table 8.11) and the plenum is Wells' closed form driven by a
+declared mean absorption — neither is a liner model.
+Mean-flow effects — convection, temperature gradients, the
 flow-dependent impedance of perforates — are outside the no-flow element
 matrices used here. Nothing on this page is a measurement: no part of ISO 7235
 is implemented, shell breakout and the end corrections at the area jumps are
@@ -2098,8 +2099,9 @@ over interior volume) — the two numbers a prediction never captures.
 ## What this guide covers
 
 **Covered.** The Bies §8.11-8.17 / ASHRAE HVAC methods —
-`hvac.end_reflection_loss` and `hvac.elbow_insertion_loss` (interpolated
-tables), `hvac.plenum_attenuation` (Wells' closed form) and
+`hvac.end_reflection_loss` (interpolated table) and
+`hvac.elbow_insertion_loss` (Table 8.11 lookup),
+`hvac.plenum_attenuation` (Wells' closed form) and
 `hvac.flow_noise_straight_duct` / `flow_noise_bend` (VDI 2081) — and the
 machine-enclosure insertion loss of Bies §7.4, Eqs. (7.103) and (7.111),
 through `enclosure_insertion_loss`, which combines a supplied panel
@@ -2108,9 +2110,11 @@ transmission loss with the interior room-constant correction, together with the
 
 **Not covered.** The reactive elements — expansion chambers, side branches,
 extended tubes — live in [Silencers](https://jmrplens.github.io/phonometry/devices/noise-control/silencers/). Dissipative duct-lining
-silencers are modelled from liner properties nowhere in the library; the lined
-elbow and the plenum here are interpolated installation tables. Nothing on this
-page is a measurement: the ISO 11546 procedure of section 2 is described so a
+silencers are modelled from liner properties nowhere in the library: the
+lined-elbow figure here is a table lookup (Bies Table 8.11) and the plenum is
+Wells' closed form driven by a declared mean absorption — neither is a liner
+model. Nothing on this page is a measurement: the ISO 11546 procedure of
+section 2 is described so a
 declared figure can be read, not implemented. Structure-borne transmission from
 a machine into its enclosure or its slab is outside every model here.
 

--- a/site/public/llms/llms-devices-noise-control.txt
+++ b/site/public/llms/llms-devices-noise-control.txt
@@ -89,8 +89,8 @@ source of a supplier's figures, not implemented. Within the predictions, three
 limits are structural. **Only reactive silencer elements are computed** —
 dissipative duct-lining silencers are discussed for selection but are not
 modelled from liner properties anywhere in the library, and on the HVAC page
-the lined-elbow figure is a table lookup (Bies Table 8.11) and the plenum is
-Wells' closed form driven by a declared mean absorption — neither is a liner
+the lined-elbow figure is a table lookup (Bies Table 8.11) and the plenum
+attenuation is Wells' closed form driven by a declared mean absorption — neither is a liner
 model. **Mean flow is outside the element matrices**:
 convection, temperature gradients and the flow-dependent impedance of
 perforates do not appear, so a silencer carrying significant flow is predicted

--- a/site/public/llms/llms-devices.txt
+++ b/site/public/llms/llms-devices.txt
@@ -114,11 +114,12 @@ Three specific absences are worth knowing before you plan a job. ISO 9614-1's
 discrete fixed-point power summation is **not implemented at all** — only its
 field indicators are, reused by the scanning routes. Dissipative duct-lining
 silencers are **not modelled from liner properties** anywhere: the reactive
-elements are computed exactly, and the lined-elbow figure is a table lookup
-(Bies Table 8.11) and the plenum Wells' closed form driven by a declared mean
-absorption — neither is a liner model. And no page here predicts a panel's
-transmission loss: `enclosure_insertion_loss` combines a value you supply with
-the interior correction, and the prediction itself is [Insulation
+elements are computed exactly within the no-flow plane-wave model, and the
+lined-elbow figure is a table lookup (Bies Table 8.11) and the plenum Wells'
+closed form driven by a declared mean absorption — neither is a liner model.
+And no page here predicts a panel's transmission loss:
+`enclosure_insertion_loss` combines a value you supply with the interior
+correction, and the prediction itself is [Insulation
 design](https://jmrplens.github.io/phonometry/buildings/design/).
 
 Editions are pinned rather than current in two places: the distortion metrics

--- a/site/public/llms/llms-devices.txt
+++ b/site/public/llms/llms-devices.txt
@@ -115,8 +115,8 @@ discrete fixed-point power summation is **not implemented at all** — only its
 field indicators are, reused by the scanning routes. Dissipative duct-lining
 silencers are **not modelled from liner properties** anywhere: the reactive
 elements are computed exactly within the no-flow plane-wave model, and the
-lined-elbow figure is a table lookup (Bies Table 8.11) and the plenum Wells'
-closed form driven by a declared mean absorption — neither is a liner model.
+lined-elbow figure is a table lookup (Bies Table 8.11) and the plenum
+attenuation Wells' closed form driven by a declared mean absorption — neither is a liner model.
 And no page here predicts a panel's transmission loss:
 `enclosure_insertion_loss` combines a value you supply with the interior
 correction, and the prediction itself is [Insulation

--- a/site/public/llms/llms-devices.txt
+++ b/site/public/llms/llms-devices.txt
@@ -114,8 +114,9 @@ Three specific absences are worth knowing before you plan a job. ISO 9614-1's
 discrete fixed-point power summation is **not implemented at all** — only its
 field indicators are, reused by the scanning routes. Dissipative duct-lining
 silencers are **not modelled from liner properties** anywhere: the reactive
-elements are computed exactly, and the lined-elbow and plenum figures are
-interpolated installation tables. And no page here predicts a panel's
+elements are computed exactly, and the lined-elbow figure is a table lookup
+(Bies Table 8.11) and the plenum Wells' closed form driven by a declared mean
+absorption — neither is a liner model. And no page here predicts a panel's
 transmission loss: `enclosure_insertion_loss` combines a value you supply with
 the interior correction, and the prediction itself is [Insulation
 design](https://jmrplens.github.io/phonometry/buildings/design/).

--- a/site/public/llms/llms-perception-hearing.txt
+++ b/site/public/llms/llms-perception-hearing.txt
@@ -76,9 +76,13 @@ In the order the chain runs.
 **Nothing here is a verdict about a person.** ISO 1999 does not define a
 hearing handicap or a compensable fence — that line is set by national
 regulation, and the library applies none of it, so you supply and check the
-criterion yourself. The same is true of the exposure action values: the LEX,8h
-and its one-sided 95 % upper limit come out of ISO 9612, and the numbers they
-are compared against are in your jurisdiction's directive, not here.
+criterion yourself. The exposure side stops one step later: the LEX,8h and its
+one-sided 95 % upper limit come out of ISO 9612, and the fiche written by
+`ExposureResult.report()` does compare the LEX,8h against the Directive
+2003/10/EC action and limit values (80, 85 and 87 dB(A)) and issues the
+PASS/FAIL verdict against the limit value — but that is a verdict on an
+unprotected exposure, not on a person: the effective exposure behind hearing
+protectors, and any stricter national transposition, are still yours to check.
 
 Two implementation boundaries follow the standards. Only **database A** is
 implemented for ISO 1999: `htlan` always draws its age component from ISO

--- a/site/public/llms/llms-underwater.txt
+++ b/site/public/llms/llms-underwater.txt
@@ -1510,7 +1510,7 @@ print(round(float(modes.wavenumbers[0]), 5))    # 0.20885  computed kr1
 print(round(np.sqrt(k**2 - (np.pi / 200.0) ** 2), 5))   # 0.20885  exact
 ```
 
-## 3. Ray tracing: travel times and convergence zones
+## 3. Ray tracing: turning points and convergence zones
 
 In the high-frequency limit the Helmholtz equation collapses to the eikonal
 equation, and its characteristics are **rays**: trajectories integrated from
@@ -1551,7 +1551,7 @@ print(round(z_turn, 1))                     # 583.3  analytic turning depth
 print(round(float(rays.depths.max()), 1))   # 583.7  traced
 ```
 
-Rays buy geometry: eigenray paths, travel times and convergence-zone ranges
+Rays buy geometry: paths, turning depths and convergence-zone ranges
 at a cost independent of frequency. What they do not carry here is a full
 amplitude: the geometric ray-tube intensity diverges at caustics, so the
 result object returns the paths and leaves the level to the modal or PE
@@ -1657,12 +1657,12 @@ and boundaries decide the answer, pick the solver by frequency and geometry
 
 | Solver | Natural regime | What it buys you |
 |---|---|---|
-| `ray_trace` | High frequency (water depth ≫ λ), deep water | Eigenray geometry, travel times, convergence zones; cost independent of frequency |
+| `ray_trace` | High frequency (water depth ≫ λ), deep water | Ray-path geometry, turning depths, convergence zones; cost independent of frequency |
 | `normal_modes` | Low frequency, shallow water, range-independent | Finite-difference modal sum with few propagating modes ($m < kD/\pi$); the reference solution for its regime, validated against the ideal waveguide's exact modes |
 | `parabolic_equation` | Low frequency, long one-way paths | Full-field TL($z$,$r$) with refraction, marched in range over the range-independent $c(z)$ all three solvers assume |
 
 The boundaries blur in practice: rays remain usable at surprisingly low
-frequencies for travel-time work, and the PE remains the workhorse well above
+frequencies for path-geometry work, and the PE remains the workhorse well above
 its formal small-angle regime. When two of the three agree on a case, as the
 modes and the PE do in the section 1 figure, that agreement is the practical
 convergence test.
@@ -1687,7 +1687,7 @@ equation is why they all live in one module.
 ### Which underwater propagation solver should I use?
 
 Pick by frequency and geometry (Jensen et al. 2011, Ch. 1): rays for high
-frequency and deep water (eigenray geometry and travel times at a cost
+frequency and deep water (ray-path geometry and convergence zones at a cost
 independent of frequency), normal modes for low frequency in shallow water
 (few propagating modes, $m < kD/\pi$, the reference solution for its
 regime) and the parabolic equation for low-frequency, long one-way paths

--- a/site/public/llms/llms-underwater.txt
+++ b/site/public/llms/llms-underwater.txt
@@ -96,8 +96,8 @@ pile-driving noise has no closed form here or anywhere in the library.
 fluid-fluid Rayleigh reflection, so sediment attenuation is out of scope, and
 all three solvers assume a **range-independent** water column with no
 absorbing or elastic bottom and no real bathymetry — which rules out
-range-dependent problems entirely. The ray solver returns paths and travel
-times but not amplitudes (no ray-tube intensity, no caustic correction), and
+range-dependent problems entirely. The ray solver returns paths but not
+travel times or amplitudes (no ray-tube intensity, no caustic correction), and
 the parabolic equation is the standard small-angle Tappert form rather than a
 wide-angle Padé variant. For the elastic seabed physics these fluid solvers
 leave out, the [elastic wave solver](https://jmrplens.github.io/phonometry/simulation/elastic-waves/) is

--- a/site/public/llms/llms-vibration-human.txt
+++ b/site/public/llms/llms-vibration-human.txt
@@ -73,10 +73,12 @@ for less severe seated exposures is distributed separately by ISO and is not
 implemented, which is what makes the 1 g delineation above a routing decision
 rather than a preference.
 
-And no exposure verdict is issued. The action and limit values of Directive
-2002/44/EC are stated so that an A(8) can be read against them, but the
-library applies no national implementation of the directive, and a
-risk-assessment conclusion is not a number this section produces.
+And the verdict stops at the directive itself. An A(8) is assessed against
+the action and limit values of Directive 2002/44/EC — each marked exceeded or
+not, the exposure zone named, and a PASS/FAIL verdict issued against the
+limit value — but the library applies no national transposition of the
+directive, and the conclusion of a workplace risk assessment is not a number
+this section produces.
 
 ---
 

--- a/site/src/content/docs/buildings/design/detailed-prediction.mdx
+++ b/site/src/content/docs/buildings/design/detailed-prediction.mdx
@@ -630,8 +630,10 @@ Only homogeneous Annex B elements are calculated here; the spectrum of a
 lightweight, double or composite element is an input, from [Predicting Panel
 Sound Insulation](/phonometry/buildings/design/panel-sound-insulation/) or
 from a test report. The Annex E junction catalogue itself lives on [Predicting
-Sound Insulation](/phonometry/buildings/design/insulation-prediction/), as do
-the Annex D and F default tables of the other parts. The Type B branch is
+Sound Insulation](/phonometry/buildings/design/insulation-prediction/), and the
+Part 1 Annex D lining improvement on [Predicting Resilient-Layer
+Performance](/phonometry/buildings/design/resilient-layers/); the Annex D and F
+default tables of EN 12354-5 are implemented nowhere. The Type B branch is
 shown from its standard inputs rather than worked end to end. Airborne
 transmission through cavities and suspended ceilings is not carried at all,
 and clause 3.3.4 Note 1 warns it "can contribute to or even dominate" there.

--- a/site/src/content/docs/buildings/design/index.mdx
+++ b/site/src/content/docs/buildings/design/index.mdx
@@ -155,12 +155,16 @@ Pages elsewhere on the site that this section leans on:
 <Scope>
 <ScopeClaim status="not-covered">
 **A prediction is only as good as the element data you feed it, and the
-library takes that data as given.** The element ratings, the junction indices,
-the covering improvement and the structure-to-airborne adjustment terms of EN
-12354-5 Annexes D and F are inputs you supply from measurement or from the
-standards' own annexes; none of them is derived here. The simplified
-prediction page stops at the weighted single numbers by design, and the
-detailed page is where the per-band models live.
+library takes that data as given.** The element ratings, the junction indices
+and the covering improvements are parameters the entry points consume,
+supplied from measurement or computed with this section's own estimators —
+the Annex E junction catalogue, the floating-floor and lining improvement
+laws, the Annex B homogeneous-element chain and the panel-physics models —
+and nothing checks the numbers you pass. Only the structure-to-airborne
+adjustment terms of EN 12354-5 Annexes D and F have no estimator here at all
+and must come from the standard's own tables. The simplified prediction page
+stops at the weighted single numbers by design, and the detailed page is
+where the per-band models live.
 </ScopeClaim>
 
 <ScopeClaim status="not-covered">

--- a/site/src/content/docs/buildings/index.mdx
+++ b/site/src/content/docs/buildings/index.mdx
@@ -114,14 +114,16 @@ and from the physics of the element itself.
 <Scope>
 <ScopeClaim status="not-covered">
 **The library starts after the microphone and stops before the geometry.** On
-the measurement side, every function takes band levels already averaged over
-positions and already corrected for background noise: the position counts, the
-low-frequency procedures, the signal-to-background floors and the
-test-facility qualifications of ISO 16283, ISO 10140 and ISO 3382 are the
-operator's job, and nothing here checks that they were done. On the prediction
-side, the element ratings, the junction indices and the covering improvements
-are inputs you supply from measurement or from a standard's own annex; none is
-derived from a drawing.
+the measurement side, position averaging happens once positions are supplied
+— the insulation functions energy-average per-position spectra for you — but
+nothing verifies how the measurement was made: the position counts and
+placements, the low-frequency procedures and the test-facility qualifications
+of ISO 16283, ISO 10140 and ISO 3382 are the operator's job. So is measuring
+the background noise: only the ISO 10140-4 laboratory correction is
+implemented, warning when its 6 dB floor is broken, and field levels must
+arrive already corrected. On the prediction side, the element ratings, the
+junction indices and the covering improvements are inputs you supply from
+measurement or from a standard's own annex; none is derived from a drawing.
 </ScopeClaim>
 
 <ScopeClaim status="not-covered">

--- a/site/src/content/docs/buildings/insulation/index.mdx
+++ b/site/src/content/docs/buildings/insulation/index.mdx
@@ -101,18 +101,22 @@ related EN 12354-5, lives in
 
 <Scope>
 <ScopeClaim status="not-covered">
-**The library starts after the microphone.** Every function here takes band
-levels that were already energy-averaged over positions and already corrected
-for background noise, and nothing verifies how the measurement was made: not
-the number and placement of source and microphone positions, not the
-low-frequency procedures of ISO 16283-1/-2, not the 6 dB signal-to-background
-floor, and not the test-facility and mounting requirements of ISO 10140-1.
-Those are the operator's responsibility and the report's, and they are what
-makes the numbers here mean something. Two consequences worth naming: the
-field and laboratory background corrections are *different* rules, so a
-laboratory helper must not be applied to field data; and the intensity route
-takes both the pressure and the intensity level as inputs, with the scanning
-probe and its phase-mismatch calibration outside the library.
+**The library starts after the microphone.** Every function here accepts
+per-position spectra and energy-averages them for you, but nothing verifies
+how the measurement was made: not the number and placement of the source and
+microphone positions behind those spectra, not the low-frequency procedures
+of ISO 16283-1/-2, and not the test-facility and mounting requirements of
+ISO 10140-1. Those are the operator's responsibility and the report's, and
+they are what makes the numbers here mean something. Background noise is the
+one correction genuinely left to the caller: field levels must arrive already
+corrected, their 6 dB signal-to-background floor checked by the operator,
+while the ISO 10140-4 laboratory helper applies its rule itself, warning when
+its own floor is broken and capping the correction. Two consequences worth
+naming: the field and laboratory background corrections are *different*
+rules, so that laboratory helper must not be applied to field data; and the
+intensity route takes both the pressure and the intensity level as inputs,
+with the scanning probe and its phase-mismatch calibration outside the
+library.
 </ScopeClaim>
 
 <ScopeClaim status="not-covered">

--- a/site/src/content/docs/buildings/insulation/index.mdx
+++ b/site/src/content/docs/buildings/insulation/index.mdx
@@ -101,9 +101,12 @@ related EN 12354-5, lives in
 
 <Scope>
 <ScopeClaim status="not-covered">
-**The library starts after the microphone.** Every function here accepts
-per-position spectra and energy-averages them for you, but nothing verifies
-how the measurement was made: not the number and placement of the source and
+**The library starts after the microphone.** The field, laboratory, survey and
+intensity routines that form an insulation index accept per-position spectra
+and energy-average them for you; the heavy-impact standardization, the
+flanking indices, the ISO 717 ratings and the background-noise helpers take
+their per-band input already formed. Either way, nothing verifies how the
+measurement was made: not the number and placement of the source and
 microphone positions behind those spectra, not the low-frequency procedures
 of ISO 16283-1/-2, and not the test-facility and mounting requirements of
 ISO 10140-1. Those are the operator's responsibility and the report's, and

--- a/site/src/content/docs/devices/electroacoustics/index.mdx
+++ b/site/src/content/docs/devices/electroacoustics/index.mdx
@@ -96,9 +96,9 @@ produced them. Two implemented editions are pinned rather than current: the
 distortion metrics follow AES17-2015 and not the 2020 revision, and the
 microphone report follows IEC 60268-4:2014 and not the 2018 one. Thiele-Small
 parameter extraction from an impedance curve is not implemented, and the
-electrical and mechanical power-handling ratings of IEC 60268-5 clause 17 are
-stated by the manufacturer rather than computed. The feedback criterion is
-level bookkeeping, not an acoustic model: it consumes two direct-field levels
+electrical and mechanical power-handling ratings of IEC 60268-5 clauses 17 and
+18 are stated by the manufacturer rather than computed. The feedback criterion
+is level bookkeeping, not an acoustic model: it consumes two direct-field levels
 you supply, does not compute them from a coverage pattern, and predicts
 neither the ring frequency nor the effect of an equaliser or frequency
 shifter. And IEC 60268-16, the speech transmission index, is not part of this

--- a/site/src/content/docs/devices/electroacoustics/loudspeakers.mdx
+++ b/site/src/content/docs/devices/electroacoustics/loudspeakers.mdx
@@ -819,8 +819,8 @@ None of the conditions above is checked by the functions: they reduce and
 report the curves they are handed, so the mounting, the excitation, the gate
 and the field condition are the operator's to keep and to state with the
 result. The electrical and mechanical ratings the standard defines around
-power handling (rated noise power, long-term and short-term maximum input
-voltage, clause 17) are stated by the manufacturer, not computed here.
+power handling (rated noise power, clause 18; long-term and short-term maximum
+input voltage, clause 17) are stated by the manufacturer, not computed here.
 Thiele-Small parameter extraction from the impedance curve is not implemented:
 the impedance panel reports the measured modulus against the rated-impedance
 lines. The distortion curve itself comes from a measurement, for instance the

--- a/site/src/content/docs/devices/emission/sound-power-intensity.mdx
+++ b/site/src/content/docs/devices/emission/sound-power-intensity.mdx
@@ -615,8 +615,9 @@ screening of the A-weighted total (`a_weighting_omitted_bands`). The ISO
 9614-3 precision determination (`sound_power_intensity_precision`) with its
 own not-applicable flagging, its Annex B field indicators
 (`precision_field_indicators`) and the five Annex C acceptance criteria
-(`precision_qualification`). Both results render the accredited-style
-sound-power fiche through `.report()`.
+(`precision_qualification`). The scanning result renders the accredited-style
+sound-power fiche through `.report()`; the precision result draws its spectrum
+with `.plot()` but writes no fiche.
 </ScopeClaim>
 
 <ScopeClaim status="not-covered" label="Not covered">

--- a/site/src/content/docs/devices/index.mdx
+++ b/site/src/content/docs/devices/index.mdx
@@ -115,8 +115,9 @@ Three specific absences are worth knowing before you plan a job. ISO 9614-1's
 discrete fixed-point power summation is **not implemented at all** — only its
 field indicators are, reused by the scanning routes. Dissipative duct-lining
 silencers are **not modelled from liner properties** anywhere: the reactive
-elements are computed exactly, and the lined-elbow and plenum figures are
-interpolated installation tables. And no page here predicts a panel's
+elements are computed exactly, and the lined-elbow figure is a table lookup
+(Bies Table 8.11) and the plenum Wells' closed form driven by a declared mean
+absorption — neither is a liner model. And no page here predicts a panel's
 transmission loss: `enclosure_insertion_loss` combines a value you supply with
 the interior correction, and the prediction itself is [Insulation
 design](/phonometry/buildings/design/).

--- a/site/src/content/docs/devices/index.mdx
+++ b/site/src/content/docs/devices/index.mdx
@@ -115,11 +115,12 @@ Three specific absences are worth knowing before you plan a job. ISO 9614-1's
 discrete fixed-point power summation is **not implemented at all** — only its
 field indicators are, reused by the scanning routes. Dissipative duct-lining
 silencers are **not modelled from liner properties** anywhere: the reactive
-elements are computed exactly, and the lined-elbow figure is a table lookup
-(Bies Table 8.11) and the plenum Wells' closed form driven by a declared mean
-absorption — neither is a liner model. And no page here predicts a panel's
-transmission loss: `enclosure_insertion_loss` combines a value you supply with
-the interior correction, and the prediction itself is [Insulation
+elements are computed exactly within the no-flow plane-wave model, and the
+lined-elbow figure is a table lookup (Bies Table 8.11) and the plenum Wells'
+closed form driven by a declared mean absorption — neither is a liner model.
+And no page here predicts a panel's transmission loss:
+`enclosure_insertion_loss` combines a value you supply with the interior
+correction, and the prediction itself is [Insulation
 design](/phonometry/buildings/design/).
 </ScopeClaim>
 

--- a/site/src/content/docs/devices/index.mdx
+++ b/site/src/content/docs/devices/index.mdx
@@ -116,8 +116,8 @@ discrete fixed-point power summation is **not implemented at all** — only its
 field indicators are, reused by the scanning routes. Dissipative duct-lining
 silencers are **not modelled from liner properties** anywhere: the reactive
 elements are computed exactly within the no-flow plane-wave model, and the
-lined-elbow figure is a table lookup (Bies Table 8.11) and the plenum Wells'
-closed form driven by a declared mean absorption — neither is a liner model.
+lined-elbow figure is a table lookup (Bies Table 8.11) and the plenum
+attenuation Wells' closed form driven by a declared mean absorption — neither is a liner model.
 And no page here predicts a panel's transmission loss:
 `enclosure_insertion_loss` combines a value you supply with the interior
 correction, and the prediction itself is [Insulation

--- a/site/src/content/docs/devices/noise-control/duct-path.mdx
+++ b/site/src/content/docs/devices/noise-control/duct-path.mdx
@@ -1104,8 +1104,8 @@ analysis.
 <ScopeClaim status="not-covered" label="Not covered">
 No fan or terminal-device data is predicted where the manufacturer publishes
 it, and this sheet expects the published figure. There is no dissipative-liner
-model: the splitter estimate is a lined-duct regression and the plenum is
-Wells' closed form. Above the first cut-on the element models stand on their
+model: the splitter estimate is a lined-duct regression and the plenum attenuation
+is Wells' closed form. Above the first cut-on the element models stand on their
 empirical fit alone. And **four noise paths of a real installation are outside
 this calculation entirely**, which is why a passing sheet and a failing room
 are usually one of them:

--- a/site/src/content/docs/devices/noise-control/index.mdx
+++ b/site/src/content/docs/devices/noise-control/index.mdx
@@ -88,8 +88,8 @@ source of a supplier's figures, not implemented. Within the predictions, three
 limits are structural. **Only reactive silencer elements are computed** —
 dissipative duct-lining silencers are discussed for selection but are not
 modelled from liner properties anywhere in the library, and on the HVAC page
-the lined-elbow figure is a table lookup (Bies Table 8.11) and the plenum is
-Wells' closed form driven by a declared mean absorption — neither is a liner
+the lined-elbow figure is a table lookup (Bies Table 8.11) and the plenum
+attenuation is Wells' closed form driven by a declared mean absorption — neither is a liner
 model. **Mean flow is outside the element matrices**:
 convection, temperature gradients and the flow-dependent impedance of
 perforates do not appear, so a silencer carrying significant flow is predicted

--- a/site/src/content/docs/devices/noise-control/index.mdx
+++ b/site/src/content/docs/devices/noise-control/index.mdx
@@ -87,9 +87,10 @@ declared data, and the measurement standards named above are cited as the
 source of a supplier's figures, not implemented. Within the predictions, three
 limits are structural. **Only reactive silencer elements are computed** —
 dissipative duct-lining silencers are discussed for selection but are not
-modelled from liner properties anywhere in the library, and the lined-elbow
-and plenum figures on the HVAC page are interpolated installation tables
-rather than a liner model. **Mean flow is outside the element matrices**:
+modelled from liner properties anywhere in the library, and on the HVAC page
+the lined-elbow figure is a table lookup (Bies Table 8.11) and the plenum is
+Wells' closed form driven by a declared mean absorption — neither is a liner
+model. **Mean flow is outside the element matrices**:
 convection, temperature gradients and the flow-dependent impedance of
 perforates do not appear, so a silencer carrying significant flow is predicted
 as though it were not. And `enclosure_insertion_loss` **never predicts the

--- a/site/src/content/docs/devices/noise-control/noise-control.mdx
+++ b/site/src/content/docs/devices/noise-control/noise-control.mdx
@@ -557,10 +557,11 @@ with a value computed here compares two different things.
 
 <Scope>
 <ScopeClaim status="covered" label="Covered">
-The Bies §8.11-8.17 / ASHRAE HVAC methods: `hvac.end_reflection_loss` and
-`hvac.elbow_insertion_loss` (interpolated tables), `hvac.plenum_attenuation`
-(Wells closed form) and `hvac.flow_noise_straight_duct`/`flow_noise_bend` (VDI
-2081). The machine- enclosure insertion loss of Bies §7.4 (Eqs. (7.103),
+The Bies §8.11-8.17 / ASHRAE HVAC methods: `hvac.end_reflection_loss`
+(interpolated table) and `hvac.elbow_insertion_loss` (Table 8.11 lookup),
+`hvac.plenum_attenuation` (Wells closed form) and
+`hvac.flow_noise_straight_duct`/`flow_noise_bend` (VDI 2081). The machine-
+enclosure insertion loss of Bies §7.4 (Eqs. (7.103),
 (7.111)), `enclosure_insertion_loss`, combining a supplied panel transmission
 loss with the interior room-constant correction, and the composite of panels,
 doors and openings that feeds it (`composite_transmission_loss`).
@@ -571,7 +572,9 @@ The reactive silencer elements (expansion chambers, side branches, extended
 tubes) have moved to
 [Silencers](/phonometry/devices/noise-control/silencers/), and dissipative
 duct-lining silencers are not modelled from liner properties anywhere: the
-lined-elbow and plenum values here are interpolated installation tables.
+lined-elbow figure here is a table lookup (Bies Table 8.11) and the plenum is
+Wells' closed form driven by a declared mean absorption — neither is a liner
+model.
 `enclosure_insertion_loss` never predicts the panel transmission loss $R$
 itself; you supply it measured or from another model, and the module only
 combines it with the interior correction. Nothing here is a measurement: the

--- a/site/src/content/docs/devices/noise-control/noise-control.mdx
+++ b/site/src/content/docs/devices/noise-control/noise-control.mdx
@@ -254,8 +254,9 @@ plt.show()
 
 </details>
 
-The end-reflection and elbow methods interpolate the ASHRAE tables (they pass
-exactly through the tabulated nodes); the plenum (Wells) and flow-noise (VDI
+The end-reflection method interpolates its ASHRAE table (it passes exactly
+through the tabulated nodes) and the elbow method reads Table 8.11 by the band
+its $W/\lambda$ falls in; the plenum (Wells) and flow-noise (VDI
 2081) methods are closed forms. `end_reflection_loss`, `elbow_insertion_loss`,
 `flow_noise_straight_duct` and `flow_noise_bend` return an `HvacSpectrumResult`
 (attenuation or regenerated sound power level) with `.plot()`; `plenum_attenuation`

--- a/site/src/content/docs/devices/noise-control/silencers.mdx
+++ b/site/src/content/docs/devices/noise-control/silencers.mdx
@@ -731,10 +731,11 @@ include_unlined=True)` for the two linings, and
 for the splitter unit.
 
 phonometry models the reactive family in closed form on this page. The
-dissipative side enters through the installation data of the
+dissipative side enters at installation level, through the
 [HVAC methods](/phonometry/devices/noise-control/noise-control/): the lined-elbow
-insertion loss and the lined plenum attenuation of Wells' method, both from
-interpolated ASHRAE data rather than a liner model. The porous physics that
+insertion loss read from tabulated ASHRAE data and the lined plenum
+attenuation from Wells' closed form, neither of them a liner model. The
+porous physics that
 a first-principles liner calculation needs, the equivalent-fluid models fed
 by the airflow resistivity, is the same material theory as
 [Porous and Multilayer Absorbers](/phonometry/materials/absorbers/porous-absorbers/).
@@ -830,8 +831,9 @@ Munjal Eq. (3.27)): the closed-form `expansion_chamber` (Eq. (8.111)),
 `helmholtz_resonator` and `quarter_wave_resonator` (Eqs. (8.46), (8.44)),
 `extended_tube_chamber`, and the `duct_matrix`/
 `shunt_matrix`/`cascade`/`transmission_loss`/`insertion_loss` building blocks
-for arbitrary element chains, each with its to-scale `.plot_geometry()`
-drawing, cross-checked against the independent FDTD solver; the
+for arbitrary element chains; the to-scale `.plot_geometry()` drawing on each
+of the four constructors' results, and the expansion chamber cross-checked
+against the independent FDTD solver; the
 `plane_wave_limit` that bounds all of them; and, as prose rather than as code,
 the ISO 7235 substitution measurement that produces the insertion loss a
 supplier publishes.
@@ -840,9 +842,11 @@ supplier publishes.
 <ScopeClaim status="not-covered" label="Not covered">
 Only reactive elements are computed: dissipative (absorptive, duct-lining)
 silencers are discussed for selection but not modelled from the liner
-properties, and the lined-elbow and plenum data of the [HVAC
-methods](/phonometry/devices/noise-control/noise-control/) are interpolated
-installation tables, not a liner model. Mean-flow effects (convection,
+properties, and in the [HVAC
+methods](/phonometry/devices/noise-control/noise-control/) the lined-elbow
+figure is a table lookup (Bies Table 8.11) and the plenum is Wells' closed
+form driven by a declared mean absorption — neither is a liner model.
+Mean-flow effects (convection,
 temperature gradients, flow-dependent impedance of perforates) are outside the
 no-flow element matrices used here. Nothing on this page is a measurement: no
 part of ISO 7235 is implemented, the shell breakout and the end corrections at

--- a/site/src/content/docs/devices/noise-control/silencers.mdx
+++ b/site/src/content/docs/devices/noise-control/silencers.mdx
@@ -844,8 +844,8 @@ Only reactive elements are computed: dissipative (absorptive, duct-lining)
 silencers are discussed for selection but not modelled from the liner
 properties, and in the [HVAC
 methods](/phonometry/devices/noise-control/noise-control/) the lined-elbow
-figure is a table lookup (Bies Table 8.11) and the plenum is Wells' closed
-form driven by a declared mean absorption — neither is a liner model.
+figure is a table lookup (Bies Table 8.11) and the plenum attenuation is
+Wells' closed form driven by a declared mean absorption — neither is a liner model.
 Mean-flow effects (convection,
 temperature gradients, flow-dependent impedance of perforates) are outside the
 no-flow element matrices used here. Nothing on this page is a measurement: no

--- a/site/src/content/docs/es/buildings/design/detailed-prediction.mdx
+++ b/site/src/content/docs/es/buildings/design/detailed-prediction.mdx
@@ -666,10 +666,12 @@ elemento ligero, doble o compuesto es un dato de entrada, que sale de
 paneles](/phonometry/es/buildings/design/panel-sound-insulation/) o de un
 informe de ensayo. El propio catálogo de uniones del Anexo E vive en
 [Predicción del aislamiento acústico (EN
-12354)](/phonometry/es/buildings/design/insulation-prediction/), igual que las
-tablas por defecto de los anexos D y F de las demás partes. La rama de Tipo B
-se muestra a partir de sus entradas normativas en lugar de resolverse de
-principio a fin. La transmisión aérea a través de cámaras y de techos
+12354)](/phonometry/es/buildings/design/insulation-prediction/), y la mejora
+por trasdosado del Anexo D de la Parte 1 en [Predicción del comportamiento de
+capas elásticas](/phonometry/es/buildings/design/resilient-layers/); las tablas
+por defecto de los anexos D y F de EN 12354-5 no están implementadas en
+ninguna parte. La rama de Tipo B se muestra a partir de sus entradas
+normativas en lugar de resolverse de principio a fin. La transmisión aérea a través de cámaras y de techos
 suspendidos no se lleva en absoluto, y la nota 1 del apartado 3.3.4 advierte
 de que ahí «puede contribuir o incluso dominar». Y la valoración ISO 717
 necesita el espectro entero: de 100 Hz a 3150 Hz en tercios de octava, o de

--- a/site/src/content/docs/es/buildings/design/index.mdx
+++ b/site/src/content/docs/es/buildings/design/index.mdx
@@ -168,12 +168,16 @@ Páginas de otras áreas del sitio en las que se apoya esta sección:
 <ScopeClaim status="not-covered">
 **Una predicción vale lo que valen los datos de elemento que le des, y la
 biblioteca toma esos datos como dados.** Las magnitudes globales de los
-elementos, los índices de unión, la mejora del revestimiento y los términos de
-ajuste de estructural a aéreo de los anexos D y F de EN 12354-5 son entradas
-que aportas tú desde una medición o desde los propios anexos de las normas;
-ninguno se deriva aquí. La página de predicción simplificada se detiene por
-diseño en los números únicos ponderados, y la página detallada es donde viven
-los modelos por bandas.
+elementos, los índices de unión y las mejoras de los revestimientos son
+parámetros que consumen los puntos de entrada, aportados desde una medición o
+calculados con los propios estimadores de esta sección — el catálogo de
+uniones del anexo E, las leyes de mejora del suelo flotante y del trasdosado,
+la cadena de elemento homogéneo del anexo B y los modelos físicos de panel —,
+y nada comprueba los números que pases. Solo los términos de ajuste de
+estructural a aéreo de los anexos D y F de EN 12354-5 carecen aquí de
+estimador y han de salir de las tablas de la propia norma. La página de
+predicción simplificada se detiene por diseño en los números únicos
+ponderados, y la página detallada es donde viven los modelos por bandas.
 </ScopeClaim>
 
 <ScopeClaim status="not-covered">

--- a/site/src/content/docs/es/buildings/index.mdx
+++ b/site/src/content/docs/es/buildings/index.mdx
@@ -125,12 +125,15 @@ datos de elemento y a partir de la física del propio elemento.
 <Scope>
 <ScopeClaim status="not-covered">
 **La biblioteca empieza después del micrófono y se detiene antes de la
-geometría.** Del lado de la medición, cada función toma niveles de banda ya
-promediados sobre las posiciones y ya corregidos por el ruido de fondo: el
-número de posiciones, los procedimientos de baja frecuencia, los mínimos de
-señal frente al ruido de fondo y las cualificaciones de la instalación de
-ensayo de ISO 16283, ISO 10140 e ISO 3382 son cosa del operador, y aquí nada
-comprueba que se hayan cumplido. Del lado de la predicción, los índices
+geometría.** Del lado de la medición, el promediado entre posiciones ocurre
+en cuanto aportas las posiciones — las funciones de aislamiento promedian en
+energía los espectros por posición por ti —, pero nada verifica cómo se hizo
+la medición: el número y la colocación de las posiciones, los procedimientos
+de baja frecuencia y las cualificaciones de la instalación de ensayo de
+ISO 16283, ISO 10140 e ISO 3382 son cosa del operador. También lo es medir el
+ruido de fondo: solo está implementada la corrección de laboratorio de
+ISO 10140-4, que avisa cuando se incumple su mínimo de 6 dB, y los niveles de
+campo han de llegar ya corregidos. Del lado de la predicción, los índices
 globales de los elementos, los índices de unión y las mejoras de los
 revestimientos son entradas que aportas tú desde una medición o desde el
 propio anexo de una norma; ninguna se deriva de un plano.

--- a/site/src/content/docs/es/buildings/insulation/index.mdx
+++ b/site/src/content/docs/es/buildings/insulation/index.mdx
@@ -106,19 +106,23 @@ emparentada EN 12354-5, vive en
 
 <Scope>
 <ScopeClaim status="not-covered">
-**La biblioteca empieza después del micrófono.** Cada función de aquí toma
-niveles de banda que ya se han promediado en energía sobre las posiciones y ya
-se han corregido por ruido de fondo, y nada verifica cómo se hizo la medición:
-ni el número y la colocación de las posiciones de fuente y de micrófono, ni
-los procedimientos de baja frecuencia de ISO 16283-1/-2, ni el mínimo de 6 dB
-de señal frente al ruido de fondo, ni los requisitos de instalación de ensayo
-y de montaje de ISO 10140-1. Eso es cosa del operador y del informe, y es lo
-que hace que los números de aquí signifiquen algo. Dos consecuencias que
+**La biblioteca empieza después del micrófono.** Cada función de aquí acepta
+espectros por posición y los promedia en energía por ti, pero nada verifica
+cómo se hizo la medición: ni el número y la colocación de las posiciones de
+fuente y de micrófono detrás de esos espectros, ni los procedimientos de baja
+frecuencia de ISO 16283-1/-2, ni los requisitos de instalación de ensayo y de
+montaje de ISO 10140-1. Eso es cosa del operador y del informe, y es lo que
+hace que los números de aquí signifiquen algo. El ruido de fondo es la única
+corrección que de verdad queda en manos de quien llama: los niveles de campo
+han de llegar ya corregidos, con su mínimo de 6 dB de señal frente al ruido
+de fondo comprobado por el operador, mientras que la función auxiliar de
+laboratorio de ISO 10140-4 aplica su regla por sí misma, avisando cuando se
+incumple su propio mínimo y acotando la corrección. Dos consecuencias que
 conviene nombrar: las correcciones por ruido de fondo de campo y de
-laboratorio son reglas *distintas*, así que una función auxiliar de
+laboratorio son reglas *distintas*, así que esa función auxiliar de
 laboratorio no debe aplicarse a datos de campo; y la vía de intensidad toma
-como entradas tanto el nivel de presión como el de intensidad, con la sonda de
-barrido y su calibración del desajuste de fase fuera de la biblioteca.
+como entradas tanto el nivel de presión como el de intensidad, con la sonda
+de barrido y su calibración del desajuste de fase fuera de la biblioteca.
 </ScopeClaim>
 
 <ScopeClaim status="not-covered">

--- a/site/src/content/docs/es/buildings/insulation/index.mdx
+++ b/site/src/content/docs/es/buildings/insulation/index.mdx
@@ -106,8 +106,12 @@ emparentada EN 12354-5, vive en
 
 <Scope>
 <ScopeClaim status="not-covered">
-**La biblioteca empieza después del micrófono.** Cada función de aquí acepta
-espectros por posición y los promedia en energía por ti, pero nada verifica
+**La biblioteca empieza después del micrófono.** Las funciones de campo, de
+laboratorio, de control y de intensidad que forman un índice de aislamiento
+aceptan espectros por posición y los promedian en energía por ti; la
+estandarización de impacto pesado, los índices de flanco, los índices
+globales de ISO 717 y las funciones auxiliares de ruido de fondo toman su
+entrada por banda ya formada. En cualquiera de los dos casos, nada verifica
 cómo se hizo la medición: ni el número y la colocación de las posiciones de
 fuente y de micrófono detrás de esos espectros, ni los procedimientos de baja
 frecuencia de ISO 16283-1/-2, ni los requisitos de instalación de ensayo y de

--- a/site/src/content/docs/es/devices/electroacoustics/index.mdx
+++ b/site/src/content/docs/es/devices/electroacoustics/index.mdx
@@ -103,9 +103,9 @@ implementadas están fijadas en vez de vigentes: las métricas de distorsión
 siguen AES17-2015 y no la revisión de 2020, y el informe de micrófono sigue
 IEC 60268-4:2014 y no el de 2018. La extracción de parámetros de Thiele-Small
 a partir de una curva de impedancia no está implementada, y los valores
-eléctricos y mecánicos de potencia admisible del apartado 17 de IEC 60268-5
-los declara el fabricante, no se calculan. El criterio de realimentación es
-una contabilidad de niveles, no un modelo acústico: consume dos niveles de
+eléctricos y mecánicos de potencia admisible de los apartados 17 y 18 de IEC
+60268-5 los declara el fabricante, no se calculan. El criterio de
+realimentación es una contabilidad de niveles, no un modelo acústico: consume dos niveles de
 campo directo que aportas tú, no los calcula a partir de un patrón de
 cobertura, y no predice ni la frecuencia de acoplo ni el efecto de un
 ecualizador o de un desplazador de frecuencia. Y la IEC 60268-16, el índice de

--- a/site/src/content/docs/es/devices/electroacoustics/loudspeakers.mdx
+++ b/site/src/content/docs/es/devices/electroacoustics/loudspeakers.mdx
@@ -855,9 +855,10 @@ presentan las curvas que se les entregan, así que el montaje, la excitación,
 el enventanado y la condición de campo quedan a cargo de quien opera, que
 además tiene que declararlos junto al resultado. Los valores eléctricos y
 mecánicos que la norma define en torno a la potencia admisible (potencia de
-ruido nominal, tensiones máximas de entrada de corta y larga duración,
-apartado 17) los declara el fabricante, no se calculan aquí. La extracción de
-parámetros de Thiele-Small de la curva de impedancia no está implementada: el
+ruido nominal, apartado 18; tensiones máximas de entrada de corta y larga
+duración, apartado 17) los declara el fabricante, no se calculan aquí. La
+extracción de parámetros de Thiele-Small de la curva de impedancia no está
+implementada: el
 panel de impedancia presenta el módulo medido frente a las líneas de
 impedancia nominal. La propia curva de distorsión procede de una medición, por
 ejemplo de la cadena de [distorsión con barrido

--- a/site/src/content/docs/es/devices/emission/sound-power-intensity.mdx
+++ b/site/src/content/docs/es/devices/emission/sound-power-intensity.mdx
@@ -645,9 +645,10 @@ cribado del apartado 10.6 b) del total ponderado A
 (`a_weighting_omitted_bands`). La determinación de precisión de ISO 9614-3
 (`sound_power_intensity_precision`) con su propio marcado de no aplicable, sus
 indicadores de campo del Anexo B (`precision_field_indicators`) y los cinco
-criterios de aceptación del Anexo C (`precision_qualification`). Ambos
-resultados presentan la ficha de potencia acústica de estilo acreditado
-mediante `.report()`.
+criterios de aceptación del Anexo C (`precision_qualification`). El resultado
+de barrido presenta la ficha de potencia acústica de estilo acreditado mediante
+`.report()`; el resultado de precisión dibuja su espectro con `.plot()`, pero
+no escribe ninguna ficha.
 </ScopeClaim>
 
 <ScopeClaim status="not-covered" label="No cubierto">

--- a/site/src/content/docs/es/devices/index.mdx
+++ b/site/src/content/docs/es/devices/index.mdx
@@ -123,9 +123,11 @@ implementada en absoluto**: sí lo están solo sus indicadores de campo,
 reutilizados por las vías de barrido. Los silenciadores disipativos de
 conducto revestido **no se modelan a partir de las propiedades del
 revestimiento** en ningún sitio: los elementos reactivos se calculan
-exactamente, y las cifras de codo revestido y de plenum son tablas de
-instalación interpoladas. Y aquí ninguna página predice la pérdida por
-transmisión de un panel: `enclosure_insertion_loss` combina un valor que
+exactamente, y la cifra de codo revestido es una lectura de tabla (la Tabla
+8.11 de Bies) y el plenum la forma cerrada de Wells gobernada por una
+absorción media declarada — ninguno de los dos es un modelo de revestimiento.
+Y aquí ninguna página predice la pérdida por transmisión de un panel:
+`enclosure_insertion_loss` combina un valor que
 aportas tú con la corrección interior, y la predicción en sí es [Diseño del
 aislamiento](/phonometry/es/buildings/design/).
 </ScopeClaim>

--- a/site/src/content/docs/es/devices/index.mdx
+++ b/site/src/content/docs/es/devices/index.mdx
@@ -123,11 +123,11 @@ implementada en absoluto**: sí lo están solo sus indicadores de campo,
 reutilizados por las vías de barrido. Los silenciadores disipativos de
 conducto revestido **no se modelan a partir de las propiedades del
 revestimiento** en ningún sitio: los elementos reactivos se calculan
-exactamente, y la cifra de codo revestido es una lectura de tabla (la Tabla
-8.11 de Bies) y el plenum la forma cerrada de Wells gobernada por una
-absorción media declarada — ninguno de los dos es un modelo de revestimiento.
-Y aquí ninguna página predice la pérdida por transmisión de un panel:
-`enclosure_insertion_loss` combina un valor que
+exactamente dentro del modelo de onda plana sin flujo, y la cifra de codo
+revestido es una lectura de tabla (la Tabla 8.11 de Bies) y el plenum la forma
+cerrada de Wells gobernada por una absorción media declarada — ninguno de los
+dos es un modelo de revestimiento. Y aquí ninguna página predice la pérdida por
+transmisión de un panel: `enclosure_insertion_loss` combina un valor que
 aportas tú con la corrección interior, y la predicción en sí es [Diseño del
 aislamiento](/phonometry/es/buildings/design/).
 </ScopeClaim>

--- a/site/src/content/docs/es/devices/index.mdx
+++ b/site/src/content/docs/es/devices/index.mdx
@@ -124,8 +124,8 @@ reutilizados por las vías de barrido. Los silenciadores disipativos de
 conducto revestido **no se modelan a partir de las propiedades del
 revestimiento** en ningún sitio: los elementos reactivos se calculan
 exactamente dentro del modelo de onda plana sin flujo, y la cifra de codo
-revestido es una lectura de tabla (la Tabla 8.11 de Bies) y el plenum la forma
-cerrada de Wells gobernada por una absorción media declarada — ninguno de los
+revestido es una lectura de tabla (la Tabla 8.11 de Bies) y la atenuación del
+plenum la forma cerrada de Wells gobernada por una absorción media declarada — ninguno de los
 dos es un modelo de revestimiento. Y aquí ninguna página predice la pérdida por
 transmisión de un panel: `enclosure_insertion_loss` combina un valor que
 aportas tú con la corrección interior, y la predicción en sí es [Diseño del

--- a/site/src/content/docs/es/devices/noise-control/duct-path.mdx
+++ b/site/src/content/docs/es/devices/noise-control/duct-path.mdx
@@ -1158,7 +1158,8 @@ sin revestir, `flexible_duct_insertion_loss`, `elbow_insertion_loss`,
 No se predice ningún dato de ventilador ni de unidad terminal allí donde lo
 publica el fabricante, y esta hoja espera la cifra publicada. No hay modelo de
 revestimiento disipativo: la estimación del silenciador de bafles es una
-regresión de conducto revestido y el plenum es la forma cerrada de Wells. Por
+regresión de conducto revestido y la atenuación del plenum es la forma cerrada
+de Wells. Por
 encima del primer corte los modelos de elemento se sostienen solo sobre su
 ajuste empírico. Y **cuatro trayectos de ruido de una instalación real quedan
 por completo fuera de este cálculo**, que es la razón de que una hoja que

--- a/site/src/content/docs/es/devices/noise-control/index.mdx
+++ b/site/src/content/docs/es/devices/noise-control/index.mdx
@@ -97,10 +97,12 @@ como origen de las cifras de un proveedor, no se implementan. Dentro de las
 predicciones, tres límites son estructurales. **Solo se calculan los elementos
 de silenciador reactivos**: los silenciadores disipativos de conducto
 revestido se comentan para la selección, pero no se modelan a partir de las
-propiedades del revestimiento en ningún punto de la biblioteca, y las cifras
-de codo revestido y de plenum de la página de HVAC son tablas de instalación
-interpoladas y no un modelo de revestimiento. **El flujo medio queda fuera de
-las matrices de elemento**: no aparecen la convección, los gradientes de
+propiedades del revestimiento en ningún punto de la biblioteca, y en la página
+de HVAC la cifra de codo revestido es una lectura de tabla (la Tabla 8.11 de
+Bies) y el plenum es la forma cerrada de Wells gobernada por una absorción
+media declarada — ninguno de los dos es un modelo de revestimiento. **El flujo
+medio queda fuera de las matrices de elemento**: no aparecen la convección,
+los gradientes de
 temperatura ni la impedancia dependiente del flujo de los perforados, así que
 un silenciador que transporta un flujo apreciable se predice como si no lo
 hiciera. Y `enclosure_insertion_loss` **nunca predice la pérdida por

--- a/site/src/content/docs/es/devices/noise-control/index.mdx
+++ b/site/src/content/docs/es/devices/noise-control/index.mdx
@@ -99,7 +99,8 @@ de silenciador reactivos**: los silenciadores disipativos de conducto
 revestido se comentan para la selección, pero no se modelan a partir de las
 propiedades del revestimiento en ningún punto de la biblioteca, y en la página
 de HVAC la cifra de codo revestido es una lectura de tabla (la Tabla 8.11 de
-Bies) y el plenum es la forma cerrada de Wells gobernada por una absorción
+Bies) y la atenuación del plenum es la forma cerrada de Wells gobernada por
+una absorción
 media declarada — ninguno de los dos es un modelo de revestimiento. **El flujo
 medio queda fuera de las matrices de elemento**: no aparecen la convección,
 los gradientes de

--- a/site/src/content/docs/es/devices/noise-control/noise-control.mdx
+++ b/site/src/content/docs/es/devices/noise-control/noise-control.mdx
@@ -577,10 +577,10 @@ comparar dos cosas distintas.
 
 <Scope>
 <ScopeClaim status="covered" label="Cubierto">
-Los métodos HVAC de Bies §8.11-8.17 / ASHRAE: `hvac.end_reflection_loss` y
-`hvac.elbow_insertion_loss` (tablas interpoladas), `hvac.plenum_attenuation`
-(forma cerrada de Wells) y `hvac.flow_noise_straight_duct`/`flow_noise_bend`
-(VDI 2081). La pérdida por inserción de cerramientos de máquina de Bies §7.4
+Los métodos HVAC de Bies §8.11-8.17 / ASHRAE: `hvac.end_reflection_loss`
+(tabla interpolada) y `hvac.elbow_insertion_loss` (lectura de la Tabla 8.11),
+`hvac.plenum_attenuation` (forma cerrada de Wells) y
+`hvac.flow_noise_straight_duct`/`flow_noise_bend` (VDI 2081). La pérdida por inserción de cerramientos de máquina de Bies §7.4
 (Ecs. (7.103), (7.111)), `enclosure_insertion_loss`, que combina una pérdida
 de transmisión de panel aportada con la corrección por la constante de sala
 interior, y el compuesto de paneles, puertas y aberturas que la alimenta
@@ -592,8 +592,10 @@ Los elementos de silenciador reactivo (cámaras de expansión, ramas laterales,
 tubos extendidos) se han trasladado a
 [Silenciadores](/phonometry/es/devices/noise-control/silencers/), y los
 silenciadores disipativos con revestimiento interior no se modelan a partir de
-las propiedades del revestimiento en ninguna parte: los valores de codo
-revestido y de plenum de esta página son tablas de instalación interpoladas.
+las propiedades del revestimiento en ninguna parte: la cifra de codo revestido
+de esta página es una lectura de tabla (la Tabla 8.11 de Bies) y el plenum es
+la forma cerrada de Wells gobernada por una absorción media declarada —
+ninguno de los dos es un modelo de revestimiento.
 `enclosure_insertion_loss` nunca predice la pérdida de transmisión de panel
 $R$; se aporta medida o de otro modelo, y el módulo solo la combina con la
 corrección interior. Nada de lo que hay aquí es una medición: el procedimiento

--- a/site/src/content/docs/es/devices/noise-control/noise-control.mdx
+++ b/site/src/content/docs/es/devices/noise-control/noise-control.mdx
@@ -265,8 +265,9 @@ plt.show()
 
 </details>
 
-Los métodos de reflexión de extremo y de codos interpolan las tablas ASHRAE
-(pasan exactamente por los nodos tabulados); los métodos de plenum (Wells) y de
+El método de reflexión de extremo interpola su tabla ASHRAE (pasa exactamente
+por los nodos tabulados) y el de codos lee la Tabla 8.11 según la banda en la
+que cae su $W/\lambda$; los métodos de plenum (Wells) y de
 ruido de flujo (VDI 2081) son formas cerradas. `end_reflection_loss`,
 `elbow_insertion_loss`, `flow_noise_straight_duct` y `flow_noise_bend` devuelven
 un `HvacSpectrumResult` (atenuación o nivel de potencia acústica regenerada) con

--- a/site/src/content/docs/es/devices/noise-control/silencers.mdx
+++ b/site/src/content/docs/es/devices/noise-control/silencers.mdx
@@ -767,12 +767,12 @@ include_unlined=True)` para los dos revestimientos, y
 para la unidad de bafles.
 
 phonometry modela la familia reactiva en forma cerrada en esta página. El
-lado disipativo entra por los datos de instalación de los
+lado disipativo entra a nivel de instalación, por los
 [métodos HVAC](/phonometry/es/devices/noise-control/noise-control/): la pérdida por inserción
-del codo revestido y la atenuación del plenum revestido del método de Wells,
-ambas a partir de datos ASHRAE interpolados y no de un modelo de
-revestimiento. La física porosa que necesitaría un cálculo de revestimiento
-desde primeros principios, los modelos de fluido equivalente alimentados por
+del codo revestido, leída de datos ASHRAE tabulados, y la atenuación del
+plenum revestido según la forma cerrada de Wells; ninguna de las dos es un
+modelo de revestimiento. La física porosa que necesitaría un cálculo de
+revestimiento desde primeros principios, los modelos de fluido equivalente alimentados por
 la resistividad al flujo de aire, es la misma teoría de materiales que
 [Absorbentes porosos y multicapa](/phonometry/es/materials/absorbers/porous-absorbers/).
 
@@ -877,8 +877,9 @@ polos (Bies §8.8-8.9, Munjal Ec. (3.27)): la forma cerrada `expansion_chamber`
 (Ec. (8.111)), `helmholtz_resonator` y `quarter_wave_resonator` (Ecs. (8.46),
 (8.44)), `extended_tube_chamber`, y los bloques
 `duct_matrix`/`shunt_matrix`/`cascade`/`transmission_loss`/ `insertion_loss`
-para encadenar elementos arbitrarios, cada uno con su dibujo a escala
-`.plot_geometry()`, contrastados con la simulación FDTD independiente; el
+para encadenar elementos arbitrarios; el dibujo a escala `.plot_geometry()`
+del resultado de cada uno de los cuatro constructores, y la cámara de
+expansión contrastada con la simulación FDTD independiente; el
 `plane_wave_limit` que acota a todos ellos; y, como prosa y no como código, la
 medición por sustitución de ISO 7235 que produce la pérdida por inserción que
 publica un suministrador.
@@ -887,10 +888,11 @@ publica un suministrador.
 <ScopeClaim status="not-covered" label="No cubierto">
 Solo se calculan elementos reactivos: los silenciadores disipativos
 (absorbentes, con revestimiento interior) se discuten para la selección pero
-no se modelan a partir de las propiedades del revestimiento, y los datos de
-codo revestido y plenum de los [métodos
-HVAC](/phonometry/es/devices/noise-control/noise-control/) son tablas de
-instalación interpoladas, no un modelo de revestimiento. Los efectos del flujo
+no se modelan a partir de las propiedades del revestimiento, y en los [métodos
+HVAC](/phonometry/es/devices/noise-control/noise-control/) la cifra de codo
+revestido es una lectura de tabla (la Tabla 8.11 de Bies) y el plenum es la
+forma cerrada de Wells gobernada por una absorción media declarada — ninguno
+de los dos es un modelo de revestimiento. Los efectos del flujo
 medio (convección, gradientes de temperatura, impedancia de los perforados
 dependiente del flujo) quedan fuera de las matrices de elemento sin flujo que
 se usan aquí. Nada de lo que hay en esta página es una medición: no se

--- a/site/src/content/docs/es/materials/absorbers/porous-absorbers.mdx
+++ b/site/src/content/docs/es/materials/absorbers/porous-absorbers.mdx
@@ -1334,7 +1334,7 @@ detrás, y la diferencia de tamaño finito entre un $\alpha_{dif}$ predicho y un
 $\alpha_s$ medido se enuncia pero no se modela: nada de aquí reproduce el
 efecto de borde. El libro de Cox y D'Antonio trata tanto difusores como
 absorbentes, pero esta guía solo implementa la mitad de absorbentes. La
-predicción del difusor de gradiente de fase de Schroeder vive en un módulo
+predicción del difusor de rejilla de fase de Schroeder vive en un módulo
 aparte (`materials.diffusers.design`), documentada en [Difusores y sus
 coeficientes](/phonometry/es/materials/diffusers/diffusers/) y, para los
 paneles en sublongitud de onda profunda cargados con resonadores, en

--- a/site/src/content/docs/es/materials/diffusers/diffusers.mdx
+++ b/site/src/content/docs/es/materials/diffusers/diffusers.mdx
@@ -188,7 +188,7 @@ las rompió.
   antes y después de **cada** una de las cuatro situaciones y usar la media por
   situación (apartado 7.4).
 
-**Absorción a partir del tiempo de reverberación (apartado 6).** Cada situación se
+**Absorción a partir del tiempo de reverberación (apartado 8.1).** Cada situación se
 convierte en un coeficiente de absorción de Sabine con el propio término de
 atenuación del aire de la norma:
 
@@ -1212,7 +1212,7 @@ sonido») no es ninguno de los dos.
 <ScopeClaim status="covered" label="Cubierto">
 El coeficiente de dispersión de incidencia aleatoria de la ISO
 17497-1:2004+A1:2014 (las relaciones de absorción a partir del tiempo de
-reverberación del apartado 6 y la Fórmula (5)) con los límites de placa base
+reverberación del apartado 8.1 y la Fórmula (5)) con los límites de placa base
 de la Tabla 1, mediante `materials.random_incidence_absorption`,
 `materials.specular_absorption_coefficient`,
 `materials.scattering_coefficient`,

--- a/site/src/content/docs/es/perception/hearing/index.mdx
+++ b/site/src/content/docs/es/perception/hearing/index.mdx
@@ -78,10 +78,14 @@ En el orden en que discurre la cadena.
 **Nada de lo que hay aquí es un veredicto sobre una persona.** ISO 1999 no
 define un hándicap auditivo ni un umbral indemnizable: esa línea la fija la
 regulación nacional, y la biblioteca no aplica ninguna, así que el criterio lo
-aportas y lo compruebas tú. Lo mismo vale para los valores de acción de la
-exposición: el LEX,8h y su límite superior unilateral al 95 % salen de ISO
-9612, y las cifras con las que se comparan están en la directiva de tu
-jurisdicción, no aquí.
+aportas y lo compruebas tú. El lado de la exposición se detiene un paso más
+tarde: el LEX,8h y su límite superior unilateral al 95 % salen de ISO 9612, y
+la ficha que escribe `ExposureResult.report()` sí compara el LEX,8h con los
+valores de acción y el valor límite de la Directiva 2003/10/CE (80, 85 y
+87 dB(A)) y emite el veredicto CUMPLE/NO CUMPLE frente al valor límite; pero
+ese veredicto juzga una exposición sin protección, no a una persona: la
+exposición efectiva tras los protectores auditivos y cualquier transposición
+nacional más estricta siguen corriendo de tu cuenta.
 </ScopeClaim>
 
 <ScopeClaim status="not-covered">

--- a/site/src/content/docs/es/perception/psychoacoustics/psychoacoustic-annoyance.mdx
+++ b/site/src/content/docs/es/perception/psychoacoustics/psychoacoustic-annoyance.mdx
@@ -432,9 +432,9 @@ magnitudes a partir de una señal ($N_5$ Zwicker de la ISO 532-1, $S$ de la DIN
 </ScopeClaim>
 
 <ScopeClaim status="not-covered" label="No cubierto">
-El modelo de Osses 2016 no persigue explícitamente su exactitud para tonos FM.
-Aquí solo se validan estímulos AM. El front-end también se aparta del
-planteamiento exacto del artículo (tramas de 2 s, solape del 90 %, umbral
+La exactitud del modelo de Osses 2016 para tonos FM no se persigue
+explícitamente. Aquí solo se validan estímulos AM. El front-end también se
+aparta del planteamiento exacto del artículo (tramas de 2 s, solape del 90 %, umbral
 absoluto de audición). Como resultado, un tono estacionario de 1 kHz marca
 unos 0,09 vacil en vez de 0, y el ruido de banda ancha estacionario marca unos
 0,15-0,19 vacil. Para el ruido de banda ancha AM, cita

--- a/site/src/content/docs/es/signals/spectra/test-signals.mdx
+++ b/site/src/content/docs/es/signals/spectra/test-signals.mdx
@@ -329,12 +329,18 @@ banda atenuada y la anchura de transición de `resample_signal`.
 </ScopeClaim>
 
 <ScopeClaim status="not-covered" label="No cubierto">
-La IEC 60268-1:1985 es una norma general para equipos de sistemas de sonido.
-Aquí solo se implementan los apartados de ráfagas tonales del anexo A; el
-resto de sus partes (amplificadores, altavoces, conectores, etc.) quedan sin
-tocar. `fractional_delay` y los generadores de ruido de colores de
-`noise_signal` son herramientas de DSP de propósito general sin norma que las
-gobierne; sus afirmaciones de exactitud son formas cerradas, no normativas.
+La IEC 60268-1:1985 es una norma general para equipos de sistemas de sonido;
+en esta página solo se implementan los apartados de ráfagas tonales del
+anexo A. Las partes de dispositivos no se cubren aquí, pero tampoco quedan
+sin tocar: los amplificadores (IEC 60268-3), los micrófonos (IEC 60268-4) y
+los altavoces (IEC 60268-5) tienen sus propias guías en
+[Electroacústica](/phonometry/es/devices/electroacoustics/), y el índice de
+transmisión del habla de la IEC 60268-16 tiene la guía del
+[Índice de transmisión del habla](/phonometry/es/perception/speech/speech-transmission/);
+solo las partes de conectores están ausentes de la biblioteca por completo.
+`fractional_delay` y los generadores de ruido de colores de `noise_signal`
+son herramientas de DSP de propósito general sin norma que las gobierne; sus
+afirmaciones de exactitud son formas cerradas, no normativas.
 </ScopeClaim>
 </Scope>
 

--- a/site/src/content/docs/es/underwater/index.mdx
+++ b/site/src/content/docs/es/underwater/index.mdx
@@ -103,8 +103,8 @@ una reflexión de Rayleigh fluido-fluido sin pérdidas, así que la atenuación
 del sedimento queda fuera de alcance, y los tres métodos suponen una columna
 de agua **independiente de la distancia**, sin fondo absorbente ni elástico y
 sin batimetría real — lo que deja fuera por completo los problemas
-dependientes de la distancia. El trazado de rayos devuelve caminos y tiempos
-de propagación pero no amplitudes (sin intensidad de tubo de rayos, sin
+dependientes de la distancia. El trazado de rayos devuelve caminos pero no
+tiempos de propagación ni amplitudes (sin intensidad de tubo de rayos, sin
 corrección de cáusticas), y la ecuación parabólica es la forma estándar de
 ángulos pequeños de Tappert y no una variante de gran angular de Padé. Para la
 física del lecho elástico que estos métodos fluidos dejan fuera, el [esquema

--- a/site/src/content/docs/es/underwater/underwater-solvers.mdx
+++ b/site/src/content/docs/es/underwater/underwater-solvers.mdx
@@ -267,7 +267,7 @@ cuyo ángulo crítico y gradiente de pérdida por reflexión codifican exactamen
 lo que estas condiciones de contorno omiten, y lee la respuesta modal como una
 cota superior del nivel recibido.
 
-## 3. Trazado de rayos: tiempos de propagación y zonas de convergencia
+## 3. Trazado de rayos: puntos de giro y zonas de convergencia
 
 En el límite de alta frecuencia la ecuación de Helmholtz colapsa en la
 ecuación eikonal, y sus características son los **rayos**: trayectorias
@@ -352,9 +352,8 @@ plt.show()
 
 </details>
 
-Los rayos compran geometría: caminos de eigenrayos, tiempos de propagación
-y distancias de las zonas de convergencia a un coste independiente de la
-frecuencia. Lo que aquí no llevan es una amplitud completa: la intensidad
+Los rayos compran geometría: caminos, profundidades de giro y distancias de
+las zonas de convergencia a un coste independiente de la frecuencia. Lo que aquí no llevan es una amplitud completa: la intensidad
 geométrica del tubo de rayos diverge en las cáusticas, así que el objeto de
 resultado devuelve los caminos y deja el nivel al campo modal o de la PE.
 
@@ -573,12 +572,12 @@ cap. 1):
 
 | Método | Régimen natural | Qué aporta |
 |---|---|---|
-| `ray_trace` | Alta frecuencia (profundidad ≫ λ), océano profundo | Geometría de eigenrayos, tiempos de propagación, zonas de convergencia; coste independiente de la frecuencia |
+| `ray_trace` | Alta frecuencia (profundidad ≫ λ), océano profundo | Geometría de los caminos de rayos, profundidades de giro, zonas de convergencia; coste independiente de la frecuencia |
 | `normal_modes` | Baja frecuencia, aguas someras, independiente de la distancia | Suma modal por diferencias finitas con pocos modos propagantes ($M \approx kD/\pi$); la solución de referencia en su régimen, validada frente a los modos exactos de la guía de ondas ideal |
 | `parabolic_equation` | Baja frecuencia, caminos largos de un solo sentido | TL($z$,$r$) de campo completo con refracción, avanzada en distancia sobre el $c(z)$ independiente de la distancia que suponen los tres métodos |
 
 En la práctica las fronteras se difuminan: los rayos siguen siendo útiles a
-frecuencias sorprendentemente bajas para trabajo de tiempos de propagación, y
+frecuencias sorprendentemente bajas para trabajo de geometría de caminos, y
 la PE sigue siendo el caballo de batalla bastante por encima de su régimen
 formal de ángulos pequeños. Cuando dos de los tres coinciden en un caso, como
 hacen los modos y la PE en la figura de la sección 1, esa coincidencia es la
@@ -695,7 +694,7 @@ Los tres métodos suponen una columna de agua independiente de la distancia con
 un contorno de presión nula (o, para los modos, opcionalmente rígido): no hay
 fondo absorbente ni elástico, ni atenuación del sedimento, ni batimetría real,
 así que los problemas dependientes de la distancia quedan fuera de alcance. El
-trazado de rayos devuelve caminos y tiempos de propagación, no amplitudes: la
+trazado de rayos devuelve caminos, no tiempos de propagación ni amplitudes: la
 intensidad de tubo de rayos con correcciones de cáusticas no se calcula. La PE
 es la forma estándar de ángulos pequeños (Tappert), no una variante de gran
 angular de Padé. Para la física del lecho elástico que estos métodos fluidos
@@ -727,8 +726,8 @@ fluido-sólido](/phonometry/es/simulation/elastic-waves/).
 ### ¿Qué método de propagación submarina debo usar?
 
 Elige por frecuencia y geometría (Jensen et al. 2011, cap. 1): rayos para
-alta frecuencia y océano profundo (geometría de eigenrayos y tiempos de
-propagación a un coste independiente de la frecuencia), modos normales para
+alta frecuencia y océano profundo (geometría de los caminos de rayos y zonas
+de convergencia a un coste independiente de la frecuencia), modos normales para
 baja frecuencia en aguas someras (pocos modos propagantes, $M \approx kD/\pi$,
 la solución de referencia en su régimen) y la ecuación parabólica para caminos
 largos de un solo sentido a baja frecuencia (el campo completo TL($z$,$r$)

--- a/site/src/content/docs/es/vibration/human/index.mdx
+++ b/site/src/content/docs/es/vibration/human/index.mdx
@@ -86,11 +86,12 @@ preferencia.
 </ScopeClaim>
 
 <ScopeClaim status="not-covered">
-Y no se emite ningún veredicto de exposición. Los valores de acción y límite
-de la Directiva 2002/44/CE se enuncian para poder contrastar un A(8) con
-ellos, pero la biblioteca no aplica ninguna transposición nacional de la
-directiva, y una conclusión de evaluación de riesgos no es un número que
-produzca esta sección.
+Y el veredicto se detiene en la propia directiva. Un A(8) se evalúa frente a
+los valores de acción y límite de la Directiva 2002/44/CE — cada uno marcado
+como superado o no, con su zona de exposición y un veredicto CUMPLE/NO CUMPLE
+frente al valor límite — pero la biblioteca no aplica ninguna transposición
+nacional de la directiva, y la conclusión de una evaluación de riesgos
+laborales no es un número que produzca esta sección.
 </ScopeClaim>
 </Scope>
 

--- a/site/src/content/docs/materials/diffusers/diffusers.mdx
+++ b/site/src/content/docs/materials/diffusers/diffusers.mdx
@@ -179,7 +179,7 @@ snippets further down cannot repair a run that broke them.
   before and after **each** of the four situations and use the mean per
   situation (Clause 7.4).
 
-**Absorption from reverberation time (Clause 6).** Each situation converts to a
+**Absorption from reverberation time (Clause 8.1).** Each situation converts to a
 Sabine absorption coefficient with the standard's own air-attenuation term:
 
 $$
@@ -1161,7 +1161,7 @@ no longer small against the wavelength; a frequency-blind single number
 <Scope>
 <ScopeClaim status="covered" label="Covered">
 ISO 17497-1:2004+A1:2014's random-incidence scattering coefficient (the Clause
-6 absorption-from-reverberation-time relations and Eq. (5)) with the Table 1
+8.1 absorption-from-reverberation-time relations and Eq. (5)) with the Table 1
 base-plate ceilings, via `materials.random_incidence_absorption`,
 `materials.specular_absorption_coefficient`,
 `materials.scattering_coefficient`,

--- a/site/src/content/docs/perception/hearing/index.mdx
+++ b/site/src/content/docs/perception/hearing/index.mdx
@@ -75,9 +75,13 @@ In the order the chain runs.
 **Nothing here is a verdict about a person.** ISO 1999 does not define a
 hearing handicap or a compensable fence — that line is set by national
 regulation, and the library applies none of it, so you supply and check the
-criterion yourself. The same is true of the exposure action values: the LEX,8h
-and its one-sided 95 % upper limit come out of ISO 9612, and the numbers they
-are compared against are in your jurisdiction's directive, not here.
+criterion yourself. The exposure side stops one step later: the LEX,8h and its
+one-sided 95 % upper limit come out of ISO 9612, and the fiche written by
+`ExposureResult.report()` does compare the LEX,8h against the Directive
+2003/10/EC action and limit values (80, 85 and 87 dB(A)) and issues the
+PASS/FAIL verdict against the limit value — but that is a verdict on an
+unprotected exposure, not on a person: the effective exposure behind hearing
+protectors, and any stricter national transposition, are still yours to check.
 </ScopeClaim>
 
 <ScopeClaim status="not-covered">

--- a/site/src/content/docs/signals/spectra/test-signals.mdx
+++ b/site/src/content/docs/signals/spectra/test-signals.mdx
@@ -310,12 +310,18 @@ transition width.
 </ScopeClaim>
 
 <ScopeClaim status="not-covered" label="Not covered">
-IEC 60268-1:1985 is a general standard for sound system equipment. Only the
-Annex A tone-burst clauses are implemented here; its other parts (amplifiers,
-loudspeakers, connectors, and so on) are untouched. `fractional_delay` and the
-colored-noise generators of `noise_signal` are general-purpose DSP tools with
-no governing standard of their own; their accuracy claims are closed-form, not
-normative.
+IEC 60268-1:1985 is a general standard for sound system equipment; only the
+Annex A tone-burst clauses are implemented on this page. The device parts are
+not covered here, but they are not untouched either: amplifiers
+(IEC 60268-3), microphones (IEC 60268-4) and loudspeakers (IEC 60268-5) have
+their own guides under
+[Electroacoustics](/phonometry/devices/electroacoustics/), and the speech
+transmission index of IEC 60268-16 has the
+[Speech Transmission Index](/phonometry/perception/speech/speech-transmission/)
+guide; only the connector parts are absent from the library altogether.
+`fractional_delay` and the colored-noise generators of `noise_signal` are
+general-purpose DSP tools with no governing standard of their own; their
+accuracy claims are closed-form, not normative.
 </ScopeClaim>
 </Scope>
 

--- a/site/src/content/docs/underwater/index.mdx
+++ b/site/src/content/docs/underwater/index.mdx
@@ -97,8 +97,8 @@ pile-driving noise has no closed form here or anywhere in the library.
 fluid-fluid Rayleigh reflection, so sediment attenuation is out of scope, and
 all three solvers assume a **range-independent** water column with no
 absorbing or elastic bottom and no real bathymetry — which rules out
-range-dependent problems entirely. The ray solver returns paths and travel
-times but not amplitudes (no ray-tube intensity, no caustic correction), and
+range-dependent problems entirely. The ray solver returns paths but not
+travel times or amplitudes (no ray-tube intensity, no caustic correction), and
 the parabolic equation is the standard small-angle Tappert form rather than a
 wide-angle Padé variant. For the elastic seabed physics these fluid solvers
 leave out, the [elastic wave solver](/phonometry/simulation/elastic-waves/) is

--- a/site/src/content/docs/underwater/underwater-solvers.mdx
+++ b/site/src/content/docs/underwater/underwater-solvers.mdx
@@ -259,7 +259,7 @@ whose critical angle and reflection-loss gradient encode exactly what these
 boundary conditions omit, and read the modal answer as an upper bound on the
 received level.
 
-## 3. Ray tracing: travel times and convergence zones
+## 3. Ray tracing: turning points and convergence zones
 
 In the high-frequency limit the Helmholtz equation collapses to the eikonal
 equation, and its characteristics are **rays**: trajectories integrated from
@@ -341,7 +341,7 @@ plt.show()
 
 </details>
 
-Rays buy geometry: eigenray paths, travel times and convergence-zone ranges
+Rays buy geometry: paths, turning depths and convergence-zone ranges
 at a cost independent of frequency. What they do not carry here is a full
 amplitude: the geometric ray-tube intensity diverges at caustics, so the
 result object returns the paths and leaves the level to the modal or PE
@@ -550,12 +550,12 @@ and boundaries decide the answer, pick the solver by frequency and geometry
 
 | Solver | Natural regime | What it buys you |
 |---|---|---|
-| `ray_trace` | High frequency (water depth ≫ λ), deep water | Eigenray geometry, travel times, convergence zones; cost independent of frequency |
+| `ray_trace` | High frequency (water depth ≫ λ), deep water | Ray-path geometry, turning depths, convergence zones; cost independent of frequency |
 | `normal_modes` | Low frequency, shallow water, range-independent | Finite-difference modal sum with few propagating modes ($M \approx kD/\pi$); the reference solution for its regime, validated against the ideal waveguide's exact modes |
 | `parabolic_equation` | Low frequency, long one-way paths | Full-field TL($z$,$r$) with refraction, marched in range over the range-independent $c(z)$ all three solvers assume |
 
 The boundaries blur in practice: rays remain usable at surprisingly low
-frequencies for travel-time work, and the PE remains the workhorse well above
+frequencies for path-geometry work, and the PE remains the workhorse well above
 its formal small-angle regime. When two of the three agree on a case, as the
 modes and the PE do in the section 1 figure, that agreement is the practical
 convergence test.
@@ -667,8 +667,8 @@ modal and PE transmission loss.
 All three solvers assume a range-independent water column with a
 pressure-release (or, for the modes, optionally rigid) boundary: there is no
 absorbing or elastic bottom, no sediment attenuation and no real bathymetry,
-so range-dependent problems are out of scope. The ray solver returns paths and
-travel times, not amplitudes: ray-tube intensity with caustic corrections is
+so range-dependent problems are out of scope. The ray solver returns paths,
+not travel times or amplitudes: ray-tube intensity with caustic corrections is
 not computed. The PE is the standard small-angle (Tappert) form, not a
 wide-angle Padé variant. For the elastic seabed physics these fluid solvers
 leave out, see [Elastic waves and fluid-solid
@@ -697,7 +697,7 @@ coupling](/phonometry/simulation/elastic-waves/).
 ### Which underwater propagation solver should I use?
 
 Pick by frequency and geometry (Jensen et al. 2011, Ch. 1): rays for high
-frequency and deep water (eigenray geometry and travel times at a cost
+frequency and deep water (ray-path geometry and convergence zones at a cost
 independent of frequency), normal modes for low frequency in shallow water
 (few propagating modes, $M \approx kD/\pi$, the reference solution for its
 regime) and the parabolic equation for low-frequency, long one-way paths

--- a/site/src/content/docs/vibration/human/index.mdx
+++ b/site/src/content/docs/vibration/human/index.mdx
@@ -78,10 +78,12 @@ rather than a preference.
 </ScopeClaim>
 
 <ScopeClaim status="not-covered">
-And no exposure verdict is issued. The action and limit values of Directive
-2002/44/EC are stated so that an A(8) can be read against them, but the
-library applies no national implementation of the directive, and a
-risk-assessment conclusion is not a number this section produces.
+And the verdict stops at the directive itself. An A(8) is assessed against
+the action and limit values of Directive 2002/44/EC — each marked exceeded or
+not, the exposure zone named, and a PASS/FAIL verdict issued against the
+limit value — but the library applies no national transposition of the
+directive, and the conclusion of a workplace risk assessment is not a number
+this section produces.
 </ScopeClaim>
 </Scope>
 


### PR DESCRIPTION
## What and why

The scope panels made every coverage claim enumerable, so all 582 were audited claim by claim against the code: every covered claim had to name implemented, tested machinery, and every not-covered claim had to describe a real absence. Twenty-two findings survived adversarial verification, and they run almost entirely in one direction: the documentation undersold the library. Five claims denied functionality that ships and is tested (the Directive 2003/10/EC exposure verdict of the ISO 9612 fiche, the Directive 2002/44/EC assessment and its PASS/FAIL banner, the IEC 60268 device parts implemented since electroacoustics landed, binaural summation, internal position averaging). A cluster of section indexes compressed their children's carefully drawn boundaries into false generalizations that the child pages themselves state correctly. The remainder are citation slips, one stale pointer, one closed form described as an interpolated table in three places, and two Spanish twins whose meaning had drifted from their English originals. The one claim that flattered the library, the ray solver returning travel times it does not compute, is corrected the other way.

This corrects the claims; it implements nothing. The audit's feature candidates (the absences where partial machinery already exists) are a separate triage.

31 corrections across 17 English pages and 19 Spanish counterparts. The census still parses identically from the authored MDX and the built HTML, with unchanged counts: no claim changed status, only its text became true.

## Validation

No new computation.

## Checklist

Ran locally, same as CI:

- [x] `ruff check .`, plus `ruff format --check` on the files touched
- [x] `mypy src scripts`
- [x] `bandit -r src` (any finding fails, including Low)
- [x] `pytest -q`

Regenerated where this change touches them:

- [x] `make llms`, with `llms.txt`, `llms-full.txt` and the shards under `site/public/llms/` committed

Always:

- [x] Documentation updated in English and Spanish, kept in step
- [x] CHANGELOG entry under `[Unreleased]`

## Summary by Sourcery

Align documentation scope claims with actual library capabilities across buildings, devices, underwater propagation, perception, and vibration sections in both English and Spanish, without changing any implemented functionality.

Documentation:
- Clarify where insulation and buildings tooling performs position averaging and background-noise corrections, distinguishing field and lab treatment and ISO 10140-4 helper behavior.
- Update underwater ray-tracing documentation to state that the solver returns geometric paths, turning depths, and convergence zones but not travel times or amplitudes.
- Correct electroacoustics and test-signal docs to reflect implemented IEC 60268 device guides and speech transmission index coverage, while noting non-implemented connector parts and Thiele-Small/power-handling calculations.
- Refine HVAC and silencer docs and indices to state that lined-elbow and plenum figures come from tabulated data and Wells’ closed form rather than liner-property models, and that dissipative duct linings are not modelled from material properties.
- Clarify EN 12354 building design docs on which element and junction parameters are user-supplied versus estimated, and that certain Annex D/F tables remain unimplemented.
- Adjust hearing and human-vibration perception docs to describe that exposure reports issue PASS/FAIL verdicts against EU directives for unprotected exposures while leaving national transpositions and risk-assessment conclusions out of scope.
- Tighten psychoacoustic-annoyance and porous-absorber/diffuser docs around validation scope, clause numbering, and which Schroeder diffuser formulations are implemented.
- Keep English and Spanish documentation in sync and regenerate LLMS shard text files to reflect the corrected coverage claims without altering census counts or implementation.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Updated documentation across multiple sections to clarify the library's scope regarding measurement data processing and background noise correction.</li>
<li>Clarified that the library now performs energy-averaging of per-position spectra, while maintaining that measurement quality and background noise correction (for field data) remain the operator's responsibility.</li>
<li>Refined descriptions of prediction capabilities, specifically noting the inclusion of estimators for junction catalogues, floating-floor/lining improvements, and panel-physics models.</li>
<li>Updated documentation for ISO 10140-4 laboratory background noise correction to reflect that it now automatically applies and warns when the 6 dB floor is exceeded.</li>
</ul></div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added heavy- and soft-impact source support and suspended-ceiling plenum functionality.
  * Added figure typography/font outlining and improved mathematical and Spanish decimal-format validation.
* **Bug Fixes**
  * Corrected typography, layout, collision handling, regenerated clips, and 31 English and Spanish coverage descriptions.
* **Documentation**
  * Clarified acoustic inputs, measurement responsibilities, noise correction, silencer models, exposure reporting, and underwater ray-tracing outputs.
  * Corrected standards references, scope statements, terminology, and synchronized English and Spanish documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->