### PR TITLE
Cascade the extended-tube chamber over the length its extensions leave

### DIFF
--- a/.github/images/silencer_extended_tube.svg
+++ b/.github/images/silencer_extended_tube.svg
@@ -1110,391 +1110,300 @@ L 705.763438 397.716018
 " clip-path="url(#p8843daa6dd)" style="fill: none; stroke-dasharray: 5.92,2.56; stroke-dashoffset: 0; stroke: #000000; stroke-width: 1.6"/>
    </g>
    <g id="line2d_28">
-    <path d="M 40.925781 397.298043 
-L 44.251355 395.7181 
-L 48.131191 393.623058 
-L 52.842421 390.803279 
-L 58.939307 386.868376 
-L 81.1098 372.311634 
-L 87.760948 368.342701 
-L 93.857833 364.960635 
-L 99.677587 361.978295 
-L 105.497342 359.244472 
-L 111.317096 356.76239 
-L 116.859719 354.632771 
-L 122.402343 352.730406 
-L 127.944966 351.053252 
-L 133.487589 349.598984 
-L 139.030212 348.36533 
-L 144.572836 347.350294 
-L 150.115459 346.552317 
-L 155.658082 345.970385 
-L 161.200705 345.604113 
-L 166.743329 345.453802 
-L 172.285952 345.52048 
-L 177.828575 345.805938 
-L 183.371198 346.312748 
-L 188.913821 347.044278 
-L 194.456445 348.004688 
-L 199.999068 349.198901 
-L 205.26456 350.555083 
-L 210.530052 352.132668 
-L 215.795544 353.937301 
-L 221.061036 355.974699 
-L 226.326528 358.250258 
-L 231.59202 360.768431 
-L 236.857512 363.531786 
-L 242.123004 366.539575 
-L 247.665628 369.962804 
-L 253.485382 373.821661 
-L 260.13653 378.51102 
-L 280.367105 393.018267 
-L 283.96981 395.202031 
-L 287.018253 396.818553 
-L 289.789564 398.058123 
-L 292.283745 398.954093 
-L 294.777925 399.615779 
-L 296.994974 399.989897 
-L 299.212024 400.15048 
-L 301.429073 400.090076 
-L 303.646122 399.805747 
-L 305.863172 399.299258 
-L 308.080221 398.576958 
-L 310.574401 397.519666 
-L 313.068582 396.222932 
-L 315.839893 394.531147 
-L 318.888336 392.408226 
-L 322.491041 389.613903 
-L 326.92514 385.865607 
-L 333.022025 380.387401 
-L 348.818502 366.063837 
-L 355.192518 360.643671 
-L 361.012273 355.974574 
-L 366.832027 351.595545 
-L 372.37465 347.702805 
-L 377.917274 344.081943 
-L 383.459897 340.729982 
-L 389.00252 337.64194 
-L 394.545143 334.81198 
-L 400.087766 332.23416 
-L 405.63039 329.902908 
-L 411.173013 327.813337 
-L 416.715636 325.961445 
-L 422.258259 324.344258 
-L 427.800883 322.959932 
-L 433.343506 321.807846 
-L 438.886129 320.888682 
-L 444.428752 320.204524 
-L 449.694244 319.775506 
-L 454.959736 319.566265 
-L 460.225228 319.582716 
-L 465.213589 319.813288 
-L 470.20195 320.261037 
-L 475.190311 320.935434 
-L 479.901541 321.790586 
-L 484.612771 322.868998 
-L 489.324 324.183461 
-L 493.758099 325.649315 
-L 498.192198 327.350975 
-L 502.349165 329.173994 
-L 506.506132 331.231321 
-L 510.6631 333.537352 
-L 514.820067 336.106604 
-L 518.977035 338.952552 
-L 523.134002 342.085545 
-L 527.29097 345.509171 
-L 531.725068 349.470436 
-L 536.713429 354.255909 
-L 549.184331 366.426346 
-L 551.678512 368.45331 
-L 553.895561 369.963876 
-L 555.835479 370.990947 
-L 557.498266 371.605663 
-L 558.883922 371.903509 
-L 560.269578 371.986737 
-L 561.655234 371.839938 
-L 563.040889 371.451559 
-L 564.426545 370.814634 
-L 565.812201 369.927237 
-L 567.197857 368.792604 
-L 568.860644 367.116501 
-L 570.523431 365.118625 
-L 572.463349 362.420412 
-L 574.680398 358.919025 
-L 577.174579 354.549933 
-L 580.223021 348.756521 
-L 584.65712 339.792212 
-L 604.056301 299.957749 
-L 611.538843 285.41681 
-L 621.238433 267.107661 
-L 635.094991 240.956899 
-L 641.191877 228.940732 
-L 645.903107 219.194131 
-L 650.060074 210.104778 
-L 653.662779 201.724938 
-L 656.988353 193.44756 
-L 660.036796 185.272714 
-L 662.808107 177.22067 
-L 665.302288 169.33572 
-L 667.796468 160.685508 
-L 670.013518 152.180946 
-L 671.953436 143.93825 
-L 673.893354 134.73981 
-L 675.556141 125.880327 
-L 677.218928 115.847798 
-L 678.881715 104.252728 
-L 680.267371 92.962976 
-L 681.653026 79.592846 
-L 682.761551 66.765489 
-L 683.870076 51.131187 
-L 684.701469 36.646556 
-L 685.532863 18.438178 
-L 686.209499 -1 
-M 690.525162 -1 
-L 691.352617 22.00727 
-L 692.184011 39.424457 
-L 693.292535 57.51759 
-L 694.40106 71.942769 
-L 695.786716 86.663557 
-L 697.172371 98.891056 
-L 698.558027 109.363322 
-L 700.220814 120.240889 
-L 701.883601 129.740378 
-L 703.823519 139.512058 
-L 705.763438 148.199144 
-L 705.763438 148.199144 
+    <path d="M 40.925781 398.596858 
+L 44.805618 397.361778 
+L 48.962585 395.807262 
+L 53.673815 393.804921 
+L 59.216438 391.196554 
+L 66.144717 387.677584 
+L 78.89275 380.89268 
+L 91.086521 374.50565 
+L 99.677587 370.25084 
+L 107.714391 366.519965 
+L 115.196933 363.289411 
+L 122.402343 360.412284 
+L 129.607753 357.770107 
+L 136.813163 355.364709 
+L 144.018573 353.195692 
+L 151.223983 351.261406 
+L 158.429394 349.55963 
+L 165.634804 348.088043 
+L 172.840214 346.844545 
+L 180.045624 345.827487 
+L 187.251034 345.035833 
+L 194.456445 344.469279 
+L 201.661855 344.128344 
+L 208.867265 344.014449 
+L 216.072675 344.129974 
+L 223.000954 344.460571 
+L 229.929233 345.010386 
+L 236.857512 345.78434 
+L 243.785791 346.788342 
+L 250.436939 347.975009 
+L 257.088087 349.386994 
+L 263.739235 351.032011 
+L 270.113252 352.834868 
+L 276.487268 354.867071 
+L 282.861285 357.136254 
+L 289.235302 359.649439 
+L 295.609319 362.41211 
+L 301.983335 365.426747 
+L 308.357352 368.690558 
+L 315.0085 372.349295 
+L 322.21391 376.569984 
+L 331.913501 382.539586 
+L 342.998747 389.328049 
+L 348.264239 392.285292 
+L 352.421207 394.367818 
+L 356.023912 395.920853 
+L 359.072355 397.006501 
+L 361.843666 397.780368 
+L 364.614978 398.326103 
+L 367.109158 398.604788 
+L 369.603339 398.669599 
+L 372.097519 398.512321 
+L 374.5917 398.129076 
+L 377.08588 397.520572 
+L 379.580061 396.692047 
+L 382.351372 395.525021 
+L 385.122684 394.116227 
+L 388.171127 392.314065 
+L 391.4967 390.08479 
+L 395.376537 387.196438 
+L 399.810635 383.604107 
+L 405.63039 378.574219 
+L 415.607111 369.590373 
+L 426.969489 359.446388 
+L 435.006293 352.576905 
+L 442.211703 346.706254 
+L 449.139982 341.338686 
+L 456.068261 336.246533 
+L 462.99654 331.424934 
+L 470.20195 326.687295 
+L 477.40736 322.218797 
+L 484.889902 317.847935 
+L 492.372443 313.735683 
+L 500.132116 309.727508 
+L 508.168919 305.833891 
+L 516.205723 302.18543 
+L 524.519658 298.651993 
+L 533.110724 295.240549 
+L 541.978921 291.956442 
+L 551.124249 288.80298 
+L 560.82384 285.695019 
+L 571.077693 282.646951 
+L 582.16294 279.588122 
+L 595.188104 276.236361 
+L 625.672532 268.510699 
+L 632.32368 266.514821 
+L 637.312041 264.801843 
+L 641.469008 263.160676 
+L 645.071713 261.518679 
+L 648.397287 259.759316 
+L 651.168599 258.059967 
+L 653.662779 256.299571 
+L 656.15696 254.264782 
+L 658.374009 252.170054 
+L 660.591058 249.741657 
+L 662.530976 247.281196 
+L 664.470894 244.437572 
+L 666.133681 241.631631 
+L 667.796468 238.41585 
+L 669.459255 234.707599 
+L 671.122042 230.402921 
+L 672.784829 225.368853 
+L 674.170485 220.492885 
+L 675.556141 214.859677 
+L 676.941797 208.297239 
+L 678.327453 200.572337 
+L 679.713108 191.35484 
+L 680.821633 182.582463 
+L 681.930158 172.162277 
+L 683.038682 159.50043 
+L 684.147207 143.590489 
+L 684.9786 128.431104 
+L 685.809994 108.812028 
+L 686.364256 91.691866 
+L 686.918519 68.915421 
+L 687.472781 34.946706 
+L 687.81481 -1 
+M 688.918734 -1 
+L 689.412699 45.643167 
+L 689.966961 75.699466 
+L 690.798355 105.146693 
+L 691.629748 125.703373 
+L 692.461142 141.429612 
+L 693.569666 157.82189 
+L 694.678191 170.802582 
+L 695.786716 181.450317 
+L 697.172371 192.413718 
+L 698.558027 201.453551 
+L 699.943683 209.041924 
+L 701.329339 215.496294 
+L 702.714995 221.042084 
+L 704.377782 226.729759 
+L 705.763438 230.809642 
+L 705.763438 230.809642 
 " clip-path="url(#p8843daa6dd)" style="fill: none; stroke: #1f77b4; stroke-width: 1.9; stroke-linecap: square"/>
    </g>
    <g id="line2d_29">
-    <path d="M 40.925781 394.743388 
-L 44.251355 392.193107 
-L 48.408323 388.686901 
-L 54.505208 383.2077 
-L 65.313323 373.484628 
-L 70.855947 368.807446 
-L 76.121439 364.658014 
-L 81.1098 361.021703 
-L 85.821029 357.863523 
-L 90.532259 354.97836 
-L 94.966358 352.512947 
-L 99.400456 350.288782 
-L 103.834555 348.303877 
-L 108.268653 346.556081 
-L 112.702752 345.043513 
-L 117.136851 343.764868 
-L 121.570949 342.719639 
-L 126.005048 341.908297 
-L 130.439146 341.332439 
-L 134.596114 341.008962 
-L 138.753081 340.898426 
-L 142.910049 341.005488 
-L 147.067016 341.336116 
-L 151.223983 341.89771 
-L 155.10382 342.638147 
-L 158.983656 343.596254 
-L 162.863492 344.782134 
-L 166.743329 346.207435 
-L 170.623165 347.88545 
-L 174.22587 349.68295 
-L 177.828575 351.724489 
-L 181.43128 354.024339 
-L 185.033985 356.597398 
-L 188.63669 359.458393 
-L 192.239395 362.620406 
-L 195.8421 366.09226 
-L 199.444806 369.874007 
-L 203.324642 374.273898 
-L 208.035872 379.984143 
-L 216.349806 390.148923 
-L 218.843987 392.813576 
-L 220.783905 394.594425 
-L 222.446692 395.845715 
-L 223.832348 396.651036 
-L 225.218004 397.206486 
-L 226.326528 397.451417 
-L 227.435053 397.505358 
-L 228.543578 397.358469 
-L 229.652102 397.004133 
-L 230.760627 396.439322 
-L 232.146283 395.438808 
-L 233.531938 394.120389 
-L 234.917594 392.501757 
-L 236.580381 390.197742 
-L 238.520299 387.075868 
-L 240.737349 383.044204 
-L 243.50866 377.498668 
-L 247.388497 369.181111 
-L 260.413661 340.866507 
-L 265.679153 330.141989 
-L 270.944645 319.944086 
-L 276.210137 310.225236 
-L 282.029892 299.949533 
-L 288.958171 288.194138 
-L 299.489155 270.839733 
-L 308.911614 255.166855 
-L 314.454238 245.515983 
-L 318.888336 237.352691 
-L 322.768172 229.728812 
-L 326.093746 222.700647 
-L 329.142189 215.724891 
-L 331.913501 208.805631 
-L 334.407681 201.971015 
-L 336.62473 195.278356 
-L 338.84178 187.84238 
-L 340.781698 180.555661 
-L 342.721616 172.325151 
-L 344.384403 164.294865 
-L 346.04719 155.075508 
-L 347.432846 146.190198 
-L 348.818502 135.828057 
-L 349.927026 126.100273 
-L 351.035551 114.604057 
-L 352.144076 100.583471 
-L 352.975469 87.632418 
-L 353.806862 71.482117 
-L 354.638256 50.107923 
-L 355.192518 30.823947 
-L 355.817716 -1 
-M 357.983279 -1 
-L 358.518092 28.359949 
-L 359.349486 58.693579 
-L 360.180879 80.264707 
-L 361.289404 102.019011 
-L 362.397928 119.119143 
-L 363.783584 136.523854 
-L 365.16924 151.063795 
-L 366.832027 165.998864 
-L 368.494814 179.037476 
-L 370.434732 192.576089 
-L 372.651781 206.501016 
-L 375.145962 220.813574 
-L 378.194405 237.045985 
-L 382.628503 259.331003 
-L 391.4967 303.616004 
-L 395.653668 325.738199 
-L 402.581947 363.015542 
-L 403.967603 369.141578 
-L 405.076127 373.174919 
-L 405.907521 375.557416 
-L 406.738914 377.311583 
-L 407.293177 378.110558 
-L 407.847439 378.607996 
-L 408.401701 378.807635 
-L 408.955964 378.720211 
-L 409.510226 378.362621 
-L 410.064488 377.756686 
-L 410.895882 376.437998 
-L 412.004406 374.058989 
-L 413.390062 370.386811 
-L 415.607111 363.697699 
-L 420.04121 350.213935 
-L 422.535391 343.368792 
-L 425.029571 337.192156 
-L 427.523751 331.653857 
-L 430.017932 326.692341 
-L 432.512112 322.24063 
-L 435.006293 318.236165 
-L 437.500473 314.623867 
-L 440.271785 311.012933 
-L 443.043096 307.773479 
-L 445.814408 304.860283 
-L 448.862851 301.987998 
-L 451.911294 299.423979 
-L 454.959736 297.13439 
-L 458.28531 294.916984 
-L 461.610884 292.963258 
-L 465.213589 291.116112 
-L 468.816294 289.524632 
-L 472.419 288.168391 
-L 476.298836 286.952048 
-L 480.178672 285.973009 
-L 484.058508 285.218458 
-L 487.938345 284.678636 
-L 492.095312 284.330504 
-L 496.252279 284.21496 
-L 500.409247 284.329031 
-L 504.566214 284.672369 
-L 508.723182 285.247172 
-L 512.880149 286.0582 
-L 516.759985 287.034787 
-L 520.639822 288.231839 
-L 524.519658 289.659961 
-L 528.399494 291.332371 
-L 532.002199 293.118134 
-L 535.604904 295.143949 
-L 539.207609 297.428159 
-L 542.810315 299.992303 
-L 546.135889 302.629329 
-L 549.461462 305.548953 
-L 552.787036 308.776835 
-L 555.835479 312.030767 
-L 558.883922 315.591029 
-L 561.932365 319.481309 
-L 564.980807 323.723051 
-L 568.02925 328.330586 
-L 571.354824 333.771105 
-L 575.23466 340.59482 
-L 582.994333 354.444184 
-L 584.934251 357.360983 
-L 586.319907 359.110662 
-L 587.705563 360.48971 
-L 588.814087 361.270601 
-L 589.645481 361.642376 
-L 590.476874 361.814871 
-L 591.308268 361.776651 
-L 592.139661 361.519654 
-L 592.971055 361.039655 
-L 593.802448 360.336516 
-L 594.910973 359.059292 
-L 596.019498 357.412661 
-L 597.405153 354.881049 
-L 599.06794 351.24713 
-L 601.007858 346.363935 
-L 603.502039 339.396628 
-L 607.659006 326.975423 
-L 614.864417 305.465542 
-L 619.575646 292.138122 
-L 624.286876 279.461662 
-L 629.552368 265.929983 
-L 636.480647 248.793288 
-L 649.505812 216.719801 
-L 654.217041 204.424488 
-L 658.096878 193.661578 
-L 661.422452 183.762397 
-L 664.193763 174.861736 
-L 666.687944 166.181942 
-L 669.182124 156.67407 
-L 671.399173 147.314963 
-L 673.339092 138.209664 
-L 675.27901 127.981251 
-L 676.941797 118.034607 
-L 678.604584 106.621058 
-L 679.990239 95.58908 
-L 681.375895 82.627819 
-L 682.48442 70.30364 
-L 683.592945 55.444466 
-L 684.424338 41.858566 
-L 685.255732 25.07075 
-L 686.087125 3.062562 
-L 686.209949 -1 
-M 690.524685 -1 
-L 691.352617 22.035563 
-L 692.184011 39.470737 
-L 693.292535 57.594729 
-L 694.40106 72.058659 
-L 695.786716 86.839046 
-L 697.172371 99.138635 
-L 698.835158 111.641111 
-L 700.497945 122.381671 
-L 702.437864 133.298488 
-L 704.377782 142.922087 
-L 705.763438 149.181607 
-L 705.763438 149.181607 
+    <path d="M 40.925781 399.037566 
+L 45.082749 397.939185 
+L 49.516847 396.5317 
+L 54.228077 394.801989 
+L 59.493569 392.62778 
+L 65.590455 389.856816 
+L 72.795865 386.326156 
+L 82.495455 381.306212 
+L 118.522506 362.429663 
+L 130.162015 356.702819 
+L 141.247262 351.492932 
+L 152.332508 346.524381 
+L 163.694886 341.673489 
+L 175.611526 336.831866 
+L 188.082428 332.009795 
+L 201.384724 327.108315 
+L 216.072675 321.937719 
+L 233.80907 315.942012 
+L 276.210137 301.725106 
+L 285.909728 298.166987 
+L 293.6694 295.086282 
+L 300.043417 292.317749 
+L 305.308909 289.799848 
+L 310.020139 287.304465 
+L 314.177106 284.848763 
+L 317.779812 282.468023 
+L 321.105385 280.001268 
+L 324.153828 277.449234 
+L 326.92514 274.821384 
+L 329.41932 272.138806 
+L 331.63637 269.437209 
+L 333.853419 266.361417 
+L 335.793337 263.286494 
+L 337.733255 259.761469 
+L 339.396042 256.292009 
+L 341.058829 252.302692 
+L 342.721616 247.655582 
+L 344.107272 243.144045 
+L 345.492928 237.889117 
+L 346.878583 231.674596 
+L 347.987108 225.805527 
+L 349.095633 218.891363 
+L 350.204157 210.591904 
+L 351.312682 200.381888 
+L 352.144076 190.966418 
+L 352.975469 179.389265 
+L 353.806862 164.605897 
+L 354.638256 144.58554 
+L 355.192518 126.193274 
+L 355.746781 100.085721 
+L 356.301043 56.002522 
+L 356.613714 -1 
+M 357.204232 -1 
+L 357.409568 42.809844 
+L 357.96383 97.410687 
+L 358.518092 128.727185 
+L 359.349486 160.157176 
+L 360.180879 182.732447 
+L 361.289404 205.649548 
+L 362.397928 223.666249 
+L 363.506453 238.476577 
+L 364.892109 253.769941 
+L 366.277765 266.325726 
+L 367.663421 276.669277 
+L 369.049076 285.137173 
+L 370.157601 290.731384 
+L 371.266126 295.397941 
+L 372.37465 299.241446 
+L 373.483175 302.362356 
+L 374.5917 304.856784 
+L 375.700224 306.815095 
+L 376.808749 308.320317 
+L 377.917274 309.446964 
+L 379.025798 310.260472 
+L 380.134323 310.817223 
+L 381.519979 311.224211 
+L 382.905634 311.380771 
+L 384.568421 311.322242 
+L 386.50834 311.012519 
+L 389.00252 310.367241 
+L 392.605225 309.169969 
+L 412.8358 302.031733 
+L 419.764079 299.985329 
+L 427.24662 298.006408 
+L 435.560555 296.043457 
+L 444.705883 294.117911 
+L 454.959736 292.19288 
+L 466.322114 290.290555 
+L 479.070147 288.386643 
+L 493.203837 286.503018 
+L 509.277444 284.591124 
+L 527.568101 282.646125 
+L 550.015725 280.493603 
+L 596.57376 276.104305 
+L 607.659006 274.79134 
+L 616.250072 273.556117 
+L 623.178351 272.335826 
+L 628.720975 271.145781 
+L 633.432204 269.924928 
+L 637.589172 268.632782 
+L 641.191877 267.299689 
+L 644.517451 265.84356 
+L 647.565894 264.268265 
+L 650.337205 262.586535 
+L 652.831386 260.821946 
+L 655.325566 258.765537 
+L 657.542615 256.639341 
+L 659.759665 254.171628 
+L 661.699583 251.674723 
+L 663.639501 248.798639 
+L 665.579419 245.46695 
+L 667.242206 242.176505 
+L 668.904993 238.405836 
+L 670.56778 234.060972 
+L 672.230567 229.022834 
+L 673.893354 223.137218 
+L 675.27901 217.439065 
+L 676.664666 210.852436 
+L 678.050321 203.162963 
+L 679.435977 194.068781 
+L 680.544502 185.488203 
+L 681.653026 175.383814 
+L 682.761551 163.230218 
+L 683.870076 148.156377 
+L 684.701469 134.014975 
+L 685.532863 116.081909 
+L 686.364256 91.733119 
+L 686.918519 68.937086 
+L 687.472781 34.954998 
+L 687.814832 -1 
+M 688.918706 -1 
+L 689.412699 45.654386 
+L 689.966961 75.725712 
+L 690.798355 105.207046 
+L 691.629748 125.811307 
+L 692.461142 141.597996 
+L 693.569666 158.089573 
+L 694.678191 171.188975 
+L 695.786716 181.972416 
+L 697.172371 193.125373 
+L 698.558027 202.371982 
+L 699.943683 210.179158 
+L 701.329339 216.859446 
+L 702.992126 223.695088 
+L 704.654913 229.498612 
+L 705.763438 232.895229 
+L 705.763438 232.895229 
 " clip-path="url(#p8843daa6dd)" style="fill: none; stroke-dasharray: 10.88,2.72,1.7,2.72; stroke-dashoffset: 0; stroke: #d62728; stroke-width: 1.7"/>
    </g>
    <g id="line2d_30">
     <path d="M 356.916935 400.915781 
 L 356.916935 26.318125 
+" clip-path="url(#p8843daa6dd)" style="fill: none; stroke-dasharray: 1.2,1.98; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_31">
+    <path d="M 688.369429 400.915781 
+L 688.369429 26.318125 
 " clip-path="url(#p8843daa6dd)" style="fill: none; stroke-dasharray: 1.2,1.98; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-width: 1.2"/>
    </g>
    <g id="patch_3">
@@ -1518,17 +1427,17 @@ L 705.763438 26.318125
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_7">
-    <path d="M 486.019169 195.59123 
-Q 422.087599 276.701741 358.848125 356.934185 
+    <path d="M 223.984507 121.547227 
+Q 289.539975 150.887616 354.074956 179.771271 
 " style="fill: none; stroke: #000000; stroke-linecap: round"/>
-    <path d="M 362.219154 355.348642 
-L 358.848125 356.934185 
-L 359.602309 353.286036 
+    <path d="M 351.714257 176.889452 
+L 354.074956 179.771271 
+L 350.353081 179.930738 
 " style="fill: none; stroke: #000000; stroke-linecap: round"/>
    </g>
    <g id="text_16">
-    <!-- $c/2L$ = 429 Hz: the plain chamber is transparent (0.0 dB), -->
-    <g transform="translate(376.804084 179.187092) scale(0.0833 -0.0833)">
+    <!-- $c/2L$ = 429 Hz: plain chamber 0.0 dB and the $L/4$ inlet -->
+    <g transform="translate(71.848463 95.896667) scale(0.0833 -0.0833)">
      <defs>
       <path id="DejaVuSans-Oblique-46" d="M 3431 3366 
 L 3316 2797 
@@ -1627,46 +1536,6 @@ L 750 2516
 L 750 3309 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-57" d="M 1172 4494 
-L 1172 3500 
-L 2356 3500 
-L 2356 3053 
-L 1172 3053 
-L 1172 1153 
-Q 1172 725 1289 603 
-Q 1406 481 1766 481 
-L 2356 481 
-L 2356 0 
-L 1766 0 
-Q 1100 0 847 248 
-Q 594 497 594 1153 
-L 594 3053 
-L 172 3053 
-L 172 3500 
-L 594 3500 
-L 594 4494 
-L 1172 4494 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-4b" d="M 3513 2113 
-L 3513 0 
-L 2938 0 
-L 2938 2094 
-Q 2938 2591 2744 2837 
-Q 2550 3084 2163 3084 
-Q 1697 3084 1428 2787 
-Q 1159 2491 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 4863 
-L 1159 4863 
-L 1159 2956 
-Q 1366 3272 1645 3428 
-Q 1925 3584 2291 3584 
-Q 2894 3584 3203 3211 
-Q 3513 2838 3513 2113 
-z
-" transform="scale(0.015625)"/>
       <path id="DejaVuSans-53" d="M 1159 525 
 L 1159 -1331 
 L 581 -1331 
@@ -1691,6 +1560,25 @@ Q 1159 1113 1420 752
 Q 1681 391 2138 391 
 Q 2594 391 2855 752 
 Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-4b" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSans-45" d="M 3116 1747 
@@ -1719,19 +1607,6 @@ L 1159 4863
 L 1159 2969 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-b" d="M 1984 4856 
-Q 1566 4138 1362 3434 
-Q 1159 2731 1159 2009 
-Q 1159 1288 1364 580 
-Q 1569 -128 1984 -844 
-L 1484 -844 
-Q 1016 -109 783 600 
-Q 550 1309 550 2009 
-Q 550 2706 781 3412 
-Q 1013 4119 1484 4856 
-L 1984 4856 
-z
-" transform="scale(0.015625)"/>
       <path id="DejaVuSans-11" d="M 684 794 
 L 1344 794 
 L 1344 0 
@@ -1739,26 +1614,25 @@ L 684 0
 L 684 794 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-c" d="M 513 4856 
-L 1013 4856 
-Q 1481 4119 1714 3412 
-Q 1947 2706 1947 2009 
-Q 1947 1309 1714 600 
-Q 1481 -109 1013 -844 
-L 513 -844 
-Q 928 -128 1133 580 
-Q 1338 1288 1338 2009 
-Q 1338 2731 1133 3434 
-Q 928 4138 513 4856 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-f" d="M 750 794 
-L 1409 794 
-L 1409 256 
-L 897 -744 
-L 494 -744 
-L 750 256 
-L 750 794 
+      <path id="DejaVuSans-57" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
 z
 " transform="scale(0.015625)"/>
      </defs>
@@ -1777,51 +1651,262 @@ z
      <use xlink:href="#DejaVuSans-5d" transform="translate(653.222656 0.015625)"/>
      <use xlink:href="#DejaVuSans-1d" transform="translate(705.712891 0.015625)"/>
      <use xlink:href="#DejaVuSans-3" transform="translate(739.404297 0.015625)"/>
-     <use xlink:href="#DejaVuSans-57" transform="translate(771.191406 0.015625)"/>
-     <use xlink:href="#DejaVuSans-4b" transform="translate(810.400391 0.015625)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(873.779297 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(935.302734 0.015625)"/>
-     <use xlink:href="#DejaVuSans-53" transform="translate(967.089844 0.015625)"/>
-     <use xlink:href="#DejaVuSans-4f" transform="translate(1030.566406 0.015625)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(1058.349609 0.015625)"/>
-     <use xlink:href="#DejaVuSans-4c" transform="translate(1119.628906 0.015625)"/>
-     <use xlink:href="#DejaVuSans-51" transform="translate(1147.412109 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1210.791016 0.015625)"/>
-     <use xlink:href="#DejaVuSans-46" transform="translate(1242.578125 0.015625)"/>
-     <use xlink:href="#DejaVuSans-4b" transform="translate(1297.558594 0.015625)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(1360.9375 0.015625)"/>
-     <use xlink:href="#DejaVuSans-50" transform="translate(1422.216797 0.015625)"/>
-     <use xlink:href="#DejaVuSans-45" transform="translate(1519.628906 0.015625)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(1583.105469 0.015625)"/>
-     <use xlink:href="#DejaVuSans-55" transform="translate(1644.628906 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1685.742188 0.015625)"/>
-     <use xlink:href="#DejaVuSans-4c" transform="translate(1717.529297 0.015625)"/>
-     <use xlink:href="#DejaVuSans-56" transform="translate(1745.3125 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1797.412109 0.015625)"/>
-     <use xlink:href="#DejaVuSans-57" transform="translate(1829.199219 0.015625)"/>
-     <use xlink:href="#DejaVuSans-55" transform="translate(1868.408203 0.015625)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(1909.521484 0.015625)"/>
-     <use xlink:href="#DejaVuSans-51" transform="translate(1970.800781 0.015625)"/>
-     <use xlink:href="#DejaVuSans-56" transform="translate(2034.179688 0.015625)"/>
-     <use xlink:href="#DejaVuSans-53" transform="translate(2086.279297 0.015625)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(2149.755859 0.015625)"/>
-     <use xlink:href="#DejaVuSans-55" transform="translate(2211.035156 0.015625)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(2250.148438 0.015625)"/>
-     <use xlink:href="#DejaVuSans-51" transform="translate(2311.671875 0.015625)"/>
-     <use xlink:href="#DejaVuSans-57" transform="translate(2375.050781 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(2414.259766 0.015625)"/>
-     <use xlink:href="#DejaVuSans-b" transform="translate(2446.046875 0.015625)"/>
-     <use xlink:href="#DejaVuSans-13" transform="translate(2485.060547 0.015625)"/>
-     <use xlink:href="#DejaVuSans-11" transform="translate(2548.683594 0.015625)"/>
-     <use xlink:href="#DejaVuSans-13" transform="translate(2580.470703 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(2644.09375 0.015625)"/>
-     <use xlink:href="#DejaVuSans-47" transform="translate(2675.880859 0.015625)"/>
-     <use xlink:href="#DejaVuSans-25" transform="translate(2739.357422 0.015625)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(2807.960938 0.015625)"/>
-     <use xlink:href="#DejaVuSans-f" transform="translate(2846.974609 0.015625)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(771.191406 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(834.667969 0.015625)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(862.451172 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(923.730469 0.015625)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(951.513672 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1014.892578 0.015625)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1046.679688 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4b" transform="translate(1101.660156 0.015625)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1165.039062 0.015625)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(1226.318359 0.015625)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(1323.730469 0.015625)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1387.207031 0.015625)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(1448.730469 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1489.84375 0.015625)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(1521.630859 0.015625)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(1585.253906 0.015625)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(1617.041016 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1680.664062 0.015625)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(1712.451172 0.015625)"/>
+     <use xlink:href="#DejaVuSans-25" transform="translate(1775.927734 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1844.53125 0.015625)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1876.318359 0.015625)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1937.597656 0.015625)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(2000.976562 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2064.453125 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(2096.240234 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4b" transform="translate(2135.449219 0.015625)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(2198.828125 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2260.351562 0.015625)"/>
+     <use xlink:href="#DejaVuSans-Oblique-2f" transform="translate(2292.138672 0.015625)"/>
+     <use xlink:href="#DejaVuSans-12" transform="translate(2347.851562 0.015625)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(2381.542969 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2445.166016 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(2476.953125 0.015625)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(2504.736328 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(2568.115234 0.015625)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(2595.898438 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(2657.421875 0.015625)"/>
     </g>
-    <!-- the $L/4$ inlet gives 5.1 dB and the $L/4$ + $L/2$ pair 74 dB -->
-    <g transform="translate(376.804084 189.186671) scale(0.0833 -0.0833)">
+    <!-- still only 0.6 dB, because $L/4$ is not tuned here. -->
+    <g transform="translate(71.848463 105.896246) scale(0.0833 -0.0833)">
+     <defs>
+      <path id="DejaVuSans-f" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-56" transform="translate(0 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(52.099609 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(91.308594 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(119.091797 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(146.875 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(174.658203 0.015625)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(206.445312 0.015625)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(267.626953 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(331.005859 0.015625)"/>
+     <use xlink:href="#DejaVuSans-5c" transform="translate(358.789062 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(417.96875 0.015625)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(449.755859 0.015625)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(513.378906 0.015625)"/>
+     <use xlink:href="#DejaVuSans-19" transform="translate(545.166016 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(608.789062 0.015625)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(640.576172 0.015625)"/>
+     <use xlink:href="#DejaVuSans-25" transform="translate(704.052734 0.015625)"/>
+     <use xlink:href="#DejaVuSans-f" transform="translate(772.65625 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(804.443359 0.015625)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(836.230469 0.015625)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(899.707031 0.015625)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(961.230469 0.015625)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1016.210938 0.015625)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(1077.490234 0.015625)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(1140.869141 0.015625)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1192.96875 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1254.492188 0.015625)"/>
+     <use xlink:href="#DejaVuSans-Oblique-2f" transform="translate(1286.279297 0.015625)"/>
+     <use xlink:href="#DejaVuSans-12" transform="translate(1341.992188 0.015625)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(1375.683594 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1439.306641 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(1471.09375 0.015625)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(1498.876953 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1550.976562 0.015625)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1582.763672 0.015625)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(1646.142578 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1707.324219 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1746.533203 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1778.320312 0.015625)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(1817.529297 0.015625)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1880.908203 0.015625)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1944.287109 0.015625)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(2005.810547 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2069.287109 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4b" transform="translate(2101.074219 0.015625)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(2164.453125 0.015625)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(2225.976562 0.015625)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(2265.089844 0.015625)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(2326.613281 0.015625)"/>
+    </g>
+    <!-- The $L/2$ outlet is, and shorts the duct -->
+    <g transform="translate(71.848463 115.895825) scale(0.0833 -0.0833)">
+     <use xlink:href="#DejaVuSans-37" transform="translate(0 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4b" transform="translate(61.083984 0.015625)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(124.462891 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(185.986328 0.015625)"/>
+     <use xlink:href="#DejaVuSans-Oblique-2f" transform="translate(217.773438 0.015625)"/>
+     <use xlink:href="#DejaVuSans-12" transform="translate(273.486328 0.015625)"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(307.177734 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(370.800781 0.015625)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(402.587891 0.015625)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(463.769531 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(527.148438 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(566.357422 0.015625)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(594.140625 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(655.664062 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(694.873047 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(726.660156 0.015625)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(754.443359 0.015625)"/>
+     <use xlink:href="#DejaVuSans-f" transform="translate(806.542969 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(838.330078 0.015625)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(870.117188 0.015625)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(931.396484 0.015625)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(994.775391 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1058.251953 0.015625)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(1090.039062 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4b" transform="translate(1142.138672 0.015625)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(1205.517578 0.015625)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(1266.699219 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1307.8125 0.015625)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(1347.021484 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1399.121094 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1430.908203 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4b" transform="translate(1470.117188 0.015625)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1533.496094 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1595.019531 0.015625)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(1626.806641 0.015625)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(1690.283203 0.015625)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1753.662109 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1808.642578 0.015625)"/>
+    </g>
+   </g>
+   <g id="patch_8">
+    <path d="M 613.322691 201.045904 
+Q 649.881867 191.301566 685.360724 181.845172 
+" style="fill: none; stroke: #1f77b4; stroke-linecap: round"/>
+    <path d="M 681.712055 181.093512 
+L 685.360724 181.845172 
+L 682.570195 184.313111 
+" style="fill: none; stroke: #1f77b4; stroke-linecap: round"/>
+   </g>
+   <g id="text_17">
+    <!-- $c/L$ = 858 Hz: -->
+    <g style="fill: #1f77b4" transform="translate(553.082697 201.762523) scale(0.0833 -0.0833)">
+     <use xlink:href="#DejaVuSans-Oblique-46" transform="translate(0 0.78125)"/>
+     <use xlink:href="#DejaVuSans-12" transform="translate(54.980469 0.78125)"/>
+     <use xlink:href="#DejaVuSans-Oblique-2f" transform="translate(88.671875 0.78125)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(144.384766 0.78125)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(176.171875 0.78125)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(259.960938 0.78125)"/>
+     <use xlink:href="#DejaVuSans-1b" transform="translate(291.748047 0.78125)"/>
+     <use xlink:href="#DejaVuSans-18" transform="translate(355.371094 0.78125)"/>
+     <use xlink:href="#DejaVuSans-1b" transform="translate(418.994141 0.78125)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(482.617188 0.78125)"/>
+     <use xlink:href="#DejaVuSans-2b" transform="translate(514.404297 0.78125)"/>
+     <use xlink:href="#DejaVuSans-5d" transform="translate(589.599609 0.78125)"/>
+     <use xlink:href="#DejaVuSans-1d" transform="translate(642.089844 0.78125)"/>
+    </g>
+    <!-- the $L/4$ inlet -->
+    <g style="fill: #1f77b4" transform="translate(553.082697 211.762103) scale(0.0833 -0.0833)">
+     <use xlink:href="#DejaVuSans-57" transform="translate(0 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4b" transform="translate(39.208984 0.015625)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(102.587891 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(164.111328 0.015625)"/>
+     <use xlink:href="#DejaVuSans-Oblique-2f" transform="translate(195.898438 0.015625)"/>
+     <use xlink:href="#DejaVuSans-12" transform="translate(251.611328 0.015625)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(285.302734 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(348.925781 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(380.712891 0.015625)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(408.496094 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(471.875 0.015625)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(499.658203 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(561.181641 0.015625)"/>
+    </g>
+    <!-- is tuned here -->
+    <g style="fill: #1f77b4" transform="translate(553.082697 221.76038) scale(0.0833 -0.0833)">
+     <use xlink:href="#DejaVuSans-4c"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(27.78125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(79.875 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(111.65625 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(150.859375 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(214.234375 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(277.609375 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(339.140625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(402.625 0)"/>
+     <use xlink:href="#DejaVuSans-4b" transform="translate(434.40625 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(497.78125 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(559.3125 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(598.21875 0)"/>
+    </g>
+   </g>
+   <g id="patch_9">
+    <path d="M 227.929205 313.137783 
+Q 297.461693 355.286378 366.038089 396.855416 
+" style="fill: none; stroke: #1f77b4; stroke-linecap: round"/>
+    <path d="M 364.052315 393.703515 
+L 366.038089 396.855416 
+L 362.325103 396.552894 
+" style="fill: none; stroke: #1f77b4; stroke-linecap: round"/>
+   </g>
+   <g id="text_18">
+    <!-- the inlet alone only moves -->
+    <g style="fill: #1f77b4" transform="translate(141.424497 297.268089) scale(0.0833 -0.0833)">
+     <defs>
+      <path id="DejaVuSans-59" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-57"/>
+     <use xlink:href="#DejaVuSans-4b" transform="translate(39.203125 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(102.578125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(164.109375 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(195.890625 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(223.671875 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(287.046875 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(314.828125 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(376.359375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(415.5625 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(447.34375 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(508.625 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(536.40625 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(597.59375 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(660.96875 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(722.5 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(754.28125 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(815.46875 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(878.84375 0)"/>
+     <use xlink:href="#DejaVuSans-5c" transform="translate(906.625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(965.8125 0)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(997.59375 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(1095 0)"/>
+     <use xlink:href="#DejaVuSans-59" transform="translate(1156.1875 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1215.375 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(1276.90625 0)"/>
+    </g>
+    <!-- the surviving trough, to 444 Hz -->
+    <g style="fill: #1f77b4" transform="translate(141.424497 307.266367) scale(0.0833 -0.0833)">
      <defs>
       <path id="DejaVuSans-4a" d="M 2906 1791 
 Q 2906 2416 2648 2759 
@@ -1857,173 +1942,38 @@ L 3481 3500
 L 3481 434 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-59" d="M 191 3500 
-L 800 3500 
-L 1894 563 
-L 2988 3500 
-L 3597 3500 
-L 2284 0 
-L 1503 0 
-L 191 3500 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-e" d="M 2944 4013 
-L 2944 2272 
-L 4684 2272 
-L 4684 1741 
-L 2944 1741 
-L 2944 0 
-L 2419 0 
-L 2419 1741 
-L 678 1741 
-L 678 2272 
-L 2419 2272 
-L 2419 4013 
-L 2944 4013 
-z
-" transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-57" transform="translate(0 0.015625)"/>
-     <use xlink:href="#DejaVuSans-4b" transform="translate(39.208984 0.015625)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(102.587891 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(164.111328 0.015625)"/>
-     <use xlink:href="#DejaVuSans-Oblique-2f" transform="translate(195.898438 0.015625)"/>
-     <use xlink:href="#DejaVuSans-12" transform="translate(251.611328 0.015625)"/>
-     <use xlink:href="#DejaVuSans-17" transform="translate(285.302734 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(348.925781 0.015625)"/>
-     <use xlink:href="#DejaVuSans-4c" transform="translate(380.712891 0.015625)"/>
-     <use xlink:href="#DejaVuSans-51" transform="translate(408.496094 0.015625)"/>
-     <use xlink:href="#DejaVuSans-4f" transform="translate(471.875 0.015625)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(499.658203 0.015625)"/>
-     <use xlink:href="#DejaVuSans-57" transform="translate(561.181641 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(600.390625 0.015625)"/>
-     <use xlink:href="#DejaVuSans-4a" transform="translate(632.177734 0.015625)"/>
-     <use xlink:href="#DejaVuSans-4c" transform="translate(695.654297 0.015625)"/>
-     <use xlink:href="#DejaVuSans-59" transform="translate(723.4375 0.015625)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(782.617188 0.015625)"/>
-     <use xlink:href="#DejaVuSans-56" transform="translate(844.140625 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(896.240234 0.015625)"/>
-     <use xlink:href="#DejaVuSans-18" transform="translate(928.027344 0.015625)"/>
-     <use xlink:href="#DejaVuSans-11" transform="translate(991.650391 0.015625)"/>
-     <use xlink:href="#DejaVuSans-14" transform="translate(1023.4375 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1087.060547 0.015625)"/>
-     <use xlink:href="#DejaVuSans-47" transform="translate(1118.847656 0.015625)"/>
-     <use xlink:href="#DejaVuSans-25" transform="translate(1182.324219 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1250.927734 0.015625)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(1282.714844 0.015625)"/>
-     <use xlink:href="#DejaVuSans-51" transform="translate(1343.994141 0.015625)"/>
-     <use xlink:href="#DejaVuSans-47" transform="translate(1407.373047 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1470.849609 0.015625)"/>
-     <use xlink:href="#DejaVuSans-57" transform="translate(1502.636719 0.015625)"/>
-     <use xlink:href="#DejaVuSans-4b" transform="translate(1541.845703 0.015625)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(1605.224609 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1666.748047 0.015625)"/>
-     <use xlink:href="#DejaVuSans-Oblique-2f" transform="translate(1698.535156 0.015625)"/>
-     <use xlink:href="#DejaVuSans-12" transform="translate(1754.248047 0.015625)"/>
-     <use xlink:href="#DejaVuSans-17" transform="translate(1787.939453 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1851.5625 0.015625)"/>
-     <use xlink:href="#DejaVuSans-e" transform="translate(1883.349609 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1967.138672 0.015625)"/>
-     <use xlink:href="#DejaVuSans-Oblique-2f" transform="translate(1998.925781 0.015625)"/>
-     <use xlink:href="#DejaVuSans-12" transform="translate(2054.638672 0.015625)"/>
-     <use xlink:href="#DejaVuSans-15" transform="translate(2088.330078 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(2151.953125 0.015625)"/>
-     <use xlink:href="#DejaVuSans-53" transform="translate(2183.740234 0.015625)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(2247.216797 0.015625)"/>
-     <use xlink:href="#DejaVuSans-4c" transform="translate(2308.496094 0.015625)"/>
-     <use xlink:href="#DejaVuSans-55" transform="translate(2336.279297 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(2377.392578 0.015625)"/>
-     <use xlink:href="#DejaVuSans-1a" transform="translate(2409.179688 0.015625)"/>
-     <use xlink:href="#DejaVuSans-17" transform="translate(2472.802734 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(2536.425781 0.015625)"/>
-     <use xlink:href="#DejaVuSans-47" transform="translate(2568.212891 0.015625)"/>
-     <use xlink:href="#DejaVuSans-25" transform="translate(2631.689453 0.015625)"/>
-    </g>
-   </g>
-   <g id="patch_8">
-    <path d="M 268.251257 277.388862 
-Q 283.822723 336.556503 299.109639 394.642926 
-" style="fill: none; stroke: #d62728; stroke-linecap: round"/>
-    <path d="M 299.872754 390.996635 
-L 299.109639 394.642926 
-L 296.650476 391.84466 
-" style="fill: none; stroke: #d62728; stroke-linecap: round"/>
-   </g>
-   <g id="text_17">
-    <!-- new trough, -->
-    <g style="fill: #d62728" transform="translate(239.604011 260.622667) scale(0.0833 -0.0833)">
-     <defs>
-      <path id="DejaVuSans-5a" d="M 269 3500 
-L 844 3500 
-L 1563 769 
-L 2278 3500 
-L 2956 3500 
-L 3675 769 
-L 4391 3500 
-L 4966 3500 
-L 4050 0 
-L 3372 0 
-L 2619 2869 
-L 1863 0 
-L 1184 0 
-L 269 3500 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-51"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(63.375 0)"/>
-     <use xlink:href="#DejaVuSans-5a" transform="translate(124.90625 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(206.6875 0)"/>
-     <use xlink:href="#DejaVuSans-57" transform="translate(238.46875 0)"/>
-     <use xlink:href="#DejaVuSans-55" transform="translate(277.671875 0)"/>
-     <use xlink:href="#DejaVuSans-52" transform="translate(316.578125 0)"/>
-     <use xlink:href="#DejaVuSans-58" transform="translate(377.765625 0)"/>
-     <use xlink:href="#DejaVuSans-4a" transform="translate(441.140625 0)"/>
-     <use xlink:href="#DejaVuSans-4b" transform="translate(504.625 0)"/>
-     <use xlink:href="#DejaVuSans-f" transform="translate(568 0)"/>
-    </g>
-    <!-- 0.1 dB -->
-    <g style="fill: #d62728" transform="translate(239.604011 270.620944) scale(0.0833 -0.0833)">
-     <use xlink:href="#DejaVuSans-13"/>
-     <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
-     <use xlink:href="#DejaVuSans-14" transform="translate(95.40625 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(159.03125 0)"/>
-     <use xlink:href="#DejaVuSans-47" transform="translate(190.8125 0)"/>
-     <use xlink:href="#DejaVuSans-25" transform="translate(254.296875 0)"/>
-    </g>
-   </g>
-   <g id="patch_9">
-    <path d="M 195.582955 277.388862 
-Q 211.154421 336.556503 226.441337 394.642926 
-" style="fill: none; stroke: #d62728; stroke-linecap: round"/>
-    <path d="M 227.204452 390.996635 
-L 226.441337 394.642926 
-L 223.982174 391.84466 
-" style="fill: none; stroke: #d62728; stroke-linecap: round"/>
-   </g>
-   <g id="text_18">
-    <!-- new trough, -->
-    <g style="fill: #d62728" transform="translate(166.935709 260.622667) scale(0.0833 -0.0833)">
-     <use xlink:href="#DejaVuSans-51"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(63.375 0)"/>
-     <use xlink:href="#DejaVuSans-5a" transform="translate(124.90625 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(206.6875 0)"/>
-     <use xlink:href="#DejaVuSans-57" transform="translate(238.46875 0)"/>
-     <use xlink:href="#DejaVuSans-55" transform="translate(277.671875 0)"/>
-     <use xlink:href="#DejaVuSans-52" transform="translate(316.578125 0)"/>
-     <use xlink:href="#DejaVuSans-58" transform="translate(377.765625 0)"/>
-     <use xlink:href="#DejaVuSans-4a" transform="translate(441.140625 0)"/>
-     <use xlink:href="#DejaVuSans-4b" transform="translate(504.625 0)"/>
-     <use xlink:href="#DejaVuSans-f" transform="translate(568 0)"/>
-    </g>
-    <!-- 0.4 dB -->
-    <g style="fill: #d62728" transform="translate(166.935709 270.620944) scale(0.0833 -0.0833)">
-     <use xlink:href="#DejaVuSans-13"/>
-     <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
-     <use xlink:href="#DejaVuSans-17" transform="translate(95.40625 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(159.03125 0)"/>
-     <use xlink:href="#DejaVuSans-47" transform="translate(190.8125 0)"/>
-     <use xlink:href="#DejaVuSans-25" transform="translate(254.296875 0)"/>
+     <use xlink:href="#DejaVuSans-57"/>
+     <use xlink:href="#DejaVuSans-4b" transform="translate(39.203125 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(102.578125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(164.109375 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(195.890625 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(247.984375 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(311.359375 0)"/>
+     <use xlink:href="#DejaVuSans-59" transform="translate(352.46875 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(411.65625 0)"/>
+     <use xlink:href="#DejaVuSans-59" transform="translate(439.4375 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(498.625 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(526.40625 0)"/>
+     <use xlink:href="#DejaVuSans-4a" transform="translate(589.78125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(653.265625 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(685.046875 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(724.25 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(763.15625 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(824.34375 0)"/>
+     <use xlink:href="#DejaVuSans-4a" transform="translate(887.71875 0)"/>
+     <use xlink:href="#DejaVuSans-4b" transform="translate(951.203125 0)"/>
+     <use xlink:href="#DejaVuSans-f" transform="translate(1014.578125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1046.359375 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1078.140625 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(1117.34375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1178.53125 0)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(1210.3125 0)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(1273.9375 0)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(1337.5625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1401.1875 0)"/>
+     <use xlink:href="#DejaVuSans-2b" transform="translate(1432.96875 0)"/>
+     <use xlink:href="#DejaVuSans-5d" transform="translate(1508.171875 0)"/>
     </g>
    </g>
    <g id="text_19">
@@ -2065,6 +2015,22 @@ L 1997 2009
 L 1997 1497 
 L 313 1497 
 L 313 2009 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-5a" d="M 269 3500 
+L 844 3500 
+L 1563 769 
+L 2278 3500 
+L 2956 3500 
+L 3675 769 
+L 4391 3500 
+L 4966 3500 
+L 4050 0 
+L 3372 0 
+L 2619 2869 
+L 1863 0 
+L 1184 0 
+L 269 3500 
 z
 " transform="scale(0.015625)"/>
      </defs>
@@ -2142,7 +2108,7 @@ Q 535.414938 70.47168 537.080938 70.47168
 z
 " style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
     </g>
-    <g id="line2d_31">
+    <g id="line2d_32">
      <path d="M 538.746938 37.229123 
 L 547.076938 37.229123 
 L 555.406938 37.229123 
@@ -2196,7 +2162,7 @@ z
       <use xlink:href="#DejaVuSans-50" transform="translate(969.84375 0)"/>
      </g>
     </g>
-    <g id="line2d_32">
+    <g id="line2d_33">
      <path d="M 538.746938 49.726076 
 L 547.076938 49.726076 
 L 555.406938 49.726076 
@@ -2244,7 +2210,7 @@ z
       <use xlink:href="#DejaVuSans-50" transform="translate(1327.052734 0.015625)"/>
      </g>
     </g>
-    <g id="line2d_33">
+    <g id="line2d_34">
      <path d="M 538.746938 62.223028 
 L 547.076938 62.223028 
 L 555.406938 62.223028 

--- a/.github/images/silencer_extended_tube_dark.svg
+++ b/.github/images/silencer_extended_tube_dark.svg
@@ -1110,391 +1110,300 @@ L 705.763438 397.716018
 " clip-path="url(#p8843daa6dd)" style="fill: none; stroke-dasharray: 5.92,2.56; stroke-dashoffset: 0; stroke: #ffffff; stroke-width: 1.6"/>
    </g>
    <g id="line2d_28">
-    <path d="M 40.925781 397.298043 
-L 44.251355 395.7181 
-L 48.131191 393.623058 
-L 52.842421 390.803279 
-L 58.939307 386.868376 
-L 81.1098 372.311634 
-L 87.760948 368.342701 
-L 93.857833 364.960635 
-L 99.677587 361.978295 
-L 105.497342 359.244472 
-L 111.317096 356.76239 
-L 116.859719 354.632771 
-L 122.402343 352.730406 
-L 127.944966 351.053252 
-L 133.487589 349.598984 
-L 139.030212 348.36533 
-L 144.572836 347.350294 
-L 150.115459 346.552317 
-L 155.658082 345.970385 
-L 161.200705 345.604113 
-L 166.743329 345.453802 
-L 172.285952 345.52048 
-L 177.828575 345.805938 
-L 183.371198 346.312748 
-L 188.913821 347.044278 
-L 194.456445 348.004688 
-L 199.999068 349.198901 
-L 205.26456 350.555083 
-L 210.530052 352.132668 
-L 215.795544 353.937301 
-L 221.061036 355.974699 
-L 226.326528 358.250258 
-L 231.59202 360.768431 
-L 236.857512 363.531786 
-L 242.123004 366.539575 
-L 247.665628 369.962804 
-L 253.485382 373.821661 
-L 260.13653 378.51102 
-L 280.367105 393.018267 
-L 283.96981 395.202031 
-L 287.018253 396.818553 
-L 289.789564 398.058123 
-L 292.283745 398.954093 
-L 294.777925 399.615779 
-L 296.994974 399.989897 
-L 299.212024 400.15048 
-L 301.429073 400.090076 
-L 303.646122 399.805747 
-L 305.863172 399.299258 
-L 308.080221 398.576958 
-L 310.574401 397.519666 
-L 313.068582 396.222932 
-L 315.839893 394.531147 
-L 318.888336 392.408226 
-L 322.491041 389.613903 
-L 326.92514 385.865607 
-L 333.022025 380.387401 
-L 348.818502 366.063837 
-L 355.192518 360.643671 
-L 361.012273 355.974574 
-L 366.832027 351.595545 
-L 372.37465 347.702805 
-L 377.917274 344.081943 
-L 383.459897 340.729982 
-L 389.00252 337.64194 
-L 394.545143 334.81198 
-L 400.087766 332.23416 
-L 405.63039 329.902908 
-L 411.173013 327.813337 
-L 416.715636 325.961445 
-L 422.258259 324.344258 
-L 427.800883 322.959932 
-L 433.343506 321.807846 
-L 438.886129 320.888682 
-L 444.428752 320.204524 
-L 449.694244 319.775506 
-L 454.959736 319.566265 
-L 460.225228 319.582716 
-L 465.213589 319.813288 
-L 470.20195 320.261037 
-L 475.190311 320.935434 
-L 479.901541 321.790586 
-L 484.612771 322.868998 
-L 489.324 324.183461 
-L 493.758099 325.649315 
-L 498.192198 327.350975 
-L 502.349165 329.173994 
-L 506.506132 331.231321 
-L 510.6631 333.537352 
-L 514.820067 336.106604 
-L 518.977035 338.952552 
-L 523.134002 342.085545 
-L 527.29097 345.509171 
-L 531.725068 349.470436 
-L 536.713429 354.255909 
-L 549.184331 366.426346 
-L 551.678512 368.45331 
-L 553.895561 369.963876 
-L 555.835479 370.990947 
-L 557.498266 371.605663 
-L 558.883922 371.903509 
-L 560.269578 371.986737 
-L 561.655234 371.839938 
-L 563.040889 371.451559 
-L 564.426545 370.814634 
-L 565.812201 369.927237 
-L 567.197857 368.792604 
-L 568.860644 367.116501 
-L 570.523431 365.118625 
-L 572.463349 362.420412 
-L 574.680398 358.919025 
-L 577.174579 354.549933 
-L 580.223021 348.756521 
-L 584.65712 339.792212 
-L 604.056301 299.957749 
-L 611.538843 285.41681 
-L 621.238433 267.107661 
-L 635.094991 240.956899 
-L 641.191877 228.940732 
-L 645.903107 219.194131 
-L 650.060074 210.104778 
-L 653.662779 201.724938 
-L 656.988353 193.44756 
-L 660.036796 185.272714 
-L 662.808107 177.22067 
-L 665.302288 169.33572 
-L 667.796468 160.685508 
-L 670.013518 152.180946 
-L 671.953436 143.93825 
-L 673.893354 134.73981 
-L 675.556141 125.880327 
-L 677.218928 115.847798 
-L 678.881715 104.252728 
-L 680.267371 92.962976 
-L 681.653026 79.592846 
-L 682.761551 66.765489 
-L 683.870076 51.131187 
-L 684.701469 36.646556 
-L 685.532863 18.438178 
-L 686.209499 -1 
-M 690.525162 -1 
-L 691.352617 22.00727 
-L 692.184011 39.424457 
-L 693.292535 57.51759 
-L 694.40106 71.942769 
-L 695.786716 86.663557 
-L 697.172371 98.891056 
-L 698.558027 109.363322 
-L 700.220814 120.240889 
-L 701.883601 129.740378 
-L 703.823519 139.512058 
-L 705.763438 148.199144 
-L 705.763438 148.199144 
+    <path d="M 40.925781 398.596858 
+L 44.805618 397.361778 
+L 48.962585 395.807262 
+L 53.673815 393.804921 
+L 59.216438 391.196554 
+L 66.144717 387.677584 
+L 78.89275 380.89268 
+L 91.086521 374.50565 
+L 99.677587 370.25084 
+L 107.714391 366.519965 
+L 115.196933 363.289411 
+L 122.402343 360.412284 
+L 129.607753 357.770107 
+L 136.813163 355.364709 
+L 144.018573 353.195692 
+L 151.223983 351.261406 
+L 158.429394 349.55963 
+L 165.634804 348.088043 
+L 172.840214 346.844545 
+L 180.045624 345.827487 
+L 187.251034 345.035833 
+L 194.456445 344.469279 
+L 201.661855 344.128344 
+L 208.867265 344.014449 
+L 216.072675 344.129974 
+L 223.000954 344.460571 
+L 229.929233 345.010386 
+L 236.857512 345.78434 
+L 243.785791 346.788342 
+L 250.436939 347.975009 
+L 257.088087 349.386994 
+L 263.739235 351.032011 
+L 270.113252 352.834868 
+L 276.487268 354.867071 
+L 282.861285 357.136254 
+L 289.235302 359.649439 
+L 295.609319 362.41211 
+L 301.983335 365.426747 
+L 308.357352 368.690558 
+L 315.0085 372.349295 
+L 322.21391 376.569984 
+L 331.913501 382.539586 
+L 342.998747 389.328049 
+L 348.264239 392.285292 
+L 352.421207 394.367818 
+L 356.023912 395.920853 
+L 359.072355 397.006501 
+L 361.843666 397.780368 
+L 364.614978 398.326103 
+L 367.109158 398.604788 
+L 369.603339 398.669599 
+L 372.097519 398.512321 
+L 374.5917 398.129076 
+L 377.08588 397.520572 
+L 379.580061 396.692047 
+L 382.351372 395.525021 
+L 385.122684 394.116227 
+L 388.171127 392.314065 
+L 391.4967 390.08479 
+L 395.376537 387.196438 
+L 399.810635 383.604107 
+L 405.63039 378.574219 
+L 415.607111 369.590373 
+L 426.969489 359.446388 
+L 435.006293 352.576905 
+L 442.211703 346.706254 
+L 449.139982 341.338686 
+L 456.068261 336.246533 
+L 462.99654 331.424934 
+L 470.20195 326.687295 
+L 477.40736 322.218797 
+L 484.889902 317.847935 
+L 492.372443 313.735683 
+L 500.132116 309.727508 
+L 508.168919 305.833891 
+L 516.205723 302.18543 
+L 524.519658 298.651993 
+L 533.110724 295.240549 
+L 541.978921 291.956442 
+L 551.124249 288.80298 
+L 560.82384 285.695019 
+L 571.077693 282.646951 
+L 582.16294 279.588122 
+L 595.188104 276.236361 
+L 625.672532 268.510699 
+L 632.32368 266.514821 
+L 637.312041 264.801843 
+L 641.469008 263.160676 
+L 645.071713 261.518679 
+L 648.397287 259.759316 
+L 651.168599 258.059967 
+L 653.662779 256.299571 
+L 656.15696 254.264782 
+L 658.374009 252.170054 
+L 660.591058 249.741657 
+L 662.530976 247.281196 
+L 664.470894 244.437572 
+L 666.133681 241.631631 
+L 667.796468 238.41585 
+L 669.459255 234.707599 
+L 671.122042 230.402921 
+L 672.784829 225.368853 
+L 674.170485 220.492885 
+L 675.556141 214.859677 
+L 676.941797 208.297239 
+L 678.327453 200.572337 
+L 679.713108 191.35484 
+L 680.821633 182.582463 
+L 681.930158 172.162277 
+L 683.038682 159.50043 
+L 684.147207 143.590489 
+L 684.9786 128.431104 
+L 685.809994 108.812028 
+L 686.364256 91.691866 
+L 686.918519 68.915421 
+L 687.472781 34.946706 
+L 687.81481 -1 
+M 688.918734 -1 
+L 689.412699 45.643167 
+L 689.966961 75.699466 
+L 690.798355 105.146693 
+L 691.629748 125.703373 
+L 692.461142 141.429612 
+L 693.569666 157.82189 
+L 694.678191 170.802582 
+L 695.786716 181.450317 
+L 697.172371 192.413718 
+L 698.558027 201.453551 
+L 699.943683 209.041924 
+L 701.329339 215.496294 
+L 702.714995 221.042084 
+L 704.377782 226.729759 
+L 705.763438 230.809642 
+L 705.763438 230.809642 
 " clip-path="url(#p8843daa6dd)" style="fill: none; stroke: #1f77b4; stroke-width: 1.9; stroke-linecap: square"/>
    </g>
    <g id="line2d_29">
-    <path d="M 40.925781 394.743388 
-L 44.251355 392.193107 
-L 48.408323 388.686901 
-L 54.505208 383.2077 
-L 65.313323 373.484628 
-L 70.855947 368.807446 
-L 76.121439 364.658014 
-L 81.1098 361.021703 
-L 85.821029 357.863523 
-L 90.532259 354.97836 
-L 94.966358 352.512947 
-L 99.400456 350.288782 
-L 103.834555 348.303877 
-L 108.268653 346.556081 
-L 112.702752 345.043513 
-L 117.136851 343.764868 
-L 121.570949 342.719639 
-L 126.005048 341.908297 
-L 130.439146 341.332439 
-L 134.596114 341.008962 
-L 138.753081 340.898426 
-L 142.910049 341.005488 
-L 147.067016 341.336116 
-L 151.223983 341.89771 
-L 155.10382 342.638147 
-L 158.983656 343.596254 
-L 162.863492 344.782134 
-L 166.743329 346.207435 
-L 170.623165 347.88545 
-L 174.22587 349.68295 
-L 177.828575 351.724489 
-L 181.43128 354.024339 
-L 185.033985 356.597398 
-L 188.63669 359.458393 
-L 192.239395 362.620406 
-L 195.8421 366.09226 
-L 199.444806 369.874007 
-L 203.324642 374.273898 
-L 208.035872 379.984143 
-L 216.349806 390.148923 
-L 218.843987 392.813576 
-L 220.783905 394.594425 
-L 222.446692 395.845715 
-L 223.832348 396.651036 
-L 225.218004 397.206486 
-L 226.326528 397.451417 
-L 227.435053 397.505358 
-L 228.543578 397.358469 
-L 229.652102 397.004133 
-L 230.760627 396.439322 
-L 232.146283 395.438808 
-L 233.531938 394.120389 
-L 234.917594 392.501757 
-L 236.580381 390.197742 
-L 238.520299 387.075868 
-L 240.737349 383.044204 
-L 243.50866 377.498668 
-L 247.388497 369.181111 
-L 260.413661 340.866507 
-L 265.679153 330.141989 
-L 270.944645 319.944086 
-L 276.210137 310.225236 
-L 282.029892 299.949533 
-L 288.958171 288.194138 
-L 299.489155 270.839733 
-L 308.911614 255.166855 
-L 314.454238 245.515983 
-L 318.888336 237.352691 
-L 322.768172 229.728812 
-L 326.093746 222.700647 
-L 329.142189 215.724891 
-L 331.913501 208.805631 
-L 334.407681 201.971015 
-L 336.62473 195.278356 
-L 338.84178 187.84238 
-L 340.781698 180.555661 
-L 342.721616 172.325151 
-L 344.384403 164.294865 
-L 346.04719 155.075508 
-L 347.432846 146.190198 
-L 348.818502 135.828057 
-L 349.927026 126.100273 
-L 351.035551 114.604057 
-L 352.144076 100.583471 
-L 352.975469 87.632418 
-L 353.806862 71.482117 
-L 354.638256 50.107923 
-L 355.192518 30.823947 
-L 355.817716 -1 
-M 357.983279 -1 
-L 358.518092 28.359949 
-L 359.349486 58.693579 
-L 360.180879 80.264707 
-L 361.289404 102.019011 
-L 362.397928 119.119143 
-L 363.783584 136.523854 
-L 365.16924 151.063795 
-L 366.832027 165.998864 
-L 368.494814 179.037476 
-L 370.434732 192.576089 
-L 372.651781 206.501016 
-L 375.145962 220.813574 
-L 378.194405 237.045985 
-L 382.628503 259.331003 
-L 391.4967 303.616004 
-L 395.653668 325.738199 
-L 402.581947 363.015542 
-L 403.967603 369.141578 
-L 405.076127 373.174919 
-L 405.907521 375.557416 
-L 406.738914 377.311583 
-L 407.293177 378.110558 
-L 407.847439 378.607996 
-L 408.401701 378.807635 
-L 408.955964 378.720211 
-L 409.510226 378.362621 
-L 410.064488 377.756686 
-L 410.895882 376.437998 
-L 412.004406 374.058989 
-L 413.390062 370.386811 
-L 415.607111 363.697699 
-L 420.04121 350.213935 
-L 422.535391 343.368792 
-L 425.029571 337.192156 
-L 427.523751 331.653857 
-L 430.017932 326.692341 
-L 432.512112 322.24063 
-L 435.006293 318.236165 
-L 437.500473 314.623867 
-L 440.271785 311.012933 
-L 443.043096 307.773479 
-L 445.814408 304.860283 
-L 448.862851 301.987998 
-L 451.911294 299.423979 
-L 454.959736 297.13439 
-L 458.28531 294.916984 
-L 461.610884 292.963258 
-L 465.213589 291.116112 
-L 468.816294 289.524632 
-L 472.419 288.168391 
-L 476.298836 286.952048 
-L 480.178672 285.973009 
-L 484.058508 285.218458 
-L 487.938345 284.678636 
-L 492.095312 284.330504 
-L 496.252279 284.21496 
-L 500.409247 284.329031 
-L 504.566214 284.672369 
-L 508.723182 285.247172 
-L 512.880149 286.0582 
-L 516.759985 287.034787 
-L 520.639822 288.231839 
-L 524.519658 289.659961 
-L 528.399494 291.332371 
-L 532.002199 293.118134 
-L 535.604904 295.143949 
-L 539.207609 297.428159 
-L 542.810315 299.992303 
-L 546.135889 302.629329 
-L 549.461462 305.548953 
-L 552.787036 308.776835 
-L 555.835479 312.030767 
-L 558.883922 315.591029 
-L 561.932365 319.481309 
-L 564.980807 323.723051 
-L 568.02925 328.330586 
-L 571.354824 333.771105 
-L 575.23466 340.59482 
-L 582.994333 354.444184 
-L 584.934251 357.360983 
-L 586.319907 359.110662 
-L 587.705563 360.48971 
-L 588.814087 361.270601 
-L 589.645481 361.642376 
-L 590.476874 361.814871 
-L 591.308268 361.776651 
-L 592.139661 361.519654 
-L 592.971055 361.039655 
-L 593.802448 360.336516 
-L 594.910973 359.059292 
-L 596.019498 357.412661 
-L 597.405153 354.881049 
-L 599.06794 351.24713 
-L 601.007858 346.363935 
-L 603.502039 339.396628 
-L 607.659006 326.975423 
-L 614.864417 305.465542 
-L 619.575646 292.138122 
-L 624.286876 279.461662 
-L 629.552368 265.929983 
-L 636.480647 248.793288 
-L 649.505812 216.719801 
-L 654.217041 204.424488 
-L 658.096878 193.661578 
-L 661.422452 183.762397 
-L 664.193763 174.861736 
-L 666.687944 166.181942 
-L 669.182124 156.67407 
-L 671.399173 147.314963 
-L 673.339092 138.209664 
-L 675.27901 127.981251 
-L 676.941797 118.034607 
-L 678.604584 106.621058 
-L 679.990239 95.58908 
-L 681.375895 82.627819 
-L 682.48442 70.30364 
-L 683.592945 55.444466 
-L 684.424338 41.858566 
-L 685.255732 25.07075 
-L 686.087125 3.062562 
-L 686.209949 -1 
-M 690.524685 -1 
-L 691.352617 22.035563 
-L 692.184011 39.470737 
-L 693.292535 57.594729 
-L 694.40106 72.058659 
-L 695.786716 86.839046 
-L 697.172371 99.138635 
-L 698.835158 111.641111 
-L 700.497945 122.381671 
-L 702.437864 133.298488 
-L 704.377782 142.922087 
-L 705.763438 149.181607 
-L 705.763438 149.181607 
+    <path d="M 40.925781 399.037566 
+L 45.082749 397.939185 
+L 49.516847 396.5317 
+L 54.228077 394.801989 
+L 59.493569 392.62778 
+L 65.590455 389.856816 
+L 72.795865 386.326156 
+L 82.495455 381.306212 
+L 118.522506 362.429663 
+L 130.162015 356.702819 
+L 141.247262 351.492932 
+L 152.332508 346.524381 
+L 163.694886 341.673489 
+L 175.611526 336.831866 
+L 188.082428 332.009795 
+L 201.384724 327.108315 
+L 216.072675 321.937719 
+L 233.80907 315.942012 
+L 276.210137 301.725106 
+L 285.909728 298.166987 
+L 293.6694 295.086282 
+L 300.043417 292.317749 
+L 305.308909 289.799848 
+L 310.020139 287.304465 
+L 314.177106 284.848763 
+L 317.779812 282.468023 
+L 321.105385 280.001268 
+L 324.153828 277.449234 
+L 326.92514 274.821384 
+L 329.41932 272.138806 
+L 331.63637 269.437209 
+L 333.853419 266.361417 
+L 335.793337 263.286494 
+L 337.733255 259.761469 
+L 339.396042 256.292009 
+L 341.058829 252.302692 
+L 342.721616 247.655582 
+L 344.107272 243.144045 
+L 345.492928 237.889117 
+L 346.878583 231.674596 
+L 347.987108 225.805527 
+L 349.095633 218.891363 
+L 350.204157 210.591904 
+L 351.312682 200.381888 
+L 352.144076 190.966418 
+L 352.975469 179.389265 
+L 353.806862 164.605897 
+L 354.638256 144.58554 
+L 355.192518 126.193274 
+L 355.746781 100.085721 
+L 356.301043 56.002522 
+L 356.613714 -1 
+M 357.204232 -1 
+L 357.409568 42.809844 
+L 357.96383 97.410687 
+L 358.518092 128.727185 
+L 359.349486 160.157176 
+L 360.180879 182.732447 
+L 361.289404 205.649548 
+L 362.397928 223.666249 
+L 363.506453 238.476577 
+L 364.892109 253.769941 
+L 366.277765 266.325726 
+L 367.663421 276.669277 
+L 369.049076 285.137173 
+L 370.157601 290.731384 
+L 371.266126 295.397941 
+L 372.37465 299.241446 
+L 373.483175 302.362356 
+L 374.5917 304.856784 
+L 375.700224 306.815095 
+L 376.808749 308.320317 
+L 377.917274 309.446964 
+L 379.025798 310.260472 
+L 380.134323 310.817223 
+L 381.519979 311.224211 
+L 382.905634 311.380771 
+L 384.568421 311.322242 
+L 386.50834 311.012519 
+L 389.00252 310.367241 
+L 392.605225 309.169969 
+L 412.8358 302.031733 
+L 419.764079 299.985329 
+L 427.24662 298.006408 
+L 435.560555 296.043457 
+L 444.705883 294.117911 
+L 454.959736 292.19288 
+L 466.322114 290.290555 
+L 479.070147 288.386643 
+L 493.203837 286.503018 
+L 509.277444 284.591124 
+L 527.568101 282.646125 
+L 550.015725 280.493603 
+L 596.57376 276.104305 
+L 607.659006 274.79134 
+L 616.250072 273.556117 
+L 623.178351 272.335826 
+L 628.720975 271.145781 
+L 633.432204 269.924928 
+L 637.589172 268.632782 
+L 641.191877 267.299689 
+L 644.517451 265.84356 
+L 647.565894 264.268265 
+L 650.337205 262.586535 
+L 652.831386 260.821946 
+L 655.325566 258.765537 
+L 657.542615 256.639341 
+L 659.759665 254.171628 
+L 661.699583 251.674723 
+L 663.639501 248.798639 
+L 665.579419 245.46695 
+L 667.242206 242.176505 
+L 668.904993 238.405836 
+L 670.56778 234.060972 
+L 672.230567 229.022834 
+L 673.893354 223.137218 
+L 675.27901 217.439065 
+L 676.664666 210.852436 
+L 678.050321 203.162963 
+L 679.435977 194.068781 
+L 680.544502 185.488203 
+L 681.653026 175.383814 
+L 682.761551 163.230218 
+L 683.870076 148.156377 
+L 684.701469 134.014975 
+L 685.532863 116.081909 
+L 686.364256 91.733119 
+L 686.918519 68.937086 
+L 687.472781 34.954998 
+L 687.814832 -1 
+M 688.918706 -1 
+L 689.412699 45.654386 
+L 689.966961 75.725712 
+L 690.798355 105.207046 
+L 691.629748 125.811307 
+L 692.461142 141.597996 
+L 693.569666 158.089573 
+L 694.678191 171.188975 
+L 695.786716 181.972416 
+L 697.172371 193.125373 
+L 698.558027 202.371982 
+L 699.943683 210.179158 
+L 701.329339 216.859446 
+L 702.992126 223.695088 
+L 704.654913 229.498612 
+L 705.763438 232.895229 
+L 705.763438 232.895229 
 " clip-path="url(#p8843daa6dd)" style="fill: none; stroke-dasharray: 10.88,2.72,1.7,2.72; stroke-dashoffset: 0; stroke: #d62728; stroke-width: 1.7"/>
    </g>
    <g id="line2d_30">
     <path d="M 356.916935 400.915781 
 L 356.916935 26.318125 
+" clip-path="url(#p8843daa6dd)" style="fill: none; stroke-dasharray: 1.2,1.98; stroke-dashoffset: 0; stroke: #555555; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_31">
+    <path d="M 688.369429 400.915781 
+L 688.369429 26.318125 
 " clip-path="url(#p8843daa6dd)" style="fill: none; stroke-dasharray: 1.2,1.98; stroke-dashoffset: 0; stroke: #555555; stroke-width: 1.2"/>
    </g>
    <g id="patch_3">
@@ -1518,17 +1427,17 @@ L 705.763438 26.318125
 " style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_7">
-    <path d="M 486.019169 195.59123 
-Q 422.087599 276.701741 358.848125 356.934185 
+    <path d="M 223.984507 121.547227 
+Q 289.539975 150.887616 354.074956 179.771271 
 " style="fill: none; stroke: #ffffff; stroke-linecap: round"/>
-    <path d="M 362.219154 355.348642 
-L 358.848125 356.934185 
-L 359.602309 353.286036 
+    <path d="M 351.714257 176.889452 
+L 354.074956 179.771271 
+L 350.353081 179.930738 
 " style="fill: none; stroke: #ffffff; stroke-linecap: round"/>
    </g>
    <g id="text_16">
-    <!-- $c/2L$ = 429 Hz: the plain chamber is transparent (0.0 dB), -->
-    <g style="fill: #ffffff" transform="translate(376.804084 179.187092) scale(0.0833 -0.0833)">
+    <!-- $c/2L$ = 429 Hz: plain chamber 0.0 dB and the $L/4$ inlet -->
+    <g style="fill: #ffffff" transform="translate(71.848463 95.896667) scale(0.0833 -0.0833)">
      <defs>
       <path id="DejaVuSans-Oblique-46" d="M 3431 3366 
 L 3316 2797 
@@ -1627,46 +1536,6 @@ L 750 2516
 L 750 3309 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-57" d="M 1172 4494 
-L 1172 3500 
-L 2356 3500 
-L 2356 3053 
-L 1172 3053 
-L 1172 1153 
-Q 1172 725 1289 603 
-Q 1406 481 1766 481 
-L 2356 481 
-L 2356 0 
-L 1766 0 
-Q 1100 0 847 248 
-Q 594 497 594 1153 
-L 594 3053 
-L 172 3053 
-L 172 3500 
-L 594 3500 
-L 594 4494 
-L 1172 4494 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-4b" d="M 3513 2113 
-L 3513 0 
-L 2938 0 
-L 2938 2094 
-Q 2938 2591 2744 2837 
-Q 2550 3084 2163 3084 
-Q 1697 3084 1428 2787 
-Q 1159 2491 1159 1978 
-L 1159 0 
-L 581 0 
-L 581 4863 
-L 1159 4863 
-L 1159 2956 
-Q 1366 3272 1645 3428 
-Q 1925 3584 2291 3584 
-Q 2894 3584 3203 3211 
-Q 3513 2838 3513 2113 
-z
-" transform="scale(0.015625)"/>
       <path id="DejaVuSans-53" d="M 1159 525 
 L 1159 -1331 
 L 581 -1331 
@@ -1691,6 +1560,25 @@ Q 1159 1113 1420 752
 Q 1681 391 2138 391 
 Q 2594 391 2855 752 
 Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-4b" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSans-45" d="M 3116 1747 
@@ -1719,19 +1607,6 @@ L 1159 4863
 L 1159 2969 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-b" d="M 1984 4856 
-Q 1566 4138 1362 3434 
-Q 1159 2731 1159 2009 
-Q 1159 1288 1364 580 
-Q 1569 -128 1984 -844 
-L 1484 -844 
-Q 1016 -109 783 600 
-Q 550 1309 550 2009 
-Q 550 2706 781 3412 
-Q 1013 4119 1484 4856 
-L 1984 4856 
-z
-" transform="scale(0.015625)"/>
       <path id="DejaVuSans-11" d="M 684 794 
 L 1344 794 
 L 1344 0 
@@ -1739,26 +1614,25 @@ L 684 0
 L 684 794 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-c" d="M 513 4856 
-L 1013 4856 
-Q 1481 4119 1714 3412 
-Q 1947 2706 1947 2009 
-Q 1947 1309 1714 600 
-Q 1481 -109 1013 -844 
-L 513 -844 
-Q 928 -128 1133 580 
-Q 1338 1288 1338 2009 
-Q 1338 2731 1133 3434 
-Q 928 4138 513 4856 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-f" d="M 750 794 
-L 1409 794 
-L 1409 256 
-L 897 -744 
-L 494 -744 
-L 750 256 
-L 750 794 
+      <path id="DejaVuSans-57" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
 z
 " transform="scale(0.015625)"/>
      </defs>
@@ -1777,51 +1651,262 @@ z
      <use xlink:href="#DejaVuSans-5d" transform="translate(653.222656 0.015625)"/>
      <use xlink:href="#DejaVuSans-1d" transform="translate(705.712891 0.015625)"/>
      <use xlink:href="#DejaVuSans-3" transform="translate(739.404297 0.015625)"/>
-     <use xlink:href="#DejaVuSans-57" transform="translate(771.191406 0.015625)"/>
-     <use xlink:href="#DejaVuSans-4b" transform="translate(810.400391 0.015625)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(873.779297 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(935.302734 0.015625)"/>
-     <use xlink:href="#DejaVuSans-53" transform="translate(967.089844 0.015625)"/>
-     <use xlink:href="#DejaVuSans-4f" transform="translate(1030.566406 0.015625)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(1058.349609 0.015625)"/>
-     <use xlink:href="#DejaVuSans-4c" transform="translate(1119.628906 0.015625)"/>
-     <use xlink:href="#DejaVuSans-51" transform="translate(1147.412109 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1210.791016 0.015625)"/>
-     <use xlink:href="#DejaVuSans-46" transform="translate(1242.578125 0.015625)"/>
-     <use xlink:href="#DejaVuSans-4b" transform="translate(1297.558594 0.015625)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(1360.9375 0.015625)"/>
-     <use xlink:href="#DejaVuSans-50" transform="translate(1422.216797 0.015625)"/>
-     <use xlink:href="#DejaVuSans-45" transform="translate(1519.628906 0.015625)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(1583.105469 0.015625)"/>
-     <use xlink:href="#DejaVuSans-55" transform="translate(1644.628906 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1685.742188 0.015625)"/>
-     <use xlink:href="#DejaVuSans-4c" transform="translate(1717.529297 0.015625)"/>
-     <use xlink:href="#DejaVuSans-56" transform="translate(1745.3125 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1797.412109 0.015625)"/>
-     <use xlink:href="#DejaVuSans-57" transform="translate(1829.199219 0.015625)"/>
-     <use xlink:href="#DejaVuSans-55" transform="translate(1868.408203 0.015625)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(1909.521484 0.015625)"/>
-     <use xlink:href="#DejaVuSans-51" transform="translate(1970.800781 0.015625)"/>
-     <use xlink:href="#DejaVuSans-56" transform="translate(2034.179688 0.015625)"/>
-     <use xlink:href="#DejaVuSans-53" transform="translate(2086.279297 0.015625)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(2149.755859 0.015625)"/>
-     <use xlink:href="#DejaVuSans-55" transform="translate(2211.035156 0.015625)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(2250.148438 0.015625)"/>
-     <use xlink:href="#DejaVuSans-51" transform="translate(2311.671875 0.015625)"/>
-     <use xlink:href="#DejaVuSans-57" transform="translate(2375.050781 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(2414.259766 0.015625)"/>
-     <use xlink:href="#DejaVuSans-b" transform="translate(2446.046875 0.015625)"/>
-     <use xlink:href="#DejaVuSans-13" transform="translate(2485.060547 0.015625)"/>
-     <use xlink:href="#DejaVuSans-11" transform="translate(2548.683594 0.015625)"/>
-     <use xlink:href="#DejaVuSans-13" transform="translate(2580.470703 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(2644.09375 0.015625)"/>
-     <use xlink:href="#DejaVuSans-47" transform="translate(2675.880859 0.015625)"/>
-     <use xlink:href="#DejaVuSans-25" transform="translate(2739.357422 0.015625)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(2807.960938 0.015625)"/>
-     <use xlink:href="#DejaVuSans-f" transform="translate(2846.974609 0.015625)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(771.191406 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(834.667969 0.015625)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(862.451172 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(923.730469 0.015625)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(951.513672 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1014.892578 0.015625)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1046.679688 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4b" transform="translate(1101.660156 0.015625)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1165.039062 0.015625)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(1226.318359 0.015625)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(1323.730469 0.015625)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1387.207031 0.015625)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(1448.730469 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1489.84375 0.015625)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(1521.630859 0.015625)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(1585.253906 0.015625)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(1617.041016 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1680.664062 0.015625)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(1712.451172 0.015625)"/>
+     <use xlink:href="#DejaVuSans-25" transform="translate(1775.927734 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1844.53125 0.015625)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1876.318359 0.015625)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1937.597656 0.015625)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(2000.976562 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2064.453125 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(2096.240234 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4b" transform="translate(2135.449219 0.015625)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(2198.828125 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2260.351562 0.015625)"/>
+     <use xlink:href="#DejaVuSans-Oblique-2f" transform="translate(2292.138672 0.015625)"/>
+     <use xlink:href="#DejaVuSans-12" transform="translate(2347.851562 0.015625)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(2381.542969 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2445.166016 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(2476.953125 0.015625)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(2504.736328 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(2568.115234 0.015625)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(2595.898438 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(2657.421875 0.015625)"/>
     </g>
-    <!-- the $L/4$ inlet gives 5.1 dB and the $L/4$ + $L/2$ pair 74 dB -->
-    <g style="fill: #ffffff" transform="translate(376.804084 189.186671) scale(0.0833 -0.0833)">
+    <!-- still only 0.6 dB, because $L/4$ is not tuned here. -->
+    <g style="fill: #ffffff" transform="translate(71.848463 105.896246) scale(0.0833 -0.0833)">
+     <defs>
+      <path id="DejaVuSans-f" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-56" transform="translate(0 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(52.099609 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(91.308594 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(119.091797 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(146.875 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(174.658203 0.015625)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(206.445312 0.015625)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(267.626953 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(331.005859 0.015625)"/>
+     <use xlink:href="#DejaVuSans-5c" transform="translate(358.789062 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(417.96875 0.015625)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(449.755859 0.015625)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(513.378906 0.015625)"/>
+     <use xlink:href="#DejaVuSans-19" transform="translate(545.166016 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(608.789062 0.015625)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(640.576172 0.015625)"/>
+     <use xlink:href="#DejaVuSans-25" transform="translate(704.052734 0.015625)"/>
+     <use xlink:href="#DejaVuSans-f" transform="translate(772.65625 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(804.443359 0.015625)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(836.230469 0.015625)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(899.707031 0.015625)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(961.230469 0.015625)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1016.210938 0.015625)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(1077.490234 0.015625)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(1140.869141 0.015625)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1192.96875 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1254.492188 0.015625)"/>
+     <use xlink:href="#DejaVuSans-Oblique-2f" transform="translate(1286.279297 0.015625)"/>
+     <use xlink:href="#DejaVuSans-12" transform="translate(1341.992188 0.015625)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(1375.683594 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1439.306641 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(1471.09375 0.015625)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(1498.876953 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1550.976562 0.015625)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1582.763672 0.015625)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(1646.142578 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1707.324219 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1746.533203 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1778.320312 0.015625)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(1817.529297 0.015625)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1880.908203 0.015625)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1944.287109 0.015625)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(2005.810547 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2069.287109 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4b" transform="translate(2101.074219 0.015625)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(2164.453125 0.015625)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(2225.976562 0.015625)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(2265.089844 0.015625)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(2326.613281 0.015625)"/>
+    </g>
+    <!-- The $L/2$ outlet is, and shorts the duct -->
+    <g style="fill: #ffffff" transform="translate(71.848463 115.895825) scale(0.0833 -0.0833)">
+     <use xlink:href="#DejaVuSans-37" transform="translate(0 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4b" transform="translate(61.083984 0.015625)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(124.462891 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(185.986328 0.015625)"/>
+     <use xlink:href="#DejaVuSans-Oblique-2f" transform="translate(217.773438 0.015625)"/>
+     <use xlink:href="#DejaVuSans-12" transform="translate(273.486328 0.015625)"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(307.177734 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(370.800781 0.015625)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(402.587891 0.015625)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(463.769531 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(527.148438 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(566.357422 0.015625)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(594.140625 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(655.664062 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(694.873047 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(726.660156 0.015625)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(754.443359 0.015625)"/>
+     <use xlink:href="#DejaVuSans-f" transform="translate(806.542969 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(838.330078 0.015625)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(870.117188 0.015625)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(931.396484 0.015625)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(994.775391 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1058.251953 0.015625)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(1090.039062 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4b" transform="translate(1142.138672 0.015625)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(1205.517578 0.015625)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(1266.699219 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1307.8125 0.015625)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(1347.021484 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1399.121094 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1430.908203 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4b" transform="translate(1470.117188 0.015625)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1533.496094 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1595.019531 0.015625)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(1626.806641 0.015625)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(1690.283203 0.015625)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1753.662109 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1808.642578 0.015625)"/>
+    </g>
+   </g>
+   <g id="patch_8">
+    <path d="M 613.322691 201.045904 
+Q 649.881867 191.301566 685.360724 181.845172 
+" style="fill: none; stroke: #1f77b4; stroke-linecap: round"/>
+    <path d="M 681.712055 181.093512 
+L 685.360724 181.845172 
+L 682.570195 184.313111 
+" style="fill: none; stroke: #1f77b4; stroke-linecap: round"/>
+   </g>
+   <g id="text_17">
+    <!-- $c/L$ = 858 Hz: -->
+    <g style="fill: #1f77b4" transform="translate(553.082697 201.762523) scale(0.0833 -0.0833)">
+     <use xlink:href="#DejaVuSans-Oblique-46" transform="translate(0 0.78125)"/>
+     <use xlink:href="#DejaVuSans-12" transform="translate(54.980469 0.78125)"/>
+     <use xlink:href="#DejaVuSans-Oblique-2f" transform="translate(88.671875 0.78125)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(144.384766 0.78125)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(176.171875 0.78125)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(259.960938 0.78125)"/>
+     <use xlink:href="#DejaVuSans-1b" transform="translate(291.748047 0.78125)"/>
+     <use xlink:href="#DejaVuSans-18" transform="translate(355.371094 0.78125)"/>
+     <use xlink:href="#DejaVuSans-1b" transform="translate(418.994141 0.78125)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(482.617188 0.78125)"/>
+     <use xlink:href="#DejaVuSans-2b" transform="translate(514.404297 0.78125)"/>
+     <use xlink:href="#DejaVuSans-5d" transform="translate(589.599609 0.78125)"/>
+     <use xlink:href="#DejaVuSans-1d" transform="translate(642.089844 0.78125)"/>
+    </g>
+    <!-- the $L/4$ inlet -->
+    <g style="fill: #1f77b4" transform="translate(553.082697 211.762103) scale(0.0833 -0.0833)">
+     <use xlink:href="#DejaVuSans-57" transform="translate(0 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4b" transform="translate(39.208984 0.015625)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(102.587891 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(164.111328 0.015625)"/>
+     <use xlink:href="#DejaVuSans-Oblique-2f" transform="translate(195.898438 0.015625)"/>
+     <use xlink:href="#DejaVuSans-12" transform="translate(251.611328 0.015625)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(285.302734 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(348.925781 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(380.712891 0.015625)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(408.496094 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(471.875 0.015625)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(499.658203 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(561.181641 0.015625)"/>
+    </g>
+    <!-- is tuned here -->
+    <g style="fill: #1f77b4" transform="translate(553.082697 221.76038) scale(0.0833 -0.0833)">
+     <use xlink:href="#DejaVuSans-4c"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(27.78125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(79.875 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(111.65625 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(150.859375 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(214.234375 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(277.609375 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(339.140625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(402.625 0)"/>
+     <use xlink:href="#DejaVuSans-4b" transform="translate(434.40625 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(497.78125 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(559.3125 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(598.21875 0)"/>
+    </g>
+   </g>
+   <g id="patch_9">
+    <path d="M 227.929205 313.137783 
+Q 297.461693 355.286378 366.038089 396.855416 
+" style="fill: none; stroke: #1f77b4; stroke-linecap: round"/>
+    <path d="M 364.052315 393.703515 
+L 366.038089 396.855416 
+L 362.325103 396.552894 
+" style="fill: none; stroke: #1f77b4; stroke-linecap: round"/>
+   </g>
+   <g id="text_18">
+    <!-- the inlet alone only moves -->
+    <g style="fill: #1f77b4" transform="translate(141.424497 297.268089) scale(0.0833 -0.0833)">
+     <defs>
+      <path id="DejaVuSans-59" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-57"/>
+     <use xlink:href="#DejaVuSans-4b" transform="translate(39.203125 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(102.578125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(164.109375 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(195.890625 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(223.671875 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(287.046875 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(314.828125 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(376.359375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(415.5625 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(447.34375 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(508.625 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(536.40625 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(597.59375 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(660.96875 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(722.5 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(754.28125 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(815.46875 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(878.84375 0)"/>
+     <use xlink:href="#DejaVuSans-5c" transform="translate(906.625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(965.8125 0)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(997.59375 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(1095 0)"/>
+     <use xlink:href="#DejaVuSans-59" transform="translate(1156.1875 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1215.375 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(1276.90625 0)"/>
+    </g>
+    <!-- the surviving trough, to 444 Hz -->
+    <g style="fill: #1f77b4" transform="translate(141.424497 307.266367) scale(0.0833 -0.0833)">
      <defs>
       <path id="DejaVuSans-4a" d="M 2906 1791 
 Q 2906 2416 2648 2759 
@@ -1857,173 +1942,38 @@ L 3481 3500
 L 3481 434 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-59" d="M 191 3500 
-L 800 3500 
-L 1894 563 
-L 2988 3500 
-L 3597 3500 
-L 2284 0 
-L 1503 0 
-L 191 3500 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-e" d="M 2944 4013 
-L 2944 2272 
-L 4684 2272 
-L 4684 1741 
-L 2944 1741 
-L 2944 0 
-L 2419 0 
-L 2419 1741 
-L 678 1741 
-L 678 2272 
-L 2419 2272 
-L 2419 4013 
-L 2944 4013 
-z
-" transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-57" transform="translate(0 0.015625)"/>
-     <use xlink:href="#DejaVuSans-4b" transform="translate(39.208984 0.015625)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(102.587891 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(164.111328 0.015625)"/>
-     <use xlink:href="#DejaVuSans-Oblique-2f" transform="translate(195.898438 0.015625)"/>
-     <use xlink:href="#DejaVuSans-12" transform="translate(251.611328 0.015625)"/>
-     <use xlink:href="#DejaVuSans-17" transform="translate(285.302734 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(348.925781 0.015625)"/>
-     <use xlink:href="#DejaVuSans-4c" transform="translate(380.712891 0.015625)"/>
-     <use xlink:href="#DejaVuSans-51" transform="translate(408.496094 0.015625)"/>
-     <use xlink:href="#DejaVuSans-4f" transform="translate(471.875 0.015625)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(499.658203 0.015625)"/>
-     <use xlink:href="#DejaVuSans-57" transform="translate(561.181641 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(600.390625 0.015625)"/>
-     <use xlink:href="#DejaVuSans-4a" transform="translate(632.177734 0.015625)"/>
-     <use xlink:href="#DejaVuSans-4c" transform="translate(695.654297 0.015625)"/>
-     <use xlink:href="#DejaVuSans-59" transform="translate(723.4375 0.015625)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(782.617188 0.015625)"/>
-     <use xlink:href="#DejaVuSans-56" transform="translate(844.140625 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(896.240234 0.015625)"/>
-     <use xlink:href="#DejaVuSans-18" transform="translate(928.027344 0.015625)"/>
-     <use xlink:href="#DejaVuSans-11" transform="translate(991.650391 0.015625)"/>
-     <use xlink:href="#DejaVuSans-14" transform="translate(1023.4375 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1087.060547 0.015625)"/>
-     <use xlink:href="#DejaVuSans-47" transform="translate(1118.847656 0.015625)"/>
-     <use xlink:href="#DejaVuSans-25" transform="translate(1182.324219 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1250.927734 0.015625)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(1282.714844 0.015625)"/>
-     <use xlink:href="#DejaVuSans-51" transform="translate(1343.994141 0.015625)"/>
-     <use xlink:href="#DejaVuSans-47" transform="translate(1407.373047 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1470.849609 0.015625)"/>
-     <use xlink:href="#DejaVuSans-57" transform="translate(1502.636719 0.015625)"/>
-     <use xlink:href="#DejaVuSans-4b" transform="translate(1541.845703 0.015625)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(1605.224609 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1666.748047 0.015625)"/>
-     <use xlink:href="#DejaVuSans-Oblique-2f" transform="translate(1698.535156 0.015625)"/>
-     <use xlink:href="#DejaVuSans-12" transform="translate(1754.248047 0.015625)"/>
-     <use xlink:href="#DejaVuSans-17" transform="translate(1787.939453 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1851.5625 0.015625)"/>
-     <use xlink:href="#DejaVuSans-e" transform="translate(1883.349609 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1967.138672 0.015625)"/>
-     <use xlink:href="#DejaVuSans-Oblique-2f" transform="translate(1998.925781 0.015625)"/>
-     <use xlink:href="#DejaVuSans-12" transform="translate(2054.638672 0.015625)"/>
-     <use xlink:href="#DejaVuSans-15" transform="translate(2088.330078 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(2151.953125 0.015625)"/>
-     <use xlink:href="#DejaVuSans-53" transform="translate(2183.740234 0.015625)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(2247.216797 0.015625)"/>
-     <use xlink:href="#DejaVuSans-4c" transform="translate(2308.496094 0.015625)"/>
-     <use xlink:href="#DejaVuSans-55" transform="translate(2336.279297 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(2377.392578 0.015625)"/>
-     <use xlink:href="#DejaVuSans-1a" transform="translate(2409.179688 0.015625)"/>
-     <use xlink:href="#DejaVuSans-17" transform="translate(2472.802734 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(2536.425781 0.015625)"/>
-     <use xlink:href="#DejaVuSans-47" transform="translate(2568.212891 0.015625)"/>
-     <use xlink:href="#DejaVuSans-25" transform="translate(2631.689453 0.015625)"/>
-    </g>
-   </g>
-   <g id="patch_8">
-    <path d="M 268.251257 277.388862 
-Q 283.822723 336.556503 299.109639 394.642926 
-" style="fill: none; stroke: #d62728; stroke-linecap: round"/>
-    <path d="M 299.872754 390.996635 
-L 299.109639 394.642926 
-L 296.650476 391.84466 
-" style="fill: none; stroke: #d62728; stroke-linecap: round"/>
-   </g>
-   <g id="text_17">
-    <!-- new trough, -->
-    <g style="fill: #d62728" transform="translate(239.604011 260.622667) scale(0.0833 -0.0833)">
-     <defs>
-      <path id="DejaVuSans-5a" d="M 269 3500 
-L 844 3500 
-L 1563 769 
-L 2278 3500 
-L 2956 3500 
-L 3675 769 
-L 4391 3500 
-L 4966 3500 
-L 4050 0 
-L 3372 0 
-L 2619 2869 
-L 1863 0 
-L 1184 0 
-L 269 3500 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-51"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(63.375 0)"/>
-     <use xlink:href="#DejaVuSans-5a" transform="translate(124.90625 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(206.6875 0)"/>
-     <use xlink:href="#DejaVuSans-57" transform="translate(238.46875 0)"/>
-     <use xlink:href="#DejaVuSans-55" transform="translate(277.671875 0)"/>
-     <use xlink:href="#DejaVuSans-52" transform="translate(316.578125 0)"/>
-     <use xlink:href="#DejaVuSans-58" transform="translate(377.765625 0)"/>
-     <use xlink:href="#DejaVuSans-4a" transform="translate(441.140625 0)"/>
-     <use xlink:href="#DejaVuSans-4b" transform="translate(504.625 0)"/>
-     <use xlink:href="#DejaVuSans-f" transform="translate(568 0)"/>
-    </g>
-    <!-- 0.1 dB -->
-    <g style="fill: #d62728" transform="translate(239.604011 270.620944) scale(0.0833 -0.0833)">
-     <use xlink:href="#DejaVuSans-13"/>
-     <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
-     <use xlink:href="#DejaVuSans-14" transform="translate(95.40625 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(159.03125 0)"/>
-     <use xlink:href="#DejaVuSans-47" transform="translate(190.8125 0)"/>
-     <use xlink:href="#DejaVuSans-25" transform="translate(254.296875 0)"/>
-    </g>
-   </g>
-   <g id="patch_9">
-    <path d="M 195.582955 277.388862 
-Q 211.154421 336.556503 226.441337 394.642926 
-" style="fill: none; stroke: #d62728; stroke-linecap: round"/>
-    <path d="M 227.204452 390.996635 
-L 226.441337 394.642926 
-L 223.982174 391.84466 
-" style="fill: none; stroke: #d62728; stroke-linecap: round"/>
-   </g>
-   <g id="text_18">
-    <!-- new trough, -->
-    <g style="fill: #d62728" transform="translate(166.935709 260.622667) scale(0.0833 -0.0833)">
-     <use xlink:href="#DejaVuSans-51"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(63.375 0)"/>
-     <use xlink:href="#DejaVuSans-5a" transform="translate(124.90625 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(206.6875 0)"/>
-     <use xlink:href="#DejaVuSans-57" transform="translate(238.46875 0)"/>
-     <use xlink:href="#DejaVuSans-55" transform="translate(277.671875 0)"/>
-     <use xlink:href="#DejaVuSans-52" transform="translate(316.578125 0)"/>
-     <use xlink:href="#DejaVuSans-58" transform="translate(377.765625 0)"/>
-     <use xlink:href="#DejaVuSans-4a" transform="translate(441.140625 0)"/>
-     <use xlink:href="#DejaVuSans-4b" transform="translate(504.625 0)"/>
-     <use xlink:href="#DejaVuSans-f" transform="translate(568 0)"/>
-    </g>
-    <!-- 0.4 dB -->
-    <g style="fill: #d62728" transform="translate(166.935709 270.620944) scale(0.0833 -0.0833)">
-     <use xlink:href="#DejaVuSans-13"/>
-     <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
-     <use xlink:href="#DejaVuSans-17" transform="translate(95.40625 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(159.03125 0)"/>
-     <use xlink:href="#DejaVuSans-47" transform="translate(190.8125 0)"/>
-     <use xlink:href="#DejaVuSans-25" transform="translate(254.296875 0)"/>
+     <use xlink:href="#DejaVuSans-57"/>
+     <use xlink:href="#DejaVuSans-4b" transform="translate(39.203125 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(102.578125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(164.109375 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(195.890625 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(247.984375 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(311.359375 0)"/>
+     <use xlink:href="#DejaVuSans-59" transform="translate(352.46875 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(411.65625 0)"/>
+     <use xlink:href="#DejaVuSans-59" transform="translate(439.4375 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(498.625 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(526.40625 0)"/>
+     <use xlink:href="#DejaVuSans-4a" transform="translate(589.78125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(653.265625 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(685.046875 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(724.25 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(763.15625 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(824.34375 0)"/>
+     <use xlink:href="#DejaVuSans-4a" transform="translate(887.71875 0)"/>
+     <use xlink:href="#DejaVuSans-4b" transform="translate(951.203125 0)"/>
+     <use xlink:href="#DejaVuSans-f" transform="translate(1014.578125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1046.359375 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1078.140625 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(1117.34375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1178.53125 0)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(1210.3125 0)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(1273.9375 0)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(1337.5625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1401.1875 0)"/>
+     <use xlink:href="#DejaVuSans-2b" transform="translate(1432.96875 0)"/>
+     <use xlink:href="#DejaVuSans-5d" transform="translate(1508.171875 0)"/>
     </g>
    </g>
    <g id="text_19">
@@ -2065,6 +2015,22 @@ L 1997 2009
 L 1997 1497 
 L 313 1497 
 L 313 2009 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-5a" d="M 269 3500 
+L 844 3500 
+L 1563 769 
+L 2278 3500 
+L 2956 3500 
+L 3675 769 
+L 4391 3500 
+L 4966 3500 
+L 4050 0 
+L 3372 0 
+L 2619 2869 
+L 1863 0 
+L 1184 0 
+L 269 3500 
 z
 " transform="scale(0.015625)"/>
      </defs>
@@ -2142,7 +2108,7 @@ Q 535.414938 70.47168 537.080938 70.47168
 z
 " style="opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
     </g>
-    <g id="line2d_31">
+    <g id="line2d_32">
      <path d="M 538.746938 37.229123 
 L 547.076938 37.229123 
 L 555.406938 37.229123 
@@ -2196,7 +2162,7 @@ z
       <use xlink:href="#DejaVuSans-50" transform="translate(969.84375 0)"/>
      </g>
     </g>
-    <g id="line2d_32">
+    <g id="line2d_33">
      <path d="M 538.746938 49.726076 
 L 547.076938 49.726076 
 L 555.406938 49.726076 
@@ -2244,7 +2210,7 @@ z
       <use xlink:href="#DejaVuSans-50" transform="translate(1327.052734 0.015625)"/>
      </g>
     </g>
-    <g id="line2d_33">
+    <g id="line2d_34">
      <path d="M 538.746938 62.223028 
 L 547.076938 62.223028 
 L 555.406938 62.223028 

--- a/.github/images/silencer_extended_tube_es.svg
+++ b/.github/images/silencer_extended_tube_es.svg
@@ -1182,393 +1182,300 @@ L 706.163438 398.196018
 " clip-path="url(#pfffd36bc2b)" style="fill: none; stroke-dasharray: 5.92,2.56; stroke-dashoffset: 0; stroke: #000000; stroke-width: 1.6"/>
    </g>
    <g id="line2d_28">
-    <path d="M 41.325781 397.778043 
-L 44.651355 396.1981 
-L 48.531191 394.103058 
-L 53.242421 391.283279 
-L 59.339307 387.348376 
-L 81.5098 372.791634 
-L 88.160948 368.822701 
-L 94.257833 365.440635 
-L 100.077587 362.458295 
-L 105.897342 359.724472 
-L 111.717096 357.24239 
-L 117.259719 355.112771 
-L 122.802343 353.210406 
-L 128.344966 351.533252 
-L 133.887589 350.078984 
-L 139.430212 348.84533 
-L 144.972836 347.830294 
-L 150.515459 347.032317 
-L 156.058082 346.450385 
-L 161.600705 346.084113 
-L 167.143329 345.933802 
-L 172.685952 346.00048 
-L 178.228575 346.285938 
-L 183.771198 346.792748 
-L 189.313821 347.524278 
-L 194.856445 348.484688 
-L 200.399068 349.678901 
-L 205.66456 351.035083 
-L 210.930052 352.612668 
-L 216.195544 354.417301 
-L 221.461036 356.454699 
-L 226.726528 358.730258 
-L 231.99202 361.248431 
-L 237.257512 364.011786 
-L 242.523004 367.019575 
-L 248.065628 370.442804 
-L 253.885382 374.301661 
-L 260.53653 378.99102 
-L 280.767105 393.498267 
-L 284.36981 395.682031 
-L 287.418253 397.298553 
-L 290.189564 398.538123 
-L 292.683745 399.434093 
-L 295.177925 400.095779 
-L 297.394974 400.469897 
-L 299.612024 400.63048 
-L 301.829073 400.570076 
-L 304.046122 400.285747 
-L 306.263172 399.779258 
-L 308.480221 399.056958 
-L 310.974401 397.999666 
-L 313.468582 396.702932 
-L 316.239893 395.011147 
-L 319.288336 392.888226 
-L 322.891041 390.093903 
-L 327.32514 386.345607 
-L 333.422025 380.867401 
-L 349.218502 366.543837 
-L 355.592518 361.123671 
-L 361.412273 356.454574 
-L 367.232027 352.075545 
-L 372.77465 348.182805 
-L 378.317274 344.561943 
-L 383.859897 341.209982 
-L 389.40252 338.12194 
-L 394.945143 335.29198 
-L 400.487766 332.71416 
-L 406.03039 330.382908 
-L 411.573013 328.293337 
-L 417.115636 326.441445 
-L 422.658259 324.824258 
-L 428.200883 323.439932 
-L 433.743506 322.287846 
-L 439.286129 321.368682 
-L 444.828752 320.684524 
-L 450.094244 320.255506 
-L 455.359736 320.046265 
-L 460.625228 320.062716 
-L 465.613589 320.293288 
-L 470.60195 320.741037 
-L 475.590311 321.415434 
-L 480.301541 322.270586 
-L 485.012771 323.348998 
-L 489.724 324.663461 
-L 494.158099 326.129315 
-L 498.592198 327.830975 
-L 502.749165 329.653994 
-L 506.906132 331.711321 
-L 511.0631 334.017352 
-L 515.220067 336.586604 
-L 519.377035 339.432552 
-L 523.534002 342.565545 
-L 527.69097 345.989171 
-L 532.125068 349.950436 
-L 537.113429 354.735909 
-L 549.584331 366.906346 
-L 552.078512 368.93331 
-L 554.295561 370.443876 
-L 556.235479 371.470947 
-L 557.898266 372.085663 
-L 559.283922 372.383509 
-L 560.669578 372.466737 
-L 562.055234 372.319938 
-L 563.440889 371.931559 
-L 564.826545 371.294634 
-L 566.212201 370.407237 
-L 567.597857 369.272604 
-L 569.260644 367.596501 
-L 570.923431 365.598625 
-L 572.863349 362.900412 
-L 575.080398 359.399025 
-L 577.574579 355.029933 
-L 580.623021 349.236521 
-L 585.05712 340.272212 
-L 604.456301 300.437749 
-L 611.938843 285.89681 
-L 621.638433 267.587661 
-L 635.494991 241.436899 
-L 641.591877 229.420732 
-L 646.303107 219.674131 
-L 650.460074 210.584778 
-L 654.062779 202.204938 
-L 657.388353 193.92756 
-L 660.436796 185.752714 
-L 663.208107 177.70067 
-L 665.702288 169.81572 
-L 668.196468 161.165508 
-L 670.413518 152.660946 
-L 672.353436 144.41825 
-L 674.293354 135.21981 
-L 675.956141 126.360327 
-L 677.618928 116.327798 
-L 679.281715 104.732728 
-L 680.667371 93.442976 
-L 682.053026 80.072846 
-L 683.161551 67.245489 
-L 684.270076 51.611187 
-L 685.101469 37.126556 
-L 685.932863 18.918178 
-L 686.624017 -1 
-M 690.911053 -1 
-L 691.475486 15.582912 
-L 692.306879 34.559235 
-L 693.415404 53.886142 
-L 694.523929 69.07944 
-L 695.632453 81.610352 
-L 697.018109 94.723615 
-L 698.403765 105.831559 
-L 700.066552 117.268398 
-L 701.729339 127.184181 
-L 703.669257 137.323531 
-L 705.609175 146.292338 
-L 706.163438 148.679144 
-L 706.163438 148.679144 
+    <path d="M 41.325781 399.076858 
+L 45.205618 397.841778 
+L 49.362585 396.287262 
+L 54.073815 394.284921 
+L 59.616438 391.676554 
+L 66.544717 388.157584 
+L 79.29275 381.37268 
+L 91.486521 374.98565 
+L 100.077587 370.73084 
+L 108.114391 366.999965 
+L 115.596933 363.769411 
+L 122.802343 360.892284 
+L 130.007753 358.250107 
+L 137.213163 355.844709 
+L 144.418573 353.675692 
+L 151.623983 351.741406 
+L 158.829394 350.03963 
+L 166.034804 348.568043 
+L 173.240214 347.324545 
+L 180.445624 346.307487 
+L 187.651034 345.515833 
+L 194.856445 344.949279 
+L 202.061855 344.608344 
+L 209.267265 344.494449 
+L 216.472675 344.609974 
+L 223.400954 344.940571 
+L 230.329233 345.490386 
+L 237.257512 346.26434 
+L 244.185791 347.268342 
+L 250.836939 348.455009 
+L 257.488087 349.866994 
+L 264.139235 351.512011 
+L 270.513252 353.314868 
+L 276.887268 355.347071 
+L 283.261285 357.616254 
+L 289.635302 360.129439 
+L 296.009319 362.89211 
+L 302.383335 365.906747 
+L 308.757352 369.170558 
+L 315.4085 372.829295 
+L 322.61391 377.049984 
+L 332.313501 383.019586 
+L 343.398747 389.808049 
+L 348.664239 392.765292 
+L 352.821207 394.847818 
+L 356.423912 396.400853 
+L 359.472355 397.486501 
+L 362.243666 398.260368 
+L 365.014978 398.806103 
+L 367.509158 399.084788 
+L 370.003339 399.149599 
+L 372.497519 398.992321 
+L 374.9917 398.609076 
+L 377.48588 398.000572 
+L 379.980061 397.172047 
+L 382.751372 396.005021 
+L 385.522684 394.596227 
+L 388.571127 392.794065 
+L 391.8967 390.56479 
+L 395.776537 387.676438 
+L 400.210635 384.084107 
+L 406.03039 379.054219 
+L 416.007111 370.070373 
+L 427.369489 359.926388 
+L 435.406293 353.056905 
+L 442.611703 347.186254 
+L 449.539982 341.818686 
+L 456.468261 336.726533 
+L 463.39654 331.904934 
+L 470.60195 327.167295 
+L 477.80736 322.698797 
+L 485.289902 318.327935 
+L 492.772443 314.215683 
+L 500.532116 310.207508 
+L 508.568919 306.313891 
+L 516.605723 302.66543 
+L 524.919658 299.131993 
+L 533.510724 295.720549 
+L 542.378921 292.436442 
+L 551.524249 289.28298 
+L 561.22384 286.175019 
+L 571.477693 283.126951 
+L 582.56294 280.068122 
+L 595.588104 276.716361 
+L 626.072532 268.990699 
+L 632.72368 266.994821 
+L 637.712041 265.281843 
+L 641.869008 263.640676 
+L 645.471713 261.998679 
+L 648.797287 260.239316 
+L 651.568599 258.539967 
+L 654.062779 256.779571 
+L 656.55696 254.744782 
+L 658.774009 252.650054 
+L 660.991058 250.221657 
+L 662.930976 247.761196 
+L 664.870894 244.917572 
+L 666.533681 242.111631 
+L 668.196468 238.89585 
+L 669.859255 235.187599 
+L 671.522042 230.882921 
+L 673.184829 225.848853 
+L 674.570485 220.972885 
+L 675.956141 215.339677 
+L 677.341797 208.777239 
+L 678.727453 201.052337 
+L 680.113108 191.83484 
+L 681.221633 183.062463 
+L 682.330158 172.642277 
+L 683.438682 159.98043 
+L 684.547207 144.070489 
+L 685.3786 128.911104 
+L 686.209994 109.292028 
+L 686.764256 92.171866 
+L 687.318519 69.395421 
+L 687.872781 35.426706 
+L 688.217982 -1 
+M 689.314543 -1 
+L 689.812699 46.123167 
+L 690.366961 76.179466 
+L 691.198355 105.626693 
+L 692.029748 126.183373 
+L 692.861142 141.909612 
+L 693.969666 158.30189 
+L 695.078191 171.282582 
+L 696.186716 181.930317 
+L 697.572371 192.893718 
+L 698.958027 201.933551 
+L 700.343683 209.521924 
+L 701.729339 215.976294 
+L 703.114995 221.522084 
+L 704.777782 227.209759 
+L 706.163438 231.289642 
+L 706.163438 231.289642 
 " clip-path="url(#pfffd36bc2b)" style="fill: none; stroke: #1f77b4; stroke-width: 1.9; stroke-linecap: square"/>
    </g>
    <g id="line2d_29">
-    <path d="M 41.325781 395.223388 
-L 44.651355 392.673107 
-L 48.808323 389.166901 
-L 54.905208 383.6877 
-L 65.713323 373.964628 
-L 71.255947 369.287446 
-L 76.521439 365.138014 
-L 81.5098 361.501703 
-L 86.221029 358.343523 
-L 90.932259 355.45836 
-L 95.366358 352.992947 
-L 99.800456 350.768782 
-L 104.234555 348.783877 
-L 108.668653 347.036081 
-L 113.102752 345.523513 
-L 117.536851 344.244868 
-L 121.970949 343.199639 
-L 126.405048 342.388297 
-L 130.839146 341.812439 
-L 134.996114 341.488962 
-L 139.153081 341.378426 
-L 143.310049 341.485488 
-L 147.467016 341.816116 
-L 151.623983 342.37771 
-L 155.50382 343.118147 
-L 159.383656 344.076254 
-L 163.263492 345.262134 
-L 167.143329 346.687435 
-L 171.023165 348.36545 
-L 174.62587 350.16295 
-L 178.228575 352.204489 
-L 181.83128 354.504339 
-L 185.433985 357.077398 
-L 189.03669 359.938393 
-L 192.639395 363.100406 
-L 196.2421 366.57226 
-L 199.844806 370.354007 
-L 203.724642 374.753898 
-L 208.435872 380.464143 
-L 216.749806 390.628923 
-L 219.243987 393.293576 
-L 221.183905 395.074425 
-L 222.846692 396.325715 
-L 224.232348 397.131036 
-L 225.618004 397.686486 
-L 226.726528 397.931417 
-L 227.835053 397.985358 
-L 228.943578 397.838469 
-L 230.052102 397.484133 
-L 231.160627 396.919322 
-L 232.546283 395.918808 
-L 233.931938 394.600389 
-L 235.317594 392.981757 
-L 236.980381 390.677742 
-L 238.920299 387.555868 
-L 241.137349 383.524204 
-L 243.90866 377.978668 
-L 247.788497 369.661111 
-L 260.813661 341.346507 
-L 266.079153 330.621989 
-L 271.344645 320.424086 
-L 276.610137 310.705236 
-L 282.429892 300.429533 
-L 289.358171 288.674138 
-L 299.889155 271.319733 
-L 309.311614 255.646855 
-L 314.854238 245.995983 
-L 319.288336 237.832691 
-L 323.168172 230.208812 
-L 326.493746 223.180647 
-L 329.542189 216.204891 
-L 332.313501 209.285631 
-L 334.807681 202.451015 
-L 337.02473 195.758356 
-L 339.24178 188.32238 
-L 341.181698 181.035661 
-L 343.121616 172.805151 
-L 344.784403 164.774865 
-L 346.44719 155.555508 
-L 347.832846 146.670198 
-L 349.218502 136.308057 
-L 350.327026 126.580273 
-L 351.435551 115.084057 
-L 352.544076 101.063471 
-L 353.375469 88.112418 
-L 354.206862 71.962117 
-L 355.038256 50.587923 
-L 355.592518 31.303947 
-L 356.224756 -1 
-M 358.375386 -1 
-L 358.918092 28.839949 
-L 359.749486 59.173579 
-L 360.580879 80.744707 
-L 361.689404 102.499011 
-L 362.797928 119.599143 
-L 364.183584 137.003854 
-L 365.56924 151.543795 
-L 367.232027 166.478864 
-L 368.894814 179.517476 
-L 370.834732 193.056089 
-L 373.051781 206.981016 
-L 375.545962 221.293574 
-L 378.594405 237.525985 
-L 383.028503 259.811003 
-L 391.8967 304.096004 
-L 396.053668 326.218199 
-L 402.981947 363.495542 
-L 404.367603 369.621578 
-L 405.476127 373.654919 
-L 406.307521 376.037416 
-L 407.138914 377.791583 
-L 407.693177 378.590558 
-L 408.247439 379.087996 
-L 408.801701 379.287635 
-L 409.355964 379.200211 
-L 409.910226 378.842621 
-L 410.464488 378.236686 
-L 411.295882 376.917998 
-L 412.404406 374.538989 
-L 413.790062 370.866811 
-L 416.007111 364.177699 
-L 420.44121 350.693935 
-L 422.935391 343.848792 
-L 425.429571 337.672156 
-L 427.923751 332.133857 
-L 430.417932 327.172341 
-L 432.912112 322.72063 
-L 435.406293 318.716165 
-L 437.900473 315.103867 
-L 440.671785 311.492933 
-L 443.443096 308.253479 
-L 446.214408 305.340283 
-L 449.262851 302.467998 
-L 452.311294 299.903979 
-L 455.359736 297.61439 
-L 458.68531 295.396984 
-L 462.010884 293.443258 
-L 465.613589 291.596112 
-L 469.216294 290.004632 
-L 472.819 288.648391 
-L 476.698836 287.432048 
-L 480.578672 286.453009 
-L 484.458508 285.698458 
-L 488.338345 285.158636 
-L 492.495312 284.810504 
-L 496.652279 284.69496 
-L 500.809247 284.809031 
-L 504.966214 285.152369 
-L 509.123182 285.727172 
-L 513.280149 286.5382 
-L 517.159985 287.514787 
-L 521.039822 288.711839 
-L 524.919658 290.139961 
-L 528.799494 291.812371 
-L 532.402199 293.598134 
-L 536.004904 295.623949 
-L 539.607609 297.908159 
-L 543.210315 300.472303 
-L 546.535889 303.109329 
-L 549.861462 306.028953 
-L 553.187036 309.256835 
-L 556.235479 312.510767 
-L 559.283922 316.071029 
-L 562.332365 319.961309 
-L 565.380807 324.203051 
-L 568.42925 328.810586 
-L 571.754824 334.251105 
-L 575.63466 341.07482 
-L 583.394333 354.924184 
-L 585.334251 357.840983 
-L 586.719907 359.590662 
-L 588.105563 360.96971 
-L 589.214087 361.750601 
-L 590.045481 362.122376 
-L 590.876874 362.294871 
-L 591.708268 362.256651 
-L 592.539661 361.999654 
-L 593.371055 361.519655 
-L 594.202448 360.816516 
-L 595.310973 359.539292 
-L 596.419498 357.892661 
-L 597.805153 355.361049 
-L 599.46794 351.72713 
-L 601.407858 346.843935 
-L 603.902039 339.876628 
-L 608.059006 327.455423 
-L 615.264417 305.945542 
-L 619.975646 292.618122 
-L 624.686876 279.941662 
-L 629.952368 266.409983 
-L 636.880647 249.273288 
-L 649.905812 217.199801 
-L 654.617041 204.904488 
-L 658.496878 194.141578 
-L 661.822452 184.242397 
-L 664.593763 175.341736 
-L 667.087944 166.661942 
-L 669.582124 157.15407 
-L 671.799173 147.794963 
-L 673.739092 138.689664 
-L 675.67901 128.461251 
-L 677.341797 118.514607 
-L 679.004584 107.101058 
-L 680.390239 96.06908 
-L 681.775895 83.107819 
-L 682.88442 70.78364 
-L 683.992945 55.924466 
-L 684.824338 42.338566 
-L 685.655732 25.55075 
-L 686.487125 3.542562 
-L 686.624461 -1 
-M 690.910638 -1 
-L 691.475486 15.60619 
-L 692.306879 34.59903 
-L 693.415404 53.954829 
-L 694.523929 69.184901 
-L 695.632453 81.760508 
-L 697.018109 94.940852 
-L 698.403765 106.128438 
-L 700.066552 117.677619 
-L 701.729339 127.724299 
-L 703.669257 138.04024 
-L 705.609175 147.211917 
-L 706.163438 149.661607 
-L 706.163438 149.661607 
+    <path d="M 41.325781 399.517566 
+L 45.482749 398.419185 
+L 49.916847 397.0117 
+L 54.628077 395.281989 
+L 59.893569 393.10778 
+L 65.990455 390.336816 
+L 73.195865 386.806156 
+L 82.895455 381.786212 
+L 118.922506 362.909663 
+L 130.562015 357.182819 
+L 141.647262 351.972932 
+L 152.732508 347.004381 
+L 164.094886 342.153489 
+L 176.011526 337.311866 
+L 188.482428 332.489795 
+L 201.784724 327.588315 
+L 216.472675 322.417719 
+L 234.20907 316.422012 
+L 276.610137 302.205106 
+L 286.309728 298.646987 
+L 294.0694 295.566282 
+L 300.443417 292.797749 
+L 305.708909 290.279848 
+L 310.420139 287.784465 
+L 314.577106 285.328763 
+L 318.179812 282.948023 
+L 321.505385 280.481268 
+L 324.553828 277.929234 
+L 327.32514 275.301384 
+L 329.81932 272.618806 
+L 332.03637 269.917209 
+L 334.253419 266.841417 
+L 336.193337 263.766494 
+L 338.133255 260.241469 
+L 339.796042 256.772009 
+L 341.458829 252.782692 
+L 343.121616 248.135582 
+L 344.507272 243.624045 
+L 345.892928 238.369117 
+L 347.278583 232.154596 
+L 348.387108 226.285527 
+L 349.495633 219.371363 
+L 350.604157 211.071904 
+L 351.712682 200.861888 
+L 352.544076 191.446418 
+L 353.375469 179.869265 
+L 354.206862 165.085897 
+L 355.038256 145.06554 
+L 355.592518 126.673274 
+L 356.146781 100.565721 
+L 356.701043 56.482522 
+L 357.014823 -1 
+M 357.601982 -1 
+L 357.809568 43.289844 
+L 358.36383 97.890687 
+L 358.918092 129.207185 
+L 359.749486 160.637176 
+L 360.580879 183.212447 
+L 361.689404 206.129548 
+L 362.797928 224.146249 
+L 363.906453 238.956577 
+L 365.292109 254.249941 
+L 366.677765 266.805726 
+L 368.063421 277.149277 
+L 369.449076 285.617173 
+L 370.557601 291.211384 
+L 371.666126 295.877941 
+L 372.77465 299.721446 
+L 373.883175 302.842356 
+L 374.9917 305.336784 
+L 376.100224 307.295095 
+L 377.208749 308.800317 
+L 378.317274 309.926964 
+L 379.425798 310.740472 
+L 380.534323 311.297223 
+L 381.919979 311.704211 
+L 383.305634 311.860771 
+L 384.968421 311.802242 
+L 386.90834 311.492519 
+L 389.40252 310.847241 
+L 393.005225 309.649969 
+L 413.2358 302.511733 
+L 420.164079 300.465329 
+L 427.64662 298.486408 
+L 435.960555 296.523457 
+L 445.105883 294.597911 
+L 455.359736 292.67288 
+L 466.722114 290.770555 
+L 479.470147 288.866643 
+L 493.603837 286.983018 
+L 509.677444 285.071124 
+L 527.968101 283.126125 
+L 550.415725 280.973603 
+L 596.97376 276.584305 
+L 608.059006 275.27134 
+L 616.650072 274.036117 
+L 623.578351 272.815826 
+L 629.120975 271.625781 
+L 633.832204 270.404928 
+L 637.989172 269.112782 
+L 641.591877 267.779689 
+L 644.917451 266.32356 
+L 647.965894 264.748265 
+L 650.737205 263.066535 
+L 653.231386 261.301946 
+L 655.725566 259.245537 
+L 657.942615 257.119341 
+L 660.159665 254.651628 
+L 662.099583 252.154723 
+L 664.039501 249.278639 
+L 665.979419 245.94695 
+L 667.642206 242.656505 
+L 669.304993 238.885836 
+L 670.96778 234.540972 
+L 672.630567 229.502834 
+L 674.293354 223.617218 
+L 675.67901 217.919065 
+L 677.064666 211.332436 
+L 678.450321 203.642963 
+L 679.835977 194.548781 
+L 680.944502 185.968203 
+L 682.053026 175.863814 
+L 683.161551 163.710218 
+L 684.270076 148.636377 
+L 685.101469 134.494975 
+L 685.932863 116.561909 
+L 686.764256 92.213119 
+L 687.318519 69.417086 
+L 687.872781 35.434998 
+L 688.218004 -1 
+M 689.314515 -1 
+L 689.812699 46.134386 
+L 690.366961 76.205712 
+L 691.198355 105.687046 
+L 692.029748 126.291307 
+L 692.861142 142.077996 
+L 693.969666 158.569573 
+L 695.078191 171.668975 
+L 696.186716 182.452416 
+L 697.572371 193.605373 
+L 698.958027 202.851982 
+L 700.343683 210.659158 
+L 701.729339 217.339446 
+L 703.392126 224.175088 
+L 705.054913 229.978612 
+L 706.163438 233.375229 
+L 706.163438 233.375229 
 " clip-path="url(#pfffd36bc2b)" style="fill: none; stroke-dasharray: 10.88,2.72,1.7,2.72; stroke-dashoffset: 0; stroke: #d62728; stroke-width: 1.7"/>
    </g>
    <g id="line2d_30">
     <path d="M 357.316935 401.395781 
 L 357.316935 26.798125 
+" clip-path="url(#pfffd36bc2b)" style="fill: none; stroke-dasharray: 1.2,1.98; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_31">
+    <path d="M 688.769429 401.395781 
+L 688.769429 26.798125 
 " clip-path="url(#pfffd36bc2b)" style="fill: none; stroke-dasharray: 1.2,1.98; stroke-dashoffset: 0; stroke: #e0e0e0; stroke-width: 1.2"/>
    </g>
    <g id="patch_3">
@@ -1592,17 +1499,17 @@ L 706.163438 26.798125
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_7">
-    <path d="M 487.880176 196.062904 
-Q 423.221129 277.182537 359.258957 357.427889 
+    <path d="M 224.863392 122.030455 
+Q 290.178656 151.367437 354.47404 180.24633 
 " style="fill: none; stroke: #000000; stroke-linecap: round"/>
-    <path d="M 362.638582 355.860753 
-L 359.258957 357.427889 
-L 360.033023 353.783908 
+    <path d="M 352.117168 177.361381 
+L 354.47404 180.24633 
+L 350.751957 180.400858 
 " style="fill: none; stroke: #000000; stroke-linecap: round"/>
    </g>
    <g id="text_16">
-    <!-- $c/2L$ = 429 Hz: la cámara simple es transparente (0,0 dB), -->
-    <g transform="translate(377.204084 179.667092) scale(0.0833 -0.0833)">
+    <!-- $c/2L$ = 429 Hz: cámara simple 0,0 dB y la entrada $L/4$ -->
+    <g transform="translate(72.248463 95.710267) scale(0.0833 -0.0833)">
      <defs>
       <path id="DejaVuSans-Oblique-46" d="M 3431 3366 
 L 3316 2797 
@@ -1701,13 +1608,6 @@ L 750 2516
 L 750 3309 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-4f" d="M 603 4863 
-L 1178 4863 
-L 1178 0 
-L 603 0 
-L 603 4863 
-z
-" transform="scale(0.015625)"/>
       <path id="DejaVuSans-a3" d="M 2194 1759 
 Q 1497 1759 1228 1600 
 Q 959 1441 959 1056 
@@ -1747,17 +1647,11 @@ L 1415 3944
 L 2290 5119 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-b" d="M 1984 4856 
-Q 1566 4138 1362 3434 
-Q 1159 2731 1159 2009 
-Q 1159 1288 1364 580 
-Q 1569 -128 1984 -844 
-L 1484 -844 
-Q 1016 -109 783 600 
-Q 550 1309 550 2009 
-Q 550 2706 781 3412 
-Q 1013 4119 1484 4856 
-L 1984 4856 
+      <path id="DejaVuSans-4f" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSans-f" d="M 750 794 
@@ -1769,17 +1663,21 @@ L 750 256
 L 750 794 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-c" d="M 513 4856 
-L 1013 4856 
-Q 1481 4119 1714 3412 
-Q 1947 2706 1947 2009 
-Q 1947 1309 1714 600 
-Q 1481 -109 1013 -844 
-L 513 -844 
-Q 928 -128 1133 580 
-Q 1338 1288 1338 2009 
-Q 1338 2731 1133 3434 
-Q 928 4138 513 4856 
+      <path id="DejaVuSans-5c" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
 z
 " transform="scale(0.015625)"/>
      </defs>
@@ -1798,85 +1696,235 @@ z
      <use xlink:href="#DejaVuSans-5d" transform="translate(653.222656 0.015625)"/>
      <use xlink:href="#DejaVuSans-1d" transform="translate(705.712891 0.015625)"/>
      <use xlink:href="#DejaVuSans-3" transform="translate(739.404297 0.015625)"/>
-     <use xlink:href="#DejaVuSans-4f" transform="translate(771.191406 0.015625)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(798.974609 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(860.253906 0.015625)"/>
-     <use xlink:href="#DejaVuSans-46" transform="translate(892.041016 0.015625)"/>
-     <use xlink:href="#DejaVuSans-a3" transform="translate(947.021484 0.015625)"/>
-     <use xlink:href="#DejaVuSans-50" transform="translate(1008.300781 0.015625)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(1105.712891 0.015625)"/>
-     <use xlink:href="#DejaVuSans-55" transform="translate(1166.992188 0.015625)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(1208.105469 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1269.384766 0.015625)"/>
-     <use xlink:href="#DejaVuSans-56" transform="translate(1301.171875 0.015625)"/>
-     <use xlink:href="#DejaVuSans-4c" transform="translate(1353.271484 0.015625)"/>
-     <use xlink:href="#DejaVuSans-50" transform="translate(1381.054688 0.015625)"/>
-     <use xlink:href="#DejaVuSans-53" transform="translate(1478.466797 0.015625)"/>
-     <use xlink:href="#DejaVuSans-4f" transform="translate(1541.943359 0.015625)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(1569.726562 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1631.25 0.015625)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(1663.037109 0.015625)"/>
-     <use xlink:href="#DejaVuSans-56" transform="translate(1724.560547 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1776.660156 0.015625)"/>
-     <use xlink:href="#DejaVuSans-57" transform="translate(1808.447266 0.015625)"/>
-     <use xlink:href="#DejaVuSans-55" transform="translate(1847.65625 0.015625)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(1888.769531 0.015625)"/>
-     <use xlink:href="#DejaVuSans-51" transform="translate(1950.048828 0.015625)"/>
-     <use xlink:href="#DejaVuSans-56" transform="translate(2013.427734 0.015625)"/>
-     <use xlink:href="#DejaVuSans-53" transform="translate(2065.527344 0.015625)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(2129.003906 0.015625)"/>
-     <use xlink:href="#DejaVuSans-55" transform="translate(2190.283203 0.015625)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(2229.396484 0.015625)"/>
-     <use xlink:href="#DejaVuSans-51" transform="translate(2290.919922 0.015625)"/>
-     <use xlink:href="#DejaVuSans-57" transform="translate(2354.298828 0.015625)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(2393.507812 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(2455.03125 0.015625)"/>
-     <use xlink:href="#DejaVuSans-b" transform="translate(2486.818359 0.015625)"/>
-     <use xlink:href="#DejaVuSans-13" transform="translate(2525.832031 0.015625)"/>
-     <use xlink:href="#DejaVuSans-f" transform="translate(2589.455078 0.015625)"/>
-     <use xlink:href="#DejaVuSans-13" transform="translate(2621.242188 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(2684.865234 0.015625)"/>
-     <use xlink:href="#DejaVuSans-47" transform="translate(2716.652344 0.015625)"/>
-     <use xlink:href="#DejaVuSans-25" transform="translate(2780.128906 0.015625)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(2848.732422 0.015625)"/>
-     <use xlink:href="#DejaVuSans-f" transform="translate(2887.746094 0.015625)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(771.191406 0.015625)"/>
+     <use xlink:href="#DejaVuSans-a3" transform="translate(826.171875 0.015625)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(887.451172 0.015625)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(984.863281 0.015625)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(1046.142578 0.015625)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1087.255859 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1148.535156 0.015625)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(1180.322266 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(1232.421875 0.015625)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(1260.205078 0.015625)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(1357.617188 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(1421.09375 0.015625)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1448.876953 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1510.400391 0.015625)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(1542.1875 0.015625)"/>
+     <use xlink:href="#DejaVuSans-f" transform="translate(1605.810547 0.015625)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(1637.597656 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1701.220703 0.015625)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(1733.007812 0.015625)"/>
+     <use xlink:href="#DejaVuSans-25" transform="translate(1796.484375 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1865.087891 0.015625)"/>
+     <use xlink:href="#DejaVuSans-5c" transform="translate(1896.875 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1956.054688 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(1987.841797 0.015625)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(2015.625 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2076.904297 0.015625)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(2108.691406 0.015625)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(2170.214844 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(2233.59375 0.015625)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(2272.802734 0.015625)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(2313.916016 0.015625)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(2375.195312 0.015625)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(2438.671875 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2499.951172 0.015625)"/>
+     <use xlink:href="#DejaVuSans-Oblique-2f" transform="translate(2531.738281 0.015625)"/>
+     <use xlink:href="#DejaVuSans-12" transform="translate(2587.451172 0.015625)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(2621.142578 0.015625)"/>
     </g>
-    <!-- la entrada $L/4$ da 5,1 dB y el par $L/4$ + $L/2$, 74 dB -->
-    <g transform="translate(377.204084 189.666671) scale(0.0833 -0.0833)">
+    <!-- solo 0,6 dB, porque $L/4$ no está sintonizada aquí. -->
+    <g transform="translate(72.248463 106.043046) scale(0.0833 -0.0833)">
      <defs>
-      <path id="DejaVuSans-5c" d="M 2059 -325 
-Q 1816 -950 1584 -1140 
-Q 1353 -1331 966 -1331 
-L 506 -1331 
-L 506 -850 
-L 844 -850 
-Q 1081 -850 1212 -737 
-Q 1344 -625 1503 -206 
-L 1606 56 
-L 191 3500 
-L 800 3500 
-L 1894 763 
-L 2988 3500 
-L 3597 3500 
-L 2059 -325 
+      <path id="DejaVuSans-54" d="M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+M 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 -1331 
+L 2906 -1331 
+L 2906 525 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-e" d="M 2944 4013 
-L 2944 2272 
-L 4684 2272 
-L 4684 1741 
-L 2944 1741 
-L 2944 0 
-L 2419 0 
-L 2419 1741 
-L 678 1741 
-L 678 2272 
-L 2419 2272 
-L 2419 4013 
-L 2944 4013 
+      <path id="DejaVuSans-af" d="M 1325 5119 
+L 1947 5119 
+L 929 3944 
+L 450 3944 
+L 1325 5119 
+z
+M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 891 3584 
+L 891 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-11" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
 z
 " transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-56" transform="translate(0 0.015625)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(52.099609 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(113.28125 0.015625)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(141.064453 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(202.246094 0.015625)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(234.033203 0.015625)"/>
+     <use xlink:href="#DejaVuSans-f" transform="translate(297.65625 0.015625)"/>
+     <use xlink:href="#DejaVuSans-19" transform="translate(329.443359 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(393.066406 0.015625)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(424.853516 0.015625)"/>
+     <use xlink:href="#DejaVuSans-25" transform="translate(488.330078 0.015625)"/>
+     <use xlink:href="#DejaVuSans-f" transform="translate(556.933594 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(588.720703 0.015625)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(620.507812 0.015625)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(683.984375 0.015625)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(745.166016 0.015625)"/>
+     <use xlink:href="#DejaVuSans-54" transform="translate(784.279297 0.015625)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(847.755859 0.015625)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(911.134766 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(972.658203 0.015625)"/>
+     <use xlink:href="#DejaVuSans-Oblique-2f" transform="translate(1004.445312 0.015625)"/>
+     <use xlink:href="#DejaVuSans-12" transform="translate(1060.158203 0.015625)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(1093.849609 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1157.472656 0.015625)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1189.259766 0.015625)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(1252.638672 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1313.820312 0.015625)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1345.607422 0.015625)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(1407.130859 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1459.230469 0.015625)"/>
+     <use xlink:href="#DejaVuSans-a3" transform="translate(1498.439453 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1559.71875 0.015625)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(1591.505859 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(1643.605469 0.015625)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1671.388672 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1734.767578 0.015625)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(1773.976562 0.015625)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1835.158203 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(1898.537109 0.015625)"/>
+     <use xlink:href="#DejaVuSans-5d" transform="translate(1926.320312 0.015625)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1978.810547 0.015625)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(2040.089844 0.015625)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(2103.566406 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2164.845703 0.015625)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(2196.632812 0.015625)"/>
+     <use xlink:href="#DejaVuSans-54" transform="translate(2257.912109 0.015625)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(2321.388672 0.015625)"/>
+     <use xlink:href="#DejaVuSans-af" transform="translate(2384.767578 0.015625)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(2412.550781 0.015625)"/>
+    </g>
+    <!-- La salida $L/2$ sí, y cortocircuita el conducto -->
+    <g transform="translate(72.248463 116.375825) scale(0.0833 -0.0833)">
+     <defs>
+      <path id="DejaVuSans-2f" d="M 628 4666 
+L 1259 4666 
+L 1259 531 
+L 3531 531 
+L 3531 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(0 0.015625)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(55.712891 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(116.992188 0.015625)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(148.779297 0.015625)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(200.878906 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(262.158203 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(289.941406 0.015625)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(317.724609 0.015625)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(381.201172 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(442.480469 0.015625)"/>
+     <use xlink:href="#DejaVuSans-Oblique-2f" transform="translate(474.267578 0.015625)"/>
+     <use xlink:href="#DejaVuSans-12" transform="translate(529.980469 0.015625)"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(563.671875 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(627.294922 0.015625)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(659.082031 0.015625)"/>
+     <use xlink:href="#DejaVuSans-af" transform="translate(711.181641 0.015625)"/>
+     <use xlink:href="#DejaVuSans-f" transform="translate(738.964844 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(770.751953 0.015625)"/>
+     <use xlink:href="#DejaVuSans-5c" transform="translate(802.539062 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(861.71875 0.015625)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(893.505859 0.015625)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(948.486328 0.015625)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(1009.667969 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1050.78125 0.015625)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(1089.990234 0.015625)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1151.171875 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(1206.152344 0.015625)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(1233.935547 0.015625)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1273.048828 0.015625)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(1328.029297 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(1391.408203 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1419.191406 0.015625)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1458.400391 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1519.679688 0.015625)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1551.466797 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(1612.990234 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1640.773438 0.015625)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1672.560547 0.015625)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(1727.541016 0.015625)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1788.722656 0.015625)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(1852.101562 0.015625)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(1915.578125 0.015625)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1978.957031 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(2033.9375 0.015625)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(2073.146484 0.015625)"/>
+    </g>
+   </g>
+   <g id="patch_8">
+    <path d="M 615.475137 201.104702 
+Q 651.158237 191.57153 685.761188 182.326932 
+" style="fill: none; stroke: #1f77b4; stroke-linecap: round"/>
+    <path d="M 682.11208 181.577404 
+L 685.761188 182.326932 
+L 682.972101 184.796502 
+" style="fill: none; stroke: #1f77b4; stroke-linecap: round"/>
+   </g>
+   <g id="text_17">
+    <!-- $c/L$ = 858 Hz: -->
+    <g style="fill: #1f77b4" transform="translate(553.482697 201.909323) scale(0.0833 -0.0833)">
+     <use xlink:href="#DejaVuSans-Oblique-46" transform="translate(0 0.78125)"/>
+     <use xlink:href="#DejaVuSans-12" transform="translate(54.980469 0.78125)"/>
+     <use xlink:href="#DejaVuSans-Oblique-2f" transform="translate(88.671875 0.78125)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(144.384766 0.78125)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(176.171875 0.78125)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(259.960938 0.78125)"/>
+     <use xlink:href="#DejaVuSans-1b" transform="translate(291.748047 0.78125)"/>
+     <use xlink:href="#DejaVuSans-18" transform="translate(355.371094 0.78125)"/>
+     <use xlink:href="#DejaVuSans-1b" transform="translate(418.994141 0.78125)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(482.617188 0.78125)"/>
+     <use xlink:href="#DejaVuSans-2b" transform="translate(514.404297 0.78125)"/>
+     <use xlink:href="#DejaVuSans-5d" transform="translate(589.599609 0.78125)"/>
+     <use xlink:href="#DejaVuSans-1d" transform="translate(642.089844 0.78125)"/>
+    </g>
+    <!-- la entrada $L/4$ -->
+    <g style="fill: #1f77b4" transform="translate(553.482697 211.908903) scale(0.0833 -0.0833)">
      <use xlink:href="#DejaVuSans-4f" transform="translate(0 0.015625)"/>
      <use xlink:href="#DejaVuSans-44" transform="translate(27.783203 0.015625)"/>
      <use xlink:href="#DejaVuSans-3" transform="translate(89.0625 0.015625)"/>
@@ -1891,122 +1939,93 @@ z
      <use xlink:href="#DejaVuSans-Oblique-2f" transform="translate(543.896484 0.015625)"/>
      <use xlink:href="#DejaVuSans-12" transform="translate(599.609375 0.015625)"/>
      <use xlink:href="#DejaVuSans-17" transform="translate(633.300781 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(696.923828 0.015625)"/>
-     <use xlink:href="#DejaVuSans-47" transform="translate(728.710938 0.015625)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(792.1875 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(853.466797 0.015625)"/>
-     <use xlink:href="#DejaVuSans-18" transform="translate(885.253906 0.015625)"/>
-     <use xlink:href="#DejaVuSans-f" transform="translate(948.876953 0.015625)"/>
-     <use xlink:href="#DejaVuSans-14" transform="translate(980.664062 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1044.287109 0.015625)"/>
-     <use xlink:href="#DejaVuSans-47" transform="translate(1076.074219 0.015625)"/>
-     <use xlink:href="#DejaVuSans-25" transform="translate(1139.550781 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1208.154297 0.015625)"/>
-     <use xlink:href="#DejaVuSans-5c" transform="translate(1239.941406 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1299.121094 0.015625)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(1330.908203 0.015625)"/>
-     <use xlink:href="#DejaVuSans-4f" transform="translate(1392.431641 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1420.214844 0.015625)"/>
-     <use xlink:href="#DejaVuSans-53" transform="translate(1452.001953 0.015625)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(1515.478516 0.015625)"/>
-     <use xlink:href="#DejaVuSans-55" transform="translate(1576.757812 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1617.871094 0.015625)"/>
-     <use xlink:href="#DejaVuSans-Oblique-2f" transform="translate(1649.658203 0.015625)"/>
-     <use xlink:href="#DejaVuSans-12" transform="translate(1705.371094 0.015625)"/>
-     <use xlink:href="#DejaVuSans-17" transform="translate(1739.0625 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1802.685547 0.015625)"/>
-     <use xlink:href="#DejaVuSans-e" transform="translate(1834.472656 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1918.261719 0.015625)"/>
-     <use xlink:href="#DejaVuSans-Oblique-2f" transform="translate(1950.048828 0.015625)"/>
-     <use xlink:href="#DejaVuSans-12" transform="translate(2005.761719 0.015625)"/>
-     <use xlink:href="#DejaVuSans-15" transform="translate(2039.453125 0.015625)"/>
-     <use xlink:href="#DejaVuSans-f" transform="translate(2103.076172 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(2134.863281 0.015625)"/>
-     <use xlink:href="#DejaVuSans-1a" transform="translate(2166.650391 0.015625)"/>
-     <use xlink:href="#DejaVuSans-17" transform="translate(2230.273438 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(2293.896484 0.015625)"/>
-     <use xlink:href="#DejaVuSans-47" transform="translate(2325.683594 0.015625)"/>
-     <use xlink:href="#DejaVuSans-25" transform="translate(2389.160156 0.015625)"/>
     </g>
-   </g>
-   <g id="patch_8">
-    <path d="M 268.242416 277.869154 
-Q 284.015015 337.036651 299.49963 395.12384 
-" style="fill: none; stroke: #d62728; stroke-linecap: round"/>
-    <path d="M 300.251157 391.475143 
-L 299.49963 395.12384 
-L 297.031589 392.333401 
-" style="fill: none; stroke: #d62728; stroke-linecap: round"/>
-   </g>
-   <g id="text_17">
-    <!-- cero nuevo, -->
-    <g style="fill: #d62728" transform="translate(240.004011 261.102667) scale(0.0833 -0.0833)">
-     <defs>
-      <path id="DejaVuSans-59" d="M 191 3500 
-L 800 3500 
-L 1894 563 
-L 2988 3500 
-L 3597 3500 
-L 2284 0 
-L 1503 0 
-L 191 3500 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-46"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(54.984375 0)"/>
-     <use xlink:href="#DejaVuSans-55" transform="translate(116.515625 0)"/>
-     <use xlink:href="#DejaVuSans-52" transform="translate(155.421875 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(216.609375 0)"/>
-     <use xlink:href="#DejaVuSans-51" transform="translate(248.390625 0)"/>
-     <use xlink:href="#DejaVuSans-58" transform="translate(311.765625 0)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(375.140625 0)"/>
-     <use xlink:href="#DejaVuSans-59" transform="translate(436.671875 0)"/>
-     <use xlink:href="#DejaVuSans-52" transform="translate(495.859375 0)"/>
-     <use xlink:href="#DejaVuSans-f" transform="translate(557.046875 0)"/>
-    </g>
-    <!-- 0,1 dB -->
-    <g style="fill: #d62728" transform="translate(240.004011 271.100944) scale(0.0833 -0.0833)">
-     <use xlink:href="#DejaVuSans-13"/>
-     <use xlink:href="#DejaVuSans-f" transform="translate(63.625 0)"/>
-     <use xlink:href="#DejaVuSans-14" transform="translate(95.40625 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(159.03125 0)"/>
-     <use xlink:href="#DejaVuSans-47" transform="translate(190.8125 0)"/>
-     <use xlink:href="#DejaVuSans-25" transform="translate(254.296875 0)"/>
+    <!-- sí lo está -->
+    <g style="fill: #1f77b4" transform="translate(553.482697 222.24038) scale(0.0833 -0.0833)">
+     <use xlink:href="#DejaVuSans-56"/>
+     <use xlink:href="#DejaVuSans-af" transform="translate(52.09375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(79.875 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(111.65625 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(139.4375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(200.625 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(232.40625 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(293.9375 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(346.03125 0)"/>
+     <use xlink:href="#DejaVuSans-a3" transform="translate(385.234375 0)"/>
     </g>
    </g>
    <g id="patch_9">
-    <path d="M 195.574114 277.869154 
-Q 211.346713 337.036651 226.831328 395.12384 
-" style="fill: none; stroke: #d62728; stroke-linecap: round"/>
-    <path d="M 227.582855 391.475143 
-L 226.831328 395.12384 
-L 224.363287 392.333401 
-" style="fill: none; stroke: #d62728; stroke-linecap: round"/>
+    <path d="M 224.969735 313.600386 
+Q 296.176926 355.76669 366.422101 397.363323 
+" style="fill: none; stroke: #1f77b4; stroke-linecap: round"/>
+    <path d="M 364.403946 394.232057 
+L 366.422101 397.363323 
+L 362.706195 397.099088 
+" style="fill: none; stroke: #1f77b4; stroke-linecap: round"/>
    </g>
    <g id="text_18">
-    <!-- cero nuevo, -->
-    <g style="fill: #d62728" transform="translate(167.335709 261.102667) scale(0.0833 -0.0833)">
-     <use xlink:href="#DejaVuSans-46"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(54.984375 0)"/>
-     <use xlink:href="#DejaVuSans-55" transform="translate(116.515625 0)"/>
-     <use xlink:href="#DejaVuSans-52" transform="translate(155.421875 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(216.609375 0)"/>
-     <use xlink:href="#DejaVuSans-51" transform="translate(248.390625 0)"/>
-     <use xlink:href="#DejaVuSans-58" transform="translate(311.765625 0)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(375.140625 0)"/>
-     <use xlink:href="#DejaVuSans-59" transform="translate(436.671875 0)"/>
-     <use xlink:href="#DejaVuSans-52" transform="translate(495.859375 0)"/>
-     <use xlink:href="#DejaVuSans-f" transform="translate(557.046875 0)"/>
+    <!-- la entrada sola solo desplaza -->
+    <g style="fill: #1f77b4" transform="translate(141.824497 297.414889) scale(0.0833 -0.0833)">
+     <use xlink:href="#DejaVuSans-4f"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(27.78125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(89.0625 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(120.84375 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(182.375 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(245.75 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(284.953125 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(326.0625 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(387.34375 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(450.828125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(512.109375 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(543.890625 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(595.984375 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(657.171875 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(684.953125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(746.234375 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(778.015625 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(830.109375 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(891.296875 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(919.078125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(980.265625 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(1012.046875 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1075.53125 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(1137.0625 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(1189.15625 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(1252.640625 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1280.421875 0)"/>
+     <use xlink:href="#DejaVuSans-5d" transform="translate(1341.703125 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1394.1875 0)"/>
     </g>
-    <!-- 0,4 dB -->
-    <g style="fill: #d62728" transform="translate(167.335709 271.100944) scale(0.0833 -0.0833)">
-     <use xlink:href="#DejaVuSans-13"/>
-     <use xlink:href="#DejaVuSans-f" transform="translate(63.625 0)"/>
-     <use xlink:href="#DejaVuSans-17" transform="translate(95.40625 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(159.03125 0)"/>
-     <use xlink:href="#DejaVuSans-47" transform="translate(190.8125 0)"/>
-     <use xlink:href="#DejaVuSans-25" transform="translate(254.296875 0)"/>
+    <!-- la caída que queda, a 444 Hz -->
+    <g style="fill: #1f77b4" transform="translate(141.824497 307.746367) scale(0.0833 -0.0833)">
+     <use xlink:href="#DejaVuSans-4f"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(27.78125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(89.0625 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(120.84375 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(175.828125 0)"/>
+     <use xlink:href="#DejaVuSans-af" transform="translate(237.109375 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(264.890625 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(328.375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(389.65625 0)"/>
+     <use xlink:href="#DejaVuSans-54" transform="translate(421.4375 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(484.921875 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(548.296875 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(609.828125 0)"/>
+     <use xlink:href="#DejaVuSans-54" transform="translate(641.609375 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(705.09375 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(768.46875 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(830 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(893.484375 0)"/>
+     <use xlink:href="#DejaVuSans-f" transform="translate(954.765625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(986.546875 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1018.328125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1079.609375 0)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(1111.390625 0)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(1175.015625 0)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(1238.640625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1302.265625 0)"/>
+     <use xlink:href="#DejaVuSans-2b" transform="translate(1334.046875 0)"/>
+     <use xlink:href="#DejaVuSans-5d" transform="translate(1409.25 0)"/>
     </g>
    </g>
    <g id="text_19">
@@ -2161,7 +2180,7 @@ Q 525.818938 71.61808 527.484938 71.61808
 z
 " style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
     </g>
-    <g id="line2d_31">
+    <g id="line2d_32">
      <path d="M 529.150938 38.042323 
 L 537.480938 38.042323 
 L 545.810938 38.042323 
@@ -2192,7 +2211,7 @@ L 545.810938 38.042323
       <use xlink:href="#DejaVuSans-50" transform="translate(1008.421875 0)"/>
      </g>
     </g>
-    <g id="line2d_32">
+    <g id="line2d_33">
      <path d="M 529.150938 50.872476 
 L 537.480938 50.872476 
 L 545.810938 50.872476 
@@ -2253,7 +2272,7 @@ z
       <use xlink:href="#DejaVuSans-50" transform="translate(1657.373047 0.015625)"/>
      </g>
     </g>
-    <g id="line2d_33">
+    <g id="line2d_34">
      <path d="M 529.150938 63.369428 
 L 537.480938 63.369428 
 L 545.810938 63.369428 

--- a/.github/images/silencer_extended_tube_es_dark.svg
+++ b/.github/images/silencer_extended_tube_es_dark.svg
@@ -1182,393 +1182,300 @@ L 706.163438 398.196018
 " clip-path="url(#pfffd36bc2b)" style="fill: none; stroke-dasharray: 5.92,2.56; stroke-dashoffset: 0; stroke: #ffffff; stroke-width: 1.6"/>
    </g>
    <g id="line2d_28">
-    <path d="M 41.325781 397.778043 
-L 44.651355 396.1981 
-L 48.531191 394.103058 
-L 53.242421 391.283279 
-L 59.339307 387.348376 
-L 81.5098 372.791634 
-L 88.160948 368.822701 
-L 94.257833 365.440635 
-L 100.077587 362.458295 
-L 105.897342 359.724472 
-L 111.717096 357.24239 
-L 117.259719 355.112771 
-L 122.802343 353.210406 
-L 128.344966 351.533252 
-L 133.887589 350.078984 
-L 139.430212 348.84533 
-L 144.972836 347.830294 
-L 150.515459 347.032317 
-L 156.058082 346.450385 
-L 161.600705 346.084113 
-L 167.143329 345.933802 
-L 172.685952 346.00048 
-L 178.228575 346.285938 
-L 183.771198 346.792748 
-L 189.313821 347.524278 
-L 194.856445 348.484688 
-L 200.399068 349.678901 
-L 205.66456 351.035083 
-L 210.930052 352.612668 
-L 216.195544 354.417301 
-L 221.461036 356.454699 
-L 226.726528 358.730258 
-L 231.99202 361.248431 
-L 237.257512 364.011786 
-L 242.523004 367.019575 
-L 248.065628 370.442804 
-L 253.885382 374.301661 
-L 260.53653 378.99102 
-L 280.767105 393.498267 
-L 284.36981 395.682031 
-L 287.418253 397.298553 
-L 290.189564 398.538123 
-L 292.683745 399.434093 
-L 295.177925 400.095779 
-L 297.394974 400.469897 
-L 299.612024 400.63048 
-L 301.829073 400.570076 
-L 304.046122 400.285747 
-L 306.263172 399.779258 
-L 308.480221 399.056958 
-L 310.974401 397.999666 
-L 313.468582 396.702932 
-L 316.239893 395.011147 
-L 319.288336 392.888226 
-L 322.891041 390.093903 
-L 327.32514 386.345607 
-L 333.422025 380.867401 
-L 349.218502 366.543837 
-L 355.592518 361.123671 
-L 361.412273 356.454574 
-L 367.232027 352.075545 
-L 372.77465 348.182805 
-L 378.317274 344.561943 
-L 383.859897 341.209982 
-L 389.40252 338.12194 
-L 394.945143 335.29198 
-L 400.487766 332.71416 
-L 406.03039 330.382908 
-L 411.573013 328.293337 
-L 417.115636 326.441445 
-L 422.658259 324.824258 
-L 428.200883 323.439932 
-L 433.743506 322.287846 
-L 439.286129 321.368682 
-L 444.828752 320.684524 
-L 450.094244 320.255506 
-L 455.359736 320.046265 
-L 460.625228 320.062716 
-L 465.613589 320.293288 
-L 470.60195 320.741037 
-L 475.590311 321.415434 
-L 480.301541 322.270586 
-L 485.012771 323.348998 
-L 489.724 324.663461 
-L 494.158099 326.129315 
-L 498.592198 327.830975 
-L 502.749165 329.653994 
-L 506.906132 331.711321 
-L 511.0631 334.017352 
-L 515.220067 336.586604 
-L 519.377035 339.432552 
-L 523.534002 342.565545 
-L 527.69097 345.989171 
-L 532.125068 349.950436 
-L 537.113429 354.735909 
-L 549.584331 366.906346 
-L 552.078512 368.93331 
-L 554.295561 370.443876 
-L 556.235479 371.470947 
-L 557.898266 372.085663 
-L 559.283922 372.383509 
-L 560.669578 372.466737 
-L 562.055234 372.319938 
-L 563.440889 371.931559 
-L 564.826545 371.294634 
-L 566.212201 370.407237 
-L 567.597857 369.272604 
-L 569.260644 367.596501 
-L 570.923431 365.598625 
-L 572.863349 362.900412 
-L 575.080398 359.399025 
-L 577.574579 355.029933 
-L 580.623021 349.236521 
-L 585.05712 340.272212 
-L 604.456301 300.437749 
-L 611.938843 285.89681 
-L 621.638433 267.587661 
-L 635.494991 241.436899 
-L 641.591877 229.420732 
-L 646.303107 219.674131 
-L 650.460074 210.584778 
-L 654.062779 202.204938 
-L 657.388353 193.92756 
-L 660.436796 185.752714 
-L 663.208107 177.70067 
-L 665.702288 169.81572 
-L 668.196468 161.165508 
-L 670.413518 152.660946 
-L 672.353436 144.41825 
-L 674.293354 135.21981 
-L 675.956141 126.360327 
-L 677.618928 116.327798 
-L 679.281715 104.732728 
-L 680.667371 93.442976 
-L 682.053026 80.072846 
-L 683.161551 67.245489 
-L 684.270076 51.611187 
-L 685.101469 37.126556 
-L 685.932863 18.918178 
-L 686.624017 -1 
-M 690.911053 -1 
-L 691.475486 15.582912 
-L 692.306879 34.559235 
-L 693.415404 53.886142 
-L 694.523929 69.07944 
-L 695.632453 81.610352 
-L 697.018109 94.723615 
-L 698.403765 105.831559 
-L 700.066552 117.268398 
-L 701.729339 127.184181 
-L 703.669257 137.323531 
-L 705.609175 146.292338 
-L 706.163438 148.679144 
-L 706.163438 148.679144 
+    <path d="M 41.325781 399.076858 
+L 45.205618 397.841778 
+L 49.362585 396.287262 
+L 54.073815 394.284921 
+L 59.616438 391.676554 
+L 66.544717 388.157584 
+L 79.29275 381.37268 
+L 91.486521 374.98565 
+L 100.077587 370.73084 
+L 108.114391 366.999965 
+L 115.596933 363.769411 
+L 122.802343 360.892284 
+L 130.007753 358.250107 
+L 137.213163 355.844709 
+L 144.418573 353.675692 
+L 151.623983 351.741406 
+L 158.829394 350.03963 
+L 166.034804 348.568043 
+L 173.240214 347.324545 
+L 180.445624 346.307487 
+L 187.651034 345.515833 
+L 194.856445 344.949279 
+L 202.061855 344.608344 
+L 209.267265 344.494449 
+L 216.472675 344.609974 
+L 223.400954 344.940571 
+L 230.329233 345.490386 
+L 237.257512 346.26434 
+L 244.185791 347.268342 
+L 250.836939 348.455009 
+L 257.488087 349.866994 
+L 264.139235 351.512011 
+L 270.513252 353.314868 
+L 276.887268 355.347071 
+L 283.261285 357.616254 
+L 289.635302 360.129439 
+L 296.009319 362.89211 
+L 302.383335 365.906747 
+L 308.757352 369.170558 
+L 315.4085 372.829295 
+L 322.61391 377.049984 
+L 332.313501 383.019586 
+L 343.398747 389.808049 
+L 348.664239 392.765292 
+L 352.821207 394.847818 
+L 356.423912 396.400853 
+L 359.472355 397.486501 
+L 362.243666 398.260368 
+L 365.014978 398.806103 
+L 367.509158 399.084788 
+L 370.003339 399.149599 
+L 372.497519 398.992321 
+L 374.9917 398.609076 
+L 377.48588 398.000572 
+L 379.980061 397.172047 
+L 382.751372 396.005021 
+L 385.522684 394.596227 
+L 388.571127 392.794065 
+L 391.8967 390.56479 
+L 395.776537 387.676438 
+L 400.210635 384.084107 
+L 406.03039 379.054219 
+L 416.007111 370.070373 
+L 427.369489 359.926388 
+L 435.406293 353.056905 
+L 442.611703 347.186254 
+L 449.539982 341.818686 
+L 456.468261 336.726533 
+L 463.39654 331.904934 
+L 470.60195 327.167295 
+L 477.80736 322.698797 
+L 485.289902 318.327935 
+L 492.772443 314.215683 
+L 500.532116 310.207508 
+L 508.568919 306.313891 
+L 516.605723 302.66543 
+L 524.919658 299.131993 
+L 533.510724 295.720549 
+L 542.378921 292.436442 
+L 551.524249 289.28298 
+L 561.22384 286.175019 
+L 571.477693 283.126951 
+L 582.56294 280.068122 
+L 595.588104 276.716361 
+L 626.072532 268.990699 
+L 632.72368 266.994821 
+L 637.712041 265.281843 
+L 641.869008 263.640676 
+L 645.471713 261.998679 
+L 648.797287 260.239316 
+L 651.568599 258.539967 
+L 654.062779 256.779571 
+L 656.55696 254.744782 
+L 658.774009 252.650054 
+L 660.991058 250.221657 
+L 662.930976 247.761196 
+L 664.870894 244.917572 
+L 666.533681 242.111631 
+L 668.196468 238.89585 
+L 669.859255 235.187599 
+L 671.522042 230.882921 
+L 673.184829 225.848853 
+L 674.570485 220.972885 
+L 675.956141 215.339677 
+L 677.341797 208.777239 
+L 678.727453 201.052337 
+L 680.113108 191.83484 
+L 681.221633 183.062463 
+L 682.330158 172.642277 
+L 683.438682 159.98043 
+L 684.547207 144.070489 
+L 685.3786 128.911104 
+L 686.209994 109.292028 
+L 686.764256 92.171866 
+L 687.318519 69.395421 
+L 687.872781 35.426706 
+L 688.217982 -1 
+M 689.314543 -1 
+L 689.812699 46.123167 
+L 690.366961 76.179466 
+L 691.198355 105.626693 
+L 692.029748 126.183373 
+L 692.861142 141.909612 
+L 693.969666 158.30189 
+L 695.078191 171.282582 
+L 696.186716 181.930317 
+L 697.572371 192.893718 
+L 698.958027 201.933551 
+L 700.343683 209.521924 
+L 701.729339 215.976294 
+L 703.114995 221.522084 
+L 704.777782 227.209759 
+L 706.163438 231.289642 
+L 706.163438 231.289642 
 " clip-path="url(#pfffd36bc2b)" style="fill: none; stroke: #1f77b4; stroke-width: 1.9; stroke-linecap: square"/>
    </g>
    <g id="line2d_29">
-    <path d="M 41.325781 395.223388 
-L 44.651355 392.673107 
-L 48.808323 389.166901 
-L 54.905208 383.6877 
-L 65.713323 373.964628 
-L 71.255947 369.287446 
-L 76.521439 365.138014 
-L 81.5098 361.501703 
-L 86.221029 358.343523 
-L 90.932259 355.45836 
-L 95.366358 352.992947 
-L 99.800456 350.768782 
-L 104.234555 348.783877 
-L 108.668653 347.036081 
-L 113.102752 345.523513 
-L 117.536851 344.244868 
-L 121.970949 343.199639 
-L 126.405048 342.388297 
-L 130.839146 341.812439 
-L 134.996114 341.488962 
-L 139.153081 341.378426 
-L 143.310049 341.485488 
-L 147.467016 341.816116 
-L 151.623983 342.37771 
-L 155.50382 343.118147 
-L 159.383656 344.076254 
-L 163.263492 345.262134 
-L 167.143329 346.687435 
-L 171.023165 348.36545 
-L 174.62587 350.16295 
-L 178.228575 352.204489 
-L 181.83128 354.504339 
-L 185.433985 357.077398 
-L 189.03669 359.938393 
-L 192.639395 363.100406 
-L 196.2421 366.57226 
-L 199.844806 370.354007 
-L 203.724642 374.753898 
-L 208.435872 380.464143 
-L 216.749806 390.628923 
-L 219.243987 393.293576 
-L 221.183905 395.074425 
-L 222.846692 396.325715 
-L 224.232348 397.131036 
-L 225.618004 397.686486 
-L 226.726528 397.931417 
-L 227.835053 397.985358 
-L 228.943578 397.838469 
-L 230.052102 397.484133 
-L 231.160627 396.919322 
-L 232.546283 395.918808 
-L 233.931938 394.600389 
-L 235.317594 392.981757 
-L 236.980381 390.677742 
-L 238.920299 387.555868 
-L 241.137349 383.524204 
-L 243.90866 377.978668 
-L 247.788497 369.661111 
-L 260.813661 341.346507 
-L 266.079153 330.621989 
-L 271.344645 320.424086 
-L 276.610137 310.705236 
-L 282.429892 300.429533 
-L 289.358171 288.674138 
-L 299.889155 271.319733 
-L 309.311614 255.646855 
-L 314.854238 245.995983 
-L 319.288336 237.832691 
-L 323.168172 230.208812 
-L 326.493746 223.180647 
-L 329.542189 216.204891 
-L 332.313501 209.285631 
-L 334.807681 202.451015 
-L 337.02473 195.758356 
-L 339.24178 188.32238 
-L 341.181698 181.035661 
-L 343.121616 172.805151 
-L 344.784403 164.774865 
-L 346.44719 155.555508 
-L 347.832846 146.670198 
-L 349.218502 136.308057 
-L 350.327026 126.580273 
-L 351.435551 115.084057 
-L 352.544076 101.063471 
-L 353.375469 88.112418 
-L 354.206862 71.962117 
-L 355.038256 50.587923 
-L 355.592518 31.303947 
-L 356.224756 -1 
-M 358.375386 -1 
-L 358.918092 28.839949 
-L 359.749486 59.173579 
-L 360.580879 80.744707 
-L 361.689404 102.499011 
-L 362.797928 119.599143 
-L 364.183584 137.003854 
-L 365.56924 151.543795 
-L 367.232027 166.478864 
-L 368.894814 179.517476 
-L 370.834732 193.056089 
-L 373.051781 206.981016 
-L 375.545962 221.293574 
-L 378.594405 237.525985 
-L 383.028503 259.811003 
-L 391.8967 304.096004 
-L 396.053668 326.218199 
-L 402.981947 363.495542 
-L 404.367603 369.621578 
-L 405.476127 373.654919 
-L 406.307521 376.037416 
-L 407.138914 377.791583 
-L 407.693177 378.590558 
-L 408.247439 379.087996 
-L 408.801701 379.287635 
-L 409.355964 379.200211 
-L 409.910226 378.842621 
-L 410.464488 378.236686 
-L 411.295882 376.917998 
-L 412.404406 374.538989 
-L 413.790062 370.866811 
-L 416.007111 364.177699 
-L 420.44121 350.693935 
-L 422.935391 343.848792 
-L 425.429571 337.672156 
-L 427.923751 332.133857 
-L 430.417932 327.172341 
-L 432.912112 322.72063 
-L 435.406293 318.716165 
-L 437.900473 315.103867 
-L 440.671785 311.492933 
-L 443.443096 308.253479 
-L 446.214408 305.340283 
-L 449.262851 302.467998 
-L 452.311294 299.903979 
-L 455.359736 297.61439 
-L 458.68531 295.396984 
-L 462.010884 293.443258 
-L 465.613589 291.596112 
-L 469.216294 290.004632 
-L 472.819 288.648391 
-L 476.698836 287.432048 
-L 480.578672 286.453009 
-L 484.458508 285.698458 
-L 488.338345 285.158636 
-L 492.495312 284.810504 
-L 496.652279 284.69496 
-L 500.809247 284.809031 
-L 504.966214 285.152369 
-L 509.123182 285.727172 
-L 513.280149 286.5382 
-L 517.159985 287.514787 
-L 521.039822 288.711839 
-L 524.919658 290.139961 
-L 528.799494 291.812371 
-L 532.402199 293.598134 
-L 536.004904 295.623949 
-L 539.607609 297.908159 
-L 543.210315 300.472303 
-L 546.535889 303.109329 
-L 549.861462 306.028953 
-L 553.187036 309.256835 
-L 556.235479 312.510767 
-L 559.283922 316.071029 
-L 562.332365 319.961309 
-L 565.380807 324.203051 
-L 568.42925 328.810586 
-L 571.754824 334.251105 
-L 575.63466 341.07482 
-L 583.394333 354.924184 
-L 585.334251 357.840983 
-L 586.719907 359.590662 
-L 588.105563 360.96971 
-L 589.214087 361.750601 
-L 590.045481 362.122376 
-L 590.876874 362.294871 
-L 591.708268 362.256651 
-L 592.539661 361.999654 
-L 593.371055 361.519655 
-L 594.202448 360.816516 
-L 595.310973 359.539292 
-L 596.419498 357.892661 
-L 597.805153 355.361049 
-L 599.46794 351.72713 
-L 601.407858 346.843935 
-L 603.902039 339.876628 
-L 608.059006 327.455423 
-L 615.264417 305.945542 
-L 619.975646 292.618122 
-L 624.686876 279.941662 
-L 629.952368 266.409983 
-L 636.880647 249.273288 
-L 649.905812 217.199801 
-L 654.617041 204.904488 
-L 658.496878 194.141578 
-L 661.822452 184.242397 
-L 664.593763 175.341736 
-L 667.087944 166.661942 
-L 669.582124 157.15407 
-L 671.799173 147.794963 
-L 673.739092 138.689664 
-L 675.67901 128.461251 
-L 677.341797 118.514607 
-L 679.004584 107.101058 
-L 680.390239 96.06908 
-L 681.775895 83.107819 
-L 682.88442 70.78364 
-L 683.992945 55.924466 
-L 684.824338 42.338566 
-L 685.655732 25.55075 
-L 686.487125 3.542562 
-L 686.624461 -1 
-M 690.910638 -1 
-L 691.475486 15.60619 
-L 692.306879 34.59903 
-L 693.415404 53.954829 
-L 694.523929 69.184901 
-L 695.632453 81.760508 
-L 697.018109 94.940852 
-L 698.403765 106.128438 
-L 700.066552 117.677619 
-L 701.729339 127.724299 
-L 703.669257 138.04024 
-L 705.609175 147.211917 
-L 706.163438 149.661607 
-L 706.163438 149.661607 
+    <path d="M 41.325781 399.517566 
+L 45.482749 398.419185 
+L 49.916847 397.0117 
+L 54.628077 395.281989 
+L 59.893569 393.10778 
+L 65.990455 390.336816 
+L 73.195865 386.806156 
+L 82.895455 381.786212 
+L 118.922506 362.909663 
+L 130.562015 357.182819 
+L 141.647262 351.972932 
+L 152.732508 347.004381 
+L 164.094886 342.153489 
+L 176.011526 337.311866 
+L 188.482428 332.489795 
+L 201.784724 327.588315 
+L 216.472675 322.417719 
+L 234.20907 316.422012 
+L 276.610137 302.205106 
+L 286.309728 298.646987 
+L 294.0694 295.566282 
+L 300.443417 292.797749 
+L 305.708909 290.279848 
+L 310.420139 287.784465 
+L 314.577106 285.328763 
+L 318.179812 282.948023 
+L 321.505385 280.481268 
+L 324.553828 277.929234 
+L 327.32514 275.301384 
+L 329.81932 272.618806 
+L 332.03637 269.917209 
+L 334.253419 266.841417 
+L 336.193337 263.766494 
+L 338.133255 260.241469 
+L 339.796042 256.772009 
+L 341.458829 252.782692 
+L 343.121616 248.135582 
+L 344.507272 243.624045 
+L 345.892928 238.369117 
+L 347.278583 232.154596 
+L 348.387108 226.285527 
+L 349.495633 219.371363 
+L 350.604157 211.071904 
+L 351.712682 200.861888 
+L 352.544076 191.446418 
+L 353.375469 179.869265 
+L 354.206862 165.085897 
+L 355.038256 145.06554 
+L 355.592518 126.673274 
+L 356.146781 100.565721 
+L 356.701043 56.482522 
+L 357.014823 -1 
+M 357.601982 -1 
+L 357.809568 43.289844 
+L 358.36383 97.890687 
+L 358.918092 129.207185 
+L 359.749486 160.637176 
+L 360.580879 183.212447 
+L 361.689404 206.129548 
+L 362.797928 224.146249 
+L 363.906453 238.956577 
+L 365.292109 254.249941 
+L 366.677765 266.805726 
+L 368.063421 277.149277 
+L 369.449076 285.617173 
+L 370.557601 291.211384 
+L 371.666126 295.877941 
+L 372.77465 299.721446 
+L 373.883175 302.842356 
+L 374.9917 305.336784 
+L 376.100224 307.295095 
+L 377.208749 308.800317 
+L 378.317274 309.926964 
+L 379.425798 310.740472 
+L 380.534323 311.297223 
+L 381.919979 311.704211 
+L 383.305634 311.860771 
+L 384.968421 311.802242 
+L 386.90834 311.492519 
+L 389.40252 310.847241 
+L 393.005225 309.649969 
+L 413.2358 302.511733 
+L 420.164079 300.465329 
+L 427.64662 298.486408 
+L 435.960555 296.523457 
+L 445.105883 294.597911 
+L 455.359736 292.67288 
+L 466.722114 290.770555 
+L 479.470147 288.866643 
+L 493.603837 286.983018 
+L 509.677444 285.071124 
+L 527.968101 283.126125 
+L 550.415725 280.973603 
+L 596.97376 276.584305 
+L 608.059006 275.27134 
+L 616.650072 274.036117 
+L 623.578351 272.815826 
+L 629.120975 271.625781 
+L 633.832204 270.404928 
+L 637.989172 269.112782 
+L 641.591877 267.779689 
+L 644.917451 266.32356 
+L 647.965894 264.748265 
+L 650.737205 263.066535 
+L 653.231386 261.301946 
+L 655.725566 259.245537 
+L 657.942615 257.119341 
+L 660.159665 254.651628 
+L 662.099583 252.154723 
+L 664.039501 249.278639 
+L 665.979419 245.94695 
+L 667.642206 242.656505 
+L 669.304993 238.885836 
+L 670.96778 234.540972 
+L 672.630567 229.502834 
+L 674.293354 223.617218 
+L 675.67901 217.919065 
+L 677.064666 211.332436 
+L 678.450321 203.642963 
+L 679.835977 194.548781 
+L 680.944502 185.968203 
+L 682.053026 175.863814 
+L 683.161551 163.710218 
+L 684.270076 148.636377 
+L 685.101469 134.494975 
+L 685.932863 116.561909 
+L 686.764256 92.213119 
+L 687.318519 69.417086 
+L 687.872781 35.434998 
+L 688.218004 -1 
+M 689.314515 -1 
+L 689.812699 46.134386 
+L 690.366961 76.205712 
+L 691.198355 105.687046 
+L 692.029748 126.291307 
+L 692.861142 142.077996 
+L 693.969666 158.569573 
+L 695.078191 171.668975 
+L 696.186716 182.452416 
+L 697.572371 193.605373 
+L 698.958027 202.851982 
+L 700.343683 210.659158 
+L 701.729339 217.339446 
+L 703.392126 224.175088 
+L 705.054913 229.978612 
+L 706.163438 233.375229 
+L 706.163438 233.375229 
 " clip-path="url(#pfffd36bc2b)" style="fill: none; stroke-dasharray: 10.88,2.72,1.7,2.72; stroke-dashoffset: 0; stroke: #d62728; stroke-width: 1.7"/>
    </g>
    <g id="line2d_30">
     <path d="M 357.316935 401.395781 
 L 357.316935 26.798125 
+" clip-path="url(#pfffd36bc2b)" style="fill: none; stroke-dasharray: 1.2,1.98; stroke-dashoffset: 0; stroke: #555555; stroke-width: 1.2"/>
+   </g>
+   <g id="line2d_31">
+    <path d="M 688.769429 401.395781 
+L 688.769429 26.798125 
 " clip-path="url(#pfffd36bc2b)" style="fill: none; stroke-dasharray: 1.2,1.98; stroke-dashoffset: 0; stroke: #555555; stroke-width: 1.2"/>
    </g>
    <g id="patch_3">
@@ -1592,17 +1499,17 @@ L 706.163438 26.798125
 " style="fill: none; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_7">
-    <path d="M 487.880176 196.062904 
-Q 423.221129 277.182537 359.258957 357.427889 
+    <path d="M 224.863392 122.030455 
+Q 290.178656 151.367437 354.47404 180.24633 
 " style="fill: none; stroke: #ffffff; stroke-linecap: round"/>
-    <path d="M 362.638582 355.860753 
-L 359.258957 357.427889 
-L 360.033023 353.783908 
+    <path d="M 352.117168 177.361381 
+L 354.47404 180.24633 
+L 350.751957 180.400858 
 " style="fill: none; stroke: #ffffff; stroke-linecap: round"/>
    </g>
    <g id="text_16">
-    <!-- $c/2L$ = 429 Hz: la cámara simple es transparente (0,0 dB), -->
-    <g style="fill: #ffffff" transform="translate(377.204084 179.667092) scale(0.0833 -0.0833)">
+    <!-- $c/2L$ = 429 Hz: cámara simple 0,0 dB y la entrada $L/4$ -->
+    <g style="fill: #ffffff" transform="translate(72.248463 95.710267) scale(0.0833 -0.0833)">
      <defs>
       <path id="DejaVuSans-Oblique-46" d="M 3431 3366 
 L 3316 2797 
@@ -1701,13 +1608,6 @@ L 750 2516
 L 750 3309 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-4f" d="M 603 4863 
-L 1178 4863 
-L 1178 0 
-L 603 0 
-L 603 4863 
-z
-" transform="scale(0.015625)"/>
       <path id="DejaVuSans-a3" d="M 2194 1759 
 Q 1497 1759 1228 1600 
 Q 959 1441 959 1056 
@@ -1747,17 +1647,11 @@ L 1415 3944
 L 2290 5119 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-b" d="M 1984 4856 
-Q 1566 4138 1362 3434 
-Q 1159 2731 1159 2009 
-Q 1159 1288 1364 580 
-Q 1569 -128 1984 -844 
-L 1484 -844 
-Q 1016 -109 783 600 
-Q 550 1309 550 2009 
-Q 550 2706 781 3412 
-Q 1013 4119 1484 4856 
-L 1984 4856 
+      <path id="DejaVuSans-4f" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSans-f" d="M 750 794 
@@ -1769,17 +1663,21 @@ L 750 256
 L 750 794 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-c" d="M 513 4856 
-L 1013 4856 
-Q 1481 4119 1714 3412 
-Q 1947 2706 1947 2009 
-Q 1947 1309 1714 600 
-Q 1481 -109 1013 -844 
-L 513 -844 
-Q 928 -128 1133 580 
-Q 1338 1288 1338 2009 
-Q 1338 2731 1133 3434 
-Q 928 4138 513 4856 
+      <path id="DejaVuSans-5c" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
 z
 " transform="scale(0.015625)"/>
      </defs>
@@ -1798,85 +1696,235 @@ z
      <use xlink:href="#DejaVuSans-5d" transform="translate(653.222656 0.015625)"/>
      <use xlink:href="#DejaVuSans-1d" transform="translate(705.712891 0.015625)"/>
      <use xlink:href="#DejaVuSans-3" transform="translate(739.404297 0.015625)"/>
-     <use xlink:href="#DejaVuSans-4f" transform="translate(771.191406 0.015625)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(798.974609 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(860.253906 0.015625)"/>
-     <use xlink:href="#DejaVuSans-46" transform="translate(892.041016 0.015625)"/>
-     <use xlink:href="#DejaVuSans-a3" transform="translate(947.021484 0.015625)"/>
-     <use xlink:href="#DejaVuSans-50" transform="translate(1008.300781 0.015625)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(1105.712891 0.015625)"/>
-     <use xlink:href="#DejaVuSans-55" transform="translate(1166.992188 0.015625)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(1208.105469 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1269.384766 0.015625)"/>
-     <use xlink:href="#DejaVuSans-56" transform="translate(1301.171875 0.015625)"/>
-     <use xlink:href="#DejaVuSans-4c" transform="translate(1353.271484 0.015625)"/>
-     <use xlink:href="#DejaVuSans-50" transform="translate(1381.054688 0.015625)"/>
-     <use xlink:href="#DejaVuSans-53" transform="translate(1478.466797 0.015625)"/>
-     <use xlink:href="#DejaVuSans-4f" transform="translate(1541.943359 0.015625)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(1569.726562 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1631.25 0.015625)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(1663.037109 0.015625)"/>
-     <use xlink:href="#DejaVuSans-56" transform="translate(1724.560547 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1776.660156 0.015625)"/>
-     <use xlink:href="#DejaVuSans-57" transform="translate(1808.447266 0.015625)"/>
-     <use xlink:href="#DejaVuSans-55" transform="translate(1847.65625 0.015625)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(1888.769531 0.015625)"/>
-     <use xlink:href="#DejaVuSans-51" transform="translate(1950.048828 0.015625)"/>
-     <use xlink:href="#DejaVuSans-56" transform="translate(2013.427734 0.015625)"/>
-     <use xlink:href="#DejaVuSans-53" transform="translate(2065.527344 0.015625)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(2129.003906 0.015625)"/>
-     <use xlink:href="#DejaVuSans-55" transform="translate(2190.283203 0.015625)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(2229.396484 0.015625)"/>
-     <use xlink:href="#DejaVuSans-51" transform="translate(2290.919922 0.015625)"/>
-     <use xlink:href="#DejaVuSans-57" transform="translate(2354.298828 0.015625)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(2393.507812 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(2455.03125 0.015625)"/>
-     <use xlink:href="#DejaVuSans-b" transform="translate(2486.818359 0.015625)"/>
-     <use xlink:href="#DejaVuSans-13" transform="translate(2525.832031 0.015625)"/>
-     <use xlink:href="#DejaVuSans-f" transform="translate(2589.455078 0.015625)"/>
-     <use xlink:href="#DejaVuSans-13" transform="translate(2621.242188 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(2684.865234 0.015625)"/>
-     <use xlink:href="#DejaVuSans-47" transform="translate(2716.652344 0.015625)"/>
-     <use xlink:href="#DejaVuSans-25" transform="translate(2780.128906 0.015625)"/>
-     <use xlink:href="#DejaVuSans-c" transform="translate(2848.732422 0.015625)"/>
-     <use xlink:href="#DejaVuSans-f" transform="translate(2887.746094 0.015625)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(771.191406 0.015625)"/>
+     <use xlink:href="#DejaVuSans-a3" transform="translate(826.171875 0.015625)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(887.451172 0.015625)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(984.863281 0.015625)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(1046.142578 0.015625)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1087.255859 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1148.535156 0.015625)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(1180.322266 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(1232.421875 0.015625)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(1260.205078 0.015625)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(1357.617188 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(1421.09375 0.015625)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1448.876953 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1510.400391 0.015625)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(1542.1875 0.015625)"/>
+     <use xlink:href="#DejaVuSans-f" transform="translate(1605.810547 0.015625)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(1637.597656 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1701.220703 0.015625)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(1733.007812 0.015625)"/>
+     <use xlink:href="#DejaVuSans-25" transform="translate(1796.484375 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1865.087891 0.015625)"/>
+     <use xlink:href="#DejaVuSans-5c" transform="translate(1896.875 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1956.054688 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(1987.841797 0.015625)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(2015.625 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2076.904297 0.015625)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(2108.691406 0.015625)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(2170.214844 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(2233.59375 0.015625)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(2272.802734 0.015625)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(2313.916016 0.015625)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(2375.195312 0.015625)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(2438.671875 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2499.951172 0.015625)"/>
+     <use xlink:href="#DejaVuSans-Oblique-2f" transform="translate(2531.738281 0.015625)"/>
+     <use xlink:href="#DejaVuSans-12" transform="translate(2587.451172 0.015625)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(2621.142578 0.015625)"/>
     </g>
-    <!-- la entrada $L/4$ da 5,1 dB y el par $L/4$ + $L/2$, 74 dB -->
-    <g style="fill: #ffffff" transform="translate(377.204084 189.666671) scale(0.0833 -0.0833)">
+    <!-- solo 0,6 dB, porque $L/4$ no está sintonizada aquí. -->
+    <g style="fill: #ffffff" transform="translate(72.248463 106.043046) scale(0.0833 -0.0833)">
      <defs>
-      <path id="DejaVuSans-5c" d="M 2059 -325 
-Q 1816 -950 1584 -1140 
-Q 1353 -1331 966 -1331 
-L 506 -1331 
-L 506 -850 
-L 844 -850 
-Q 1081 -850 1212 -737 
-Q 1344 -625 1503 -206 
-L 1606 56 
-L 191 3500 
-L 800 3500 
-L 1894 763 
-L 2988 3500 
-L 3597 3500 
-L 2059 -325 
+      <path id="DejaVuSans-54" d="M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+M 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 -1331 
+L 2906 -1331 
+L 2906 525 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-e" d="M 2944 4013 
-L 2944 2272 
-L 4684 2272 
-L 4684 1741 
-L 2944 1741 
-L 2944 0 
-L 2419 0 
-L 2419 1741 
-L 678 1741 
-L 678 2272 
-L 2419 2272 
-L 2419 4013 
-L 2944 4013 
+      <path id="DejaVuSans-af" d="M 1325 5119 
+L 1947 5119 
+L 929 3944 
+L 450 3944 
+L 1325 5119 
+z
+M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 891 3584 
+L 891 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-11" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
 z
 " transform="scale(0.015625)"/>
      </defs>
+     <use xlink:href="#DejaVuSans-56" transform="translate(0 0.015625)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(52.099609 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(113.28125 0.015625)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(141.064453 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(202.246094 0.015625)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(234.033203 0.015625)"/>
+     <use xlink:href="#DejaVuSans-f" transform="translate(297.65625 0.015625)"/>
+     <use xlink:href="#DejaVuSans-19" transform="translate(329.443359 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(393.066406 0.015625)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(424.853516 0.015625)"/>
+     <use xlink:href="#DejaVuSans-25" transform="translate(488.330078 0.015625)"/>
+     <use xlink:href="#DejaVuSans-f" transform="translate(556.933594 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(588.720703 0.015625)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(620.507812 0.015625)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(683.984375 0.015625)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(745.166016 0.015625)"/>
+     <use xlink:href="#DejaVuSans-54" transform="translate(784.279297 0.015625)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(847.755859 0.015625)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(911.134766 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(972.658203 0.015625)"/>
+     <use xlink:href="#DejaVuSans-Oblique-2f" transform="translate(1004.445312 0.015625)"/>
+     <use xlink:href="#DejaVuSans-12" transform="translate(1060.158203 0.015625)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(1093.849609 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1157.472656 0.015625)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1189.259766 0.015625)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(1252.638672 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1313.820312 0.015625)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1345.607422 0.015625)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(1407.130859 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1459.230469 0.015625)"/>
+     <use xlink:href="#DejaVuSans-a3" transform="translate(1498.439453 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1559.71875 0.015625)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(1591.505859 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(1643.605469 0.015625)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1671.388672 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1734.767578 0.015625)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(1773.976562 0.015625)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1835.158203 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(1898.537109 0.015625)"/>
+     <use xlink:href="#DejaVuSans-5d" transform="translate(1926.320312 0.015625)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1978.810547 0.015625)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(2040.089844 0.015625)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(2103.566406 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2164.845703 0.015625)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(2196.632812 0.015625)"/>
+     <use xlink:href="#DejaVuSans-54" transform="translate(2257.912109 0.015625)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(2321.388672 0.015625)"/>
+     <use xlink:href="#DejaVuSans-af" transform="translate(2384.767578 0.015625)"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(2412.550781 0.015625)"/>
+    </g>
+    <!-- La salida $L/2$ sí, y cortocircuita el conducto -->
+    <g style="fill: #ffffff" transform="translate(72.248463 116.375825) scale(0.0833 -0.0833)">
+     <defs>
+      <path id="DejaVuSans-2f" d="M 628 4666 
+L 1259 4666 
+L 1259 531 
+L 3531 531 
+L 3531 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-2f" transform="translate(0 0.015625)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(55.712891 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(116.992188 0.015625)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(148.779297 0.015625)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(200.878906 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(262.158203 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(289.941406 0.015625)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(317.724609 0.015625)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(381.201172 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(442.480469 0.015625)"/>
+     <use xlink:href="#DejaVuSans-Oblique-2f" transform="translate(474.267578 0.015625)"/>
+     <use xlink:href="#DejaVuSans-12" transform="translate(529.980469 0.015625)"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(563.671875 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(627.294922 0.015625)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(659.082031 0.015625)"/>
+     <use xlink:href="#DejaVuSans-af" transform="translate(711.181641 0.015625)"/>
+     <use xlink:href="#DejaVuSans-f" transform="translate(738.964844 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(770.751953 0.015625)"/>
+     <use xlink:href="#DejaVuSans-5c" transform="translate(802.539062 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(861.71875 0.015625)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(893.505859 0.015625)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(948.486328 0.015625)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(1009.667969 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1050.78125 0.015625)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(1089.990234 0.015625)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1151.171875 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(1206.152344 0.015625)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(1233.935547 0.015625)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1273.048828 0.015625)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(1328.029297 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(1391.408203 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1419.191406 0.015625)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1458.400391 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1519.679688 0.015625)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1551.466797 0.015625)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(1612.990234 0.015625)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1640.773438 0.015625)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1672.560547 0.015625)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(1727.541016 0.015625)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1788.722656 0.015625)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(1852.101562 0.015625)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(1915.578125 0.015625)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1978.957031 0.015625)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(2033.9375 0.015625)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(2073.146484 0.015625)"/>
+    </g>
+   </g>
+   <g id="patch_8">
+    <path d="M 615.475137 201.104702 
+Q 651.158237 191.57153 685.761188 182.326932 
+" style="fill: none; stroke: #1f77b4; stroke-linecap: round"/>
+    <path d="M 682.11208 181.577404 
+L 685.761188 182.326932 
+L 682.972101 184.796502 
+" style="fill: none; stroke: #1f77b4; stroke-linecap: round"/>
+   </g>
+   <g id="text_17">
+    <!-- $c/L$ = 858 Hz: -->
+    <g style="fill: #1f77b4" transform="translate(553.482697 201.909323) scale(0.0833 -0.0833)">
+     <use xlink:href="#DejaVuSans-Oblique-46" transform="translate(0 0.78125)"/>
+     <use xlink:href="#DejaVuSans-12" transform="translate(54.980469 0.78125)"/>
+     <use xlink:href="#DejaVuSans-Oblique-2f" transform="translate(88.671875 0.78125)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(144.384766 0.78125)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(176.171875 0.78125)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(259.960938 0.78125)"/>
+     <use xlink:href="#DejaVuSans-1b" transform="translate(291.748047 0.78125)"/>
+     <use xlink:href="#DejaVuSans-18" transform="translate(355.371094 0.78125)"/>
+     <use xlink:href="#DejaVuSans-1b" transform="translate(418.994141 0.78125)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(482.617188 0.78125)"/>
+     <use xlink:href="#DejaVuSans-2b" transform="translate(514.404297 0.78125)"/>
+     <use xlink:href="#DejaVuSans-5d" transform="translate(589.599609 0.78125)"/>
+     <use xlink:href="#DejaVuSans-1d" transform="translate(642.089844 0.78125)"/>
+    </g>
+    <!-- la entrada $L/4$ -->
+    <g style="fill: #1f77b4" transform="translate(553.482697 211.908903) scale(0.0833 -0.0833)">
      <use xlink:href="#DejaVuSans-4f" transform="translate(0 0.015625)"/>
      <use xlink:href="#DejaVuSans-44" transform="translate(27.783203 0.015625)"/>
      <use xlink:href="#DejaVuSans-3" transform="translate(89.0625 0.015625)"/>
@@ -1891,122 +1939,93 @@ z
      <use xlink:href="#DejaVuSans-Oblique-2f" transform="translate(543.896484 0.015625)"/>
      <use xlink:href="#DejaVuSans-12" transform="translate(599.609375 0.015625)"/>
      <use xlink:href="#DejaVuSans-17" transform="translate(633.300781 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(696.923828 0.015625)"/>
-     <use xlink:href="#DejaVuSans-47" transform="translate(728.710938 0.015625)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(792.1875 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(853.466797 0.015625)"/>
-     <use xlink:href="#DejaVuSans-18" transform="translate(885.253906 0.015625)"/>
-     <use xlink:href="#DejaVuSans-f" transform="translate(948.876953 0.015625)"/>
-     <use xlink:href="#DejaVuSans-14" transform="translate(980.664062 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1044.287109 0.015625)"/>
-     <use xlink:href="#DejaVuSans-47" transform="translate(1076.074219 0.015625)"/>
-     <use xlink:href="#DejaVuSans-25" transform="translate(1139.550781 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1208.154297 0.015625)"/>
-     <use xlink:href="#DejaVuSans-5c" transform="translate(1239.941406 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1299.121094 0.015625)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(1330.908203 0.015625)"/>
-     <use xlink:href="#DejaVuSans-4f" transform="translate(1392.431641 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1420.214844 0.015625)"/>
-     <use xlink:href="#DejaVuSans-53" transform="translate(1452.001953 0.015625)"/>
-     <use xlink:href="#DejaVuSans-44" transform="translate(1515.478516 0.015625)"/>
-     <use xlink:href="#DejaVuSans-55" transform="translate(1576.757812 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1617.871094 0.015625)"/>
-     <use xlink:href="#DejaVuSans-Oblique-2f" transform="translate(1649.658203 0.015625)"/>
-     <use xlink:href="#DejaVuSans-12" transform="translate(1705.371094 0.015625)"/>
-     <use xlink:href="#DejaVuSans-17" transform="translate(1739.0625 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1802.685547 0.015625)"/>
-     <use xlink:href="#DejaVuSans-e" transform="translate(1834.472656 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(1918.261719 0.015625)"/>
-     <use xlink:href="#DejaVuSans-Oblique-2f" transform="translate(1950.048828 0.015625)"/>
-     <use xlink:href="#DejaVuSans-12" transform="translate(2005.761719 0.015625)"/>
-     <use xlink:href="#DejaVuSans-15" transform="translate(2039.453125 0.015625)"/>
-     <use xlink:href="#DejaVuSans-f" transform="translate(2103.076172 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(2134.863281 0.015625)"/>
-     <use xlink:href="#DejaVuSans-1a" transform="translate(2166.650391 0.015625)"/>
-     <use xlink:href="#DejaVuSans-17" transform="translate(2230.273438 0.015625)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(2293.896484 0.015625)"/>
-     <use xlink:href="#DejaVuSans-47" transform="translate(2325.683594 0.015625)"/>
-     <use xlink:href="#DejaVuSans-25" transform="translate(2389.160156 0.015625)"/>
     </g>
-   </g>
-   <g id="patch_8">
-    <path d="M 268.242416 277.869154 
-Q 284.015015 337.036651 299.49963 395.12384 
-" style="fill: none; stroke: #d62728; stroke-linecap: round"/>
-    <path d="M 300.251157 391.475143 
-L 299.49963 395.12384 
-L 297.031589 392.333401 
-" style="fill: none; stroke: #d62728; stroke-linecap: round"/>
-   </g>
-   <g id="text_17">
-    <!-- cero nuevo, -->
-    <g style="fill: #d62728" transform="translate(240.004011 261.102667) scale(0.0833 -0.0833)">
-     <defs>
-      <path id="DejaVuSans-59" d="M 191 3500 
-L 800 3500 
-L 1894 563 
-L 2988 3500 
-L 3597 3500 
-L 2284 0 
-L 1503 0 
-L 191 3500 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-46"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(54.984375 0)"/>
-     <use xlink:href="#DejaVuSans-55" transform="translate(116.515625 0)"/>
-     <use xlink:href="#DejaVuSans-52" transform="translate(155.421875 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(216.609375 0)"/>
-     <use xlink:href="#DejaVuSans-51" transform="translate(248.390625 0)"/>
-     <use xlink:href="#DejaVuSans-58" transform="translate(311.765625 0)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(375.140625 0)"/>
-     <use xlink:href="#DejaVuSans-59" transform="translate(436.671875 0)"/>
-     <use xlink:href="#DejaVuSans-52" transform="translate(495.859375 0)"/>
-     <use xlink:href="#DejaVuSans-f" transform="translate(557.046875 0)"/>
-    </g>
-    <!-- 0,1 dB -->
-    <g style="fill: #d62728" transform="translate(240.004011 271.100944) scale(0.0833 -0.0833)">
-     <use xlink:href="#DejaVuSans-13"/>
-     <use xlink:href="#DejaVuSans-f" transform="translate(63.625 0)"/>
-     <use xlink:href="#DejaVuSans-14" transform="translate(95.40625 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(159.03125 0)"/>
-     <use xlink:href="#DejaVuSans-47" transform="translate(190.8125 0)"/>
-     <use xlink:href="#DejaVuSans-25" transform="translate(254.296875 0)"/>
+    <!-- sí lo está -->
+    <g style="fill: #1f77b4" transform="translate(553.482697 222.24038) scale(0.0833 -0.0833)">
+     <use xlink:href="#DejaVuSans-56"/>
+     <use xlink:href="#DejaVuSans-af" transform="translate(52.09375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(79.875 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(111.65625 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(139.4375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(200.625 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(232.40625 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(293.9375 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(346.03125 0)"/>
+     <use xlink:href="#DejaVuSans-a3" transform="translate(385.234375 0)"/>
     </g>
    </g>
    <g id="patch_9">
-    <path d="M 195.574114 277.869154 
-Q 211.346713 337.036651 226.831328 395.12384 
-" style="fill: none; stroke: #d62728; stroke-linecap: round"/>
-    <path d="M 227.582855 391.475143 
-L 226.831328 395.12384 
-L 224.363287 392.333401 
-" style="fill: none; stroke: #d62728; stroke-linecap: round"/>
+    <path d="M 224.969735 313.600386 
+Q 296.176926 355.76669 366.422101 397.363323 
+" style="fill: none; stroke: #1f77b4; stroke-linecap: round"/>
+    <path d="M 364.403946 394.232057 
+L 366.422101 397.363323 
+L 362.706195 397.099088 
+" style="fill: none; stroke: #1f77b4; stroke-linecap: round"/>
    </g>
    <g id="text_18">
-    <!-- cero nuevo, -->
-    <g style="fill: #d62728" transform="translate(167.335709 261.102667) scale(0.0833 -0.0833)">
-     <use xlink:href="#DejaVuSans-46"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(54.984375 0)"/>
-     <use xlink:href="#DejaVuSans-55" transform="translate(116.515625 0)"/>
-     <use xlink:href="#DejaVuSans-52" transform="translate(155.421875 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(216.609375 0)"/>
-     <use xlink:href="#DejaVuSans-51" transform="translate(248.390625 0)"/>
-     <use xlink:href="#DejaVuSans-58" transform="translate(311.765625 0)"/>
-     <use xlink:href="#DejaVuSans-48" transform="translate(375.140625 0)"/>
-     <use xlink:href="#DejaVuSans-59" transform="translate(436.671875 0)"/>
-     <use xlink:href="#DejaVuSans-52" transform="translate(495.859375 0)"/>
-     <use xlink:href="#DejaVuSans-f" transform="translate(557.046875 0)"/>
+    <!-- la entrada sola solo desplaza -->
+    <g style="fill: #1f77b4" transform="translate(141.824497 297.414889) scale(0.0833 -0.0833)">
+     <use xlink:href="#DejaVuSans-4f"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(27.78125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(89.0625 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(120.84375 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(182.375 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(245.75 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(284.953125 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(326.0625 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(387.34375 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(450.828125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(512.109375 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(543.890625 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(595.984375 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(657.171875 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(684.953125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(746.234375 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(778.015625 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(830.109375 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(891.296875 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(919.078125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(980.265625 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(1012.046875 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1075.53125 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(1137.0625 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(1189.15625 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(1252.640625 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1280.421875 0)"/>
+     <use xlink:href="#DejaVuSans-5d" transform="translate(1341.703125 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1394.1875 0)"/>
     </g>
-    <!-- 0,4 dB -->
-    <g style="fill: #d62728" transform="translate(167.335709 271.100944) scale(0.0833 -0.0833)">
-     <use xlink:href="#DejaVuSans-13"/>
-     <use xlink:href="#DejaVuSans-f" transform="translate(63.625 0)"/>
-     <use xlink:href="#DejaVuSans-17" transform="translate(95.40625 0)"/>
-     <use xlink:href="#DejaVuSans-3" transform="translate(159.03125 0)"/>
-     <use xlink:href="#DejaVuSans-47" transform="translate(190.8125 0)"/>
-     <use xlink:href="#DejaVuSans-25" transform="translate(254.296875 0)"/>
+    <!-- la caída que queda, a 444 Hz -->
+    <g style="fill: #1f77b4" transform="translate(141.824497 307.746367) scale(0.0833 -0.0833)">
+     <use xlink:href="#DejaVuSans-4f"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(27.78125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(89.0625 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(120.84375 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(175.828125 0)"/>
+     <use xlink:href="#DejaVuSans-af" transform="translate(237.109375 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(264.890625 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(328.375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(389.65625 0)"/>
+     <use xlink:href="#DejaVuSans-54" transform="translate(421.4375 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(484.921875 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(548.296875 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(609.828125 0)"/>
+     <use xlink:href="#DejaVuSans-54" transform="translate(641.609375 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(705.09375 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(768.46875 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(830 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(893.484375 0)"/>
+     <use xlink:href="#DejaVuSans-f" transform="translate(954.765625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(986.546875 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1018.328125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1079.609375 0)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(1111.390625 0)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(1175.015625 0)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(1238.640625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1302.265625 0)"/>
+     <use xlink:href="#DejaVuSans-2b" transform="translate(1334.046875 0)"/>
+     <use xlink:href="#DejaVuSans-5d" transform="translate(1409.25 0)"/>
     </g>
    </g>
    <g id="text_19">
@@ -2161,7 +2180,7 @@ Q 525.818938 71.61808 527.484938 71.61808
 z
 " style="opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
     </g>
-    <g id="line2d_31">
+    <g id="line2d_32">
      <path d="M 529.150938 38.042323 
 L 537.480938 38.042323 
 L 545.810938 38.042323 
@@ -2192,7 +2211,7 @@ L 545.810938 38.042323
       <use xlink:href="#DejaVuSans-50" transform="translate(1008.421875 0)"/>
      </g>
     </g>
-    <g id="line2d_32">
+    <g id="line2d_33">
      <path d="M 529.150938 50.872476 
 L 537.480938 50.872476 
 L 545.810938 50.872476 
@@ -2253,7 +2272,7 @@ z
       <use xlink:href="#DejaVuSans-50" transform="translate(1657.373047 0.015625)"/>
      </g>
     </g>
-    <g id="line2d_33">
+    <g id="line2d_34">
      <path d="M 529.150938 63.369428 
 L 537.480938 63.369428 
 L 545.810938 63.369428 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1056,6 +1056,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- `extended_tube_chamber` cascades its straight chamber element over the length
+  the extensions leave, `L - L_a - L_b`, not the full chamber length. The
+  junction where each extended pipe ends is where its three ducts meet, so the
+  duct between the two annular side branches is the leftover section; Bies
+  Example 8.2 states the same arithmetic, `L = L_a + L_b + L_c`, and the
+  cross-section drawing in this package already computed it that way. Against
+  Bies Figure 8.20 the previous cascade opened deep spurious dips where the
+  published curves are smooth (for an area ratio of 16, 5.2 dB at
+  `kL/pi = 0.6` and 5.6 dB at 1.15, where the figure holds a dome near 28 dB);
+  the corrected curves reproduce the figure, and an independent 2D FDTD
+  simulation of the same chamber now agrees with the model to 0.97 dB where
+  the old length missed by up to 11.1 dB. Transmission and insertion loss move
+  for every call that passes a non-zero extension. Extensions that exactly meet
+  are accepted as the limit they are, the two annular branches shunting one
+  plane; extensions that would overlap are still rejected, now with a message
+  that says the straight section would come out negative.
+
 - The coverage claims tell the truth again, all 582 of them audited claim by
   claim against the code. The errors ran almost entirely in one direction: the
   documentation undersold the library. Five claims denied functionality that

--- a/docs/devices/noise-control/silencers.md
+++ b/docs/devices/noise-control/silencers.md
@@ -159,7 +159,9 @@ qw = quarter_wave_resonator(f, duct_area=0.01, length=1.516, branch_area=2e-3,
                             speed_of_sound=343.24)
 print(round(float(qw.resonances[0]), 1))        # 56.6 Hz (Bies Example 8.1)
 
-# An inlet extension of L/4 fills the first expansion-chamber trough.
+# Each extension is a quarter-wave stub, so its own length picks the trough
+# it fills: L/4 = 0.1 m shorts the duct at c/4(L/4) = c/L, the chamber's
+# second trough, and L/2 = 0.2 m would take the first one at c/2L.
 et = extended_tube_chamber(f, length=0.4, chamber_area=0.04, pipe_area=0.01,
                            inlet_extension=0.1)
 ```

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -18629,7 +18629,9 @@ qw = quarter_wave_resonator(f, duct_area=0.01, length=1.516, branch_area=2e-3,
                             speed_of_sound=343.24)
 print(round(float(qw.resonances[0]), 1))        # 56.6 Hz (Bies Example 8.1)
 
-# An inlet extension of L/4 fills the first expansion-chamber trough.
+# Each extension is a quarter-wave stub, so its own length picks the trough
+# it fills: L/4 = 0.1 m shorts the duct at c/4(L/4) = c/L, the chamber's
+# second trough, and L/2 = 0.2 m would take the first one at c/2L.
 et = extended_tube_chamber(f, length=0.4, chamber_area=0.04, pipe_area=0.01,
                            inlet_extension=0.1)
 ```

--- a/scripts/figures/devices.py
+++ b/scripts/figures/devices.py
@@ -1185,20 +1185,28 @@ def generate_silencer_extended_tube(output_dir: str) -> None:
             label="Inlet extension $L/4$ = 0.10 m")
     ax.plot(freqs, both.transmission_loss, color=COLOR_SECONDARY, lw=1.7,
             ls="-.", label="Inlet $L/4$ and outlet $L/2$ = 0.20 m")
-    trough = 343.0 / (2.0 * kwargs["length"])
-    ax.axvline(trough, color=COLOR_GRID, lw=1.2, ls=":")
-    ax.annotate(f"$c/2L$ = {trough:.0f} Hz: the plain chamber is transparent "
-                "(0.0 dB),\nthe $L/4$ inlet gives 5.1 dB and the $L/4$ + "
-                "$L/2$ pair 74 dB", xy=(trough, 5.1),
-                xytext=(trough * 1.06, 26.0),
+    # Each extension is a quarter-wave stub, so its length picks which trough
+    # it fills: c/4(L/2) = c/2L is the first, c/4(L/4) = c/L the second.
+    first = 343.0 / (2.0 * kwargs["length"])
+    second = 343.0 / kwargs["length"]
+    for fx in (first, second):
+        ax.axvline(fx, color=COLOR_GRID, lw=1.2, ls=":")
+    ax.annotate(f"$c/2L$ = {first:.0f} Hz: plain chamber 0.0 dB and the "
+                "$L/4$ inlet\nstill only 0.6 dB, because $L/4$ is not tuned "
+                "here.\nThe $L/2$ outlet is, and shorts the duct",
+                xy=(first, 27.0), xytext=(60.0, 35.0),
                 fontsize="small", color=COLOR_FG,
                 arrowprops={"arrowstyle": "->", "color": COLOR_FG, "lw": 1.0})
-    for fx, label in ((355.0, "0.1 dB"), (261.0, "0.4 dB")):
-        ax.annotate(f"new trough,\n{label}", xy=(fx, 0.4),
-                    xytext=(fx - 78.0, 16.0), fontsize="small",
-                    color=COLOR_SECONDARY,
-                    arrowprops={"arrowstyle": "->", "color": COLOR_SECONDARY,
-                                "lw": 1.0})
+    ax.annotate(f"$c/L$ = {second:.0f} Hz:\nthe $L/4$ inlet\nis tuned here",
+                xy=(second, 27.0), xytext=(second - 175.0, 22.0),
+                fontsize="small", color=COLOR_PRIMARY,
+                arrowprops={"arrowstyle": "->", "color": COLOR_PRIMARY,
+                            "lw": 1.0})
+    ax.annotate("the inlet alone only moves\nthe surviving trough, to 444 Hz",
+                xy=(444.0, 0.3), xytext=(150.0, 11.5), fontsize="small",
+                color=COLOR_PRIMARY,
+                arrowprops={"arrowstyle": "->", "color": COLOR_PRIMARY,
+                            "lw": 1.0})
     ax.set_xlim(20.0, 880.0)
     ax.set_ylim(0.0, 46.0)
     ax.set_xlabel(LABEL_FREQ_HZ)

--- a/scripts/figures/i18n.py
+++ b/scripts/figures/i18n.py
@@ -3673,10 +3673,16 @@ _ES_EXACT = {
     "Inlet extension $L/4$ = 0.10 m": "Extensión de entrada $L/4$ = 0,10 m",
     "Inlet $L/4$ and outlet $L/2$ = 0.20 m":
         "Entrada $L/4$ y salida $L/2$ = 0,20 m",
-    "$c/2L$ = 429 Hz: the plain chamber is transparent (0.0 dB),\n"
-    "the $L/4$ inlet gives 5.1 dB and the $L/4$ + $L/2$ pair 74 dB":
-        "$c/2L$ = 429 Hz: la cámara simple es transparente (0,0 dB),\n"
-        "la entrada $L/4$ da 5,1 dB y el par $L/4$ + $L/2$, 74 dB",
+    "$c/2L$ = 429 Hz: plain chamber 0.0 dB and the $L/4$ inlet\n"
+    "still only 0.6 dB, because $L/4$ is not tuned here.\n"
+    "The $L/2$ outlet is, and shorts the duct":
+        "$c/2L$ = 429 Hz: cámara simple 0,0 dB y la entrada $L/4$\n"
+        "solo 0,6 dB, porque $L/4$ no está sintonizada aquí.\n"
+        "La salida $L/2$ sí, y cortocircuita el conducto",
+    "$c/L$ = 858 Hz:\nthe $L/4$ inlet\nis tuned here":
+        "$c/L$ = 858 Hz:\nla entrada $L/4$\nsí lo está",
+    "the inlet alone only moves\nthe surviving trough, to 444 Hz":
+        "la entrada sola solo desplaza\nla caída que queda, a 444 Hz",
     # duct_attenuation_elements: the four element panels
     "(a) 36 × 24 in run, 5 ft": "(a) Tramo de 36 × 24 in, 5 ft",
     "(b) One bend, $W$ = 24 in": "(b) Un codo, $W$ = 24 in",

--- a/site/public/llms/llms-devices-noise-control.txt
+++ b/site/public/llms/llms-devices-noise-control.txt
@@ -1512,7 +1512,9 @@ qw = quarter_wave_resonator(f, duct_area=0.01, length=1.516, branch_area=2e-3,
                             speed_of_sound=343.24)
 print(round(float(qw.resonances[0]), 1))        # 56.6 Hz (Bies Example 8.1)
 
-# An inlet extension of L/4 fills the first expansion-chamber trough.
+# Each extension is a quarter-wave stub, so its own length picks the trough
+# it fills: L/4 = 0.1 m shorts the duct at c/4(L/4) = c/L, the chamber's
+# second trough, and L/2 = 0.2 m would take the first one at c/2L.
 et = extended_tube_chamber(f, length=0.4, chamber_area=0.04, pipe_area=0.01,
                            inlet_extension=0.1)
 ```

--- a/site/src/content/docs/devices/noise-control/silencers.mdx
+++ b/site/src/content/docs/devices/noise-control/silencers.mdx
@@ -354,29 +354,34 @@ qw_hot = quarter_wave_resonator(f_hot, duct_area=0.01, length=0.3,
                                 branch_area=2e-3, speed_of_sound=557.0)
 print(round(float(qw_hot.resonances[0]), 1))   # 464.2 Hz, not 285.8
 
-# An inlet extension of L/4 fills the first expansion-chamber trough.
+# Each extension is a quarter-wave stub, so its own length picks the trough
+# it fills: L/4 = 0.1 m shorts the duct at c/4(L/4) = c/L, the chamber's
+# second trough, and L/2 = 0.2 m would take the first one at c/2L.
 et = extended_tube_chamber(f, length=0.4, chamber_area=0.04, pipe_area=0.01,
                            inlet_extension=0.1)
 print(round(float(et.transmission_loss[np.argmin(abs(f - 428.75))]), 1))
-# 5.1 dB where the plain chamber reads 0.0
+# 0.6 dB at c/2L: the L/4 stub is tuned an octave above it
 ```
 
-An extension is a quarter-wave stub buried inside the chamber, so it does its
-work where the chamber has none. The plain 0.4 m chamber is transparent at
-$c/2L = 429$ Hz; a 0.1 m inlet extension ($L/4$) puts 5.1 dB back there, and
-adding a 0.2 m outlet extension ($L/2$) turns the trough into a 74 dB spike.
-The trade is visible in the same figure: each extension is itself a resonator,
-so it opens a **new** trough of its own — at 355 Hz for the inlet extension
-alone and at 261 Hz for the pair.
+An extension is a quarter-wave stub buried inside the chamber, so its own
+length decides which trough it fills: a stub of length $L_\text{ext}$ shorts
+the duct at $c/4L_\text{ext}$. The plain 0.4 m chamber is transparent at
+$c/2L = 429$ Hz and again at $c/L = 858$ Hz. The 0.1 m inlet extension ($L/4$)
+is tuned to 858 Hz, so it shorts the second trough and leaves the first almost
+untouched at 0.6 dB; the 0.2 m outlet extension ($L/2$) is the one tuned to
+429 Hz, and the pair covers both. The trade is visible in the same figure: on
+its own the inlet extension does not remove the trough it misses, it moves it,
+to 444 Hz.
 
-<ThemeImage src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/silencer_extended_tube.svg" alt="Transmission loss from 20 to 880 Hz of a 0.4 m expansion chamber in three configurations: the plain chamber as a dashed hump reaching 6.5 dB and falling to zero at 429 Hz, the same chamber with a 0.10 m inlet extension which is worth 5.1 dB at 429 Hz but opens a new zero at 355 Hz, and the chamber with both a 0.10 m inlet and a 0.20 m outlet extension which spikes past 45 dB at 429 Hz and opens its own zero at 261 Hz" width="88%" />
+<ThemeImage src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/silencer_extended_tube.svg" alt="Transmission loss from 20 to 880 Hz of a 0.4 m expansion chamber in three configurations: the plain chamber as a dashed pair of humps reaching 6.5 dB and falling to zero at 429 and at 858 Hz, the same chamber with a 0.10 m inlet extension which runs off the top of the plot at 858 Hz but reads only 0.6 dB at 429 Hz and keeps a trough there, moved to 444 Hz, and the chamber with both a 0.10 m inlet and a 0.20 m outlet extension which runs off the top at 429 and at 858 Hz and has no trough left in the band" width="88%" />
 
 *What an internal extension buys, and what it costs. The plain chamber's 0 dB
-troughs at every half wavelength are its fatal defect; a quarter-wave extension
-fills the first one, and a second extension of half the length turns it into a
-short. Each extension then rings at its own length, which is why the troughs
-move rather than disappear and why an extended-tube chamber is designed against
-the source spectrum rather than in general.*
+troughs at every half wavelength are its fatal defect, and each extension
+shorts exactly the one its own length tunes: $L/2$ takes the first, $L/4$ the
+second. A single extension therefore moves the trough it misses rather than
+removing it, which is why the extensions are sized in pairs and why an
+extended-tube chamber is designed against the source spectrum rather than in
+general.*
 
 <details>
 <summary>Show the code for this figure</summary>

--- a/site/src/content/docs/es/devices/noise-control/silencers.mdx
+++ b/site/src/content/docs/es/devices/noise-control/silencers.mdx
@@ -368,30 +368,35 @@ qw_hot = quarter_wave_resonator(f_hot, duct_area=0.01, length=0.3,
                                 branch_area=2e-3, speed_of_sound=557.0)
 print(round(float(qw_hot.resonances[0]), 1))   # 464.2 Hz, no 285.8
 
-# Una extensión de entrada de L/4 rellena la primera caída de la cámara.
+# Cada extensión es un tubo de cuarto de onda, así que su propia longitud
+# elige la caída que rellena: L/4 = 0,1 m cortocircuita el conducto en
+# c/4(L/4) = c/L, la segunda caída de la cámara, y L/2 = 0,2 m tomaría la
+# primera, en c/2L.
 et = extended_tube_chamber(f, length=0.4, chamber_area=0.04, pipe_area=0.01,
                            inlet_extension=0.1)
 print(round(float(et.transmission_loss[np.argmin(abs(f - 428.75))]), 1))
-# 5.1 dB donde la cámara simple marca 0.0
+# 0.6 dB en c/2L: el tubo L/4 está sintonizado una octava por encima
 ```
 
 Una extensión es un tubo de cuarto de onda alojado dentro de la cámara, así que
-trabaja justo donde la cámara no tiene nada. La cámara simple de 0,4 m es
-transparente en $c/2L = 429$ Hz; una extensión de entrada de 0,1 m ($L/4$)
-devuelve ahí 5,1 dB, y añadir una extensión de salida de 0,2 m ($L/2$) convierte
-la caída en un pico de 74 dB. El precio se ve en la misma figura: cada extensión
-es a su vez un resonador, así que abre una caída **nueva** propia, en 355 Hz con
-la extensión de entrada sola y en 261 Hz con las dos.
+su propia longitud decide qué caída rellena: un tubo de longitud
+$L_\text{ext}$ cortocircuita el conducto en $c/4L_\text{ext}$. La cámara simple
+de 0,4 m es transparente en $c/2L = 429$ Hz y otra vez en $c/L = 858$ Hz. La
+extensión de entrada de 0,1 m ($L/4$) está sintonizada en 858 Hz, así que
+cortocircuita la segunda caída y deja la primera casi intacta, en 0,6 dB; la
+extensión de salida de 0,2 m ($L/2$) es la sintonizada en 429 Hz, y el par
+cubre las dos. El precio se ve en la misma figura: por sí sola, la extensión de
+entrada no elimina la caída que no le toca, la desplaza, a 444 Hz.
 
-<ThemeImage src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/silencer_extended_tube_es.svg" alt="Pérdida de transmisión de 20 a 880 Hz de una cámara de expansión de 0,4 m en tres configuraciones: la cámara simple como joroba discontinua que llega a 6,5 dB y cae a cero en 429 Hz, esa misma cámara con una extensión de entrada de 0,10 m que aporta 5,1 dB en 429 Hz pero abre un cero nuevo en 355 Hz, y la cámara con extensión de entrada de 0,10 m y de salida de 0,20 m, que se dispara por encima de 45 dB en 429 Hz y abre su propio cero en 261 Hz" width="88%" />
+<ThemeImage src="https://raw.githubusercontent.com/jmrplens/phonometry/main/.github/images/silencer_extended_tube_es.svg" alt="Pérdida de transmisión de 20 a 880 Hz de una cámara de expansión de 0,4 m en tres configuraciones: la cámara simple como pareja de jorobas discontinuas que llegan a 6,5 dB y caen a cero en 429 y en 858 Hz, esa misma cámara con una extensión de entrada de 0,10 m que se sale por arriba del gráfico en 858 Hz pero solo marca 0,6 dB en 429 Hz y conserva ahí una caída, desplazada a 444 Hz, y la cámara con extensión de entrada de 0,10 m y de salida de 0,20 m, que se sale por arriba en 429 y en 858 Hz y no deja ninguna caída en la banda" width="88%" />
 
 *Lo que aporta una extensión interior, y lo que cuesta. Las caídas a 0 dB de la
-cámara simple en cada media longitud de onda son su defecto fatal; una extensión
-de cuarto de onda rellena la primera, y una segunda extensión de la mitad de
-longitud la convierte en un cortocircuito. Cada extensión pasa entonces a
-resonar en su propia longitud, que es la razón de que las caídas se muevan en
-lugar de desaparecer y de que una cámara de tubo extendido se diseñe contra el
-espectro de la fuente y no en general.*
+cámara simple en cada media longitud de onda son su defecto fatal, y cada
+extensión cortocircuita exactamente la que sintoniza su propia longitud: $L/2$
+se lleva la primera y $L/4$ la segunda. Una sola extensión, por tanto, desplaza
+la caída que no le toca en lugar de eliminarla, que es la razón de que las
+extensiones se dimensionen por parejas y de que una cámara de tubo extendido se
+diseñe contra el espectro de la fuente y no en general.*
 
 <details>
 <summary>Mostrar el código de esta figura</summary>

--- a/site/src/content/docs/reference/api/noise_control/silencers.md
+++ b/site/src/content/docs/reference/api/noise_control/silencers.md
@@ -155,12 +155,21 @@ fill the $kL = n \pi$ troughs of the plain expansion chamber. With
 both extensions `0` the result reduces exactly to
 [`expansion_chamber`](/phonometry/reference/api/noise_control/silencers/#expansion_chamber).
 
+The junction where each extended pipe ends is where its three ducts meet,
+so the straight chamber element cascaded between the two side branches is
+the length left over,
+$L_c = L - L_a - L_b$ (Bies Figure 8.19(a) and Example 8.2, where
+$L = L_a + L_b + L_c$), and not the full chamber length. When the two
+extensions meet ($L_a + L_b = L$) the straight element vanishes and
+the two annular branches shunt the same plane, which is the well-defined
+limit of the cascade; extensions that would overlap are rejected.
+
 **Parameters**
 
 | Name | Description |
 | :--- | :--- |
 | `frequencies` | Frequencies `f`, Hz (1-D array). |
-| `length` | Chamber length `L`, m. |
+| `length` | Overall chamber length `L`, m, extensions included. |
 | `chamber_area` | Chamber cross-sectional area `S_exp`, m2. |
 | `pipe_area` | Inlet/outlet pipe area `S_duct`, m2. |
 | `inlet_extension` | Inlet pipe extension into the chamber `L_a`, m. |

--- a/src/phonometry/noise_control/silencers.py
+++ b/src/phonometry/noise_control/silencers.py
@@ -118,6 +118,12 @@ if TYPE_CHECKING:
 #: Reference air properties at 20 degC, 101.325 kPa.
 _C_AIR = 343.0
 _RHO_AIR = 1.206
+#: Relative slack allowed when two extended tubes meet inside a chamber. Their
+#: sum has to clear the chamber length by more than this fraction of it to count
+#: as an overlap, which separates a geometry the user did not intend from the
+#: last bits of a sum like 0.1 + 0.2. Nine orders of magnitude below the length
+#: is far above the arithmetic and far below any dimension anyone draws.
+_MEETING_SLACK = 1e-9
 
 _Complex = NDArray[np.complex128]
 
@@ -754,16 +760,21 @@ def extended_tube_chamber(
     lb = require_non_negative(outlet_extension, "outlet_extension")
     if s_exp <= s_duct:
         raise ValueError("'chamber_area' must exceed 'pipe_area'.")
-    if la + lb > length:
+    # The straight section between the two junction planes. Extensions that
+    # meet exactly are the accepted limit, but binary arithmetic does not
+    # respect that: 0.1 + 0.2 exceeds 0.3 by an ulp, so a chamber described in
+    # round decimal metres would be refused for a geometry it does in fact
+    # have. What is rejected is therefore a materially negative section, and
+    # anything within rounding of zero is clamped to it, since a duct of
+    # negative length is not a thing either.
+    straight = length - la - lb
+    if straight < -_MEETING_SLACK * max(length, la + lb):
         raise ValueError(
             "the inlet and outlet extensions cannot together exceed the "
             "chamber length (they would overlap inside the chamber, leaving "
             "a straight chamber section of negative length)."
         )
-    # The straight section between the two junction planes. Clamped because
-    # subtracting two exactly-meeting extensions can land a rounding step
-    # below zero, and a duct of negative length is not a thing.
-    straight = max(length - la - lb, 0.0)
+    straight = max(straight, 0.0)
     annulus = s_exp - s_duct
 
     elements = []

--- a/src/phonometry/noise_control/silencers.py
+++ b/src/phonometry/noise_control/silencers.py
@@ -723,8 +723,17 @@ def extended_tube_chamber(
     both extensions ``0`` the result reduces exactly to
     :func:`expansion_chamber`.
 
+    The junction where each extended pipe ends is where its three ducts meet,
+    so the straight chamber element cascaded between the two side branches is
+    the length left over,
+    :math:`L_c = L - L_a - L_b` (Bies Figure 8.19(a) and Example 8.2, where
+    :math:`L = L_a + L_b + L_c`), and not the full chamber length. When the two
+    extensions meet (:math:`L_a + L_b = L`) the straight element vanishes and
+    the two annular branches shunt the same plane, which is the well-defined
+    limit of the cascade; extensions that would overlap are rejected.
+
     :param frequencies: Frequencies ``f``, Hz (1-D array).
-    :param length: Chamber length ``L``, m.
+    :param length: Overall chamber length ``L``, m, extensions included.
     :param chamber_area: Chamber cross-sectional area ``S_exp``, m2.
     :param pipe_area: Inlet/outlet pipe area ``S_duct``, m2.
     :param inlet_extension: Inlet pipe extension into the chamber ``L_a``, m.
@@ -740,6 +749,7 @@ def extended_tube_chamber(
     rho = require_positive(density, "density")
     s_exp = require_positive(chamber_area, "chamber_area")
     s_duct = require_positive(pipe_area, "pipe_area")
+    length = require_non_negative(length, "length")
     la = require_non_negative(inlet_extension, "inlet_extension")
     lb = require_non_negative(outlet_extension, "outlet_extension")
     if s_exp <= s_duct:
@@ -747,8 +757,13 @@ def extended_tube_chamber(
     if la + lb > length:
         raise ValueError(
             "the inlet and outlet extensions cannot together exceed the "
-            "chamber length (they would overlap inside the chamber)."
+            "chamber length (they would overlap inside the chamber, leaving "
+            "a straight chamber section of negative length)."
         )
+    # The straight section between the two junction planes. Clamped because
+    # subtracting two exactly-meeting extensions can land a rounding step
+    # below zero, and a duct of negative length is not a thing.
+    straight = max(length - la - lb, 0.0)
     annulus = s_exp - s_duct
 
     elements = []
@@ -758,7 +773,9 @@ def extended_tube_chamber(
             quarter_wave_impedance(f, la, annulus, speed_of_sound=c, density=rho)
         ))
         resonances.append(c / (4.0 * la))
-    elements.append(duct_matrix(f, length, s_exp, speed_of_sound=c, density=rho))
+    elements.append(
+        duct_matrix(f, straight, s_exp, speed_of_sound=c, density=rho)
+    )
     if lb > 0.0:
         elements.append(shunt_matrix(
             quarter_wave_impedance(f, lb, annulus, speed_of_sound=c, density=rho)

--- a/tests/noise_control/test_fdtd_crosscheck.py
+++ b/tests/noise_control/test_fdtd_crosscheck.py
@@ -16,13 +16,14 @@ frequencies. The measured ``20 log10`` ratio of the transmitted amplitudes
 (trough over peak) must reproduce the closed-form peak ``TL``. The run is
 deterministic and small (a 16x200 grid, ~3000 steps, well under a second).
 
-The Helmholtz side branch is driven with a broadband pulse instead, because
-the quantity to compare is a *resonance frequency* and a tone sweep would need
-one run per frequency. One pulse run of the bare duct and one of the duct with
-the resonator give the whole transmission spectrum
-``|p_resonator(f)| / |p_bare(f)|``, that is the insertion loss, which for equal
+The Helmholtz side branch and the extended-tube chamber are driven with a
+broadband pulse instead, because what has to be compared is a whole curve (a
+resonance frequency in one case, a transmission-loss band in the other) and a
+tone sweep would need one run per frequency. One pulse run of the bare duct and
+one of the duct with the device give the whole transmission spectrum
+``|p_device(f)| / |p_bare(f)|``, that is the insertion loss, which for equal
 inlet and outlet areas and anechoic ends is the transmission loss. The point
-sources are additive (soft), so the wave the resonator reflects back passes
+sources are additive (soft), so the wave the device reflects back passes
 through the source cell untouched and is swallowed by the upstream sponge: the
 source really does present the anechoic internal impedance that identity needs.
 """
@@ -39,6 +40,35 @@ from phonometry.noise_control import silencers as sl
 from phonometry.simulation.fdtd import CWSource, GaussianPulse, fdtd_simulation
 
 _C = 343.0
+#: FFT zero-padding factor for the pulse runs; the underlying spectrum is
+#: band-limited by the record, so interpolating it costs nothing but arithmetic.
+_PAD = 16
+
+
+def _pulse_spectrum(
+    obstacle: NDArray[np.bool_],
+    *,
+    source: tuple[int, int],
+    probe: tuple[int, int],
+    steps: int,
+    dx: float,
+    pulse_width: float,
+    sponge: int,
+) -> tuple[NDArray[np.float64], NDArray[np.complex128]]:
+    """Probe spectrum of one broadband pulse run: ``(frequencies, P(f))``."""
+    dt = 0.6 * dx / (_C * math.sqrt(2.0))
+    res = fdtd_simulation(
+        _C, dx, steps * dt,
+        sources=[GaussianPulse(ix=source[0], iy=source[1], width=pulse_width)],
+        shape=obstacle.shape, probes=[probe],
+        boundaries={"left": "absorbing", "right": "absorbing",
+                    "top": "rigid", "bottom": "rigid"},
+        absorbing_layer_cells=sponge, obstacle_mask=obstacle,
+    )
+    p = res.pressures[0]
+    n = p.size * _PAD
+    return np.fft.rfftfreq(n, dt), np.fft.rfft(p, n)
+
 
 # --- Simple expansion chamber, driven with a steady tone --------------------
 
@@ -149,7 +179,6 @@ _HSTEPS = 5000
 _HSPONGE = 20
 _HSRC = (45, _HNY - 4)                  # on the duct axis, upstream
 _HPROBE = (_HNX - 60, _HNY - 4)         # on the duct axis, downstream
-_HPAD = 16                              # FFT zero-padding factor
 
 _HS_DUCT = _HDUCT * _HDX
 _HS_NECK = _HNECK_W * _HDX
@@ -199,21 +228,12 @@ def _h_transmission(cavity_width: int | None) -> tuple[
     NDArray[np.float64], NDArray[np.complex128]
 ]:
     """Probe spectrum of one pulse run: ``(frequencies, P(f))``."""
-    dt = 0.6 * _HDX / (_C * math.sqrt(2.0))
-    # A Gaussian wide enough to cover DC up to about twice the resonance.
-    width = 1.0 / (4.0 * _h_nominal_resonance(_HCAV_NARROW))
-    res = fdtd_simulation(
-        _C, _HDX, _HSTEPS * dt,
-        sources=[GaussianPulse(ix=_HSRC[0], iy=_HSRC[1], width=width)],
-        shape=(_HNY, _HNX), probes=[_HPROBE],
-        boundaries={"left": "absorbing", "right": "absorbing",
-                    "top": "rigid", "bottom": "rigid"},
-        absorbing_layer_cells=_HSPONGE,
-        obstacle_mask=_helmholtz_mask(cavity_width),
+    return _pulse_spectrum(
+        _helmholtz_mask(cavity_width), source=_HSRC, probe=_HPROBE,
+        steps=_HSTEPS, dx=_HDX, sponge=_HSPONGE,
+        # A Gaussian wide enough to cover DC up to about twice the resonance.
+        pulse_width=1.0 / (4.0 * _h_nominal_resonance(_HCAV_NARROW)),
     )
-    p = res.pressures[0]
-    n = p.size * _HPAD
-    return np.fft.rfftfreq(n, dt), np.fft.rfft(p, n)
 
 
 @pytest.fixture(scope="module")
@@ -356,3 +376,151 @@ def test_fdtd_helmholtz_transmission_loss_curve(
     # And the branch really does short the duct: a deep notch, not a dent.
     assert measured.max() > 10.0
     assert -20.0 * math.log10(ratio.min()) > 25.0
+
+
+# --- Extended-tube chamber, driven with a broadband pulse -------------------
+#
+# The chamber runs the full grid height over columns [_EX1, _EX2); the inlet
+# and outlet pipes are the middle _EDUCT rows, and their walls (the single rows
+# just outside the duct) carry on into the chamber for _ELA and _ELB cells to
+# make the two extensions. The mapping onto the four-pole model is exact for
+# the lengths, which is what these tests are about:
+#
+#   * chamber length  L   = (_EX2 - _EX1) * _EDX
+#   * extensions      L_a = _ELA * _EDX, L_b = _ELB * _EDX, measured from the
+#     chamber end plates to the plane where each pipe ends
+#   * straight section between the two junction planes, L - L_a - L_b
+#
+# It is not exact for the annulus. A real pipe wall has thickness and the model
+# has none, so the model's annulus S_exp - S_duct is 34 cells where the grid
+# leaves 32 open; that difference is priced into the tolerance below rather
+# than hidden, because widening the chamber until it vanished would cost more
+# grid than the point is worth.
+
+_EDX = 0.01
+_ENY = 40            # chamber height, cells; the duct is _EDUCT of them
+_ENX = 260
+_EDUCT = 6
+_EDUCT0 = 17         # first duct row, so the pipe walls are rows 16 and 23
+_EX1, _EX2 = 100, 180                   # chamber columns -> L = 0.8 m
+_EL = (_EX2 - _EX1) * _EDX
+_ELA = (_EX2 - _EX1) // 2               # inlet extension L/2
+_ELB = (_EX2 - _EX1) // 4               # outlet extension L/4
+_ESTEPS = 5000
+_ESPONGE = 20
+_ESRC = (45, _EDUCT0 + 3)
+_EPROBE = (_ENX - 50, _EDUCT0 + 3)
+
+_ES_EXP = _ENY * _EDX
+_ES_DUCT = _EDUCT * _EDX
+#: Where the comparison is taken, as kL/pi. The stops well short of the inlet
+#: stub's quarter-wave resonance at kL/pi = 1 (and the outlet stub's at 2): the
+#: extensions carry end corrections of their own, which shift those peaks down
+#: and lift the shoulder underneath them, and no end correction is applied
+#: here.
+_E_KL_PI = np.array([0.20, 0.25, 0.30, 0.35, 0.40, 0.45, 0.50, 0.55])
+
+
+def _extended_tube_mask(*, extended: bool) -> NDArray[np.bool_]:
+    """Rigid-cell map; ``extended=False`` gives the bare reference duct."""
+    mask = np.ones((_ENY, _ENX), dtype=bool)
+    mask[_EDUCT0:_EDUCT0 + _EDUCT, :] = False       # the straight main duct
+    if not extended:
+        return mask
+    mask[:, _EX1:_EX2] = False                      # the chamber, full height
+    for row in (_EDUCT0 - 1, _EDUCT0 + _EDUCT):     # the two pipe walls
+        mask[row, _EX1:_EX1 + _ELA] = True          # carried on as the inlet
+        mask[row, _EX2 - _ELB:_EX2] = True          # and the outlet extension
+    return mask
+
+
+@pytest.fixture(scope="module")
+def extended_tube_loss() -> tuple[NDArray[np.float64], NDArray[np.float64]]:
+    """``(frequencies, transmission loss)`` from two FDTD runs (~1 s)."""
+    frequencies, bare = _pulse_spectrum(
+        _extended_tube_mask(extended=False), source=_ESRC, probe=_EPROBE,
+        steps=_ESTEPS, dx=_EDX, sponge=_ESPONGE,
+        pulse_width=_EL / _C,   # covers DC through several kL/pi
+    )
+    _, loaded = _pulse_spectrum(
+        _extended_tube_mask(extended=True), source=_ESRC, probe=_EPROBE,
+        steps=_ESTEPS, dx=_EDX, sponge=_ESPONGE, pulse_width=_EL / _C,
+    )
+    return frequencies, 20.0 * np.log10(np.abs(bare) / np.abs(loaded))
+
+
+def _e_measured(
+    spectrum: tuple[NDArray[np.float64], NDArray[np.float64]],
+) -> NDArray[np.float64]:
+    """Transmission loss at the comparison frequencies."""
+    frequencies, loss = spectrum
+    wanted = _E_KL_PI * _C / (2.0 * _EL)
+    return np.array([
+        loss[int(np.argmin(np.abs(frequencies - f)))] for f in wanted
+    ])
+
+
+def _e_cascade_by_hand(straight: float) -> NDArray[np.float64]:
+    """The same three elements, with the straight duct length spelled out."""
+    frequencies = _E_KL_PI * _C / (2.0 * _EL)
+    annulus = _ES_EXP - _ES_DUCT
+    return sl.transmission_loss(
+        sl.cascade(
+            sl.shunt_matrix(sl.quarter_wave_impedance(
+                frequencies, _ELA * _EDX, annulus, speed_of_sound=_C)),
+            sl.duct_matrix(frequencies, straight, _ES_EXP, speed_of_sound=_C),
+            sl.shunt_matrix(sl.quarter_wave_impedance(
+                frequencies, _ELB * _EDX, annulus, speed_of_sound=_C)),
+        ),
+        inlet_area=_ES_DUCT, outlet_area=_ES_DUCT, speed_of_sound=_C,
+    )
+
+
+@pytest.mark.xdist_group("fdtd-extended-tube")
+def test_fdtd_matches_extended_tube_chamber(
+    extended_tube_loss: tuple[NDArray[np.float64], NDArray[np.float64]],
+) -> None:
+    # Error budget for the 1.5 dB bound, largest term first.
+    #
+    # The pipe walls are one cell thick, so the grid leaves 32 cells of annulus
+    # where the model, whose pipe wall is infinitely thin, assumes 34. Feeding
+    # the model the annulus the grid actually has moves its answer by 0.28 to
+    # 0.33 dB across this band, uniformly and in one direction.
+    #
+    # The extensions have end corrections of their own (Bies Eq. (8.169),
+    # Munjal Eq. (8.8)) which lower their quarter-wave tuning by a few per cent
+    # and lift the shoulder below it. None is applied, so the residual grows
+    # toward kL/pi = 1 and the band stops at 0.55.
+    #
+    # Grid dispersion is not a term at this scale: the shortest wavelength in
+    # the band spans 291 cells, so (k dx)^2 / 24 = 1.9e-5, two thousandths of a
+    # per cent of frequency and nothing measurable in dB. Nor is the grid
+    # itself: growing it from 260 to 420 columns and the record from 5000 to
+    # 9000 steps moves the residuals by at most 0.25 dB.
+    #
+    # Measured: -0.30 to +0.97 dB.
+    measured = _e_measured(extended_tube_loss)
+    analytic = sl.extended_tube_chamber(
+        _E_KL_PI * _C / (2.0 * _EL), _EL, _ES_EXP, _ES_DUCT,
+        inlet_extension=_ELA * _EDX, outlet_extension=_ELB * _EDX,
+        speed_of_sound=_C,
+    ).transmission_loss
+    assert measured == pytest.approx(analytic, abs=1.5)
+
+
+@pytest.mark.xdist_group("fdtd-extended-tube")
+def test_fdtd_rejects_a_chamber_element_of_the_full_length(
+    extended_tube_loss: tuple[NDArray[np.float64], NDArray[np.float64]],
+) -> None:
+    # The straight element between the two junction planes is what the
+    # extensions leave over. Cascading the full chamber length instead is not a
+    # refinement the simulation cannot resolve, it is a different device: over
+    # this band it reads 3.7 dB high at the bottom and 11.1 dB low at the top,
+    # against 0.97 dB worst case for the length the library uses.
+    measured = _e_measured(extended_tube_loss)
+    right = _e_cascade_by_hand(_EL - (_ELA + _ELB) * _EDX)
+    wrong = _e_cascade_by_hand(_EL)
+
+    assert measured == pytest.approx(right, abs=1.5)
+    assert np.max(np.abs(measured - wrong)) > 5.0
+    assert np.max(np.abs(measured - right)) < np.max(np.abs(measured - wrong))

--- a/tests/noise_control/test_fdtd_crosscheck.py
+++ b/tests/noise_control/test_fdtd_crosscheck.py
@@ -1,18 +1,30 @@
 #  Copyright (c) 2026. Jose Manuel Requena Plens
-"""Independent FDTD cross-check of a single 2D expansion chamber.
+"""Independent FDTD cross-checks of the reactive silencers.
 
 The four-pole expansion-chamber transmission loss (Bies Eq. (8.111)) predicts,
 for an area ratio ``m = S_exp / S_duct``, a ``TL`` peak of
 ``10 log10[1 + (1/4)(m - 1/m)^2]`` at ``kL = pi/2`` (``f = c / 4L``) and a
 ``TL = 0`` trough (fully transparent) at ``kL = pi`` (``f = c / 2L``).
 
-This test drives an *independent* solver -- the 2D FDTD engine of
-:mod:`phonometry.simulation` -- with a plane-wave duct that widens into a
-chamber and narrows back, and compares the transmitted amplitude at the peak
-and trough frequencies. The measured ``20 log10`` ratio of the transmitted
-amplitudes (trough over peak) must reproduce the closed-form peak ``TL``. The
-run is deterministic and small (a 16x200 grid, ~3000 steps, well under a
-second).
+These tests drive an *independent* solver -- the 2D FDTD engine of
+:mod:`phonometry.simulation` -- with the same geometry the four-pole model
+describes, and compare the two.
+
+The expansion chamber is driven with a steady tone: a plane-wave duct that
+widens into a chamber and narrows back, sampled at the peak and trough
+frequencies. The measured ``20 log10`` ratio of the transmitted amplitudes
+(trough over peak) must reproduce the closed-form peak ``TL``. The run is
+deterministic and small (a 16x200 grid, ~3000 steps, well under a second).
+
+The Helmholtz side branch is driven with a broadband pulse instead, because
+the quantity to compare is a *resonance frequency* and a tone sweep would need
+one run per frequency. One pulse run of the bare duct and one of the duct with
+the resonator give the whole transmission spectrum
+``|p_resonator(f)| / |p_bare(f)|``, that is the insertion loss, which for equal
+inlet and outlet areas and anechoic ends is the transmission loss. The point
+sources are additive (soft), so the wave the resonator reflects back passes
+through the source cell untouched and is swallowed by the upstream sponge: the
+source really does present the anechoic internal impedance that identity needs.
 """
 
 from __future__ import annotations
@@ -21,11 +33,15 @@ import math
 
 import numpy as np
 import pytest
+from numpy.typing import NDArray
 
 from phonometry.noise_control import silencers as sl
-from phonometry.simulation.fdtd import CWSource, fdtd_simulation
+from phonometry.simulation.fdtd import CWSource, GaussianPulse, fdtd_simulation
 
 _C = 343.0
+
+# --- Simple expansion chamber, driven with a steady tone --------------------
+
 _DX = 0.02
 _NY, _NX = 16, 200
 _DUCT_ROWS = (6, 7, 8, 9)      # 4-cell duct; chamber is the full 16 rows -> m = 4
@@ -94,3 +110,249 @@ def test_four_pole_peak_frequency_and_trough() -> None:
         10.0 * math.log10(1.0 + 0.25 * (_M - 1.0 / _M) ** 2), abs=1e-6
     )
     assert res.transmission_loss[1] == pytest.approx(0.0, abs=1e-9)
+
+
+# --- Helmholtz side branch, driven with a broadband pulse -------------------
+#
+# Geometry, in cells of _HDX, stacked from the top of the grid downwards: the
+# cavity, then the neck, then the main duct that runs the full grid length.
+# Every plane of the lumped model falls on a cell face, so the mapping carries
+# no rounding:
+#
+#   * neck area      S_neck = _HNECK_W * _HDX      (per metre of 2D depth)
+#   * duct area      S_duct = _HDUCT * _HDX
+#   * cavity volume  V      = _HCAV_D * width * _HDX^2
+#   * neck geometric length l_g = _HNECK_L * _HDX, measured between the plane
+#     flush with the duct wall and the plane flush with the cavity floor.
+#
+# The one quantity the drawing cannot fix is the *effective* neck length that
+# `helmholtz_resonator` consumes: the evanescent field at each open end of the
+# neck adds inertance, so l_e > l_g, and there is no closed form for a 2D slit
+# opening into a duct on one side and a box on the other. The tests below
+# therefore never assume a value for it. They bracket it, they check that it is
+# a property of the neck alone (the assertion that carries the 1/sqrt(V) law of
+# the Helmholtz formula), and only then do they hand the FDTD-measured
+# resonance back as l_e to compare the whole transmission-loss curve, whose
+# width and level are still predictions.
+
+_HDX = 0.01
+_HDUCT = 8          # main duct height, cells
+_HNECK_W = 3        # neck width, cells
+_HNECK_L = 8        # neck geometric length, cells
+_HCAV_D = 14        # cavity depth along the neck axis, cells (both cavities)
+_HCAV_NARROW = 14   # cavity width, cells
+_HCAV_WIDE = 28     # the same cavity, twice the volume
+_HNY = _HCAV_D + _HNECK_L + _HDUCT      # 30 rows
+_HNX = 380
+_HNECK_X = _HNX // 2 - 40               # first neck column
+_HSTEPS = 5000
+_HSPONGE = 20
+_HSRC = (45, _HNY - 4)                  # on the duct axis, upstream
+_HPROBE = (_HNX - 60, _HNY - 4)         # on the duct axis, downstream
+_HPAD = 16                              # FFT zero-padding factor
+
+_HS_DUCT = _HDUCT * _HDX
+_HS_NECK = _HNECK_W * _HDX
+
+
+def _h_volume(cavity_width: int) -> float:
+    """Cavity volume per metre of 2D depth, m3/m."""
+    return _HCAV_D * cavity_width * _HDX * _HDX
+
+
+def _h_nominal_resonance(cavity_width: int) -> float:
+    """Rough scale used to size the stimulus and the analysis band.
+
+    Deliberately independent of the library, so that the excitation the two
+    routes are compared over never depends on the model under test. The
+    assertions use :func:`_h_lumped_resonance` instead.
+    """
+    volume = _h_volume(cavity_width)
+    return (_C / (2.0 * math.pi)
+            * math.sqrt(_HS_NECK / (_HNECK_L * _HDX * volume)))
+
+
+def _h_lumped_resonance(neck_length: float, cavity_width: int) -> float:
+    """The library's own ``f_0`` for this geometry and effective neck length."""
+    result = sl.helmholtz_resonator(
+        np.array([100.0]), _HS_DUCT, _HS_NECK, neck_length,
+        _h_volume(cavity_width), speed_of_sound=_C,
+    )
+    assert result.resonances is not None
+    return float(result.resonances[0])
+
+
+def _helmholtz_mask(cavity_width: int | None) -> NDArray[np.bool_]:
+    """Rigid-cell map; ``None`` gives the bare duct used as the reference."""
+    mask = np.ones((_HNY, _HNX), dtype=bool)
+    mask[_HCAV_D + _HNECK_L:, :] = False            # the straight main duct
+    if cavity_width is None:
+        return mask
+    mask[_HCAV_D:_HCAV_D + _HNECK_L,
+         _HNECK_X:_HNECK_X + _HNECK_W] = False      # the neck
+    left = _HNECK_X + _HNECK_W // 2 - cavity_width // 2
+    mask[:_HCAV_D, left:left + cavity_width] = False    # the cavity
+    return mask
+
+
+def _h_transmission(cavity_width: int | None) -> tuple[
+    NDArray[np.float64], NDArray[np.complex128]
+]:
+    """Probe spectrum of one pulse run: ``(frequencies, P(f))``."""
+    dt = 0.6 * _HDX / (_C * math.sqrt(2.0))
+    # A Gaussian wide enough to cover DC up to about twice the resonance.
+    width = 1.0 / (4.0 * _h_nominal_resonance(_HCAV_NARROW))
+    res = fdtd_simulation(
+        _C, _HDX, _HSTEPS * dt,
+        sources=[GaussianPulse(ix=_HSRC[0], iy=_HSRC[1], width=width)],
+        shape=(_HNY, _HNX), probes=[_HPROBE],
+        boundaries={"left": "absorbing", "right": "absorbing",
+                    "top": "rigid", "bottom": "rigid"},
+        absorbing_layer_cells=_HSPONGE,
+        obstacle_mask=_helmholtz_mask(cavity_width),
+    )
+    p = res.pressures[0]
+    n = p.size * _HPAD
+    return np.fft.rfftfreq(n, dt), np.fft.rfft(p, n)
+
+
+@pytest.fixture(scope="module")
+def helmholtz_spectra() -> dict[int, tuple[NDArray[np.float64],
+                                           NDArray[np.float64]]]:
+    """One bare-duct run plus one run per cavity: transmitted pressure ratio.
+
+    Three FDTD runs in total (~1.7 s), shared by every test below.
+    """
+    freq, bare = _h_transmission(None)
+    out = {}
+    for width in (_HCAV_NARROW, _HCAV_WIDE):
+        _, loaded = _h_transmission(width)
+        nominal = _h_nominal_resonance(width)
+        band = (freq > 0.45 * nominal) & (freq < 1.45 * nominal)
+        out[width] = (freq[band],
+                      np.abs(loaded[band]) / np.abs(bare[band]))
+    return out
+
+
+def _h_resonance(freq: NDArray[np.float64],
+                 ratio: NDArray[np.float64]) -> float:
+    """Resonance from the simple zero of the transmitted amplitude.
+
+    A lossless side branch shorts the duct at ``f_0``, so ``|p/p_bare|`` has a
+    simple zero there and its square is locally parabolic. Fitting the parabola
+    over the seven bins around the minimum locates the zero far below the bin
+    width and, unlike reading off the transmission-loss maximum, does not
+    depend on how close a bin happens to fall to a near-singularity.
+    """
+    i = min(max(int(np.argmin(ratio)), 3), ratio.size - 4)
+    window = slice(i - 3, i + 4)
+    a, b, _ = np.polyfit(freq[window], ratio[window] ** 2, 2)
+    return float(-b / (2.0 * a))
+
+
+@pytest.mark.xdist_group("fdtd-helmholtz")
+@pytest.mark.parametrize("width", [_HCAV_NARROW, _HCAV_WIDE])
+def test_fdtd_helmholtz_resonance_within_end_correction_bracket(
+    helmholtz_spectra: dict[int, tuple[NDArray[np.float64],
+                                       NDArray[np.float64]]],
+    width: int,
+) -> None:
+    # Every effect the lumped model leaves out pushes the resonance *down*:
+    # the evanescent field at both ends of the neck adds inertance, and a
+    # cavity of finite depth is slightly more compliant than its volume alone
+    # (tan(kD)/kD > 1). So `helmholtz_resonator` fed the bare geometric neck
+    # length is a rigorous upper bound on what the simulation can show. For the
+    # lower bound, charge each open end of the slit a full neck width of end
+    # correction, which is generous: a 2D slit of width w opening into a
+    # channel of width W gains an inertial length of order (w/pi) ln(W/w),
+    # about 0.3 w on the duct side (W/w = 2.7) and 0.7 w on the cavity side
+    # (W/w = 4.7 and 9.3) here.
+    # Measured: 1.38 w and 1.36 w of total end correction, so the resonance
+    # lands at 0.812 of the geometric-length bound for both cavities.
+    freq, ratio = helmholtz_spectra[width]
+    measured = _h_resonance(freq, ratio)
+    geometric = _h_lumped_resonance(_HNECK_L * _HDX, width)
+    corrected = _h_lumped_resonance(
+        (_HNECK_L + 2 * _HNECK_W) * _HDX, width
+    )
+    assert corrected < measured < geometric
+
+
+@pytest.mark.xdist_group("fdtd-helmholtz")
+def test_fdtd_helmholtz_follows_inverse_root_volume(
+    helmholtz_spectra: dict[int, tuple[NDArray[np.float64],
+                                       NDArray[np.float64]]],
+) -> None:
+    # The content of the Helmholtz formula that survives the end-correction
+    # ambiguity: with the neck untouched, f_0 goes as 1 / sqrt(V). The wide
+    # cavity is the narrow one with its width doubled and its depth kept, so
+    # the volume doubles while the neck, and therefore l_e, does not.
+    #
+    # Error budget for the 1 % bound. Grid dispersion is negligible here: at
+    # 177 cells per wavelength the leapfrog scheme under-reads the frequency by
+    # (k dx)^2 / 24 = 5.3e-5, that is 0.005 %. The numerical spread of the
+    # measurement is of the same order: sweeping the grid length over
+    # 380-500 cells, the record over 5000-8000 steps and the zero-padding over
+    # 4-16 moves the ratio by less than 0.05 %. What is left is physical, the
+    # slight change of the cavity-side end correction when the cavity widens,
+    # and it measures 0.19 % (1.4115 against sqrt(2)). One percent leaves a
+    # factor of five of headroom and still rejects any other exponent by a wide
+    # margin: V^(-1/3) would give 1.26 and V^(-1) would give 2.
+    narrow = _h_resonance(*helmholtz_spectra[_HCAV_NARROW])
+    wide = _h_resonance(*helmholtz_spectra[_HCAV_WIDE])
+    # The library's own prediction of the same ratio. Any effective neck length
+    # serves: it is common to both cavities and cancels, which is exactly why
+    # the ratio is the part of the formula the simulation can pin down.
+    length = _HNECK_L * _HDX
+    predicted = (_h_lumped_resonance(length, _HCAV_NARROW)
+                 / _h_lumped_resonance(length, _HCAV_WIDE))
+    assert _h_volume(_HCAV_WIDE) == pytest.approx(2.0 * _h_volume(_HCAV_NARROW))
+    assert predicted == pytest.approx(math.sqrt(2.0), rel=1e-12)
+    assert narrow / wide == pytest.approx(predicted, rel=0.01)
+
+
+@pytest.mark.xdist_group("fdtd-helmholtz")
+@pytest.mark.parametrize("width", [_HCAV_NARROW, _HCAV_WIDE])
+def test_fdtd_helmholtz_transmission_loss_curve(
+    helmholtz_spectra: dict[int, tuple[NDArray[np.float64],
+                                       NDArray[np.float64]]],
+    width: int,
+) -> None:
+    # With the single unknown pinned -- the effective neck length read back
+    # from the measured resonance, l_e = S_neck c^2 / (4 pi^2 f_0^2 V) -- the
+    # rest of `helmholtz_resonator` is still a prediction: the width of the
+    # notch is set by c S_neck / (S_duct l_e) and its level by the shunt and
+    # transmission-loss formulae. Both are compared from 0.6 to 1.4 times the
+    # resonance, stepping around the resonance itself, where a lossless branch
+    # shorts the duct and the modelled transmission loss is singular.
+    #
+    # The 1.5 dB bound is a modelling difference, not a numerical one. The 1D
+    # model treats the cavity as a pure compliance, but at resonance the cavity
+    # spans kD = 0.50 rad, so its reactance departs from the lumped value by
+    # about (kD)^2 / 3 = 8 %, and 8.7 ln(1.08) = 0.7 dB of transmission loss on
+    # the flanks of the notch; the same argument on the neck, kl_e = 0.43 rad,
+    # adds a comparable term. Grid dispersion contributes 0.005 % of frequency
+    # and nothing measurable in dB. Measured: at most 1.00 dB for the narrow
+    # cavity and 0.33 dB for the wide one.
+    freq, ratio = helmholtz_spectra[width]
+    resonance = _h_resonance(freq, ratio)
+    volume = _h_volume(width)
+    neck_length = (
+        _HS_NECK * _C**2 / (4.0 * math.pi**2 * resonance**2 * volume)
+    )
+
+    probe = resonance * np.array(
+        [0.6, 0.7, 0.8, 0.9, 0.95, 1.05, 1.1, 1.2, 1.3, 1.4]
+    )
+    analytic = sl.helmholtz_resonator(
+        probe, _HS_DUCT, _HS_NECK, neck_length, volume, speed_of_sound=_C,
+    ).transmission_loss
+    measured = np.array([
+        -20.0 * math.log10(ratio[int(np.argmin(np.abs(freq - f)))])
+        for f in probe
+    ])
+    assert measured == pytest.approx(analytic, abs=1.5)
+
+    # And the branch really does short the duct: a deep notch, not a dent.
+    assert measured.max() > 10.0
+    assert -20.0 * math.log10(ratio.min()) > 25.0

--- a/tests/noise_control/test_silencers.py
+++ b/tests/noise_control/test_silencers.py
@@ -170,16 +170,85 @@ def test_extended_tube_reduces_to_expansion_chamber() -> None:
     assert np.allclose(ext.transmission_loss, plain.transmission_loss, atol=1e-9)
 
 
-def test_extended_tube_fills_trough() -> None:
-    # An inlet extension tuned to L/4 raises the TL at the first chamber trough.
+def test_extended_tube_fills_the_trough_its_length_tunes() -> None:
+    # An extension is a quarter-wave stub of length L_ext, so it shorts the
+    # duct at c / 4 L_ext and fills exactly the chamber trough that lands
+    # there: L/2 covers the first (c/2L), L/4 the second (c/L). The extension
+    # tuned to the *other* trough leaves this one essentially untouched.
     c, length = 343.0, 0.4
-    f = np.array([c / (2.0 * length)])  # first plain-chamber trough (TL = 0)
+    first, second = c / (2.0 * length), c / length
+    f = np.array([first, second])
     plain = sl.expansion_chamber(f, length, 0.04, 0.01)
-    tuned = sl.extended_tube_chamber(
+    half = sl.extended_tube_chamber(
+        f, length, 0.04, 0.01, inlet_extension=length / 2.0
+    )
+    quarter = sl.extended_tube_chamber(
         f, length, 0.04, 0.01, inlet_extension=length / 4.0
     )
-    assert plain.transmission_loss[0] == pytest.approx(0.0, abs=1e-9)
-    assert tuned.transmission_loss[0] > 3.0
+    assert plain.transmission_loss == pytest.approx([0.0, 0.0], abs=1e-9)
+    assert half.transmission_loss[0] > 100.0     # tuned to the first trough
+    assert half.transmission_loss[1] < 0.1       # transparent at the second
+    assert quarter.transmission_loss[1] > 100.0  # tuned to the second trough
+    assert quarter.transmission_loss[0] < 1.0    # nearly nothing at the first
+
+
+def test_extended_tube_straight_section_excludes_the_extensions() -> None:
+    # The junction where each extended pipe ends is where its ducts meet, so
+    # the straight chamber element is L - L_a - L_b (Bies Figure 8.19(a) and
+    # Example 8.2, L = L_a + L_b + L_c), not the full chamber length. Building
+    # the same cascade by hand from the documented building blocks reproduces
+    # the result; using the full length does not.
+    c, length, la, lb = 343.0, 0.5, 0.25, 0.1
+    f = np.linspace(50.0, 900.0, 400)
+    s_exp, s_duct = 0.04, 0.01
+    result = sl.extended_tube_chamber(
+        f, length, s_exp, s_duct, inlet_extension=la, outlet_extension=lb,
+        speed_of_sound=c,
+    )
+
+    def by_hand(straight: float) -> np.ndarray:
+        annulus = s_exp - s_duct
+        return sl.transmission_loss(
+            sl.cascade(
+                sl.shunt_matrix(sl.quarter_wave_impedance(
+                    f, la, annulus, speed_of_sound=c)),
+                sl.duct_matrix(f, straight, s_exp, speed_of_sound=c),
+                sl.shunt_matrix(sl.quarter_wave_impedance(
+                    f, lb, annulus, speed_of_sound=c)),
+            ),
+            inlet_area=s_duct, outlet_area=s_duct, speed_of_sound=c,
+        )
+
+    assert result.transmission_loss == pytest.approx(
+        by_hand(length - la - lb), abs=1e-9
+    )
+    assert not np.allclose(
+        result.transmission_loss, by_hand(length), atol=1.0
+    )
+
+
+def test_extended_tube_extensions_may_meet_but_not_overlap() -> None:
+    # Extensions that meet leave no straight section: the cascade degenerates
+    # to the two annular branches shunting the same plane, which is finite and
+    # well defined. Extensions that would overlap are rejected instead of
+    # cascading a duct of negative length.
+    f = np.array([200.0, 400.0])
+    meeting = sl.extended_tube_chamber(
+        f, 0.5, 0.04, 0.01, inlet_extension=0.3, outlet_extension=0.2
+    )
+    assert np.all(np.isfinite(meeting.transmission_loss))
+    by_hand = sl.transmission_loss(
+        sl.cascade(
+            sl.shunt_matrix(sl.quarter_wave_impedance(f, 0.3, 0.03)),
+            sl.shunt_matrix(sl.quarter_wave_impedance(f, 0.2, 0.03)),
+        ),
+        inlet_area=0.01, outlet_area=0.01,
+    )
+    assert meeting.transmission_loss == pytest.approx(by_hand, abs=1e-9)
+    with pytest.raises(ValueError, match="negative length"):
+        sl.extended_tube_chamber(
+            f, 0.5, 0.04, 0.01, inlet_extension=0.3, outlet_extension=0.3
+        )
 
 
 def test_insertion_loss_present_when_impedances_given() -> None:

--- a/tests/noise_control/test_silencers.py
+++ b/tests/noise_control/test_silencers.py
@@ -251,6 +251,24 @@ def test_extended_tube_extensions_may_meet_but_not_overlap() -> None:
         )
 
 
+def test_extensions_that_meet_only_in_decimal_are_still_accepted() -> None:
+    # 0.1 + 0.2 exceeds 0.3 in binary, so a chamber described in round decimal
+    # metres meets the case above without satisfying it in arithmetic. The
+    # rejection is of a materially negative straight section, not of an ulp.
+    f = np.array([200.0, 400.0])
+    assert 0.1 + 0.2 > 0.3  # the premise, so this test cannot quietly go stale
+    meeting = sl.extended_tube_chamber(
+        f, 0.3, 0.04, 0.01, inlet_extension=0.1, outlet_extension=0.2
+    )
+    assert np.all(np.isfinite(meeting.transmission_loss))
+    # An overlap far below any drawn dimension, and far above the arithmetic,
+    # is still an overlap.
+    with pytest.raises(ValueError, match="negative length"):
+        sl.extended_tube_chamber(
+            f, 0.3, 0.04, 0.01, inlet_extension=0.1, outlet_extension=0.2 + 1e-6
+        )
+
+
 def test_insertion_loss_present_when_impedances_given() -> None:
     f = np.linspace(50.0, 500.0, 20)
     res = sl.expansion_chamber(


### PR DESCRIPTION
An extended-tube chamber is two quarter-wave annular branches at the ends of a
chamber with a straight duct between them. The straight element was being
cascaded over the **whole** chamber length instead of the length the two
extensions leave, so the extension regions were counted twice.

The limit case shows it without reference to any source: when the two
extensions meet, there is no straight section left, and the old code still
cascaded a full-length duct and returned a number. The module also disagreed
with itself, since its own drawing already computed
`inlet_extension + 0.5 * (length - inlet_extension - outlet_extension)`. The
picture was right and the maths was wrong.

Bies & Hansen Example 8.2 states the junction outright ("L = La + Lb + Lc"),
and Figure 8.19(a) dimensions Lc as the segment between the two extension ends.
Against the published DTEC curves of Figure 8.20 the old model produced deep
troughs the figure does not have: for the m = 16 chamber it fell to 5.2 dB at
kL/pi = 0.6 where the figure reads a smooth dome near 29 dB.

## What moved, and one thing that was never true

`test_extended_tube_fills_trough` asserted that an inlet extension of L/4 fills
the trough at c/2L. That premise is wrong on its own terms: a branch of length
La tunes c/4La, so L/4 tunes c/L, the **second** trough, and L/2 tunes the
first. Measured on the corrected model, the L/4 inlet gives 0.57 dB at the
first trough and 82 dB at the second, and the L/2 inlet the other way round.
Only the length defect made the old assertion look true. The test is rewritten
to check each extension against the trough it actually tunes.

The figure carried the same false narrative, so it needed more than new
numbers. It now marks both trough frequencies and says which extension owns
each. Two annotated values came out entirely: a "74 dB" that was the
grid-nearest sample of a pole, and two "new troughs" at 355 Hz and 261 Hz that
do not exist.

`La + Lb == L` is now accepted rather than rejected: the straight element
vanishes and the cascade degenerates to the two branches shunting one plane,
which is the physical limit of the pipes touching. `La + Lb > L` stays
rejected, with a message that says what actually goes wrong.

## Cross-checks

Both new checks compare the transfer-matrix model against an independent
time-domain simulation of the same geometry.

The extended-tube chamber agrees within 0.97 dB over kL/pi in [0.20, 0.55],
where the defective model is out by up to 11.08 dB. The band stops short of the
stub's quarter-wave resonance, where the extensions' uncorrected end
corrections lift the shoulder underneath it.

The Helmholtz resonator has no closed-form end correction for a 2-D slit
opening into a duct at one end and a box at the other, so the tests do not
assume one. They measure it, and validate against an inverse-root-volume law
in which the unknown length is common to both runs and cancels: 1.4115 measured
against 1.4142 predicted.

## Summary by Sourcery

Correct the extended-tube chamber model so its straight duct section spans only the length left between inlet and outlet extensions, and validate it against independent FDTD simulations of reactive silencers.

Bug Fixes:
- Fix extended_tube_chamber to cascade the straight chamber element over L - L_a - L_b instead of the full chamber length, and allow the limit case where extensions meet while rejecting overlapping extensions.

Enhancements:
- Clarify extended_tube_chamber parameter semantics and error messages, and adjust handling of zero or meeting straight-section lengths.

Documentation:
- Update English and Spanish silencer documentation, figure annotations, and example narrative to reflect the correct tuning of extensions and the true behaviour of extended-tube chambers.

Tests:
- Add FDTD-based cross-checks for Helmholtz resonators and extended-tube chambers, including broadband pulse infrastructure, and rewrite extended-tube tests to assert correct trough-filling behaviour and straight-section length handling.

Chores:
- Update changelog and translated figure text for the extended-tube chamber correction.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/phonometry/pull/552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Corrected the `extended_tube_chamber` model to use the leftover straight section length (`L - L_a - L_b`) instead of the full chamber length, improving accuracy against Bies's reference curves.</li>
<li>Added clamping to the straight section length calculation to handle rounding errors when extensions meet exactly, preventing negative lengths.</li>
<li>Updated documentation and figures to clarify that extensions act as quarter-wave stubs and to reflect the corrected transmission loss behavior.</li>
<li>Expanded FDTD cross-check tests to include Helmholtz side branches and extended-tube chambers using broadband pulse simulations.</li>
</ul></div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected extended-tube chamber calculations for inlet and outlet extensions.
  - Extensions may meet at a point, while overlapping extensions are rejected with a clearer error.
  - Improved transmission- and insertion-loss results for chambers with nonzero extensions.

- **Documentation**
  - Clarified quarter-wave tuning, chamber trough coverage, and frequency shifts.
  - Updated examples, figures, translations, and published loss values.

- **Tests**
  - Added broader validation against independent FDTD simulations and reference results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->